### PR TITLE
VIM-210 Fix focus issues with the Ex panel

### DIFF
--- a/src/com/maddyhome/idea/vim/ex/ExOutputModel.java
+++ b/src/com/maddyhome/idea/vim/ex/ExOutputModel.java
@@ -56,7 +56,7 @@ public class ExOutputModel {
   public void clear() {
     myText = null;
     if (!ApplicationManager.getApplication().isUnitTestMode()) {
-      ExOutputPanel.getInstance(myEditor).deactivate();
+      ExOutputPanel.getInstance(myEditor).deactivate(false);
     }
   }
 

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -140,7 +140,7 @@ public class MotionGroup {
    */
   private void processMouseClick(@NotNull Editor editor, @NotNull MouseEvent event) {
     if (ExEntryPanel.getInstance().isActive()) {
-      ExEntryPanel.getInstance().deactivate();
+      ExEntryPanel.getInstance().deactivate(false);
     }
 
     ExOutputModel.getInstance(editor).clear();
@@ -203,7 +203,7 @@ public class MotionGroup {
    */
   private void processLineSelection(@NotNull Editor editor, boolean update) {
     if (ExEntryPanel.getInstance().isActive()) {
-      ExEntryPanel.getInstance().deactivate();
+      ExEntryPanel.getInstance().deactivate(false);
     }
 
     ExOutputModel.getInstance(editor).clear();
@@ -233,7 +233,7 @@ public class MotionGroup {
 
   private void processMouseReleased(@NotNull Editor editor, @NotNull CommandState.SubMode mode, int startOff, int endOff) {
     if (ExEntryPanel.getInstance().isActive()) {
-      ExEntryPanel.getInstance().deactivate();
+      ExEntryPanel.getInstance().deactivate(false);
     }
 
     ExOutputModel.getInstance(editor).clear();
@@ -1705,7 +1705,7 @@ public class MotionGroup {
   public static class MotionEditorChange extends FileEditorManagerAdapter {
     public void selectionChanged(@NotNull FileEditorManagerEvent event) {
       if (ExEntryPanel.getInstance().isActive()) {
-        ExEntryPanel.getInstance().deactivate();
+        ExEntryPanel.getInstance().deactivate(false);
       }
       final FileEditor fileEditor = event.getOldEditor();
       if (fileEditor instanceof TextEditor) {

--- a/src/com/maddyhome/idea/vim/group/ProcessGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ProcessGroup.java
@@ -19,13 +19,8 @@
 package com.maddyhome.idea.vim.group;
 
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.text.CharSequenceReader;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
@@ -35,7 +30,6 @@ import com.maddyhome.idea.vim.command.MappingMode;
 import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.ex.CommandParser;
 import com.maddyhome.idea.vim.ex.ExException;
-import com.maddyhome.idea.vim.helper.EditorData;
 import com.maddyhome.idea.vim.ui.ExEntryPanel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -69,17 +63,7 @@ public class ProcessGroup {
 
   public String endSearchCommand(@NotNull final Editor editor, @NotNull DataContext context) {
     ExEntryPanel panel = ExEntryPanel.getInstance();
-    panel.deactivate();
-
-    final Project project = PlatformDataKeys.PROJECT.getData(context); // API change - don't merge
-    SwingUtilities.invokeLater(new Runnable() {
-      public void run() {
-        VirtualFile vf = EditorData.getVirtualFile(editor);
-        if (!ApplicationManager.getApplication().isUnitTestMode() && project != null && vf != null) {
-          FileEditorManager.getInstance(project).openFile(vf, true);
-        }
-      }
-    });
+    panel.deactivate(true);
 
     record(editor, panel.getText());
     return panel.getText();
@@ -117,7 +101,7 @@ public class ProcessGroup {
 
   public boolean processExEntry(@NotNull final Editor editor, @NotNull final DataContext context) {
     ExEntryPanel panel = ExEntryPanel.getInstance();
-    panel.deactivate();
+    panel.deactivate(true);
     boolean res = true;
     int flags = 0;
     try {
@@ -153,23 +137,6 @@ public class ProcessGroup {
       VimPlugin.indicateError();
       res = false;
     }
-    finally {
-      final int flg = flags;
-      final Project project = PlatformDataKeys.PROJECT.getData(context); // API change - don't merge
-      SwingUtilities.invokeLater(new Runnable() {
-        public void run() {
-          //editor.getContentComponent().requestFocus();
-          // Reopening the file was the only way I could solve the focus problem introduced in IDEA at
-          // version 1050.
-          if (!ApplicationManager.getApplication().isUnitTestMode() && (flg & CommandParser.RES_DONT_REOPEN) == 0) {
-            VirtualFile vf = EditorData.getVirtualFile(editor);
-            if (project != null && vf != null) {
-              FileEditorManager.getInstance(project).openFile(vf, true);
-            }
-          }
-        }
-      });
-    }
 
     return res;
   }
@@ -178,17 +145,7 @@ public class ProcessGroup {
     CommandState.getInstance(editor).popState();
     KeyHandler.getInstance().reset(editor);
     ExEntryPanel panel = ExEntryPanel.getInstance();
-    panel.deactivate();
-    final Project project = PlatformDataKeys.PROJECT.getData(context); // API change - don't merge
-    SwingUtilities.invokeLater(new Runnable() {
-      public void run() {
-        //editor.getContentComponent().requestFocus();
-        VirtualFile vf = EditorData.getVirtualFile(editor);
-        if (project != null && vf != null) {
-          FileEditorManager.getInstance(project).openFile(vf, true);
-        }
-      }
-    });
+    panel.deactivate(true);
 
     return true;
   }

--- a/src/com/maddyhome/idea/vim/ui/ExEntryPanel.java
+++ b/src/com/maddyhome/idea/vim/ui/ExEntryPanel.java
@@ -19,9 +19,11 @@
 package com.maddyhome.idea.vim.ui;
 
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
 import com.maddyhome.idea.vim.helper.UiHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -179,14 +181,17 @@ public class ExEntryPanel extends JPanel {
   }
 
   /**
-   * Turns off the ex entry field and puts the focus back to the original component
-   *
+   * Turns off the ex entry field and optionally puts the focus back to the original component
    */
-  public void deactivate() {
+  public void deactivate(boolean refocusOwningEditor) {
     logger.info("deactivate");
     if (!active) return;
     active = false;
     if (!ApplicationManager.getApplication().isUnitTestMode()) {
+      if (refocusOwningEditor) {
+        parent.requestFocus();
+      }
+
       oldGlass.removeComponentListener(adapter);
       oldGlass.setVisible(false);
       oldGlass.remove(this);

--- a/src/com/maddyhome/idea/vim/ui/ExOutputPanel.java
+++ b/src/com/maddyhome/idea/vim/ui/ExOutputPanel.java
@@ -19,9 +19,7 @@
 package com.maddyhome.idea.vim.ui;
 
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.components.JBScrollPane;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.helper.EditorData;
@@ -113,22 +111,20 @@ public class ExOutputPanel extends JPanel {
     myText.setText(data);
     myText.setCaretPosition(0);
     if (data.length() > 0) {
-      SwingUtilities.invokeLater(new Runnable() {
-        @Override
-        public void run() {
-          activate();
-        }
-      });
+      activate();
     }
   }
 
   /**
-   * Turns off the ex entry field and puts the focus back to the original component
+   * Turns off the ex entry field and optionally puts the focus back to the original component
    */
-  public void deactivate() {
+  public void deactivate(boolean refocusOwningEditor) {
     if (!myActive) return;
     myActive = false;
     myText.setText("");
+    if (refocusOwningEditor) {
+      myEditor.getContentComponent().requestFocus();
+    }
     if (myOldGlass != null) {
       myOldGlass.removeComponentListener(myAdapter);
       myOldGlass.setVisible(false);
@@ -136,7 +132,6 @@ public class ExOutputPanel extends JPanel {
       myOldGlass.setOpaque(myWasOpaque);
       myOldGlass.setLayout(myOldLayout);
     }
-    myEditor.getContentComponent().requestFocus();
   }
 
   /**
@@ -160,17 +155,9 @@ public class ExOutputPanel extends JPanel {
     if (myOldGlass != null) {
       myOldGlass.setVisible(true);
     }
-    myActive = true;
 
-    SwingUtilities.invokeLater(new Runnable() {
-      public void run() {
-        SwingUtilities.invokeLater(new Runnable() {
-          public void run() {
-            myText.requestFocus();
-          }
-        });
-      }
-    });
+    myActive = true;
+    myText.requestFocus();
   }
 
   private void setFontForElements() {
@@ -277,11 +264,7 @@ public class ExOutputPanel extends JPanel {
   private void close(@Nullable final KeyEvent e) {
     SwingUtilities.invokeLater(new Runnable() {
       public void run() {
-        deactivate();
-        final VirtualFile vf = EditorData.getVirtualFile(myEditor);
-        if (vf != null) {
-          FileEditorManager.getInstance(myEditor.getProject()).openFile(vf, true);
-        }
+        deactivate(true);
 
         final Project project = myEditor.getProject();
 

--- a/test/org/jetbrains/plugins/ideavim/VimTestCase.java
+++ b/test/org/jetbrains/plugins/ideavim/VimTestCase.java
@@ -68,7 +68,7 @@ public abstract class VimTestCase extends UsefulTestCase {
   protected void tearDown() throws Exception {
     myFixture.tearDown();
     myFixture = null;
-    ExEntryPanel.getInstance().deactivate();
+    ExEntryPanel.getInstance().deactivate(false);
     super.tearDown();
   }
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-210 and also https://youtrack.jetbrains.com/issue/VIM-178 which is a duplicate of VIM-210.

Previously, if the editor window had been splitted, under certain
conditions some actions related to the Ex panel would cause the editor
focus to change to a different split.

The required conditions for this bug to occur:
    - no docked windows (like the Project sidebar) are open
    - 'View -> Navigation bar' is disabled

At least these actions triggered the bug:
    - search with /
    - successfully executing an Ex command
    - dismissing the Ex window with Esc
    - Ex commands that opened the output panel (e.g. :!)

All the deleted lines of the form
    FileEditorManager.getInstance(project).openFile(vf, true);
seem to be very old, non-functional workarounds for the focus issue.