### PR TITLE
VIM-265 Add window split commands

### DIFF
--- a/src/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/com/maddyhome/idea/vim/VimPlugin.java
@@ -119,6 +119,7 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
   private DigraphGroup digraph;
   private HistoryGroup history;
   private KeyGroup key;
+  private WindowGroup window;
 
   public VimPlugin(final Application app) {
     myApp = app;
@@ -135,6 +136,7 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
     digraph = new DigraphGroup();
     history = new HistoryGroup();
     key = new KeyGroup();
+    window = new WindowGroup();
 
     LOG.debug("VimPlugin ctr");
   }
@@ -282,6 +284,10 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
 
   public static KeyGroup getKey() {
     return getInstance().key;
+  }
+
+  public static WindowGroup getWindow() {
+    return getInstance().window;
   }
 
   public static PluginId getPluginId() {

--- a/src/com/maddyhome/idea/vim/ex/CommandParser.java
+++ b/src/com/maddyhome/idea/vim/ex/CommandParser.java
@@ -105,6 +105,7 @@ public class CommandParser {
     new ShiftLeftHandler();
     new ShiftRightHandler();
     new SourceHandler();
+    new SplitHandler();
     new SubstituteHandler();
     new UndoHandler();
     new WriteAllHandler();

--- a/src/com/maddyhome/idea/vim/ex/handler/SplitHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/SplitHandler.java
@@ -1,0 +1,49 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2014 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.ex.handler;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.ex.CommandHandler;
+import com.maddyhome.idea.vim.ex.CommandName;
+import com.maddyhome.idea.vim.ex.ExCommand;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ *
+ */
+public class SplitHandler extends CommandHandler {
+  public SplitHandler() {
+    super(new CommandName[]{
+      new CommandName("vs", "plit"),
+      new CommandName("sp", "lit")
+    }, RANGE_FORBIDDEN | ARGUMENT_OPTIONAL | DONT_REOPEN);
+  }
+
+  public boolean execute(@NotNull Editor editor, @NotNull DataContext context, @NotNull ExCommand cmd) {
+    if (cmd.getCommand().startsWith("v")) {
+      VimPlugin.getWindow().splitWindowVertical(context, cmd.getArgument());
+    } else {
+      VimPlugin.getWindow().splitWindowHorizontal(context, cmd.getArgument());
+    }
+
+    return true;
+  }
+}

--- a/src/com/maddyhome/idea/vim/group/FileGroup.java
+++ b/src/com/maddyhome/idea/vim/group/FileGroup.java
@@ -59,6 +59,36 @@ public class FileGroup {
     }
     Project proj = PlatformDataKeys.PROJECT.getData(context); // API change - don't merge
 
+    VirtualFile found = findFile(filename, proj);
+
+    if (found != null) {
+      if (logger.isDebugEnabled()) {
+        logger.debug("found file: " + found);
+      }
+      // Can't open a file unless it has a known file type. The next call will return the known type.
+      // If unknown, IDEA will prompt the user to pick a type.
+      FileType type = FileTypeManager.getInstance().getKnownFileTypeOrAssociate(found);
+      if (type != null) {
+        FileEditorManager fem = FileEditorManager.getInstance(proj);
+        fem.openFile(found, true);
+
+        return true;
+      }
+      else {
+        // There was no type and user didn't pick one. Don't open the file
+        // Return true here because we found the file but the user canceled by not picking a type.
+        return true;
+      }
+    }
+    else {
+      VimPlugin.showMessage("Unable to find " + filename);
+
+      return false;
+    }
+  }
+
+  @Nullable
+  public VirtualFile findFile(@NotNull String filename, @NotNull Project proj) {
     VirtualFile found = null;
     if (filename.length() > 2 && filename.charAt(0) == '~' && filename.charAt(1) == File.separatorChar) {
       String homefile = filename.substring(2);
@@ -87,30 +117,7 @@ public class FileGroup {
       }
     }
 
-    if (found != null) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("found file: " + found);
-      }
-      // Can't open a file unless it has a known file type. The next call will return the known type.
-      // If unknown, IDEA will prompt the user to pick a type.
-      FileType type = FileTypeManager.getInstance().getKnownFileTypeOrAssociate(found);
-      if (type != null) {
-        FileEditorManager fem = FileEditorManager.getInstance(proj);
-        fem.openFile(found, true);
-
-        return true;
-      }
-      else {
-        // There was no type and user didn't pick one. Don't open the file
-        // Return true here because we found the file but the user canceled by not picking a type.
-        return true;
-      }
-    }
-    else {
-      VimPlugin.showMessage("Unable to find " + filename);
-
-      return false;
-    }
+    return found;
   }
 
   @Nullable

--- a/src/com/maddyhome/idea/vim/group/WindowGroup.java
+++ b/src/com/maddyhome/idea/vim/group/WindowGroup.java
@@ -1,0 +1,82 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2014 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.group;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx;
+import com.intellij.openapi.fileEditor.impl.EditorWindow;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.maddyhome.idea.vim.VimPlugin;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ *
+ */
+public class WindowGroup {
+  public WindowGroup() {
+  }
+
+  public void splitWindowHorizontal(@NotNull DataContext context) {
+    splitWindowHorizontal(context, null);
+  }
+
+  public void splitWindowHorizontal(@NotNull DataContext context, String filename) {
+    splitWindow(SwingConstants.HORIZONTAL, context, filename);
+  }
+
+  public void splitWindowVertical(@NotNull DataContext context) {
+    splitWindowVertical(context, null);
+  }
+
+  public void splitWindowVertical(@NotNull DataContext context, String filename) {
+    splitWindow(SwingConstants.VERTICAL, context, filename);
+  }
+
+  private void splitWindow(int orientation, @NotNull DataContext context, String filename) {
+    Project proj = PlatformDataKeys.PROJECT.getData(context);
+    FileEditorManagerEx fem = FileEditorManagerEx.getInstanceEx(proj);
+
+    // If a file was passed in as an argument, open it in the newly split window
+    VirtualFile virtualFile = null;
+    if (filename != null && filename.length() > 0)
+    {
+      virtualFile = VimPlugin.getFile().findFile(filename, proj);
+
+      // Don't split if the desired file could not be found
+      if (virtualFile == null) {
+        VimPlugin.showMessage("Could not find file: " + filename);
+        return;
+      }
+    }
+
+    EditorWindow editorWindow = fem.getSplitters().getCurrentWindow();
+
+    if (editorWindow != null ) {
+      // When virtualFile is null, the current file will be split
+      editorWindow.split(orientation, true, virtualFile, true);
+    }
+  }
+
+  private static Logger logger = Logger.getInstance(WindowGroup.class.getName());
+}


### PR DESCRIPTION
This implements the sp[lit] and vs[plit] commands.  It allows for the no argument option to split the current file or providing a different file as an argument to be opened in the new window.
