### PR TITLE
Range selection(the SHIFT key combination) was fixed. 

### DIFF
--- a/keymap/Vim.xml
+++ b/keymap/Vim.xml
@@ -41,29 +41,29 @@
   <action id="EditorDeleteLine" />
   <action id="EditorDeleteToWordEnd" />
   <action id="EditorDeleteToWordStart" />
-  <action id="EditorDownWithSelection" />
+  <!--  <action id="EditorDownWithSelection" />-->
   <action id="EditorDuplicate" />
-  <action id="EditorIndentSelection" />
+  <!--  <action id="EditorIndentSelection" />-->
   <action id="EditorJoinLines" />
-  <action id="EditorLeftWithSelection" />
-  <action id="EditorLineEndWithSelection" />
-  <action id="EditorLineStartWithSelection" />
+  <!--  <action id="EditorLeftWithSelection" />-->
+  <!--  <action id="EditorLineEndWithSelection" />-->
+  <!-- <action id="EditorLineStartWithSelection" />-->
   <action id="EditorMoveToPageBottom" />
-  <action id="EditorMoveToPageBottomWithSelection" />
+  <!--  <action id="EditorMoveToPageBottomWithSelection" />-->
   <action id="EditorMoveToPageTop" />
-  <action id="EditorMoveToPageTopWithSelection" />
+  <!--  <action id="EditorMoveToPageTopWithSelection" />-->
   <action id="EditorNextWord" />
-  <action id="EditorNextWordWithSelection" />
-  <action id="EditorPageDownWithSelection" />
-  <action id="EditorPageUpWithSelection" />
+  <!--  <action id="EditorNextWordWithSelection" />-->
+  <!--  <action id="EditorPageDownWithSelection" />-->
+  <!--  <action id="EditorPageUpWithSelection" />-->
   <action id="EditorPaste">
     <keyboard-shortcut first-keystroke="shift INSERT" />
     <keyboard-shortcut first-keystroke="meta V" />
   </action>
   <action id="EditorPreviousWord" />
-  <action id="EditorPreviousWordWithSelection" />
+  <!--  <action id="EditorPreviousWordWithSelection" />-->
   <action id="EditorRedo" />
-  <action id="EditorRightWithSelection" />
+  <!--  <action id="EditorRightWithSelection" />-->
   <action id="EditorScrollDown" />
   <action id="EditorScrollToCenter" />
   <action id="EditorScrollUp" />
@@ -72,14 +72,14 @@
   <action id="EditorSplitLine" />
   <action id="EditorStartNewLine" />
   <action id="EditorTextEnd" />
-  <action id="EditorTextEndWithSelection" />
+  <!--  <action id="EditorTextEndWithSelection" />-->
   <action id="EditorTextStart" />
-  <action id="EditorTextStartWithSelection" />
+  <!--  <action id="EditorTextStartWithSelection" />-->
   <action id="EditorToggleCase" />
   <action id="EditorUnSelectWord" />
   <action id="EditorUndo" />
-  <action id="EditorUnindentSelection" />
-  <action id="EditorUpWithSelection" />
+  <!--  <action id="EditorUnindentSelection" />-->
+  <!--  <action id="EditorUpWithSelection" />-->
   <action id="Find" />
   <action id="FindNext">
     <keyboard-shortcut first-keystroke="F3" />
@@ -169,10 +169,10 @@
     <keyboard-shortcut first-keystroke="KP_UP" />
     <keyboard-shortcut first-keystroke="shift control 2" />
     <keyboard-shortcut first-keystroke="shift control SPACE" />
-    <keyboard-shortcut first-keystroke="shift DOWN" />
-    <keyboard-shortcut first-keystroke="shift LEFT" />
-    <keyboard-shortcut first-keystroke="shift RIGHT" />
-    <keyboard-shortcut first-keystroke="shift UP" />
+    <!--<keyboard-shortcut first-keystroke="shift DOWN" />-->
+    <!--<keyboard-shortcut first-keystroke="shift LEFT" />-->
+    <!--<keyboard-shortcut first-keystroke="shift RIGHT" />-->
+    <!--<keyboard-shortcut first-keystroke="shift UP" />-->
   </action>
 </keymap>
 

--- a/src/com/maddyhome/idea/vim/key/RegisterActions.java
+++ b/src/com/maddyhome/idea/vim/key/RegisterActions.java
@@ -126,27 +126,27 @@ public class RegisterActions {
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_UP, 0)),
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.CTRL_MASK)),
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_UP, KeyEvent.CTRL_MASK)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.SHIFT_MASK)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_UP, KeyEvent.SHIFT_MASK))
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.SHIFT_MASK)),
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_UP, KeyEvent.SHIFT_MASK))
     });
     parser.registerAction(KeyParser.MAPPING_INSERT, "VimMotionScrollPageDown", Command.INSERT, Command.FLAG_CLEAR_STROKES, new Shortcut[]{
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN, 0)),
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.CTRL_MASK)),
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_DOWN, KeyEvent.CTRL_MASK)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.SHIFT_MASK)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_DOWN, KeyEvent.SHIFT_MASK))
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.SHIFT_MASK)),
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_DOWN, KeyEvent.SHIFT_MASK))
     });
     parser.registerAction(KeyParser.MAPPING_INSERT, "VimMotionWordLeft", Command.INSERT, Command.FLAG_CLEAR_STROKES, new Shortcut[]{
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, KeyEvent.CTRL_MASK)),
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_LEFT, KeyEvent.CTRL_MASK)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, KeyEvent.SHIFT_MASK)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_LEFT, KeyEvent.SHIFT_MASK))
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, KeyEvent.SHIFT_MASK)),
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_LEFT, KeyEvent.SHIFT_MASK))
     });
     parser.registerAction(KeyParser.MAPPING_INSERT, "VimMotionWordRight", Command.INSERT, Command.FLAG_CLEAR_STROKES, new Shortcut[]{
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, KeyEvent.CTRL_MASK)),
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_RIGHT, KeyEvent.CTRL_MASK)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, KeyEvent.SHIFT_MASK)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_RIGHT, KeyEvent.SHIFT_MASK))
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, KeyEvent.SHIFT_MASK)),
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_KP_RIGHT, KeyEvent.SHIFT_MASK))
     });
     parser.registerAction(KeyParser.MAPPING_INSERT, "VimShiftLeftLines", Command.INSERT, Command.FLAG_SAVE_STROKE,
                           new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_D, KeyEvent.CTRL_MASK)));
@@ -597,14 +597,14 @@ public class RegisterActions {
                             new Shortcut(new KeyStroke[]{KeyStroke.getKeyStroke('z'), KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0)})
                           });
     parser.registerAction(KeyParser.MAPPING_NVO, "VimMotionScrollPageDown", Command.OTHER_READONLY, new Shortcut[]{
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.SHIFT_MASK)),
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.SHIFT_MASK)),
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_F, KeyEvent.CTRL_MASK)),
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN, 0))
     });
     parser.registerAction(KeyParser.MAPPING_NVO, "VimMotionScrollPageUp", Command.OTHER_READONLY, new Shortcut[]{
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_B, KeyEvent.CTRL_MASK)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_UP, 0)),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.SHIFT_MASK))
+      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_UP, 0))
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.SHIFT_MASK))
     });
     parser.registerAction(KeyParser.MAPPING_NVO, "VimMotionUp", Command.MOTION, Command.FLAG_MOT_LINEWISE, new Shortcut[]{
       new Shortcut('k'),
@@ -622,12 +622,12 @@ public class RegisterActions {
     parser.registerAction(KeyParser.MAPPING_NVO, "VimMotionWordEndRight", Command.MOTION, Command.FLAG_MOT_INCLUSIVE,
                           new Shortcut('e'));
     parser.registerAction(KeyParser.MAPPING_NVO, "VimMotionWordLeft", Command.MOTION, Command.FLAG_MOT_EXCLUSIVE, new Shortcut[]{
-      new Shortcut('b'),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, KeyEvent.SHIFT_MASK))
+      new Shortcut('b')
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, KeyEvent.SHIFT_MASK))
     });
     parser.registerAction(KeyParser.MAPPING_NVO, "VimMotionWordRight", Command.MOTION, Command.FLAG_MOT_EXCLUSIVE, new Shortcut[]{
-      new Shortcut('w'),
-      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, KeyEvent.SHIFT_MASK))
+      new Shortcut('w')
+//      new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, KeyEvent.SHIFT_MASK))
     });
     parser.registerAction(KeyParser.MAPPING_NVO, "VimMotionBigWordEndLeft", Command.MOTION, Command.FLAG_MOT_INCLUSIVE,
                           new Shortcut("gE"));
@@ -916,6 +916,7 @@ public class RegisterActions {
 
     // All the Alt keys
 
+    /*--------------------------------------
     // All the Ctrl keys
     parser.setupActionHandler("EditorDeleteToWordEnd", "VimDummyHandler", KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, KeyEvent.CTRL_MASK));
     parser
@@ -958,6 +959,7 @@ public class RegisterActions {
                               KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_UP, KeyEvent.CTRL_MASK | KeyEvent.SHIFT_MASK));
     parser.setupActionHandler("EditorMoveToPageBottomWithSelection", "VimDummyHandler",
                               KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN, KeyEvent.CTRL_MASK | KeyEvent.SHIFT_MASK));
+    --------------------------------------*/
   }
 
   private static RegisterActions instance;


### PR DESCRIPTION
SHIFT+UP       ... Up with Selection
SHIFT+RIGHT  ... Right with Selection
SHIFT+LEFT    .... Left with Selection
SHIFT+DOWN  ...  Down with Selection

SHIFT+Tab       .... Indent Selection
SHIFT+Ctrl+Tab .... Unindent Selection

SHIFT+Home  .... Line Start with Selection
SHIFT+End     .... Line End with Selection

SHIFT+Ctrl+Home   ... Text Start with Selection
SHIFT+Ctrl+End      ... Text End with Selection

SHIFT+Ctrl+RIGHT ... Next Word with Selection
SHIFT+Ctrl+LEFT  ... Previous Word with Selection

SHIFT+PgUP    ... Move to Page UP with Selection
SHIFT+PgDown ... Move to Page DOWN with Selection

SHIFT+Ctrl+PgUP    ... Move to Page Top with Selection
SHIFT+Ctrl+PgDown ... Move to Page Bottom with Selection
