### PR TITLE
VIM-723 Fix pasting to an empty line

### DIFF
--- a/src/com/maddyhome/idea/vim/group/CopyGroup.java
+++ b/src/com/maddyhome/idea/vim/group/CopyGroup.java
@@ -162,7 +162,10 @@ public class CopyGroup {
         }
       }
       else {
-        pos = editor.getCaretModel().getOffset() + 1;
+        pos = editor.getCaretModel().getOffset();
+        if (!EditorHelper.isLineEmpty(editor, editor.getCaretModel().getLogicalPosition().line, false)) {
+          pos++;
+        }
       }
       // In case when text is empty this can occur
       if (pos > 0 && pos > editor.getDocument().getTextLength()) {

--- a/test/org/jetbrains/plugins/ideavim/action/CopyActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/CopyActionTest.java
@@ -33,6 +33,17 @@ public class CopyActionTest extends VimTestCase {
                           "three\n");
   }
 
+  // VIM-723 |p|
+  public void testYankPasteToEmptyLine() {
+    typeTextInFile(parseKeys("yiw", "j", "p"),
+                   "foo\n" +
+                   "\n" +
+                   "bar\n");
+    myFixture.checkResult("foo\n" +
+                          "foo\n" +
+                          "bar\n");
+  }
+
   // VIM-390 |yy| |p|
   public void testYankLinePasteAtLastLine() {
     typeTextInFile(parseKeys("yy", "p"),


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-723

When pasting on an empty line, the pasted text would go to the start of
next line instead.
