### PR TITLE
Add `gc` verb that accepts a motion to comment

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -363,6 +363,10 @@
     <action id="VimRedo" class="com.maddyhome.idea.vim.action.change.RedoAction" text="Redo"/>
     <action id="VimUndo" class="com.maddyhome.idea.vim.action.change.UndoAction" text="Undo"/>
 
+    <!-- Comments -->
+    <action id="VimCommentLine" class="com.maddyhome.idea.vim.action.change.comment.CommentLineAction" text="Comment Motion"/>
+    <action id="VimCommentMotion" class="com.maddyhome.idea.vim.action.change.comment.CommentMotionAction" text="Comment Motion"/>
+
     <!-- Keys -->
     <action id="VimShortcutKeyAction" class="com.maddyhome.idea.vim.action.VimShortcutKeyAction" text="Vim Shortcuts"/>
   </actions>

--- a/src/com/maddyhome/idea/vim/RegisterActions.java
+++ b/src/com/maddyhome/idea/vim/RegisterActions.java
@@ -543,8 +543,8 @@ public class RegisterActions {
       .registerAction(MappingMode.N, "VimChangeCharacters", Command.Type.CHANGE, Command.FLAG_NO_REPEAT | Command.FLAG_MULTIKEY_UNDO,
                       new Shortcut('s'));
     parser
-      .registerAction(MappingMode.N, "VimChangeEndOfLine", Command.Type.CHANGE, Command.FLAG_NO_REPEAT | Command.FLAG_MULTIKEY_UNDO,
-                      new Shortcut('C'));
+      .registerAction(MappingMode.N, "VimChangeEndOfLine", Command.Type.CHANGE,
+                      Command.FLAG_NO_REPEAT | Command.FLAG_MULTIKEY_UNDO, new Shortcut('C'));
     parser.registerAction(MappingMode.N, "VimChangeLine", Command.Type.CHANGE,
                           Command.FLAG_NO_REPEAT | Command.FLAG_ALLOW_MID_COUNT | Command.FLAG_MULTIKEY_UNDO, new Shortcut[]{
         new Shortcut("cc"),
@@ -597,8 +597,8 @@ public class RegisterActions {
       .registerAction(MappingMode.N, "VimMotionGotoMark", Command.Type.MOTION, Command.FLAG_MOT_EXCLUSIVE | Command.FLAG_SAVE_JUMP,
                       new Shortcut('`'), Argument.Type.CHARACTER);
     parser
-      .registerAction(MappingMode.N, "VimMotionGotoMarkLine", Command.Type.MOTION, Command.FLAG_MOT_LINEWISE | Command.FLAG_SAVE_JUMP,
-                      new Shortcut('\''), Argument.Type.CHARACTER);
+      .registerAction(MappingMode.N, "VimMotionGotoMarkLine", Command.Type.MOTION,
+                      Command.FLAG_MOT_LINEWISE | Command.FLAG_SAVE_JUMP, new Shortcut('\''), Argument.Type.CHARACTER);
     parser.registerAction(MappingMode.N, "VimMotionGotoMark", Command.Type.MOTION, Command.FLAG_MOT_EXCLUSIVE,
                           new Shortcut("g`"), Argument.Type.CHARACTER);
     parser.registerAction(MappingMode.N, "VimMotionGotoMarkLine", Command.Type.MOTION, Command.FLAG_MOT_LINEWISE,
@@ -620,6 +620,12 @@ public class RegisterActions {
       new Shortcut('u'),
       new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_UNDO, 0))
     });
+
+    // Comment Actions
+    parser.registerAction(MappingMode.N, "VimCommentLine", Command.Type.CHANGE, Command.FLAG_ALLOW_MID_COUNT,
+                          new Shortcut("gcc"));
+    parser.registerAction(MappingMode.N, "VimCommentMotion", Command.Type.CHANGE, Command.FLAG_OP_PEND,
+                          new Shortcut("gc"), Argument.Type.MOTION);
 
     // File Actions
     parser.registerAction(MappingMode.N, "VimFileSaveClose", Command.Type.OTHER_WRITABLE, new Shortcut[]{

--- a/src/com/maddyhome/idea/vim/action/change/comment/CommentLineAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/comment/CommentLineAction.java
@@ -1,0 +1,43 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2014 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.action.change.comment;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.actionSystem.EditorAction;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.Argument;
+import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author dhleong
+ */
+public class CommentLineAction extends EditorAction {
+  public CommentLineAction() {
+    super(new Handler());
+  }
+
+  private static class Handler extends ChangeEditorActionHandler {
+    public boolean execute(@NotNull Editor editor, @NotNull DataContext context, int count, int rawCount, @Nullable Argument argument) {
+      return VimPlugin.getChange().commentLine(editor, count);
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/change/comment/CommentMotionAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/comment/CommentMotionAction.java
@@ -1,0 +1,43 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2014 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.action.change.comment;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.actionSystem.EditorAction;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.Argument;
+import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author dhleong
+ */
+public class CommentMotionAction extends EditorAction {
+  protected CommentMotionAction() {
+    super(new Handler());
+  }
+
+  private static class Handler extends ChangeEditorActionHandler {
+    public boolean execute(@NotNull Editor editor, @NotNull DataContext context, int count, int rawCount, @Nullable Argument argument) {
+      return argument != null && VimPlugin.getChange().commentMotion(editor, context, count, rawCount, argument, false);
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -20,6 +20,9 @@ package com.maddyhome.idea.vim.group;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.intellij.codeInsight.actions.MultiCaretCodeInsightActionHandler;
+import com.intellij.codeInsight.generation.CommentByBlockCommentHandler;
+import com.intellij.codeInsight.generation.CommentByLineCommentHandler;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.DataContext;
@@ -37,6 +40,8 @@ import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CodeStyleSettingsManager;
 import com.maddyhome.idea.vim.EventFacade;
@@ -54,7 +59,10 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.event.KeyEvent;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * Provides all the insert/replace related functionality
@@ -724,7 +732,8 @@ public class ChangeGroup {
   public boolean deleteEndOfLine(@NotNull Editor editor, int count) {
     int offset = VimPlugin.getMotion().moveCaretToLineEndOffset(editor, count - 1, true);
     if (offset != -1) {
-      boolean res = deleteText(editor, new TextRange(editor.getCaretModel().getOffset(), offset), SelectionType.CHARACTER_WISE);
+      boolean res = deleteText(editor, new TextRange(editor.getCaretModel().getOffset(), offset),
+                               SelectionType.CHARACTER_WISE);
       int pos = VimPlugin.getMotion().moveCaretHorizontal(editor, -1, false);
       if (pos != -1) {
         MotionGroup.moveCaret(editor, pos);
@@ -829,15 +838,24 @@ public class ChangeGroup {
       return (EditorHelper.getFileSize(editor) == 0);
     }
 
-    // Delete motion commands that are not linewise become linewise if all the following are true:
-    // 1) The range is across multiple lines
-    // 2) There is only whitespace before the start of the range
-    // 3) There is only whitespace after the end of the range
     final Command motion = argument.getMotion();
     if (motion == null) {
       return false;
     }
-    if (!isChange && (motion.getFlags() & Command.FLAG_MOT_LINEWISE) == 0) {
+    if (!isChange) {
+      makeMotionLinewiseIfAppropriate(editor, range, motion);
+    }
+    return deleteRange(editor, range, SelectionType.fromCommandFlags(motion.getFlags()), isChange);
+  }
+
+  /**
+   * Delete motion commands that are not linewise become linewise if all the following are true:
+   * 1) The range is across multiple lines
+   * 2) There is only whitespace before the start of the range
+   * 3) There is only whitespace after the end of the range
+   */
+  private static void makeMotionLinewiseIfAppropriate(Editor editor, TextRange range, Command motion) {
+    if ((motion.getFlags() & Command.FLAG_MOT_LINEWISE) == 0) {
       LogicalPosition start = editor.offsetToLogicalPosition(range.getStartOffset());
       LogicalPosition end = editor.offsetToLogicalPosition(range.getEndOffset());
       if (start.line != end.line) {
@@ -851,7 +869,6 @@ public class ChangeGroup {
         }
       }
     }
-    return deleteRange(editor, range, SelectionType.fromCommandFlags(motion.getFlags()), isChange);
   }
 
   @Nullable
@@ -1149,6 +1166,59 @@ public class ChangeGroup {
     }
 
     return res;
+  }
+
+  public boolean commentLine(@NotNull Editor editor, int count) {
+    int start = VimPlugin.getMotion().moveCaretToLineStart(editor);
+    int offset = Math.min(VimPlugin.getMotion().moveCaretToLineEndOffset(editor, count - 1, true) + 1,
+                          EditorHelper.getFileSize(editor, true));
+    if (logger.isDebugEnabled()) {
+      logger.debug("start=" + start);
+      logger.debug("offset=" + offset);
+    }
+    if (offset != -1) {
+      return commentRange(editor, new TextRange(start, offset), SelectionType.LINE_WISE);
+    }
+    return false;
+  }
+
+  public boolean commentMotion(@NotNull Editor editor, final DataContext context, int count, int rawCount,
+                               @NotNull final Argument argument, boolean isChange) {
+
+    final TextRange range = getDeleteMotionRange(editor, context, count, rawCount, argument);
+    if (range == null) {
+      return (EditorHelper.getFileSize(editor) == 0);
+    }
+
+    final Command motion = argument.getMotion();
+    if (motion == null) {
+      return false;
+    }
+    makeMotionLinewiseIfAppropriate(editor, range, motion);
+
+    return commentRange(editor, range, SelectionType.fromCommandFlags(motion.getFlags()));
+  }
+
+  private boolean commentRange(Editor editor, TextRange range, SelectionType selectionType) {
+
+    if (CommandState.getInstance(editor).getMode() != CommandState.Mode.VISUAL) {
+      editor.getSelectionModel().setSelection(range.getStartOffset(), range.getEndOffset());
+    }
+
+    final MultiCaretCodeInsightActionHandler handler =
+      selectionType == SelectionType.CHARACTER_WISE
+        ? new CommentByBlockCommentHandler()
+        : new CommentByLineCommentHandler();
+
+    try {
+      PsiFile file = PsiDocumentManager.getInstance(editor.getProject()).getPsiFile(editor.getDocument());
+      handler.invoke(editor.getProject(), editor, editor.getCaretModel().getCurrentCaret(), file);
+      handler.postInvoke();
+      return true;
+    } catch (RuntimeException e) {
+      e.printStackTrace(); // ???
+    }
+    return false;
   }
 
   public boolean blockInsert(@NotNull Editor editor, @NotNull DataContext context, @NotNull TextRange range, boolean append) {

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -1217,6 +1217,9 @@ public class ChangeGroup {
       return true;
     } catch (RuntimeException e) {
       e.printStackTrace(); // ???
+    } finally {
+      // remove the selection
+      editor.getSelectionModel().removeSelection();
     }
     return false;
   }

--- a/test/org/jetbrains/plugins/ideavim/JavaVimTestCase.java
+++ b/test/org/jetbrains/plugins/ideavim/JavaVimTestCase.java
@@ -6,11 +6,13 @@ import com.intellij.openapi.project.Project;
 import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.helper.EditorDataContext;
 import com.maddyhome.idea.vim.helper.RunnableHelper;
 import com.maddyhome.idea.vim.option.Options;
 import com.maddyhome.idea.vim.ui.ExEntryPanel;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.List;
@@ -60,4 +62,15 @@ public class JavaVimTestCase extends JavaCodeInsightFixtureTestCase {
     }, null, null);
     myFixture.checkResult(after);
   }
+
+  public void assertMode(@NotNull CommandState.Mode expectedMode) {
+    final CommandState.Mode mode = CommandState.getInstance(myFixture.getEditor()).getMode();
+    assertEquals(expectedMode, mode);
+  }
+
+  public void assertSelection(@Nullable String expected) {
+    final String selected = myFixture.getEditor().getSelectionModel().getSelectedText();
+    assertEquals(expected, selected);
+  }
+
 }

--- a/test/org/jetbrains/plugins/ideavim/JavaVimTestCase.java
+++ b/test/org/jetbrains/plugins/ideavim/JavaVimTestCase.java
@@ -1,0 +1,63 @@
+package org.jetbrains.plugins.ideavim;
+
+import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase;
+import com.maddyhome.idea.vim.KeyHandler;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.helper.EditorDataContext;
+import com.maddyhome.idea.vim.helper.RunnableHelper;
+import com.maddyhome.idea.vim.option.Options;
+import com.maddyhome.idea.vim.ui.ExEntryPanel;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.List;
+
+/**
+ * NB: We need to extend from JavaCodeInsightFixtureTestCase so we
+ *  can create PsiFiles with proper Java Language type
+ * @author dhleong
+ */
+public class JavaVimTestCase extends JavaCodeInsightFixtureTestCase {
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    KeyHandler.getInstance().fullReset(myFixture.getEditor());
+    Options.getInstance().resetAllOptions();
+    VimPlugin.getKey().resetKeyMappings();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+    ExEntryPanel.getInstance().deactivate(false);
+  }
+
+  @NotNull
+  protected Editor configureByJavaText(@NotNull String content) {
+    myFixture.configureByText(JavaFileType.INSTANCE, content);
+    return myFixture.getEditor();
+  }
+
+  public void doTest(final List<KeyStroke> keys, String before, String after) {
+
+    configureByJavaText(before);
+    final Editor editor = myFixture.getEditor();
+    final KeyHandler keyHandler = KeyHandler.getInstance();
+    final EditorDataContext dataContext = new EditorDataContext(editor);
+    final Project project = myFixture.getProject();
+
+    RunnableHelper.runWriteCommand(project, new Runnable() {
+      @Override
+      public void run() {
+        for (KeyStroke key : keys) {
+          keyHandler.handleKey(editor, key, dataContext);
+        }
+      }
+    }, null, null);
+    myFixture.checkResult(after);
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/VimTestCase.java
+++ b/test/org/jetbrains/plugins/ideavim/VimTestCase.java
@@ -41,16 +41,25 @@ public abstract class VimTestCase extends UsefulTestCase {
   protected void setUp() throws Exception {
     super.setUp();
     final IdeaTestFixtureFactory factory = IdeaTestFixtureFactory.getFixtureFactory();
-    final LightProjectDescriptor projectDescriptor = LightProjectDescriptor.EMPTY_PROJECT_DESCRIPTOR;
+    final LightProjectDescriptor projectDescriptor = createProjectDescriptor();
     final TestFixtureBuilder<IdeaProjectTestFixture> fixtureBuilder = factory.createLightFixtureBuilder(projectDescriptor);
     final IdeaProjectTestFixture fixture = fixtureBuilder.getFixture();
-    myFixture = IdeaTestFixtureFactory.getFixtureFactory().createCodeInsightFixture(fixture,
-                                                                                    new LightTempDirTestFixtureImpl(true));
+    myFixture = createCodeInsightFixture(fixture, new LightTempDirTestFixtureImpl(true));
     myFixture.setUp();
     myFixture.setTestDataPath(getTestDataPath());
     KeyHandler.getInstance().fullReset(myFixture.getEditor());
     Options.getInstance().resetAllOptions();
     VimPlugin.getKey().resetKeyMappings();
+  }
+
+  protected LightProjectDescriptor createProjectDescriptor() {
+    return LightProjectDescriptor.EMPTY_PROJECT_DESCRIPTOR;
+  }
+
+  protected CodeInsightTestFixture createCodeInsightFixture(IdeaProjectTestFixture fixture,
+                                                            LightTempDirTestFixtureImpl lightTempDirTestFixture) {
+    return IdeaTestFixtureFactory.getFixtureFactory()
+      .createCodeInsightFixture(fixture, lightTempDirTestFixture);
   }
 
   protected String getTestDataPath() {

--- a/test/org/jetbrains/plugins/ideavim/action/CommentActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/CommentActionTest.java
@@ -1,0 +1,98 @@
+package org.jetbrains.plugins.ideavim.action;
+
+import org.jetbrains.plugins.ideavim.JavaVimTestCase;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * @author dhleong
+ */
+public class CommentActionTest extends JavaVimTestCase {
+
+
+  // |gc| |iw|
+  public void testBlockCommentInnerWord() {
+    doTest(parseKeys("gciw"),
+           "<caret>if (condition) {\n" + "}\n",
+           "/*if*/ (condition) {\n" + "}\n");
+  }
+
+  // |gc| |iw|
+  public void testBlockCommentTillForward() {
+    doTest(parseKeys("gct{"),
+           "<caret>if (condition) {\n" + "}\n",
+           "/*if (condition) */{\n" + "}\n");
+  }
+
+  // |gc| |ab|
+  public void testBlockCommentOuterParens() {
+    doTest(parseKeys("gcab"),
+           "if (<caret>condition) {\n" + "}\n",
+           "if /*(condition)*/ {\n" + "}\n");
+  }
+
+  /*
+   * NB: linewise motions become linewise comments;
+   *  otherwise, they are incredibly difficult to undo
+   */
+
+  // |gc| |j|
+  public void testLineCommentDown() {
+    doTest(parseKeys("gcj"),
+           "<caret>if (condition) {\n" + "}\n",
+           "//if (condition) {\n" +
+           "//}\n");
+  }
+
+  // |gc| |ip|
+  public void testLineCommentInnerParagraph() {
+    doTest(parseKeys("gcip"),
+           "<caret>if (condition) {\n" + "}\n",
+           "//if (condition) {\n" +
+           "//}\n");
+  }
+
+  // |gc| |ip|
+  public void testLineCommentSingleLineInnerParagraph() {
+    doTest(parseKeys("gcip"),
+           "<caret>if (condition) {}",
+           "//if (condition) {}");
+  }
+
+  /* Ensure uncommenting works as well */
+
+  // |gc| |ip|
+  public void testLineUncommentInnerParagraph() {
+    doTest(parseKeys("gcip"),
+           "<caret>//if (condition) {\n" + "//}\n",
+           "if (condition) {\n" +
+           "}\n");
+  }
+
+  // |gc| |ip|
+  public void testLineUncommentSingleLineInnerParagraph() {
+    doTest(parseKeys("gcip"),
+           "<caret>//if (condition) {}",
+           "if (condition) {}");
+  }
+
+  /* Special shortcut gcc is always linewise */
+
+  // |gcc|
+  public void testLineCommentShortcut() {
+    doTest(parseKeys("gcc"),
+           "<caret>if (condition) {\n" + "}\n",
+           "//if (condition) {\n" +
+           "}\n");
+  }
+
+  // |gcc|
+  public void testLineUncommentShortcut() {
+    doTest(parseKeys("gcc"),
+           "<caret>//if (condition) {\n" + "}\n",
+           "if (condition) {\n" + "}\n");
+  }
+
+
+
+}

--- a/test/org/jetbrains/plugins/ideavim/action/CommentActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/CommentActionTest.java
@@ -3,18 +3,20 @@ package org.jetbrains.plugins.ideavim.action;
 import org.jetbrains.plugins.ideavim.JavaVimTestCase;
 
 import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+import static com.maddyhome.idea.vim.command.CommandState.Mode.COMMAND;
 
 /**
  * @author dhleong
  */
 public class CommentActionTest extends JavaVimTestCase {
 
-
   // |gc| |iw|
   public void testBlockCommentInnerWord() {
     doTest(parseKeys("gciw"),
            "<caret>if (condition) {\n" + "}\n",
            "/*if*/ (condition) {\n" + "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
   }
 
   // |gc| |iw|
@@ -67,6 +69,8 @@ public class CommentActionTest extends JavaVimTestCase {
            "<caret>//if (condition) {\n" + "//}\n",
            "if (condition) {\n" +
            "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
   }
 
   // |gc| |ip|
@@ -84,6 +88,8 @@ public class CommentActionTest extends JavaVimTestCase {
            "<caret>if (condition) {\n" + "}\n",
            "//if (condition) {\n" +
            "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
   }
 
   // |gcc|
@@ -91,6 +97,8 @@ public class CommentActionTest extends JavaVimTestCase {
     doTest(parseKeys("gcc"),
            "<caret>//if (condition) {\n" + "}\n",
            "if (condition) {\n" + "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
   }
 
 


### PR DESCRIPTION
Character-wise motions use block comments, and line-wise ones
use line-wise comments, mostly because IntelliJ isn't good at
removing blockwise comments with the shortcut.

Also accepts `gcc` which does a linewise comment on current line