### PR TITLE
VIM-575 Don't change cursor position of other splits in visual mode

### DIFF
--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -1733,7 +1733,6 @@ public class MotionGroup {
         for (Editor e : EditorFactory.getInstance().getEditors(editor.getDocument())) {
           if (!e.equals(editor)) {
             e.getSelectionModel().setSelection(newRange.getStartOffset(), newRange.getEndOffset());
-            e.getCaretModel().moveToOffset(editor.getCaretModel().getOffset());
           }
         }
       }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-575

If a file is opened in multiple splits, entering visual mode in one
split would change the cursor position in other splits as well.