### PR TITLE
Matching command-line font and font size to editor font and font size

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-version-id:0.26
+version-id:0.27
 platform-version:110.0
 idea.download.url=http://download.jetbrains.com/idea/ideaIU-12.0.zip
 build.number=x

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -3,6 +3,10 @@
   <id>IdeaVIM</id>
   <change-notes>
     <![CDATA[
+      <p>0.27:</p>
+      <ul>
+        <li>Command-line font and size now match your editor font and size</li>
+      </ul>
       <p>0.26:</p>
       <ul>
         <li>Added support for paste in the command mode: from a register using <code>&lt;C-R&gt;</code>, from the clipboard using <code>&lt;S-Insert&gt;</code> or <code>&lt;M-V&gt;</code></li>

--- a/src/com/maddyhome/idea/vim/ui/ExEntryPanel.java
+++ b/src/com/maddyhome/idea/vim/ui/ExEntryPanel.java
@@ -23,6 +23,8 @@ import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.colors.EditorColorsManager;
+import com.intellij.openapi.editor.colors.EditorColorsScheme;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -46,8 +48,9 @@ public class ExEntryPanel extends JPanel {
 
   private ExEntryPanel() {
     setBorder(BorderFactory.createEtchedBorder());
+    EditorColorsScheme scheme = EditorColorsManager.getInstance().getGlobalScheme();
 
-    Font font = new Font("Monospaced", Font.PLAIN, 12);
+    Font font = new Font(scheme.getEditorFontName(), Font.PLAIN, scheme.getEditorFontSize());
     label = new JLabel(" ");
     label.setFont(font);
     entry = new ExTextField();


### PR DESCRIPTION
Minor commit. Simply added the following to the command-line UI:

```
EditorColorsScheme scheme = EditorColorsManager.getInstance().getGlobalScheme();

Font font = new Font(scheme.getEditorFontName(), Font.PLAIN, scheme.getEditorFontSize());
```
