### PR TITLE
VIM-855 Fix regexp character class bugs

### DIFF
--- a/src/com/maddyhome/idea/vim/regexp/CharPointer.java
+++ b/src/com/maddyhome/idea/vim/regexp/CharPointer.java
@@ -279,7 +279,11 @@ public class CharPointer {
 
     int len = seq.length();
     for (int i = pointer; i < len; i++) {
-      if (seq.charAt(i) == c) {
+      char ch = seq.charAt(i);
+      if (ch == '\0') {
+        return null;
+      }
+      if (ch == c) {
         return ref(i - pointer);
       }
     }
@@ -312,6 +316,9 @@ public class CharPointer {
 
     for (int i = pointer; i < len; i++) {
       char ch = seq.charAt(i);
+      if (ch == '\0') {
+        return null;
+      }
       if (ch == c || ch == cc) {
         return ref(i - pointer);
       }

--- a/test/org/jetbrains/plugins/ideavim/group/SearchGroupTest.java
+++ b/test/org/jetbrains/plugins/ideavim/group/SearchGroupTest.java
@@ -74,6 +74,19 @@ public class SearchGroupTest extends VimTestCase {
     assertEquals(5, pos);
   }
 
+  // VIM-855 |/|
+  public void testCharacterClassRegression() {
+    final int pos = search("[^c]b",
+                           "<caret>bb\n");
+    assertEquals(0, pos);
+  }
+
+  // VIM-855 |/|
+  public void testCharacterClassRegressionCaseInsensitive() {
+    final int pos = search("\\c[ABC]D",
+                           "<caret>dd\n");
+    assertEquals(-1, pos);
+  }
 
   // |/|
   public void testSearchMotion() {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-855

Previously strchr and istrchr didn't consider NUL chars as end-of-string
terminators. This caused problems in regexps using character classes:
a regexp like "[^a]bc" would be effectively treated as "[^abc]bc" - i.e.
some literal characters from the rest of the pattern would accidentally be
included in the character class.