### PR TITLE
Mapleader support based on the prototype of a Vim script expressions evaluator

### DIFF
--- a/src/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/com/maddyhome/idea/vim/VimPlugin.java
@@ -41,7 +41,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.WindowManager;
 import com.maddyhome.idea.vim.ex.CommandParser;
-import com.maddyhome.idea.vim.ex.VimScriptParser;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptParser;
 import com.maddyhome.idea.vim.group.*;
 import com.maddyhome.idea.vim.helper.DocumentManager;
 import com.maddyhome.idea.vim.helper.MacKeyRepeat;

--- a/src/com/maddyhome/idea/vim/ex/CommandParser.java
+++ b/src/com/maddyhome/idea/vim/ex/CommandParser.java
@@ -79,6 +79,7 @@ public class CommandParser {
     new DumpLineHandler();
     new EditFileHandler();
     new ActionHandler();
+    new EchoHandler();
     new ExitHandler();
     new FindClassHandler();
     new FindFileHandler();
@@ -89,6 +90,7 @@ public class CommandParser {
     new HistoryHandler();
     new JoinLinesHandler();
     new JumpsHandler();
+    new LetHandler();
     new MapHandler();
     new MarkHandler();
     new MarksHandler();

--- a/src/com/maddyhome/idea/vim/ex/handler/EchoHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/EchoHandler.java
@@ -1,0 +1,54 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2015 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.ex.handler;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.ex.CommandHandler;
+import com.maddyhome.idea.vim.ex.ExCommand;
+import com.maddyhome.idea.vim.ex.ExException;
+import com.maddyhome.idea.vim.ex.ExOutputModel;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptParser;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+/**
+ * @author vlan
+ */
+public class EchoHandler extends CommandHandler {
+
+  public EchoHandler() {
+    super("ec", "ho", RANGE_FORBIDDEN | ARGUMENT_OPTIONAL);
+  }
+
+  @Override
+  public boolean execute(@NotNull Editor editor, @NotNull DataContext context,
+                         @NotNull ExCommand cmd) throws ExException {
+    final String argument = cmd.getArgument();
+    final VimScriptGlobalEnvironment env = VimScriptGlobalEnvironment.getInstance();
+    final Map<String, Object> globals = env.getVariables();
+    final Object value = VimScriptParser.evaluate(argument, globals);
+    final String text = VimScriptParser.expressionToString(value) + "\n";
+    ExOutputModel.getInstance(editor).output(text);
+    return true;
+  }
+}
+

--- a/src/com/maddyhome/idea/vim/ex/handler/LetHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/LetHandler.java
@@ -1,0 +1,78 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2015 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.ex.handler;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.ex.CommandHandler;
+import com.maddyhome.idea.vim.ex.ExCommand;
+import com.maddyhome.idea.vim.ex.ExException;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptCommandHandler;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptParser;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author vlan
+ */
+public class LetHandler extends CommandHandler implements VimScriptCommandHandler {
+  private static Pattern SIMPLE_ASSIGNMENT = Pattern.compile("([A-Za-z_][A-Za-z_0-9]*)[ \\t]*=[ \\t]*(.*)");
+
+  public LetHandler() {
+    super("let", "", RANGE_FORBIDDEN | ARGUMENT_OPTIONAL);
+  }
+
+  @Override
+  public boolean execute(@NotNull Editor editor, @NotNull DataContext context,
+                         @NotNull ExCommand cmd) throws ExException {
+    execute(cmd);
+    return true;
+  }
+
+  @Override
+  public void execute(@NotNull ExCommand cmd) throws ExException {
+    final String argument = cmd.getArgument();
+    if (argument.trim().isEmpty()) {
+      showVariables();
+    }
+    else {
+      final Matcher matcher = SIMPLE_ASSIGNMENT.matcher(argument);
+      if (matcher.matches()) {
+        final String name = matcher.group(1);
+        // TODO: Check that 'name' is global
+        final String expression = matcher.group(2);
+        final VimScriptGlobalEnvironment env = VimScriptGlobalEnvironment.getInstance();
+        final Map<String, Object> globals = env.getVariables();
+        final Object value = VimScriptParser.evaluate(expression, globals);
+        globals.put(name, value);
+      }
+      else {
+        throw new ExException("Only simple '=' assignments are supported in 'let' expressions");
+      }
+    }
+  }
+
+  private void showVariables() throws ExException {
+    throw new ExException("'let' without arguments is not supported yet");
+  }
+}

--- a/src/com/maddyhome/idea/vim/ex/handler/MapHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/MapHandler.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.MappingMode;
 import com.maddyhome.idea.vim.ex.*;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptCommandHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/com/maddyhome/idea/vim/ex/handler/SetHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/SetHandler.java
@@ -23,7 +23,7 @@ import com.intellij.openapi.editor.Editor;
 import com.maddyhome.idea.vim.ex.CommandHandler;
 import com.maddyhome.idea.vim.ex.ExCommand;
 import com.maddyhome.idea.vim.ex.ExException;
-import com.maddyhome.idea.vim.ex.VimScriptCommandHandler;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptCommandHandler;
 import com.maddyhome.idea.vim.option.Options;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/com/maddyhome/idea/vim/ex/handler/SourceHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/SourceHandler.java
@@ -21,6 +21,8 @@ package com.maddyhome.idea.vim.ex.handler;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
 import com.maddyhome.idea.vim.ex.*;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptCommandHandler;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptParser;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;

--- a/src/com/maddyhome/idea/vim/ex/vimscript/VimScriptCommandHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/vimscript/VimScriptCommandHandler.java
@@ -16,8 +16,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.maddyhome.idea.vim.ex;
+package com.maddyhome.idea.vim.ex.vimscript;
 
+import com.maddyhome.idea.vim.ex.ExCommand;
+import com.maddyhome.idea.vim.ex.ExException;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/src/com/maddyhome/idea/vim/ex/vimscript/VimScriptGlobalEnvironment.java
+++ b/src/com/maddyhome/idea/vim/ex/vimscript/VimScriptGlobalEnvironment.java
@@ -1,0 +1,45 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2015 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.ex.vimscript;
+
+import com.intellij.util.containers.hash.HashMap;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+/**
+ * @author vlan
+ */
+public class VimScriptGlobalEnvironment {
+  private static final VimScriptGlobalEnvironment ourInstance = new VimScriptGlobalEnvironment();
+
+  private final Map<String, Object> myVariables = new HashMap<String, Object>();
+
+  private VimScriptGlobalEnvironment() {}
+
+  @NotNull
+  public static VimScriptGlobalEnvironment getInstance() {
+    return ourInstance;
+  }
+
+  @NotNull
+  public Map<String, Object> getVariables() {
+    return myVariables;
+  }
+}

--- a/src/com/maddyhome/idea/vim/ex/vimscript/VimScriptParser.java
+++ b/src/com/maddyhome/idea/vim/ex/vimscript/VimScriptParser.java
@@ -16,8 +16,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.maddyhome.idea.vim.ex;
+package com.maddyhome.idea.vim.ex.vimscript;
 
+import com.maddyhome.idea.vim.ex.CommandHandler;
+import com.maddyhome.idea.vim.ex.CommandParser;
+import com.maddyhome.idea.vim.ex.ExCommand;
+import com.maddyhome.idea.vim.ex.ExException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/com/maddyhome/idea/vim/ex/vimscript/VimScriptParser.java
+++ b/src/com/maddyhome/idea/vim/ex/vimscript/VimScriptParser.java
@@ -29,6 +29,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -38,6 +40,9 @@ public class VimScriptParser {
   public static final String[] VIMRC_FILES = {".ideavimrc", "_ideavimrc"};
   public static final int BUFSIZE = 4096;
   private static final Pattern EOL_SPLIT_PATTERN = Pattern.compile(" *(\r\n|\n)+ *");
+  private static final Pattern DOUBLE_QUOTED_STRING = Pattern.compile("\"([^\"]*)\"");
+  private static final Pattern SINGLE_QUOTED_STRING = Pattern.compile("'([^']*)'");
+  private static final Pattern REFERENCE_EXPR = Pattern.compile("([A-Za-z_][A-Za-z_0-9]*)");
 
   private VimScriptParser() {
   }
@@ -88,6 +93,42 @@ public class VimScriptParser {
       catch (ExException ignored) {
       }
     }
+  }
+
+  @NotNull
+  public static Object evaluate(@NotNull String expression, @NotNull Map<String, Object> globals) throws ExException {
+    // This evaluator is very basic, no proper parsing whatsoever. It is here as the very first step necessary to
+    // support mapleader, VIM-650. See also VIM-669.
+    Matcher m;
+    m = DOUBLE_QUOTED_STRING.matcher(expression);
+    if (m.matches()) {
+      return m.group(1);
+    }
+    m = SINGLE_QUOTED_STRING.matcher(expression);
+    if (m.matches()) {
+      return m.group(1);
+    }
+    m = REFERENCE_EXPR.matcher(expression);
+    if (m.matches()) {
+      final String name = m.group(1);
+      final Object value = globals.get(name);
+      if (value != null) {
+        return value;
+      }
+      else {
+        throw new ExException(String.format("Undefined variable: %s", name));
+      }
+    }
+    throw new ExException(String.format("Invalid expression: %s", expression));
+  }
+
+  @NotNull
+  public static String expressionToString(@NotNull Object value) throws ExException {
+    // TODO: Return meaningful value representations
+    if (value instanceof String) {
+      return (String)value;
+    }
+    throw new ExException(String.format("Cannot convert '%s' to string", value));
   }
 
   @NotNull

--- a/src/com/maddyhome/idea/vim/helper/StringHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/StringHelper.java
@@ -21,6 +21,7 @@ package com.maddyhome.idea.vim.helper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.intellij.openapi.util.text.StringUtil;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment;
 import org.apache.commons.codec.binary.Base64;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -74,7 +75,6 @@ public class StringHelper {
   private static final Map<Integer, String> VIM_KEY_VALUES = invertMap(VIM_KEY_NAMES);
 
   private static final Map<String, Character> VIM_TYPED_KEY_NAMES = ImmutableMap.<String, Character>builder()
-    .put("leader", '\\')
     .put("space", ' ')
     .put("bar", '|')
     .put("bslash", '\\')
@@ -189,8 +189,12 @@ public class StringHelper {
                 throw new IllegalArgumentException("<" + specialKeyName + "> is not supported");
               }
               if (!"nop".equals(lower)) {
+                final List<KeyStroke> leader = parseMapLeader(specialKeyName);
                 final KeyStroke specialKey = parseSpecialKey(specialKeyName, 0);
-                if (specialKey != null) {
+                if (leader != null) {
+                  result.addAll(leader);
+                }
+                else if (specialKey != null) {
                   result.add(specialKey);
                 }
                 else {
@@ -215,6 +219,20 @@ public class StringHelper {
       }
     }
     return result;
+  }
+
+  @Nullable
+  private static List<KeyStroke> parseMapLeader(@NotNull String s) {
+    if ("leader".equals(s.toLowerCase())) {
+      final Object mapLeader = VimScriptGlobalEnvironment.getInstance().getVariables().get("mapleader");
+      if (mapLeader instanceof String) {
+        return stringToKeys((String)mapLeader);
+      }
+      else {
+        return stringToKeys("\\");
+      }
+    }
+    return null;
   }
 
   private static boolean isControlCharacter(char c) {

--- a/src/com/maddyhome/idea/vim/helper/StringHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/StringHelper.java
@@ -127,7 +127,7 @@ public class StringHelper {
     return res;
   }
 
-  private static enum KeyParserState {
+  private enum KeyParserState {
     INIT,
     ESCAPE,
     SPECIAL,

--- a/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
@@ -1,7 +1,7 @@
 package org.jetbrains.plugins.ideavim.ex;
 
 import com.maddyhome.idea.vim.command.CommandState;
-import com.maddyhome.idea.vim.ex.VimScriptParser;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptParser;
 import org.jetbrains.plugins.ideavim.VimTestCase;
 
 import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;

--- a/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
@@ -267,4 +267,13 @@ public class MapCommandTest extends VimTestCase {
     typeText(parseKeys("10<Del>"));
     myFixture.checkResult("aBCDEFGHIJKlmnop\n");
   }
+
+  // VIM-650 |mapleader|
+  public void testMapLeader() {
+    configureByText("\n");
+    typeText(commandToKeys("let mapleader = \",\""));
+    typeText(commandToKeys("nmap <Leader>z izzz<Esc>"));
+    typeText(parseKeys(",z"));
+    myFixture.checkResult("zzz\n");
+  }
 }

--- a/test/org/jetbrains/plugins/ideavim/ex/VimScriptParserTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/VimScriptParserTest.java
@@ -1,0 +1,21 @@
+package org.jetbrains.plugins.ideavim.ex;
+
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+/**
+ * @author vlan
+ */
+public class VimScriptParserTest extends VimTestCase {
+  public void testEchoStringLiteral() {
+    configureByText("\n");
+    typeText(commandToKeys("echo \"Hello, World!\""));
+    assertExOutput("Hello, World!\n");
+  }
+
+  public void testLetStringLiteralEcho() {
+    configureByText("\n");
+    typeText(commandToKeys("let s = \"foo\""));
+    typeText(commandToKeys("echo s"));
+    assertExOutput("foo\n");
+  }
+}


### PR DESCRIPTION
Currently only very simple `let` and `echo` commands are supported. Using the `mapleader` value in mappings is coming next.