### PR TITLE
Fixes http://youtrack.jetbrains.com/issue/VIM-287

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -194,7 +194,7 @@ public class ChangeGroup {
    * @param context The data context
    */
   public void insertNewLineBelow(@NotNull final Editor editor, @NotNull final DataContext context) {
-    MotionGroup.moveCaret(editor, VimPlugin.getMotion().moveCaretToLineEnd(editor));
+    EditorActionUtil.moveCaretToLineEnd(editor, false);
     initInsert(editor, context, CommandState.Mode.INSERT);
     runEnterAction(editor, context);
   }


### PR DESCRIPTION
`ChangeGroup` looks like it could be refactored to use [`com.intellij.openapi.editor.actions`](https://github.com/JetBrains/intellij-community/tree/master/platform/platform-impl/src/com/intellij/openapi/editor/actions) as there are a few other surprises like this one. [`EditorActionUtil.moveCaretToLineEnd(...)`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-impl/src/com/intellij/openapi/editor/actions/EditorActionUtil.java#L497) seems to put us exactly where we need to be after the fold, and takes into account soft-wraps etc. - `ChangeGroup.insertNewLineBelow(...)` and `ChangeGroup.insertNewLineAbove(...)` will now behave as expected.