### PR TITLE
deselect visual selection range '<,'> when poping up ex entry field.

### DIFF
--- a/src/com/maddyhome/idea/vim/ui/ExEntryPanel.java
+++ b/src/com/maddyhome/idea/vim/ui/ExEntryPanel.java
@@ -114,7 +114,7 @@ public class ExEntryPanel extends JPanel {
       oldGlass.addComponentListener(adapter);
       positionPanel();
       oldGlass.setVisible(true);
-      entry.requestFocus();
+      entry.requestFocusInWindow();
     }
     active = true;
   }

--- a/src/com/maddyhome/idea/vim/ui/ExTextField.java
+++ b/src/com/maddyhome/idea/vim/ui/ExTextField.java
@@ -32,6 +32,8 @@ import javax.swing.*;
 import javax.swing.text.Document;
 import javax.swing.text.Keymap;
 import java.awt.*;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.util.Date;
 import java.util.List;
@@ -59,6 +61,16 @@ public class ExTextField extends JTextField {
     loadKeymap(map, ExKeyBindings.getBindings(), actions);
     map.setDefaultAction(new ExEditorKit.DefaultExKeyHandler());
     setKeymap(map);
+    addFocusListener(new FocusListener() {
+      @Override
+      public void focusGained(FocusEvent e) {
+        setCaretPosition(getText().length());
+      }
+
+      @Override
+      public void focusLost(FocusEvent e) {
+      }
+    });
 
     //origCaret = getCaret();
     //blockCaret = new BlockCaret();


### PR DESCRIPTION
When in visual selection mode, if ex mode is triggered, the visual selection range '<,'> text is always selected. This could be annoying, because I have to press right arrow key to deselect, then type the command.

This change basically deselect the text when the ExTextField gains the focus, set the caret at the end of text.
