### PR TITLE
VIM-511 Fix buggy repeat command related to embedded backspaces.

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -511,15 +511,19 @@ public class ChangeGroup {
   }
 
   private void filterBackspaces() {
-    removeSimpleBackspaces();
-    collapseOppositeAdjacentMotions();
+    do {
+      removeSimpleBackspaces();
+    } while(collapseOppositeAdjacentMotions());
   }
 
-  private void collapseOppositeAdjacentMotions() {
+  private boolean collapseOppositeAdjacentMotions() {
+    boolean removedAny = false;
     boolean removedOne = collapseOppositeAdjacentMotion();
     while (removedOne) {
       removedOne = collapseOppositeAdjacentMotion();
+      removedAny = true;
     }
+    return removedAny;
   }
 
   private static final int LENGTH_OF_FAULTY_BACKSPACE = 3;


### PR DESCRIPTION
This is to address issue VIM-511.

The existing document listener adds an extra "right" cursor motion on backspaces, but the complications of online editing make it very difficult to spot these during editing. So, instead I added in a post-filtering step that recognizes the pattern and removes if from the strokes to be repeated before they are repeated. It is kind of a hack, but it gets the majority of cases working.
