### PR TITLE
Fix visual block deleting

### DIFF
--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -1574,17 +1574,25 @@ public class MotionGroup {
   public TextRange getVisualRange(@NotNull Editor editor) {
     final TextRange res = new TextRange(editor.getSelectionModel().getBlockSelectionStarts(),
                                         editor.getSelectionModel().getBlockSelectionEnds());
-    // If the last left/right motion was the $ command, simulate each line being selected to end-of-line
+
     final CommandState.SubMode subMode = CommandState.getInstance(editor).getSubMode();
-    if (subMode == CommandState.SubMode.VISUAL_BLOCK && EditorData.getLastColumn(editor) >= MotionGroup.LAST_COLUMN) {
-      final int[] starts = res.getStartOffsets();
+    if (subMode == CommandState.SubMode.VISUAL_BLOCK) {
       final int[] ends = res.getEndOffsets();
-      for (int i = 0; i < starts.length; i++) {
-        if (ends[i] > starts[i]) {
-          ends[i] = EditorHelper.getLineEndForOffset(editor, starts[i]);
+
+      // If the last left/right motion was the $ command, simulate each line being selected to end-of-line
+      if (EditorData.getLastColumn(editor) >= MotionGroup.LAST_COLUMN) {
+        final int[] starts = res.getStartOffsets();
+        for (int i = 0; i < starts.length; i++) {
+          if (ends[i] > starts[i]) {
+            ends[i] = EditorHelper.getLineEndForOffset(editor, starts[i]);
+          }
         }
       }
-      return new TextRange(starts, ends);
+      else {
+        for (int i = 0; i < ends.length; ++i) {
+          ends[i] += 1;
+        }
+      }
     }
     return res;
   }

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -270,9 +270,21 @@ public class ChangeActionTest extends VimTestCase {
            "bar\n" +
            "baz\n" +
            "quux\n",
-           "<caret>oo\n" +
-           "ar\n" +
-           "az\n" +
+           "<caret>o\n" +
+           "r\n" +
+           "z\n" +
+           "quux\n");
+  }
+
+  public void testDeleteCharVisualBlock() {
+    doTest(parseKeys("<C-V>", "jjl", "x"),
+           "<caret>foo\n" +
+           "bar\n" +
+           "baz\n" +
+           "quux\n",
+           "<caret>o\n" +
+           "r\n" +
+           "z\n" +
            "quux\n");
   }
 

--- a/test/org/jetbrains/plugins/ideavim/action/CopyActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/CopyActionTest.java
@@ -97,8 +97,8 @@ public class CopyActionTest extends VimTestCase {
     //
     // The problem is that the selection range should be 1-char wide when entering the visual block mode
 
-    myFixture.checkResult("* *one\n" +
-                          "* *two\n");
+    myFixture.checkResult("* * one\n" +
+                          "* * two\n");
     assertSelection(null);
     assertOffset(2);
   }


### PR DESCRIPTION
Currently deleting visual block leaves last char in line untouched. This
patch fixes that as well as tests.
