### PR TITLE
  VIM-407 Add tests. Only skip the ending line if it is empty.

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -1338,7 +1338,9 @@ public class ChangeGroup {
     int sline = editor.offsetToLogicalPosition(range.getStartOffset()).line;
     int eline = editor.offsetToLogicalPosition(range.getEndOffset()).line;
     int eoff = EditorHelper.getLineStartForOffset(editor, range.getEndOffset());
-    if (eoff == range.getEndOffset()) {
+    boolean elineIsEmpty = EditorHelper.getLineLength(editor, eline) == 0;
+    // Skip an empty ending line
+    if (eoff == range.getEndOffset() && elineIsEmpty) {
       eline--;
     }
 

--- a/test/org/jetbrains/plugins/ideavim/action/ShiftRightLinesActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ShiftRightLinesActionTest.java
@@ -1,0 +1,55 @@
+package org.jetbrains.plugins.ideavim.action;
+
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+
+/**
+ * @author abrookins
+ */
+public class ShiftRightLinesActionTest extends VimTestCase {
+  // VIM-407
+  public void testShiftShiftsOneCharacterSingleLine() {
+    myFixture.configureByText("a.txt", "<caret>w\n");
+    typeText(parseKeys(">>"));
+    myFixture.checkResult("    w\n");
+  }
+
+  // VIM-407
+  public void testShiftShiftsOneCharacterMultiLine() {
+    myFixture.configureByText("a.txt", "Hello\n<caret>w\nWorld");
+    typeText(parseKeys(">>"));
+    myFixture.checkResult("Hello\n    w\nWorld");
+  }
+
+  public void testShiftShiftsMultipleCharactersOneLine() {
+    myFixture.configureByText("a.txt", "<caret>Hello, world!\n");
+    typeText(parseKeys(">>"));
+    myFixture.checkResult("    Hello, world!\n");
+  }
+
+  public void testShiftShiftsMultipleCharactersMultipleLines() {
+    myFixture.configureByText("a.txt", "<caret>Hello,\nworld!\n");
+    typeText(parseKeys("j>>"));
+    myFixture.checkResult("Hello,\n    world!\n");
+  }
+
+  public void testShiftsSingleLineSelection() {
+    myFixture.configureByText("a.txt", "<caret>Hello,\nworld!\n");
+    typeText(parseKeys("jv$>>"));
+    myFixture.checkResult("Hello,\n    world!\n");
+  }
+
+  public void testShiftsMultiLineSelection() {
+    myFixture.configureByText("a.txt", "<caret>Hello,\nworld!\n");
+    typeText(parseKeys("vj$>>"));
+    myFixture.checkResult("    Hello,\n    world!\n");
+  }
+
+  public void testShiftsMultiLineSelectionSkipsNewline() {
+    myFixture.configureByText("a.txt", "<caret>Hello,\nworld!\n\n");
+    typeText(parseKeys("vG$>>"));
+    myFixture.checkResult("    Hello,\n    world!\n\n");
+  }
+}


### PR DESCRIPTION
This change only skips the last line of an indent range if the line is empty. Previously the line was skipped if it was one character long (thus VIM-407). I added selection tests for the right shift action to help me understand why the final line was _ever_ being skipped. It appears that the original author's intent was to avoid indenting a final line that was empty.

This is my first ideavim patch, and I don't know the editor API very well, so I'm interested in what you think of the approach. 
