### PR TITLE
Run "launchctl stop com.apple.SystemUIServer.agent" instead of OS restart

### DIFF
--- a/src/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/com/maddyhome/idea/vim/VimPlugin.java
@@ -170,7 +170,6 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
 
   private void updateState() {
     if (isEnabled() && !ApplicationManager.getApplication().isUnitTestMode()) {
-      boolean requiresRestart = false;
       if (previousStateVersion < 1 && SystemInfo.isMac && VimKeyMapUtil.isVimKeymapInstalled()) {
         if (Messages.showYesNoDialog("Vim keymap generator has been updated to create keymaps more compatible " +
                                      "with base keymaps.\n\nDo you want to reconfigure your Vim keymap?\n\n" +
@@ -185,20 +184,16 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
         final MacKeyRepeat keyRepeat = MacKeyRepeat.getInstance();
         final Boolean enabled = keyRepeat.isEnabled();
         if (enabled == null || !enabled) {
-          if (Messages.showYesNoDialog("Do you want to enable repeating keys in Mac OS X on press and hold " +
-                                       "(requires restart)?\n\n" +
+          if (Messages.showYesNoDialog("Do you want to enable repeating keys in Mac OS X on press and hold?" +
+                                       "\n\n" +
                                        "(You can do it manually by running 'defaults write -g " +
-                                       "ApplePressAndHoldEnabled 0' in the console).",
+                                       "ApplePressAndHoldEnabled 0 && launchctl stop " +
+                                       "com.apple.SystemUIServer.agent' in the console).",
                                        IDEAVIM_NOTIFICATION_TITLE,
                                        Messages.getQuestionIcon()) == Messages.YES) {
             keyRepeat.setEnabled(true);
-            requiresRestart = true;
           }
         }
-      }
-      if (requiresRestart) {
-        final ApplicationEx app = ApplicationManagerEx.getApplicationEx();
-        app.restart();
       }
     }
   }

--- a/src/com/maddyhome/idea/vim/helper/MacKeyRepeat.java
+++ b/src/com/maddyhome/idea/vim/helper/MacKeyRepeat.java
@@ -31,6 +31,7 @@ import java.io.InputStreamReader;
 */
 public class MacKeyRepeat {
   public static final String FMT = "defaults %s -globalDomain ApplePressAndHoldEnabled";
+  public static final String RestartSystemUIServer = "launchctl stop com.apple.SystemUIServer.agent";
   @NotNull private static final MacKeyRepeat INSTANCE = new MacKeyRepeat();
 
   @NotNull
@@ -67,6 +68,13 @@ public class MacKeyRepeat {
     final Process process;
     try {
       process = Runtime.getRuntime().exec(command);
+      process.waitFor();
+    }
+    catch (IOException e) {
+    }
+    final Process process;
+    try {
+      process = Runtime.getRuntime().exec(RestartSystemUIServer);
       process.waitFor();
     }
     catch (IOException e) {


### PR DESCRIPTION
The command "launchctl stop com.apple.SystemUIServer.agent" is sufficient to make the changes to the ApplePressAndHoldEnabled setting take effect, rather than requiring a restart of OS X.

PS. I haven't touched Java in 10+ years, so I'm not sure what the best idiom is for two sequential 'process' calls.