### PR TITLE
VIM-536 Fix 'cc' on second-to-last line in file

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -1026,11 +1026,12 @@ public class ChangeGroup {
    * @return true if able to delete count lines, false if not
    */
   public boolean changeLine(@NotNull Editor editor, @NotNull DataContext context, int count) {
+    final int lastLineBeforeDelete = EditorHelper.getLineCount(editor);
+    final LogicalPosition posBeforeDelete = editor.offsetToLogicalPosition(editor.getCaretModel().getOffset());
+
     boolean res = deleteLine(editor, count);
     if (res) {
-      final int lastLine = EditorHelper.getLineCount(editor) - 1;
-      final LogicalPosition pos = editor.offsetToLogicalPosition(editor.getCaretModel().getOffset());
-      if (pos.line >= lastLine) {
+      if (posBeforeDelete.line + count >= lastLineBeforeDelete) {
         insertNewLineBelow(editor, context);
       }
       else {

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -138,6 +138,15 @@ public class ChangeActionTest extends VimTestCase {
     assertOffset(4);
   }
 
+  // VIM-536 |cc|
+  public void testChangeLineAtSecondLastLine() {
+    doTest(parseKeys("ccbaz"),
+           "<caret>foo\n" +
+           "bar\n",
+           "baz\n" +
+           "bar\n");
+  }
+
   // VIM-394 |d| |v_aw|
   public void testDeleteIndentedWordBeforePunctuation() {
     doTest(parseKeys("daw"), "foo\n" + "  <caret>bar, baz\n", "foo\n" + "  , baz\n");


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-536

Previously, 'cc' on the second-to-last line of a file would instead open
a new line after the last line of the file.
