### PR TITLE
VIM-705 Fix repeated multiline indent

### DIFF
--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -1185,9 +1185,9 @@ public class MotionGroup {
     return moveCaretToLineStartSkipLeading(editor, line);
   }
 
-  public static void moveCaret(@NotNull Editor editor, int offset) {
+  public static void moveCaret(@NotNull Editor editor, int offset, boolean forceKeepVisual) {
     if (offset >= 0 && offset <= editor.getDocument().getTextLength()) {
-      final boolean keepVisual = keepVisual(editor);
+      final boolean keepVisual = forceKeepVisual || keepVisual(editor);
       if (editor.getCaretModel().getOffset() != offset) {
         if (!keepVisual) {
           // XXX: Hack for preventing the merge multiple carets that results in loosing the primary caret for |v_d|
@@ -1205,6 +1205,10 @@ public class MotionGroup {
         editor.getSelectionModel().removeSelection();
       }
     }
+  }
+
+  public static void moveCaret(@NotNull Editor editor, int offset) {
+    moveCaret(editor, offset, false);
   }
 
   private static boolean keepVisual(Editor editor) {
@@ -1461,7 +1465,7 @@ public class MotionGroup {
       CommandState.getInstance(editor).pushState(CommandState.Mode.VISUAL, mode, MappingMode.VISUAL);
       visualStart = start;
       updateSelection(editor, end);
-      MotionGroup.moveCaret(editor, visualEnd);
+      MotionGroup.moveCaret(editor, visualEnd, true);
     }
     else if (mode == currentMode) {
       exitVisual(editor);

--- a/test/org/jetbrains/plugins/ideavim/action/ShiftRightLinesActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ShiftRightLinesActionTest.java
@@ -52,4 +52,11 @@ public class ShiftRightLinesActionTest extends VimTestCase {
     typeText(parseKeys("vG$>>"));
     myFixture.checkResult("    Hello,\n    world!\n\n");
   }
+
+  // VIM-705 repeating a multiline indent would only affect last line
+  public void testShiftsMultiLineSelectionRepeat() {
+    myFixture.configureByText("a.txt", "<caret>a\nb\n");
+    typeText(parseKeys("Vj>."));
+    myFixture.checkResult("        a\n        b\n");
+  }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-705

When a visual mode command is repeated, code calls into
MotionGroup#toggleVisual() to setup a 'fake' visual mode selection. But
when MotionGroup.moveCaret() is called, it notices that the indent
command has the FLAG_EXIT_VISUAL flag, and leaves visual mode right
away.

Though all tests pass, I'm a bit unsure whether this could break other things.
