### PR TITLE
Temporary hackfix for hanging editor on Retina systems running EAP 120.77 (or later) when opening files.

### DIFF
--- a/src/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/com/maddyhome/idea/vim/VimPlugin.java
@@ -38,9 +38,11 @@ import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerAdapter;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.WindowManager;
+import com.intellij.util.ui.UIUtil;
 import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.ex.CommandParser;
 import com.maddyhome.idea.vim.group.*;
@@ -208,6 +210,10 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
         DocumentManager.getInstance().addListeners(editor.getDocument());
 
         if (VimPlugin.isEnabled()) {
+          if (UIUtil.isRetina()) {
+                Registry.get("ide.mac.disableRetinaDrawingFix").setValue(true);
+          }
+
           // Turn on insert mode if editor doesn't have any file
           if (!EditorData.isFileEditor(editor) && !CommandState.inInsertMode(editor)) {
             KeyHandler.getInstance().handleKey(editor, KeyStroke.getKeyStroke('i'), new EditorDataContext(editor));
@@ -215,6 +221,15 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
           editor.getSettings().setBlockCursor(!CommandState.inInsertMode(editor));
           editor.getSettings().setAnimatedScrolling(ANIMATED_SCROLLING_VIM_VALUE);
           editor.getSettings().setRefrainFromScrolling(REFRAIN_FROM_SCROLLING_VIM_VALUE);
+
+          if (UIUtil.isRetina()) {
+            SwingUtilities.invokeLater(new Runnable() {
+              @Override
+              public void run() {
+                Registry.get("ide.mac.disableRetinaDrawingFix").setValue(false);
+              }
+            });
+          }
         }
       }
 


### PR DESCRIPTION
This request should most likely not be accepted but it might be useful to keep open for the duration of the bug.

See: http://youtrack.jetbrains.com/issue/IDEA-90293
And: http://youtrack.jetbrains.com/issue/VIM-253

Maybe someone will find it useful meanwhile as temporary hackfix :)

You need to compile against EAP 120.77 or later.
