### PR TITLE
Fixed the findMethodOrClass in PsiHelper for new idea versions 

### DIFF
--- a/src/com/maddyhome/idea/vim/helper/PsiHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/PsiHelper.java
@@ -52,7 +52,7 @@ public class PsiHelper {
     StructureViewBuilder structureViewBuilder = LanguageStructureViewBuilder.INSTANCE.getStructureViewBuilder(file);
     if (!(structureViewBuilder instanceof TreeBasedStructureViewBuilder)) return -1;
     TreeBasedStructureViewBuilder builder = (TreeBasedStructureViewBuilder)structureViewBuilder;
-    StructureViewModel model = builder.createStructureViewModel();
+    StructureViewModel model = builder.createStructureViewModel(editor);
 
     TIntArrayList navigationOffsets = new TIntArrayList();
     addNavigationElements(model.getRoot(), navigationOffsets, isStart);


### PR DESCRIPTION
At the moment Intellij IDEA non-community edition does not work with any structural motion combinations (Tested on both 13 and 14). So nothing like: '[[', '[m', ']{' does not work at the moment.
This is deprecated in Idea API and throws *AbstractMethodError*:
     <code>(TreeBasedStructureViewBuilder)builder.createStructureViewModel();</code>

replaced it with:
<code>(TreeBasedStructureViewBuilder)builder.createStructureViewModel(editor);</code>

The change was tested on Idea 14.03 and worked fine.
