### PR TITLE
VIM-265 Add window split commands [Rebased]

### DIFF
--- a/src/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/com/maddyhome/idea/vim/VimPlugin.java
@@ -119,6 +119,7 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
   @NotNull private final DigraphGroup digraph;
   @NotNull private final HistoryGroup history;
   @NotNull private final KeyGroup key;
+  @NotNull private WindowGroup window;
 
   public VimPlugin(final Application app) {
     myApp = app;
@@ -135,6 +136,7 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
     digraph = new DigraphGroup();
     history = new HistoryGroup();
     key = new KeyGroup();
+    window = new WindowGroup();
 
     LOG.debug("VimPlugin ctr");
   }
@@ -288,6 +290,11 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
   @NotNull
   public static KeyGroup getKey() {
     return getInstance().key;
+  }
+
+  @NotNull
+  public static WindowGroup getWindow() {
+    return getInstance().window;
   }
 
   @NotNull

--- a/src/com/maddyhome/idea/vim/ex/CommandParser.java
+++ b/src/com/maddyhome/idea/vim/ex/CommandParser.java
@@ -110,6 +110,7 @@ public class CommandParser {
     new ShiftRightHandler();
     new SourceHandler();
     new SortHandler();
+    new SplitHandler();
     new SubstituteHandler();
     new UndoHandler();
     new WriteAllHandler();

--- a/src/com/maddyhome/idea/vim/ex/handler/SplitHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/SplitHandler.java
@@ -1,0 +1,49 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2014 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.ex.handler;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.ex.CommandHandler;
+import com.maddyhome.idea.vim.ex.CommandName;
+import com.maddyhome.idea.vim.ex.ExCommand;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ *
+ */
+public class SplitHandler extends CommandHandler {
+  public SplitHandler() {
+    super(new CommandName[]{
+      new CommandName("vs", "plit"),
+      new CommandName("sp", "lit")
+    }, RANGE_FORBIDDEN | ARGUMENT_OPTIONAL | DONT_REOPEN);
+  }
+
+  public boolean execute(@NotNull Editor editor, @NotNull DataContext context, @NotNull ExCommand cmd) {
+    if (cmd.getCommand().startsWith("v")) {
+      VimPlugin.getWindow().splitWindowVertical(context, cmd.getArgument());
+    } else {
+      VimPlugin.getWindow().splitWindowHorizontal(context, cmd.getArgument());
+    }
+
+    return true;
+  }
+}

--- a/src/com/maddyhome/idea/vim/group/FileGroup.java
+++ b/src/com/maddyhome/idea/vim/group/FileGroup.java
@@ -60,36 +60,7 @@ public class FileGroup {
     }
     Project proj = PlatformDataKeys.PROJECT.getData(context); // API change - don't merge
 
-    VirtualFile found = null;
-    if (filename.length() > 2 && filename.charAt(0) == '~' && filename.charAt(1) == File.separatorChar) {
-      String homefile = filename.substring(2);
-      String dir = System.getProperty("user.home");
-      if (logger.isDebugEnabled()) {
-        logger.debug("home dir file");
-        logger.debug("looking for " + homefile + " in " + dir);
-      }
-      found = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(new File(dir, homefile));
-    }
-    else {
-      if (proj == null) {
-        return false;
-      }
-      ProjectRootManager prm = ProjectRootManager.getInstance(proj);
-      VirtualFile[] roots = prm.getContentRoots();
-      for (int i = 0; i < roots.length; i++) {
-        if (logger.isDebugEnabled()) {
-          logger.debug("root[" + i + "] = " + roots[i].getPath());
-        }
-        found = findFile(roots[i], filename);
-        if (found != null) {
-          break;
-        }
-      }
-
-      if (found == null) {
-        found = LocalFileSystem.getInstance().findFileByIoFile(new File(filename));
-      }
-    }
+    VirtualFile found = findFile(filename, proj);
 
     if (found != null) {
       if (logger.isDebugEnabled()) {
@@ -115,6 +86,42 @@ public class FileGroup {
 
       return false;
     }
+  }
+
+  @Nullable
+  public VirtualFile findFile(@NotNull String filename, @NotNull Project proj) {
+    VirtualFile found = null;
+    if (filename.length() > 2 && filename.charAt(0) == '~' && filename.charAt(1) == File.separatorChar) {
+      String homefile = filename.substring(2);
+      String dir = System.getProperty("user.home");
+      if (logger.isDebugEnabled()) {
+        logger.debug("home dir file");
+        logger.debug("looking for " + homefile + " in " + dir);
+      }
+      found = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(new File(dir, homefile));
+    }
+    else {
+      if (proj == null) {
+        return null;
+      }
+      ProjectRootManager prm = ProjectRootManager.getInstance(proj);
+      VirtualFile[] roots = prm.getContentRoots();
+      for (int i = 0; i < roots.length; i++) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("root[" + i + "] = " + roots[i].getPath());
+        }
+        found = findFile(roots[i], filename);
+        if (found != null) {
+          break;
+        }
+      }
+
+      if (found == null) {
+        found = LocalFileSystem.getInstance().findFileByIoFile(new File(filename));
+      }
+    }
+
+    return found;
   }
 
   @Nullable

--- a/src/com/maddyhome/idea/vim/group/WindowGroup.java
+++ b/src/com/maddyhome/idea/vim/group/WindowGroup.java
@@ -1,0 +1,82 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2014 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.group;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx;
+import com.intellij.openapi.fileEditor.impl.EditorWindow;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.maddyhome.idea.vim.VimPlugin;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ *
+ */
+public class WindowGroup {
+  public WindowGroup() {
+  }
+
+  public void splitWindowHorizontal(@NotNull DataContext context) {
+    splitWindowHorizontal(context, null);
+  }
+
+  public void splitWindowHorizontal(@NotNull DataContext context, String filename) {
+    splitWindow(SwingConstants.HORIZONTAL, context, filename);
+  }
+
+  public void splitWindowVertical(@NotNull DataContext context) {
+    splitWindowVertical(context, null);
+  }
+
+  public void splitWindowVertical(@NotNull DataContext context, String filename) {
+    splitWindow(SwingConstants.VERTICAL, context, filename);
+  }
+
+  private void splitWindow(int orientation, @NotNull DataContext context, String filename) {
+    Project proj = PlatformDataKeys.PROJECT.getData(context);
+    FileEditorManagerEx fem = FileEditorManagerEx.getInstanceEx(proj);
+
+    // If a file was passed in as an argument, open it in the newly split window
+    VirtualFile virtualFile = null;
+    if (filename != null && filename.length() > 0)
+    {
+      virtualFile = VimPlugin.getFile().findFile(filename, proj);
+
+      // Don't split if the desired file could not be found
+      if (virtualFile == null) {
+        VimPlugin.showMessage("Could not find file: " + filename);
+        return;
+      }
+    }
+
+    EditorWindow editorWindow = fem.getSplitters().getCurrentWindow();
+
+    if (editorWindow != null ) {
+      // When virtualFile is null, the current file will be split
+      editorWindow.split(orientation, true, virtualFile, true);
+    }
+  }
+
+  private static Logger logger = Logger.getInstance(WindowGroup.class.getName());
+}


### PR DESCRIPTION
#28 Rebased on top of current master; @ghuh I picked this up because it's a feature I really want, I hope you don't mind.

@carymrobbins the `:q[uit]` behavior is an artifact of the IntelliJ OpenAPI; there is no way to close only a single instance of a file, you must close all of them.
