### PR TITLE
VIM-864 Fix visual marks gettinng changed during visual substitute

### DIFF
--- a/src/com/maddyhome/idea/vim/group/SearchGroup.java
+++ b/src/com/maddyhome/idea/vim/group/SearchGroup.java
@@ -34,6 +34,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.Command;
+import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.command.SelectionType;
 import com.maddyhome.idea.vim.common.CharacterPosition;
 import com.maddyhome.idea.vim.common.TextRange;
@@ -92,6 +93,11 @@ public class SearchGroup {
 
   public boolean searchAndReplace(@NotNull Editor editor, @NotNull LineRange range, @NotNull String excmd, String exarg) {
     boolean res = true;
+
+    // Explicitly exit visual mode here, so that visual mode marks don't change when we move the cursor to a match.
+    if (CommandState.getInstance(editor).getMode() == CommandState.Mode.VISUAL) {
+      VimPlugin.getMotion().exitVisual(editor);
+    }
 
     CharPointer cmd = new CharPointer(new StringBuffer(exarg));
     //sub_nsubs = 0;

--- a/test/org/jetbrains/plugins/ideavim/ex/SubstituteCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/SubstituteCommandTest.java
@@ -2,6 +2,8 @@ package org.jetbrains.plugins.ideavim.ex;
 
 import org.jetbrains.plugins.ideavim.VimTestCase;
 
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
 /**
  * @author vlan
  */
@@ -87,6 +89,13 @@ public class SubstituteCommandTest extends VimTestCase {
     doTest("%s/^/\\r/g",
            "<caret>one\ntwo\nthree\n",
            "\none\n\ntwo\n\nthree\n");
+  }
+
+  // VIM-864 |:substitute|
+  public void testVisualSubstituteDoesntChangeVisualMarks() {
+    myFixture.configureByText("a.java", "foo\nbar\nbaz\n");
+    typeText(parseKeys("V", "j", ":'<,'>s/foo/fuu/<Enter>", "gv", "~"));
+    myFixture.checkResult("FUU\nBAR\nbaz\n");
   }
 
   private void doTest(final String command, String before, String after) {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-864

Previously, running a substitute command in visual mode would
incorrectly set the visual mode end mark (>) to the location of the last
search match.