### PR TITLE
Make IdeaVIM build on latest intellij-community master

### DIFF
--- a/src/com/maddyhome/idea/vim/helper/PsiHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/PsiHelper.java
@@ -52,7 +52,7 @@ public class PsiHelper {
     StructureViewBuilder structureViewBuilder = LanguageStructureViewBuilder.INSTANCE.getStructureViewBuilder(file);
     if (!(structureViewBuilder instanceof TreeBasedStructureViewBuilder)) return -1;
     TreeBasedStructureViewBuilder builder = (TreeBasedStructureViewBuilder)structureViewBuilder;
-    StructureViewModel model = builder.createStructureViewModel();
+    StructureViewModel model = builder.createStructureViewModel(editor);
 
     TIntArrayList navigationOffsets = new TIntArrayList();
     addNavigationElements(model.getRoot(), navigationOffsets, isStart);


### PR DESCRIPTION
The zero-parameter overload of createStructureViewModel() has been
marked deprecated and is now removed.