### PR TITLE
Bug fix for gi behaviour

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -211,12 +211,12 @@ public class ChangeGroup extends AbstractActionGroup {
    * @param context The data context
    */
   public void insertAtPreviousInsert(Editor editor, DataContext context) {
-    int offset = CommandGroups.getInstance().getMotion().moveCaretToFileMarkLine(editor, '^');
+    int offset = CommandGroups.getInstance().getMotion().moveCaretToMark(editor, context, '^');
     if (offset != -1) {
       MotionGroup.moveCaret(editor, context, offset);
     }
 
-    insertBeforeCursor(editor, context);
+    insertAfterCursor(editor, context);
   }
 
   /**


### PR DESCRIPTION
gi shouldn't work like it does now (at least according to the documentation)
Bug description

Steps to reproduce
1. Open a file
2. Switch to insert mode
3. Insert any characters
4. Switch back to normal mode
5. Press gg (or move cursor to another position by any other means)
6. Press gi

Expected result:
Switch to insert mode with cursor after the last inserted character

Actual result:
Switch to insert mode with cursor before the first non space character in the line
