### PR TITLE
VIM-613 Fix repeat after 'd$'

### DIFF
--- a/src/com/maddyhome/idea/vim/action/motion/leftright/MotionLastColumnAction.java
+++ b/src/com/maddyhome/idea/vim/action/motion/leftright/MotionLastColumnAction.java
@@ -42,7 +42,7 @@ public class MotionLastColumnAction extends MotionEditorAction {
   private static class Handler extends MotionEditorActionHandler {
     public int getOffset(@NotNull Editor editor, DataContext context, int count, int rawCount, Argument argument) {
       boolean allow = false;
-      if (CommandState.inInsertMode(editor) || CommandState.inRepeatMode(editor)) {
+      if (CommandState.inInsertMode(editor)) {
         allow = true;
       }
       else if (CommandState.getInstance(editor).getMode() == CommandState.Mode.VISUAL) {

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -290,6 +290,17 @@ public class ChangeActionTest extends VimTestCase {
                           "}\n");
   }
 
+  // VIM-613 |.|
+  public void testDeleteEndOfLineAndAgain() {
+    configureByText("<caret>- 1\n" +
+                    "- 2\n" +
+                    "- 3\n");
+    typeText(parseKeys("d$", "j", "."));
+    myFixture.checkResult("\n" +
+                          "\n" +
+                          "- 3\n");
+  }
+
   // VIM-511 |.|
   public void testAutoCompleteCurlyBraceWithEnterWithinFunctionBody() {
     configureByJavaText("class C <caret>{\n" +


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-613

Previously, repeating a 'd$' command would incorrectly delete the
newline from the line.

I'm not thoroughly sure whether this could break other things, but all tests pass at least.
