### PR TITLE
Support comments in brace matching

### DIFF
--- a/src/com/maddyhome/idea/vim/helper/PsiHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/PsiHelper.java
@@ -109,7 +109,7 @@ public class PsiHelper {
   }
 
   @Nullable
-  private static PsiFile getFile(@NotNull Editor editor) {
+  public static PsiFile getFile(@NotNull Editor editor) {
     VirtualFile vf = EditorData.getVirtualFile(editor);
     if (vf != null) {
       Project proj = editor.getProject();

--- a/test/org/jetbrains/plugins/ideavim/VimTestCase.java
+++ b/test/org/jetbrains/plugins/ideavim/VimTestCase.java
@@ -1,6 +1,7 @@
 package org.jetbrains.plugins.ideavim;
 
 import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.ide.highlighter.XmlFileType;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Editor;
@@ -87,6 +88,12 @@ public abstract class VimTestCase extends UsefulTestCase {
   @NotNull
   protected Editor configureByJavaText(@NotNull String content) {
     myFixture.configureByText(JavaFileType.INSTANCE, content);
+    return myFixture.getEditor();
+  }
+
+  @NotNull
+  protected Editor configureByXmlText(@NotNull String content) {
+    myFixture.configureByText(XmlFileType.INSTANCE, content);
     return myFixture.getEditor();
   }
 

--- a/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
@@ -426,6 +426,76 @@ public class MotionActionTest extends VimTestCase {
     assertOffset(3);
   }
 
+  // |%|
+  public void testPercentMatchXmlCommentStart() {
+    configureByXmlText("<caret><!-- foo -->");
+    typeText(parseKeys("%"));
+    assertOffset(11);
+  }
+
+  // |%|
+  public void testPercentDoesntMatchPartialXmlComment() {
+    configureByXmlText("<!<caret>-- ");
+    typeText(parseKeys("%"));
+    assertOffset(2);
+  }
+
+  // |%|
+  public void testPercentMatchXmlCommentEnd() {
+    configureByXmlText("<!-- foo --<caret>>");
+    typeText(parseKeys("%"));
+    assertOffset(0);
+  }
+
+  // |%|
+  public void testPercentMatchJavaCommentStart() {
+    configureByJavaText("/<caret>* foo */");
+    typeText(parseKeys("%"));
+    assertOffset(8);
+  }
+
+  // |%|
+  public void testPercentDoesntMatchPartialJavaComment() {
+    configureByJavaText("<caret>/* ");
+    typeText(parseKeys("%"));
+    assertOffset(0);
+  }
+
+  // |%|
+  public void testPercentMatchJavaCommentEnd() {
+    configureByJavaText("/* foo <caret>*/");
+    typeText(parseKeys("%"));
+    assertOffset(0);
+  }
+
+  // |%|
+  public void testPercentMatchJavaDocCommentStart() {
+    configureByJavaText("/*<caret>* foo */");
+    typeText(parseKeys("%"));
+    assertOffset(9);
+  }
+
+  // |%|
+  public void testPercentMatchJavaDocCommentEnd() {
+    configureByJavaText("/** foo *<caret>/");
+    typeText(parseKeys("%"));
+    assertOffset(0);
+  }
+
+  // |%|
+  public void testPercentDoesntMatchAfterCommentStart() {
+    configureByJavaText("/*<caret> foo */");
+    typeText(parseKeys("%"));
+    assertOffset(2);
+  }
+
+  // |%|
+  public void testPercentDoesntMatchBeforeCommentEnd() {
+    configureByJavaText("/* foo <caret> */");
+    typeText(parseKeys("%"));
+    assertOffset(7);
+  }
+
   // |[(|
   public void testUnmatchedOpenParenthesis() {
     typeTextInFile(parseKeys("[("),


### PR DESCRIPTION
In Vim, `%` can be used to jump between the `/*` and `*/` of block
comments. Support this functionality in a language-independent manner.