### PR TITLE
Visual block mode overhaul

### DIFF
--- a/src/com/maddyhome/idea/vim/helper/EditorData.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorData.java
@@ -25,11 +25,13 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.LightVirtualFile;
+import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.command.SelectionType;
 import com.maddyhome.idea.vim.command.VisualChange;
 import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.ex.ExOutputModel;
+import com.maddyhome.idea.vim.group.MotionGroup;
 import com.maddyhome.idea.vim.ui.ExOutputPanel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -91,9 +93,17 @@ public class EditorData {
    * @param editor The editor
    */
   public static void setLastColumn(@NotNull Editor editor, int col) {
+    boolean previousWasDollar = getLastColumn(editor) >= MotionGroup.LAST_COLUMN;
+    boolean currentIsDollar = col >= MotionGroup.LAST_COLUMN;
+
     editor.putUserData(LAST_COLUMN, col);
     int t = getLastColumn(editor);
     if (logger.isDebugEnabled()) logger.debug("setLastColumn(" + col + ") is now " + t);
+
+    boolean inVisualBlockMode = CommandState.getInstance(editor).getSubMode() == CommandState.SubMode.VISUAL_BLOCK;
+    if (previousWasDollar != currentIsDollar && inVisualBlockMode) {
+      VimPlugin.getMotion().updateSelection(editor);
+    }
   }
 
   @Nullable

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -352,6 +352,38 @@ public class ChangeActionTest extends VimTestCase {
            "quux\n");
   }
 
+  public void testDeleteCharVisualBlockOnLastCharOfLine() {
+    doTest(parseKeys("<C-V>", "x"),
+           "fo<caret>o\n",
+           "fo\n");
+  }
+
+  public void testDeleteCharVisualBlockOnEmptyLinesDoesntDeleteAnything() {
+    doTest(parseKeys("<C-V>", "j", "x"),
+           "\n\n",
+           "\n\n");
+  }
+
+  public void testDeleteCharVisualBlockWithEmptyLineInTheMiddle() {
+    doTest(parseKeys("l", "<C-V>", "jj", "x"),
+           "foo\n" +
+           "\n" +
+           "bar\n",
+           "fo\n" +
+           "\n" +
+           "br\n");
+  }
+
+  public void testDeleteCharVisualBlockWithShorterLineInTheMiddle() {
+    doTest(parseKeys("l", "<C-V>", "jj", "x"),
+           "foo\n" +
+           "x\n" +
+           "bar\n",
+           "fo\n" +
+           "x\n" +
+           "br\n");
+  }
+
   // |r|
   public void testReplaceOneChar() {
     doTest(parseKeys("rx"),

--- a/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
@@ -597,6 +597,31 @@ public class MotionActionTest extends VimTestCase {
     myFixture.checkResult("foo \n");
   }
 
+  // |C-V|
+  public void testVisualBlockSelectionsDisplayedCorrectlyMovingRight() {
+    typeTextInFile(parseKeys("<C-V>jl"),
+                   "<caret>foo\nbar\n");
+    myFixture.checkResult("<selection>fo</selection>o\n<selection>ba</selection>r\n");
+  }
+
+  // |C-V|
+  public void testVisualBlockSelectionsDisplayedCorrectlyMovingLeft() {
+    typeTextInFile(parseKeys("<C-V>jh"),
+                   "fo<caret>o\nbar\n");
+    myFixture.checkResult("f<selection>oo</selection>\nb<selection>ar</selection>\n");
+  }
+
+  // |C-V|
+  public void testVisualBlockSelectionsDisplayedCorrectlyInDollarMode() {
+    typeTextInFile(parseKeys("<C-V>jj$"),
+                   "a<caret>b\n" +
+                   "abc\n" +
+                   "ab\n");
+    myFixture.checkResult("a<selection>b</selection>\n" +
+                          "a<selection>bc</selection>\n" +
+                          "a<selection>b</selection>\n");
+  }
+
   // |v_o|
   public void testSwapVisualSelectionEnds() {
     typeTextInFile(parseKeys("v", "l", "o", "l", "d"),


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/VIM-781 and https://youtrack.jetbrains.com/issue/VIM-845

The current visual block mode implementation has several bugs:

- The GUI never displays the rightmost characters as selected (blue)
- Due to some off-by-one, commands can't act on each line's last character
- It's possible for newlines to get deleted/changed into something else
- If the '$' mode is entered, the GUI doesn't always indicate this
- It's impossible to move to an empty line (VIM-781)

This commit fixes all of those problems. The only remaining problem are
the visible secondary carets, which makes seeing the real cursor a bit
difficult. This could be fixed later if support for per-caret visibility
would be added to IntelliJ core.