### PR TITLE
Fix incorrect behavior in substitution with offset ranges

### DIFF
--- a/src/com/maddyhome/idea/vim/ex/CommandParser.java
+++ b/src/com/maddyhome/idea/vim/ex/CommandParser.java
@@ -301,7 +301,7 @@ public class CommandParser {
               state = STATE_RANGE_MARK;
             }
             else if (ch == '+' || ch == '-') {
-              location.append('0');
+              location.append('.');
               state = STATE_RANGE_OFFSET;
             }
             else if (ch == '\\') {

--- a/test/org/jetbrains/plugins/ideavim/ex/SubstituteCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/SubstituteCommandTest.java
@@ -89,6 +89,12 @@ public class SubstituteCommandTest extends VimTestCase {
            "\none\n\ntwo\n\nthree\n");
   }
 
+  public void testOffsetRange() {
+    doTest(".,+2s/a/b/g",
+           "aaa\naa<caret>a\naaa\naaa\naaa\n",
+           "aaa\nbbb\nbbb\nbbb\naaa\n");
+  }
+
   private void doTest(final String command, String before, String after) {
     myFixture.configureByText("a.java", before);
     typeText(commandToKeys(command));


### PR DESCRIPTION
Substitution commands with offset ranges like .,+2s/a/b/g previously
did not work the way they do in Vim (replace a with b on the current
line and the next two lines). This change fixes that bug.