### PR TITLE
Bug fix for issue VIM-440

### DIFF
--- a/src/com/maddyhome/idea/vim/ex/handler/EditFileHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/EditFileHandler.java
@@ -29,6 +29,8 @@ import com.maddyhome.idea.vim.ex.ExException;
 import com.maddyhome.idea.vim.group.CommandGroups;
 import org.jetbrains.annotations.NotNull;
 
+import javax.swing.*;
+
 /**
  *
  */
@@ -40,7 +42,7 @@ public class EditFileHandler extends CommandHandler {
     }, RANGE_FORBIDDEN | ARGUMENT_OPTIONAL | DONT_REOPEN);
   }
 
-  public boolean execute(@NotNull Editor editor, @NotNull DataContext context, @NotNull ExCommand cmd) throws ExException {
+  public boolean execute(@NotNull Editor editor, @NotNull final DataContext context, @NotNull ExCommand cmd) throws ExException {
     String arg = cmd.getArgument();
     if (arg != null) {
       if (arg.equals("#")) {
@@ -59,7 +61,12 @@ public class EditFileHandler extends CommandHandler {
       }
     }
 
-    KeyHandler.executeAction("OpenFile", context);
+    SwingUtilities.invokeLater(new Runnable() {
+      @Override
+      public void run() {
+        KeyHandler.executeAction("OpenFile", context);
+      }
+    });
 
     return true;
   }


### PR DESCRIPTION
Currently calling ':ed' (:edit) or ':browse' without arguments opens the file system viewer, but nothing is listed, the loading icon remains there indefinitely. This is also described in this issue: http://youtrack.jetbrains.com/issue/VIM-440

I have added a small fix for this.
