### PR TITLE
Fix broken sorting when sorting with leading whitespace

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -17,7 +17,9 @@
  */
 package com.maddyhome.idea.vim.group;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.DataContext;
@@ -1544,7 +1546,7 @@ public class ChangeGroup {
   private boolean sortTextRange(@NotNull Editor editor, int start, int end,
                                 @NotNull Comparator<String> lineComparator) {
     final String selectedText = editor.getDocument().getText(new TextRangeInterval(start, end));
-    final List<String> lines = Arrays.asList(StringUtil.splitByLines(selectedText));
+    final List<String> lines = Lists.newArrayList(Splitter.on("\n").split(selectedText));
     if (lines.size() < 1) {
       return false;
     }

--- a/test/org/jetbrains/plugins/ideavim/ex/SortCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/SortCommandTest.java
@@ -92,4 +92,10 @@ public class SortCommandTest extends VimTestCase {
     typeText(commandToKeys("sort"));
     myFixture.checkResult("a\nb\nc\nwhatever\nzee");
   }
+
+  public void testSortWithPrecedingWhiteSpace() {
+    myFixture.configureByText("a.txt", " zee\n c\n a\n b\n whatever");
+    typeText(commandToKeys("sort"));
+    myFixture.checkResult(" a\n b\n c\n whatever\n zee");
+  }
 }


### PR DESCRIPTION
`StringUtil.splitByLines` incorrectly splits strings with leading whitespace. For example, ` a\n b\n c\n` is split into `[ a,b,c]` instead of `[ a, b, c]`.

This meant that if an IdeaVim user tried to sort lines with leading whitespace, the sorting was incorrect.

I changed the implementation from `StringUtil.splitByLines` to Guava's `Splitter` and added a unit test.
