### PR TITLE
VIM-771 Fix semicolon repeat for 'till char' motion

### DIFF
--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -678,6 +678,7 @@ public class MotionGroup {
 
   public int repeatLastMatchChar(@NotNull Editor editor, int count) {
     int res = -1;
+    int startPos = editor.getCaretModel().getOffset();
     switch (lastFTCmd) {
       case LAST_F:
         res = moveCaretToNextCharacterOnLine(editor, -count, lastFTChar);
@@ -687,9 +688,15 @@ public class MotionGroup {
         break;
       case LAST_T:
         res = moveCaretToBeforeNextCharacterOnLine(editor, -count, lastFTChar);
+        if (res == startPos && Math.abs(count) == 1) {
+          res = moveCaretToBeforeNextCharacterOnLine(editor, 2 * count, lastFTChar);
+        }
         break;
       case LAST_t:
         res = moveCaretToBeforeNextCharacterOnLine(editor, count, lastFTChar);
+        if (res == startPos && Math.abs(count) == 1) {
+          res = moveCaretToBeforeNextCharacterOnLine(editor, 2 * count, lastFTChar);
+        }
         break;
     }
 

--- a/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
@@ -84,6 +84,54 @@ public class MotionActionTest extends VimTestCase {
     assertMode(COMMAND);
   }
 
+  // VIM-771 |t| |;|
+  public void testTillCharRight() {
+    typeTextInFile(parseKeys("t:;"),
+                   "<caret> 1:a 2:b 3:c \n");
+    myFixture.checkResult(" 1:a <caret>2:b 3:c \n");
+  }
+
+  // VIM-771 |t| |;|
+  public void testTillCharRightRepeated() {
+    typeTextInFile(parseKeys("t:;"),
+                   "<caret> 1:a 2:b 3:c \n");
+    myFixture.checkResult(" 1:a <caret>2:b 3:c \n");
+  }
+
+  // VIM-771 |t| |;|
+  public void testTillCharRightRepeatedWithCount2() {
+    typeTextInFile(parseKeys("t:2;"),
+                   "<caret> 1:a 2:b 3:c \n");
+    myFixture.checkResult(" 1:a <caret>2:b 3:c \n");
+  }
+
+  // VIM-771 |t| |;|
+  public void testTillCharRightRepeatedWithCountHigherThan2() {
+    typeTextInFile(parseKeys("t:3;"), "<caret> 1:a 2:b 3:c \n");
+    myFixture.checkResult(" 1:a 2:b <caret>3:c \n");
+  }
+
+  // VIM-771 |t| |,|
+  public void testTillCharRightReverseRepeated() {
+    typeTextInFile(parseKeys("t:,,"),
+                   " 1:a 2:b<caret> 3:c \n");
+    myFixture.checkResult(" 1:<caret>a 2:b 3:c \n");
+  }
+
+  // VIM-771 |t| |,|
+  public void testTillCharRightReverseRepeatedWithCount2() {
+    typeTextInFile(parseKeys("t:,2,"),
+                   " 1:a 2:b<caret> 3:c \n");
+    myFixture.checkResult(" 1:<caret>a 2:b 3:c \n");
+  }
+
+  // VIM-771 |t| |,|
+  public void testTillCharRightReverseRepeatedWithCountHigherThan3() {
+    typeTextInFile(parseKeys("t:,3,"),
+                   " 0:_ 1:a 2:b<caret> 3:c \n");
+    myFixture.checkResult(" 0:<caret>_ 1:a 2:b 3:c \n");
+  }
+
   // VIM-326 |d| |v_ib|
   public void testDeleteInnerBlock() {
     typeTextInFile(parseKeys("di)"),


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-771

Based on empirical testing with Vim, ';' should work like this:
assuming "<caret>1:a 2:b 3:c" with ':' as the last f/t character:
- "t:" does nothing
- ";"  cursor goes to '2'
- "2;" cursor goes to '2', same as the previous
- "3;" cursor goes to '3'
