### PR TITLE
VIM-714 Set last column to caret column after delete

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -894,7 +894,8 @@ public class ChangeGroup {
       else {
         pos = EditorHelper.normalizeOffset(editor, range.getStartOffset(), isChange);
       }
-      MotionGroup.moveCaret(editor, pos);
+      int column = EditorHelper.offsetToCharacterPosition(editor, pos).column;
+      EditorData.setLastColumn(editor, column);
     }
     return res;
   }
@@ -1481,6 +1482,7 @@ public class ChangeGroup {
         VimPlugin.getMark().setMark(editor, '.', start);
         VimPlugin.getMark().setMark(editor, '[', start);
         VimPlugin.getMark().setMark(editor, ']', start);
+        editor.getCaretModel().moveToOffset(start);
       }
 
       return true;


### PR DESCRIPTION
Addresses VIM-714 by explicitly setting the editor's last column after a visual delete.