### PR TITLE
VIM-702 Fix infinite loop on s/$/\r/g

### DIFF
--- a/src/com/maddyhome/idea/vim/group/SearchGroup.java
+++ b/src/com/maddyhome/idea/vim/group/SearchGroup.java
@@ -375,6 +375,7 @@ public class SearchGroup {
             lastMatch = startoff;
             newpos = EditorHelper.offsetToCharacterPosition(editor, newend);
 
+            lnum += newpos.line - endpos.line;
             line2 += newpos.line - endpos.line;
           }
         }

--- a/test/org/jetbrains/plugins/ideavim/ex/SubstituteCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/SubstituteCommandTest.java
@@ -75,6 +75,20 @@ public class SubstituteCommandTest extends VimTestCase {
            "one\n.two\n.three\n");
   }
 
+  // VIM-702 |:substitute|
+  public void testEndOfLineToNL() {
+    doTest("%s/$/\\r/g",
+           "<caret>one\ntwo\nthree\n",
+           "one\n\ntwo\n\nthree\n\n");
+  }
+
+  // VIM-702 |:substitute|
+  public void testStartOfLineToNL() {
+    doTest("%s/^/\\r/g",
+           "<caret>one\ntwo\nthree\n",
+           "\none\n\ntwo\n\nthree\n");
+  }
+
   private void doTest(final String command, String before, String after) {
     myFixture.configureByText("a.java", before);
     typeText(commandToKeys(command));


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-702.

If the replacement contains newlines, the line number of the current
search position needs to be adjusted. Without this, e.g. s/$/\r/g would
get into an infinite loop.
