### PR TITLE
VIM-700 Remapping '0' should still allow zero to be entered in count

### DIFF
--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -111,28 +111,28 @@ public class KeyHandler {
     editor = InjectedLanguageUtil.getTopLevelEditor(editor);
     final CommandState editorState = CommandState.getInstance(editor);
 
-    if (allowKeyMappings && handleKeyMapping(editor, key, context)) {
-      return;
-    }
-
-    final boolean isRecording = editorState.isRecording();
-    boolean shouldRecord = true;
     // If this is a "regular" character keystroke, get the character
     char chKey = key.getKeyChar() == KeyEvent.CHAR_UNDEFINED ? 0 : key.getKeyChar();
 
-    if (isEditorReset(key, editorState)) {
-      handleEditorReset(editor, key, context);
-    }
-    // At this point the user must be typing in a command. Most commands can be preceded by a number. Let's
-    // check if a number can be entered at this point, and if so, did the user send us a digit.
-    else if (isCommandCount(editorState, chKey)) {
+    final boolean isRecording = editorState.isRecording();
+    boolean shouldRecord = true;
+
+    // Check for command count before key mappings - otherwise e.g. ':map 0 ^' breaks command counts that contain a zero
+    if (isCommandCount(editorState, chKey)) {
       // Update the count
       count = count * 10 + (chKey - '0');
     }
+    else if (allowKeyMappings && handleKeyMapping(editor, key, context)) {
+      return;
+    }
     // Pressing delete while entering a count "removes" the last digit entered
+    // Unlike the digits, this must be checked *after* checking for key mappings
     else if (isDeleteCommandCount(key, editorState)) {
       // "Remove" the last digit sent to us
       count /= 10;
+    }
+    else if (isEditorReset(key, editorState)) {
+      handleEditorReset(editor, key, context);
     }
     // If we got this far the user is entering a command or supplying an argument to an entered command.
     // First let's check to see if we are at the point of expecting a single character argument to a command.

--- a/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
@@ -243,4 +243,28 @@ public class MapCommandTest extends VimTestCase {
     typeText(parseKeys("A"));
     myFixture.checkResult("bar\n");
   }
+
+  // VIM-700 |:map|
+  public void testRemappingZero() {
+    configureByText("x<caret>yz\n");
+    VimScriptParser.executeText("map 0 ~");
+    typeText(parseKeys("0"));
+    myFixture.checkResult("xYz\n");
+  }
+
+  // VIM-700 |:map|
+  public void testRemappingZeroStillAllowsZeroToBeUsedInCount() {
+    configureByText("a<caret>bcdefghijklmnop\n");
+    VimScriptParser.executeText("map 0 ^");
+    typeText(parseKeys("10~"));
+    myFixture.checkResult("aBCDEFGHIJKlmnop\n");
+  }
+
+  // VIM-700 |:map|
+  public void testRemappingDeleteOverridesRemovingLastDigitFromCount() {
+    configureByText("a<caret>bcdefghijklmnop\n");
+    VimScriptParser.executeText("map <Del> ~");
+    typeText(parseKeys("10<Del>"));
+    myFixture.checkResult("aBCDEFGHIJKlmnop\n");
+  }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-700

Previously, remapping '0' in command mode would prevent a number zero
from being entered in a command count.