### PR TITLE
adds support for VIM-518, VIM-448

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,6 +23,7 @@ Contributors:
 * [Alexander Zolotov](mailto:alexander.zolotov@jetbrains.com)
 * [John Lindquist](mailto:johnlindquist@gmail.com)
 * [Ira Klotzko](mailto:iklotzko@ltech.com)
+* [mavenraven.org](http://www.mavenraven.org)
 
 If you are a contributor and your name is not listed here, feel free to
 contact the maintainer.

--- a/resources/messages.properties
+++ b/resources/messages.properties
@@ -48,3 +48,4 @@ E385=E385: search hit BOTTOM without match for: {0}
 e_patnotf2=Pattern not found: {0}
 unkopt=Unknown option: {0}
 e_invarg=Invalid argument: {0}
+inoremap_not_implemented=Only inoremap of the form "inoremap 'character sequence' <esc>" implemented.

--- a/src/com/maddyhome/idea/vim/ex/CommandParser.java
+++ b/src/com/maddyhome/idea/vim/ex/CommandParser.java
@@ -82,6 +82,7 @@ public class CommandParser {
     //new GotoLineHandler(); - not needed here
     new HelpHandler();
     new HistoryHandler();
+    new INoRemapHandler();
     new JoinLinesHandler();
     new JumpsHandler();
     new MarkHandler();

--- a/src/com/maddyhome/idea/vim/ex/handler/INoRemapHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/INoRemapHandler.java
@@ -1,0 +1,53 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2013 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.maddyhome.idea.vim.ex.handler;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.ex.CommandHandler;
+import com.maddyhome.idea.vim.ex.ExCommand;
+import com.maddyhome.idea.vim.ex.ExException;
+import com.maddyhome.idea.vim.helper.MessageHelper;
+import com.maddyhome.idea.vim.helper.Msg;
+import com.maddyhome.idea.vim.key.KeyParser;
+import com.maddyhome.idea.vim.option.iNoRemap.INoRemap;
+import com.maddyhome.idea.vim.option.iNoRemap.INoRemapResult;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class INoRemapHandler extends CommandHandler {
+  public INoRemapHandler() {
+    super("ino", "remap", ARGUMENT_REQUIRED);
+  }
+
+  public boolean execute(@Nullable Editor editor, @Nullable DataContext context, @NotNull ExCommand cmd) throws ExException {
+    INoRemap iNoRemap = new INoRemap(KeyParser.getInstance());
+    INoRemapResult result = iNoRemap.tryToAddCustomEscape(cmd.getCommand() + " " + cmd.getArgument());
+    if (result == INoRemapResult.True) {
+      return true;
+    }
+    else if (result == INoRemapResult.False) {
+      throw new ExException();
+    }
+    else {
+      VimPlugin.showMessage(MessageHelper.message(Msg.inoremap_not_implemented));
+      return false;
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/helper/Msg.java
+++ b/src/com/maddyhome/idea/vim/helper/Msg.java
@@ -70,4 +70,5 @@ public interface Msg {
   String e_patnotf2 = "e_patnotf2";
   String unkopt = "unkopt";
   String e_invarg = "e_invarg";
+  String inoremap_not_implemented = "inoremap_not_implemented";
 }

--- a/src/com/maddyhome/idea/vim/insert/InsertToCommandState.java
+++ b/src/com/maddyhome/idea/vim/insert/InsertToCommandState.java
@@ -1,0 +1,63 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2013 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.maddyhome.idea.vim.insert;
+
+import com.maddyhome.idea.vim.command.CommandState;
+import com.maddyhome.idea.vim.key.BranchNode;
+import com.maddyhome.idea.vim.key.CommandNode;
+import com.maddyhome.idea.vim.key.Node;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.KeyStroke;
+import java.util.List;
+
+public class InsertToCommandState {
+
+  private final List<KeyStroke> bufferedKeys;
+  private final InsertToCommandStateTimer timer;
+
+  public InsertToCommandState(InsertToCommandStateTimer timer, List<KeyStroke> bufferedKeys) {
+    this.bufferedKeys = bufferedKeys;
+    this.timer = timer;
+  }
+
+  public void accept(@NotNull CommandState editorState, @Nullable Node node, @NotNull InsertToCommandStateVisitor visitor) {
+    if (editorState.getMode() != CommandState.Mode.INSERT) {
+      visitor.NotInInsertToCommandState();
+    }
+    else if (timer.timeoutElapsed()) {
+      visitor.TimedOutValidCommandSequence();
+    }
+    else if (node instanceof CommandNode) {
+      visitor.EndingInsertToCommandSequenceByChangingToCommandMode((CommandNode)node);
+    }
+    else if (node instanceof BranchNode && bufferedKeys.isEmpty()) {
+      visitor.BeginningInsertToCommandSequence((BranchNode)node);
+    }
+    else if (node instanceof BranchNode && !bufferedKeys.isEmpty()) {
+      visitor.ContinuingInsertToCommandSequence((BranchNode)node);
+    }
+    else if (node == null && !bufferedKeys.isEmpty()) {
+      visitor.EndingInsertToCommandSequenceByStayingInInsertMode();
+    }
+    else {
+      visitor.NotInInsertToCommandState();
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/insert/InsertToCommandStateHandler.java
+++ b/src/com/maddyhome/idea/vim/insert/InsertToCommandStateHandler.java
@@ -1,0 +1,98 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2013 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.maddyhome.idea.vim.insert;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.command.CommandState;
+import com.maddyhome.idea.vim.group.CommandGroups;
+import com.maddyhome.idea.vim.key.BranchNode;
+import com.maddyhome.idea.vim.key.CommandNode;
+import com.maddyhome.idea.vim.key.Node;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InsertToCommandStateHandler {
+  private final InsertToCommandStateTimer timer;
+  private final InsertToCommandState insertToCommandState;
+  private List<KeyStroke> bufferedKeys;
+
+  public InsertToCommandStateHandler() {
+    this.bufferedKeys = new ArrayList<KeyStroke>(10);
+    this.timer = new InsertToCommandStateTimer();
+    this.insertToCommandState = new InsertToCommandState(timer, bufferedKeys);
+  }
+
+  public void outputBufferedKeysFromFailedInsertToCommandStateChange(@NotNull final Editor editor,
+                                                                     @NotNull final CommandState editorState,
+                                                                     @NotNull final DataContext dataContext,
+                                                                     @Nullable final Node node)
+    throws TimeoutElaspedException {
+
+    final boolean[] timedOut = {false};
+    insertToCommandState.accept(editorState, node, new InsertToCommandStateVisitor() {
+      @Override
+      public void NotInInsertToCommandState() {
+      }
+
+      @Override
+      public void TimedOutValidCommandSequence() {
+        for (KeyStroke key : bufferedKeys) {
+          CommandGroups.getInstance().getChange().processKey(editor, dataContext, key);
+        }
+        bufferedKeys.clear();
+        timer.stopTimer();
+        timedOut[0] = true;
+      }
+
+      @Override
+      public void EndingInsertToCommandSequenceByChangingToCommandMode(@NotNull CommandNode node) {
+        timer.stopTimer();
+        bufferedKeys.clear();
+      }
+
+      @Override
+      public void BeginningInsertToCommandSequence(@NotNull BranchNode node) {
+        timer.resetAndBeginTimer();
+        bufferedKeys.add(node.getKey());
+      }
+
+      @Override
+      public void ContinuingInsertToCommandSequence(@NotNull BranchNode node) {
+        bufferedKeys.add(node.getKey());
+      }
+
+      @Override
+      public void EndingInsertToCommandSequenceByStayingInInsertMode() {
+        timer.stopTimer();
+        for (KeyStroke key : bufferedKeys) {
+          CommandGroups.getInstance().getChange().processKey(editor, dataContext, key);
+        }
+        bufferedKeys.clear();
+      }
+    });
+
+    if (timedOut[0]) {
+      throw new TimeoutElaspedException();
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/insert/InsertToCommandStateTimer.java
+++ b/src/com/maddyhome/idea/vim/insert/InsertToCommandStateTimer.java
@@ -1,0 +1,48 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2013 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.maddyhome.idea.vim.insert;
+
+public class InsertToCommandStateTimer {
+  public static final long DEFAULT_KEY_SEQUENCE_TIMEOUT = 1000;
+  private final long keySequenceTimeoutMillis;
+  private boolean timeoutInProgress;
+  private long beginTimeMillis;
+
+  public InsertToCommandStateTimer() {
+    this(DEFAULT_KEY_SEQUENCE_TIMEOUT);
+  }
+
+  public InsertToCommandStateTimer(long keySequenceTimeoutMillis) {
+    this.keySequenceTimeoutMillis = keySequenceTimeoutMillis;
+    this.timeoutInProgress = false;
+  }
+
+  public void resetAndBeginTimer() {
+    timeoutInProgress = true;
+    beginTimeMillis = System.currentTimeMillis();
+  }
+
+  public boolean timeoutElapsed() {
+    long difference = System.currentTimeMillis() - beginTimeMillis;
+    return timeoutInProgress && (difference >= keySequenceTimeoutMillis);
+  }
+
+  public void stopTimer() {
+    timeoutInProgress = false;
+  }
+}

--- a/src/com/maddyhome/idea/vim/insert/InsertToCommandStateVisitor.java
+++ b/src/com/maddyhome/idea/vim/insert/InsertToCommandStateVisitor.java
@@ -1,0 +1,34 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2013 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.maddyhome.idea.vim.insert;
+
+import com.maddyhome.idea.vim.key.BranchNode;
+import com.maddyhome.idea.vim.key.CommandNode;
+import org.jetbrains.annotations.NotNull;
+
+public interface InsertToCommandStateVisitor {
+  public void NotInInsertToCommandState();
+  public void TimedOutValidCommandSequence();
+  public void EndingInsertToCommandSequenceByChangingToCommandMode(@NotNull CommandNode node);
+  public void BeginningInsertToCommandSequence(@NotNull BranchNode node);
+  public void ContinuingInsertToCommandSequence(@NotNull BranchNode node);
+  public void EndingInsertToCommandSequenceByStayingInInsertMode();
+
+
+
+}

--- a/src/com/maddyhome/idea/vim/insert/TimeoutElaspedException.java
+++ b/src/com/maddyhome/idea/vim/insert/TimeoutElaspedException.java
@@ -1,0 +1,21 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2013 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.maddyhome.idea.vim.insert;
+
+public class TimeoutElaspedException extends Throwable {
+}

--- a/src/com/maddyhome/idea/vim/option/Options.java
+++ b/src/com/maddyhome/idea/vim/option/Options.java
@@ -22,6 +22,8 @@ import com.intellij.openapi.editor.Editor;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.helper.MessageHelper;
 import com.maddyhome.idea.vim.helper.Msg;
+import com.maddyhome.idea.vim.key.KeyParser;
+import com.maddyhome.idea.vim.option.iNoRemap.INoRemap;
 import com.maddyhome.idea.vim.ui.MorePanel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -432,11 +434,13 @@ public class Options {
           try {
             final BufferedReader reader = new BufferedReader(new FileReader(file));
             String line;
+            INoRemap iNoRemap = new INoRemap(KeyParser.getInstance());
             while ((line = reader.readLine()) != null) {
               if (line.startsWith(":set") || line.startsWith("set")) {
                 final int pos = line.indexOf(' ');
                 parseOptionLine(null, line.substring(pos).trim(), false);
               }
+              iNoRemap.tryToAddCustomEscape(line);
             }
           }
           catch (Exception ignored) {

--- a/src/com/maddyhome/idea/vim/option/iNoRemap/INoRemap.java
+++ b/src/com/maddyhome/idea/vim/option/iNoRemap/INoRemap.java
@@ -1,0 +1,40 @@
+package com.maddyhome.idea.vim.option.iNoRemap;
+
+import com.maddyhome.idea.vim.command.Command;
+import com.maddyhome.idea.vim.key.KeyParser;
+import com.maddyhome.idea.vim.key.Shortcut;
+
+public class INoRemap {
+  private final KeyParser parser;
+
+  public INoRemap(KeyParser parser) {
+    this.parser = parser;
+  }
+
+  public INoRemapResult lineIsUseableINoRemap(String line) {
+    String[] split = line.split(" ");
+    if (split.length != 3) {
+      return INoRemapResult.False;
+    }
+    else if (!split[0].equals("inoremap")) {
+      return INoRemapResult.False;
+    }
+    else if (!split[2].equals("<esc>")) {
+      return INoRemapResult.NotImplemented;
+    }
+    else {
+      return INoRemapResult.True;
+    }
+  }
+
+  public INoRemapResult tryToAddCustomEscape(String line) {
+    INoRemapResult useable = lineIsUseableINoRemap(line);
+    if (useable == INoRemapResult.True) {
+      String customSequence = line.split(" ")[1];
+      parser.registerAction(KeyParser.MAPPING_INSERT, "VimInsertExitMode", Command.Type.INSERT, new Shortcut[]{
+        new Shortcut(customSequence)
+      });
+    }
+    return useable;
+  }
+}

--- a/src/com/maddyhome/idea/vim/option/iNoRemap/INoRemapResult.java
+++ b/src/com/maddyhome/idea/vim/option/iNoRemap/INoRemapResult.java
@@ -1,0 +1,7 @@
+package com.maddyhome.idea.vim.option.iNoRemap;
+
+public enum INoRemapResult {
+  True,
+  False,
+  NotImplemented
+}

--- a/test/org/jetbrains/plugins/ideavim/ex/VariousCommandsTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/VariousCommandsTest.java
@@ -1,6 +1,8 @@
 package org.jetbrains.plugins.ideavim.ex;
 
+import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.helper.StringHelper;
+import com.maddyhome.idea.vim.insert.InsertToCommandStateTimer;
 import org.jetbrains.plugins.ideavim.VimTestCase;
 
 /**
@@ -25,5 +27,76 @@ public class VariousCommandsTest extends VimTestCase {
     runExCommand("put");
     myFixture.checkResult("Hello World!\n" +
                           "<caret>Hello \n");
+  }
+
+  public void testINoRemapAllowsCustomEscape() {
+    myFixture.configureByText("a.txt", "Hello <caret>World!\n");
+    runExCommand("inoremap jk <esc>");
+    typeText(StringHelper.stringToKeys("i"));
+    assertMode(CommandState.Mode.INSERT);
+    typeText(StringHelper.stringToKeys("jk"));
+    assertMode(CommandState.Mode.COMMAND);
+  }
+
+  public void testINoRemapAllowsLeaderKey() {
+    myFixture.configureByText("a.txt", "Hello <caret>World!\n");
+    runExCommand("inoremap jk <esc>");
+    typeText(StringHelper.stringToKeys("i"));
+    typeText(StringHelper.stringToKeys("j"));
+    typeText(StringHelper.stringToKeys("q"));
+    myFixture.checkResult("Hello jq<caret>World!\n");
+  }
+
+  public void testINoRemapAllowsForTimeout() {
+    myFixture.configureByText("a.txt", "Hello <caret>World!\n");
+    runExCommand("inoremap jj <esc>");
+    typeText(StringHelper.stringToKeys("i"));
+    typeText(StringHelper.stringToKeys("j"));
+    try {
+      Thread.sleep(InsertToCommandStateTimer.DEFAULT_KEY_SEQUENCE_TIMEOUT + 500);
+    }
+    catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    typeText(StringHelper.stringToKeys("j"));
+    myFixture.checkResult("Hello jj<caret>World!\n");
+  }
+
+  public void testINoRemapAllowsForTimeoutForThreeTimeouts() {
+    myFixture.configureByText("a.txt", "Hello <caret>World!\n");
+    runExCommand("inoremap jj <esc>");
+    typeText(StringHelper.stringToKeys("i"));
+    typeText(StringHelper.stringToKeys("j"));
+    try {
+      Thread.sleep(InsertToCommandStateTimer.DEFAULT_KEY_SEQUENCE_TIMEOUT + 500);
+    }
+    catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    typeText(StringHelper.stringToKeys("j"));
+    try {
+      Thread.sleep(InsertToCommandStateTimer.DEFAULT_KEY_SEQUENCE_TIMEOUT + 500);
+    }
+    catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    typeText(StringHelper.stringToKeys("j"));
+    try {
+      Thread.sleep(InsertToCommandStateTimer.DEFAULT_KEY_SEQUENCE_TIMEOUT + 500);
+    }
+    catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    typeText(StringHelper.stringToKeys("j"));
+    myFixture.checkResult("Hello jjjj<caret>World!\n");
+  }
+  public void testInsertWorksCorrectlyWithTimeout() {
+    myFixture.configureByText("testInsertWorksCorrectlyWithTimeout.txt", "Hello <caret>World!\n");
+    typeText(StringHelper.stringToKeys("i"));
+    typeText(StringHelper.stringToKeys("h"));
+    typeText(StringHelper.stringToKeys("e"));
+    typeText(StringHelper.stringToKeys("l"));
+    myFixture.checkResult("Hello hel<caret>World!\n");
+
   }
 }

--- a/test/org/jetbrains/plugins/ideavim/ex/handler/INoRemapHandlerTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/handler/INoRemapHandlerTest.java
@@ -1,0 +1,49 @@
+package org.jetbrains.plugins.ideavim.ex.handler;
+
+import com.maddyhome.idea.vim.ex.ExCommand;
+import com.maddyhome.idea.vim.ex.ExException;
+import com.maddyhome.idea.vim.ex.handler.INoRemapHandler;
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+public class INoRemapHandlerTest extends VimTestCase{
+  public void test1ArgThrowsExException() {
+    non2ArgsThrowsExException("1arg");
+  }
+
+  public void test3ArgsThrowsExException() {
+    non2ArgsThrowsExException("1arg 2arg 3arg");
+  }
+
+  public void testImplementedIfEndsWithEsc() {
+    assertImplemented("jk <esc>", true);
+  }
+
+  public void testNotImplementIfDoesNotEndWithEsc() {
+    assertImplemented("jk ab", false);
+  }
+
+
+  public void assertImplemented(String args, boolean assertValue) {
+    INoRemapHandler handler = new INoRemapHandler();
+    ExCommand cmd = new ExCommand(null, "inoremap", args);
+    try {
+    assertEquals(handler.execute(null, null, cmd), assertValue);
+    }
+    catch (ExException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  public void non2ArgsThrowsExException(String args) {
+    INoRemapHandler handler = new INoRemapHandler();
+    ExCommand cmd = new ExCommand(null, "inoremap", args);
+    try {
+      handler.execute(null, null, cmd);
+      assertTrue(false);
+    }
+    catch (ExException e) {
+      assertTrue(true);
+    }
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/option/INoRemapTest.java
+++ b/test/org/jetbrains/plugins/ideavim/option/INoRemapTest.java
@@ -1,0 +1,52 @@
+package org.jetbrains.plugins.ideavim.option;
+
+import com.maddyhome.idea.vim.command.CommandState;
+import com.maddyhome.idea.vim.helper.StringHelper;
+import com.maddyhome.idea.vim.key.KeyParser;
+import com.maddyhome.idea.vim.option.iNoRemap.INoRemap;
+import com.maddyhome.idea.vim.option.iNoRemap.INoRemapResult;
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+public class INoRemapTest extends VimTestCase {
+  public void testLineIsUseableTrueForINoRemapWithSupportedArgs() {
+    INoRemap iNoRemap = new INoRemap(KeyParser.getInstance());
+    INoRemapResult result = iNoRemap.lineIsUseableINoRemap("inoremap jk <esc>");
+    assertTrue(result == INoRemapResult.True);
+  }
+
+  public void testLineIsUseableFalseIsDoesNotContainINoRemap() {
+    INoRemap iNoRemap = new INoRemap(KeyParser.getInstance());
+    INoRemapResult result = iNoRemap.lineIsUseableINoRemap("imap jk <esc>");
+    assertTrue(result == INoRemapResult.False);
+  }
+
+  public void testLineIsUseableFalseIfLineHasLessThanCorrectNumberOfArgs() {
+    INoRemap iNoRemap = new INoRemap(KeyParser.getInstance());
+    INoRemapResult result = iNoRemap.lineIsUseableINoRemap("inoremap jk");
+    assertTrue(result == INoRemapResult.False);
+  }
+
+  public void testLineIsUseableFalseIfLineHasMoreThanCorrectNumberOfArgs() {
+    INoRemap iNoRemap = new INoRemap(KeyParser.getInstance());
+    INoRemapResult result = iNoRemap.lineIsUseableINoRemap("inoremap jk <esc> <esc>");
+    assertTrue(result == INoRemapResult.False);
+  }
+
+  public void testLineIsUseableNotImplementedIfSecondArgDoesNotEqualBracketedEsc() {
+    INoRemap iNoRemap = new INoRemap(KeyParser.getInstance());
+    INoRemapResult result = iNoRemap.lineIsUseableINoRemap("inoremap jk esc");
+    assertTrue(result == INoRemapResult.NotImplemented);
+  }
+
+  public void testTryToAddCustomEscapeAddsForValidINoRemapLine() {
+    KeyParser kp = KeyParser.getInstance();
+    INoRemap iNoRemap = new INoRemap(kp);
+    INoRemapResult result = iNoRemap.tryToAddCustomEscape("inoremap jk <esc>");
+    myFixture.configureByText("a.txt", "Hello <caret>World!\n");
+    runExCommand("inoremap jk <esc>");
+    typeText(StringHelper.stringToKeys("i"));
+    assertMode(CommandState.Mode.INSERT);
+    typeText(StringHelper.stringToKeys("jk"));
+    assertMode(CommandState.Mode.COMMAND);
+  }
+}


### PR DESCRIPTION
Adds support for "jj" style escape chords. Allows defined
chords to be read in from a user's .vimrc, where the chord is
defined like:
inoremap jk <esc>

Allows allows the setting of a custom escape in ex mode with:
:inoremap jk <esc>
