### PR TITLE
VIM-515 Fix cW command detecting end-of-word incorrectly

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -1078,13 +1078,13 @@ public class ChangeGroup {
     }
     String id = ActionManager.getInstance().getId(motion.getAction());
     boolean kludge = false;
-    boolean bigWord = false;
+    boolean bigWord = id.equals("VimMotionBigWordRight");
     final CharSequence chars = editor.getDocument().getCharsSequence();
     final int offset = editor.getCaretModel().getOffset();
-    final CharacterHelper.CharacterType charType = CharacterHelper.charType(chars.charAt(offset), false);
+    final CharacterHelper.CharacterType charType = CharacterHelper.charType(chars.charAt(offset), bigWord);
     if (EditorHelper.getFileSize(editor) > 0 && charType != CharacterHelper.CharacterType.WHITESPACE) {
       final boolean lastWordChar = offset > EditorHelper.getFileSize(editor) ||
-                                   CharacterHelper.charType(chars.charAt(offset + 1), false) != charType;
+                                   CharacterHelper.charType(chars.charAt(offset + 1), bigWord) != charType;
       final ImmutableSet<String> wordMotions = ImmutableSet.of(
         "VimMotionWordRight", "VimMotionBigWordRight", "VimMotionCamelRight");
       if (wordMotions.contains(id) && lastWordChar) {
@@ -1101,7 +1101,6 @@ public class ChangeGroup {
       }
       else if (id.equals("VimMotionBigWordRight")) {
         kludge = true;
-        bigWord = true;
         motion.setAction(ActionManager.getInstance().getAction("VimMotionBigWordEndRight"));
         motion.setFlags(Command.FLAG_MOT_INCLUSIVE);
       }

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -123,6 +123,11 @@ public class ChangeActionTest extends VimTestCase {
     doTest(parseKeys("cw"), "on<caret>e two three\n", "on two three\n");
   }
 
+  // VIM-515 |c| |W|
+  public void testChangeBigWordWithPunctuationAndAlpha() {
+    doTest(parseKeys("cW"), "foo<caret>(bar baz\n", "foo baz\n");
+  }
+
   // VIM-300 |c| |w|
   public void testChangeWordTwoWordsWithoutWhitespace() {
     doTest(parseKeys("cw"), "<caret>$value\n", "value\n");


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-515

A cW command on text like 'x$$$$' or '$xxxx' would incorrectly delete
just the first character, and not the rest.
