### PR TITLE
VIM-769 Support for vim-surround

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -363,6 +363,8 @@
     <action id="VimRedo" class="com.maddyhome.idea.vim.action.change.RedoAction" text="Redo"/>
     <action id="VimUndo" class="com.maddyhome.idea.vim.action.change.UndoAction" text="Undo"/>
 
+    <action id="VimSurroundMotion" class="com.maddyhome.idea.vim.action.plugin.surround.SurroundMotionAction" text="Surround" />
+
     <!-- Keys -->
     <action id="VimShortcutKeyAction" class="com.maddyhome.idea.vim.action.VimShortcutKeyAction" text="Vim Shortcuts"/>
   </actions>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -364,6 +364,7 @@
     <action id="VimUndo" class="com.maddyhome.idea.vim.action.change.UndoAction" text="Undo"/>
 
     <action id="VimSurroundMotion" class="com.maddyhome.idea.vim.action.plugin.surround.SurroundMotionAction" text="Surround" />
+    <action id="VimChangeSurrounding" class="com.maddyhome.idea.vim.action.plugin.surround.ChangeSurroundingAction" text="Change Surround" />
     <action id="VimDeleteSurrounding" class="com.maddyhome.idea.vim.action.plugin.surround.DeleteSurroundingAction" text="Delete Surround" />
 
     <!-- Keys -->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -364,6 +364,7 @@
     <action id="VimUndo" class="com.maddyhome.idea.vim.action.change.UndoAction" text="Undo"/>
 
     <action id="VimSurroundMotion" class="com.maddyhome.idea.vim.action.plugin.surround.SurroundMotionAction" text="Surround" />
+    <action id="VimDeleteSurrounding" class="com.maddyhome.idea.vim.action.plugin.surround.DeleteSurroundingAction" text="Delete Surround" />
 
     <!-- Keys -->
     <action id="VimShortcutKeyAction" class="com.maddyhome.idea.vim.action.VimShortcutKeyAction" text="Vim Shortcuts"/>

--- a/src/com/maddyhome/idea/vim/GetCharListener.java
+++ b/src/com/maddyhome/idea/vim/GetCharListener.java
@@ -1,0 +1,11 @@
+package com.maddyhome.idea.vim;
+
+import javax.swing.*;
+
+/**
+ * @author dhleong
+ */
+public interface GetCharListener {
+
+  void onCharTyped(KeyStroke key, char chKey);
+}

--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -606,6 +606,16 @@ public class KeyHandler {
   }
 
   /**
+   * Check if the given keystroke was a "cancel";
+   *  pressing escape or ctrl-c constitutes a "cancel."
+   */
+  public static boolean isCancelStroke(KeyStroke key) {
+    return key.getKeyCode() == KeyEvent.VK_ESCAPE
+           || ((key.getModifiers() | KeyEvent.CTRL_DOWN_MASK) == KeyEvent.CTRL_DOWN_MASK
+               && key.getKeyCode() == KeyEvent.VK_C);
+  }
+
+  /**
    * Partially resets the state of this handler. Resets the command count, clears the key list, resets the key tree
    * node to the root for the current mode we are in.
    *

--- a/src/com/maddyhome/idea/vim/RegisterActions.java
+++ b/src/com/maddyhome/idea/vim/RegisterActions.java
@@ -20,7 +20,6 @@ package com.maddyhome.idea.vim;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx;
 import com.maddyhome.idea.vim.action.VimCommandAction;
-import com.maddyhome.idea.vim.action.plugin.Plugin;
 import com.maddyhome.idea.vim.command.Argument;
 import com.maddyhome.idea.vim.command.Command;
 import com.maddyhome.idea.vim.command.MappingMode;
@@ -36,11 +35,6 @@ public class RegisterActions {
    */
   public static void registerActions() {
 
-    // register plugins first in case they
-    //  override default behavior (this is
-    //  unintuitive coming from vim...)
-    Plugin.Registrar.registerActions();
-
     registerVimCommandActions();
 
     registerInsertModeActions();
@@ -48,6 +42,7 @@ public class RegisterActions {
     registerNVOModesActions();
     registerCommandLineActions();
     registerVariousModesActions();
+
   }
 
   private static void registerVimCommandActions() {

--- a/src/com/maddyhome/idea/vim/RegisterActions.java
+++ b/src/com/maddyhome/idea/vim/RegisterActions.java
@@ -20,6 +20,7 @@ package com.maddyhome.idea.vim;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx;
 import com.maddyhome.idea.vim.action.VimCommandAction;
+import com.maddyhome.idea.vim.action.plugin.Plugin;
 import com.maddyhome.idea.vim.command.Argument;
 import com.maddyhome.idea.vim.command.Command;
 import com.maddyhome.idea.vim.command.MappingMode;
@@ -34,6 +35,12 @@ public class RegisterActions {
    * Register all the key/action mappings for the plugin.
    */
   public static void registerActions() {
+
+    // register plugins first in case they
+    //  override default behavior (this is
+    //  unintuitive coming from vim...)
+    Plugin.Registrar.registerActions();
+
     registerVimCommandActions();
 
     registerInsertModeActions();

--- a/src/com/maddyhome/idea/vim/action/plugin/Plugin.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/Plugin.java
@@ -20,10 +20,11 @@ public interface Plugin {
       new SurroundPlugin()
     };
 
+    /** Probably, just registerActions(String) is fine */
+    @Deprecated
     public static void registerActions() {
       final KeyGroup parser = VimPlugin.getKey();
       for (Plugin plugin : plugins) {
-        System.out.println("REGISTER! " + plugin.getOptionName());
         if (Options.getInstance().isSet(plugin.getOptionName())) {
           plugin.registerActions(parser);
         }
@@ -35,8 +36,18 @@ public interface Plugin {
       for (Plugin plugin : plugins) {
         optionNames.add(plugin.getOptionName());
       }
-      System.out.println("CREATE " + optionNames);
       return optionNames;
+    }
+
+    public static void registerActions(String name) {
+      // TODO put these in a map
+      final KeyGroup parser = VimPlugin.getKey();
+      for (Plugin plugin : plugins) {
+        if (name.equals(plugin.getOptionName())) {
+          plugin.registerActions(parser);
+          return;
+        }
+      }
     }
   }
 

--- a/src/com/maddyhome/idea/vim/action/plugin/Plugin.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/Plugin.java
@@ -1,0 +1,60 @@
+package com.maddyhome.idea.vim.action.plugin;
+
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.action.plugin.surround.SurroundPlugin;
+import com.maddyhome.idea.vim.group.KeyGroup;
+import com.maddyhome.idea.vim.option.Options;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author dhleong
+ */
+public interface Plugin {
+
+  class Registrar {
+    // register plugins here
+    // Is there a more idiomatic way of doing this?
+    static final Plugin[] plugins = new Plugin[] {
+      new SurroundPlugin()
+    };
+
+    public static void registerActions() {
+      final KeyGroup parser = VimPlugin.getKey();
+      for (Plugin plugin : plugins) {
+        System.out.println("REGISTER! " + plugin.getOptionName());
+        if (Options.getInstance().isSet(plugin.getOptionName())) {
+          plugin.registerActions(parser);
+        }
+      }
+    }
+
+    public static Iterable<String> getOptionNames() {
+      List<String> optionNames = new ArrayList<String>();
+      for (Plugin plugin : plugins) {
+        optionNames.add(plugin.getOptionName());
+      }
+      System.out.println("CREATE " + optionNames);
+      return optionNames;
+    }
+  }
+
+  /**
+   * Since plugins are built into IdeaVim, they are
+   *  enabled with options. For example, the Surround
+   *  plugin is called <code>surround</code>, so you
+   *  would enable it with `set surround` in your .ideavimrc
+   *
+   * @return The name of the option
+   *  used to enable this plugin
+   */
+  String getOptionName();
+
+  /**
+   * Hook called if your plugin is enabled
+   *
+   * @param parser The KeyGroup on which to register actions
+   */
+  void registerActions(final KeyGroup parser);
+}

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/ChangeSurroundingAction.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/ChangeSurroundingAction.java
@@ -1,0 +1,65 @@
+package com.maddyhome.idea.vim.action.plugin.surround;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.actionSystem.EditorAction;
+import com.maddyhome.idea.vim.GetCharListener;
+import com.maddyhome.idea.vim.KeyHandler;
+import com.maddyhome.idea.vim.command.Argument;
+import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.event.KeyEvent;
+
+/**
+ * @author dhleong
+ */
+public class ChangeSurroundingAction extends EditorAction {
+  protected ChangeSurroundingAction() {
+    super(new Handler());
+  }
+
+  private static class Handler extends ChangeEditorActionHandler {
+    @Override
+    public boolean execute(@NotNull final Editor editor,
+                           @NotNull DataContext context,
+                           int count,
+                           int rawCount,
+                           @Nullable final Argument argument) {
+
+      if (argument == null) {
+        return false;
+      }
+
+      // TODO make this repeatable by saving the char somewhere?
+      KeyHandler.getInstance().getChar(new GetCharListener() {
+        @Override
+        public void onCharTyped(KeyStroke key, char chKey) {
+          if (key.getKeyCode() == KeyEvent.VK_ESCAPE
+              || ((key.getModifiers() | KeyEvent.CTRL_DOWN_MASK) == KeyEvent.CTRL_DOWN_MASK
+                  && key.getKeyCode() == KeyEvent.VK_C)) {
+            // action canceled
+            return;
+          }
+
+          PairExtractor.extract(chKey, new PairExtractor.PairListener() {
+            @Override
+            public void onPair(SurroundPair pair) {
+
+              KeyHandler.getInstance().reset(editor);
+
+              // now, perform the change!
+              final char chKey = argument.getCharacter();
+
+              SurroundingChanger.change(editor, chKey, pair);
+            }
+          });
+        }
+      });
+
+      return true;
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/ChangeSurroundingAction.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/ChangeSurroundingAction.java
@@ -3,15 +3,16 @@ package com.maddyhome.idea.vim.action.plugin.surround;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.actionSystem.EditorAction;
+import com.intellij.openapi.util.text.StringUtil;
 import com.maddyhome.idea.vim.GetCharListener;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.command.Argument;
-import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler;
+import com.maddyhome.idea.vim.command.Command;
+import com.maddyhome.idea.vim.command.CommandState;
+import com.maddyhome.idea.vim.handler.EditorActionHandlerBase;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.awt.event.KeyEvent;
 
 /**
  * @author dhleong
@@ -21,45 +22,55 @@ public class ChangeSurroundingAction extends EditorAction {
     super(new Handler());
   }
 
-  private static class Handler extends ChangeEditorActionHandler {
-    @Override
-    public boolean execute(@NotNull final Editor editor,
-                           @NotNull DataContext context,
-                           int count,
-                           int rawCount,
-                           @Nullable final Argument argument) {
+  private static class Handler extends EditorActionHandlerBase {
 
+    @Override
+    protected final boolean execute(@NotNull final Editor editor, @NotNull DataContext context, @NotNull final Command cmd) {
+      final Argument argument = cmd.getArgument();
       if (argument == null) {
         return false;
       }
 
-      // TODO make this repeatable by saving the char somewhere?
-      KeyHandler.getInstance().getChar(new GetCharListener() {
-        @Override
-        public void onCharTyped(KeyStroke key, char chKey) {
-          if (key.getKeyCode() == KeyEvent.VK_ESCAPE
-              || ((key.getModifiers() | KeyEvent.CTRL_DOWN_MASK) == KeyEvent.CTRL_DOWN_MASK
-                  && key.getKeyCode() == KeyEvent.VK_C)) {
-            // action canceled
-            return;
+      if (argument.getType() == Argument.Type.STRING
+          && StringUtil.length(argument.getString()) == 2) {
+        // repeat previous command
+        final String parts = argument.getString();
+        assert parts != null;
+        performChange(editor, parts.charAt(0), parts.charAt(1));
+        CommandState.getInstance(editor).saveLastChangeCommand(cmd);
+      } else {
+
+        KeyHandler.getInstance().getChar(new GetCharListener() {
+          @Override
+          public void onCharTyped(KeyStroke key, char chKey) {
+            if (KeyHandler.isCancelStroke(key)) {
+              return;
+            }
+
+            performChange(editor, argument.getCharacter(), chKey);
+
+            // make this repeatable by replacing the char arg with a 2-char str
+            // NB: If performChange requests more chars (as in `t`) then
+            //  this will not be sufficient to repeat the command
+            cmd.setArgument(new Argument("" + argument.getCharacter() + chKey));
+            CommandState.getInstance(editor).saveLastChangeCommand(cmd);
           }
 
-          PairExtractor.extract(chKey, new PairExtractor.PairListener() {
-            @Override
-            public void onPair(SurroundPair pair) {
-
-              KeyHandler.getInstance().reset(editor);
-
-              // now, perform the change!
-              final char chKey = argument.getCharacter();
-
-              SurroundingChanger.change(editor, chKey, pair);
-            }
-          });
-        }
-      });
+        });
+      }
 
       return true;
+    }
+
+    private void performChange(
+        final Editor editor, final char charFrom, final char charTo) {
+      PairExtractor.extract(charTo, new PairExtractor.PairListener() {
+        @Override
+        public void onPair(SurroundPair pair) {
+          // now, perform the change!
+          SurroundingChanger.change(editor, charFrom, pair);
+        }
+      });
     }
   }
 }

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/DeleteSurroundingAction.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/DeleteSurroundingAction.java
@@ -3,7 +3,6 @@ package com.maddyhome.idea.vim.action.plugin.surround;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.actionSystem.EditorAction;
-import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.command.Argument;
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler;
 import org.jetbrains.annotations.NotNull;
@@ -29,11 +28,7 @@ public class DeleteSurroundingAction extends EditorAction {
         return false;
       }
 
-      KeyHandler.getInstance().reset(editor);
-
-      // In a lot of cases, vim-surround seems to
-      //  implement this by using di<c> to get the
-      //  part to save, then basically da<c>P
+      // easy; deletion is changing the surroundings to be nothing
       final char chKey = argument.getCharacter();
       return SurroundingChanger.change(editor, chKey, null);
     }

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/DeleteSurroundingAction.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/DeleteSurroundingAction.java
@@ -1,0 +1,41 @@
+package com.maddyhome.idea.vim.action.plugin.surround;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.actionSystem.EditorAction;
+import com.maddyhome.idea.vim.KeyHandler;
+import com.maddyhome.idea.vim.command.Argument;
+import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author dhleong
+ */
+public class DeleteSurroundingAction extends EditorAction {
+  protected DeleteSurroundingAction() {
+    super(new Handler());
+  }
+
+  private static class Handler extends ChangeEditorActionHandler {
+    @Override
+    public boolean execute(@NotNull Editor editor,
+                           @NotNull DataContext context,
+                           int count,
+                           int rawCount,
+                           @Nullable Argument argument) {
+
+      if (argument == null) {
+        return false;
+      }
+
+      KeyHandler.getInstance().reset(editor);
+
+      // In a lot of cases, vim-surround seems to
+      //  implement this by using di<c> to get the
+      //  part to save, then basically da<c>P
+      final char chKey = argument.getCharacter();
+      return SurroundingChanger.change(editor, chKey, null);
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/PairExtractor.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/PairExtractor.java
@@ -1,0 +1,56 @@
+package com.maddyhome.idea.vim.action.plugin.surround;
+
+/**
+ *
+ * @author dhleong
+ */
+public abstract class PairExtractor {
+
+  public interface PairListener {
+    void onPair(SurroundPair pair);
+  }
+
+  static PairExtractor[] handlers = new PairExtractor[] {
+    // Should we make these proper classes?
+    new PairExtractor("b()B{}r[]a<>") {
+      @Override
+      void handle(char chKey, PairListener notify) {
+
+        final int index = matchingChars.indexOf(chKey);
+        final String spc = (index % 3) == 1 ? " " : "";
+        final int idx = index / 3 * 3;
+        final String before = matchingChars.charAt(idx + 1) + spc;
+        final String after  = spc + matchingChars.charAt(idx + 2);
+
+        notify.onPair(new SurroundPair(before, after));
+      }
+    }
+  };
+
+
+  String matchingChars;
+
+  PairExtractor(String matchingChars) {
+    this.matchingChars = matchingChars;
+  }
+
+  abstract void handle(char chKey, PairListener notify);
+
+  public static void extract(char chKey, PairListener listener) {
+
+    // should we index into a map here?
+    for (PairExtractor extractor : handlers) {
+      if (-1 != extractor.matchingChars.indexOf(chKey)) {
+        extractor.handle(chKey, listener);
+        return;
+      }
+    }
+
+    // default:
+    if (Character.isLetter(chKey)) {
+      listener.onPair(new SurroundPair(chKey, chKey));
+    }
+
+    // else nothing, I guess
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/PairExtractor.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/PairExtractor.java
@@ -47,7 +47,7 @@ public abstract class PairExtractor {
     }
 
     // default:
-    if (Character.isLetter(chKey)) {
+    if (!Character.isLetter(chKey)) {
       listener.onPair(new SurroundPair(chKey, chKey));
     }
 

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundMotionAction.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundMotionAction.java
@@ -1,0 +1,95 @@
+package com.maddyhome.idea.vim.action.plugin.surround;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.actionSystem.EditorAction;
+import com.maddyhome.idea.vim.GetCharListener;
+import com.maddyhome.idea.vim.KeyHandler;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.Argument;
+import com.maddyhome.idea.vim.command.Command;
+import com.maddyhome.idea.vim.common.TextRange;
+import com.maddyhome.idea.vim.group.ChangeGroup;
+import com.maddyhome.idea.vim.group.MotionGroup;
+import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.event.KeyEvent;
+
+/**
+ * @author dhleong
+ */
+public class SurroundMotionAction extends EditorAction {
+
+
+  public SurroundMotionAction() {
+    super(new Handler());
+  }
+
+  private static class Handler extends ChangeEditorActionHandler {
+
+    @Override
+    public boolean execute(@NotNull final Editor editor,
+                           @NotNull final DataContext context,
+                           final int count,
+                           final int rawCount,
+                           @Nullable final Argument argument) {
+
+      final Command motion = argument.getMotion();
+      if (motion == null) {
+        return false;
+      }
+
+      KeyHandler.getInstance().getChar(new GetCharListener() {
+        @Override
+        public void onCharTyped(KeyStroke key, char chKey) {
+          if (key.getKeyCode() == KeyEvent.VK_ESCAPE
+              || ((key.getModifiers() | KeyEvent.CTRL_DOWN_MASK) == KeyEvent.CTRL_DOWN_MASK
+                  && key.getKeyCode() == KeyEvent.VK_C)) {
+            // action canceled
+            System.out.println(key);
+            return;
+          }
+
+          final VimSurrounder surrounder =
+            new VimSurrounder(editor, context, count, rawCount, argument);
+          PairExtractor.extract(chKey, surrounder);
+        }
+      });
+
+      return true;
+    }
+  }
+
+
+  static class VimSurrounder implements PairExtractor.PairListener {
+
+    private final Editor myEditor;
+    private final DataContext myContext;
+    private final int myCount;
+    private final int myRawCount;
+    private final Argument myArgument;
+
+    public VimSurrounder(Editor editor, DataContext context, int count, int rawCount, Argument argument) {
+      myEditor = editor;
+      myContext = context;
+      myCount = count;
+      myRawCount = rawCount;
+      myArgument = argument;
+    }
+
+    @Override
+    public void onPair(SurroundPair pair) {
+      final TextRange range = MotionGroup.getMotionRange(
+        myEditor, myContext, myCount, myRawCount, myArgument, true);
+
+      final int before = range.getStartOffset();
+      final int after = range.getEndOffset();
+      final ChangeGroup change = VimPlugin.getChange();
+      change.insertText(myEditor, after, pair.after);
+      change.insertText(myEditor, before, pair.before);
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundMotionAction.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundMotionAction.java
@@ -61,8 +61,11 @@ public class SurroundMotionAction extends EditorAction {
             // save the argument so we can be repeated
             // NB: This would not be sufficient if the pair
             //  requests further characters (like `t`)
-            Command current = CommandState.getInstance(editor).getCommand();
-            current.setArgument(new SurroundMotionArgument(motion, chKey));
+            final Command current = CommandState.getInstance(editor).getCommand();
+            if (current != null) {
+              // it shouldn't be null...
+              current.setArgument(new SurroundMotionArgument(motion, chKey));
+            }
           }
         });
 

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundMotionAction.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundMotionAction.java
@@ -23,8 +23,6 @@ import java.awt.event.KeyEvent;
  * @author dhleong
  */
 public class SurroundMotionAction extends EditorAction {
-
-
   public SurroundMotionAction() {
     super(new Handler());
   }
@@ -51,7 +49,6 @@ public class SurroundMotionAction extends EditorAction {
               || ((key.getModifiers() | KeyEvent.CTRL_DOWN_MASK) == KeyEvent.CTRL_DOWN_MASK
                   && key.getKeyCode() == KeyEvent.VK_C)) {
             // action canceled
-            System.out.println(key);
             return;
           }
 

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPair.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPair.java
@@ -1,0 +1,22 @@
+package com.maddyhome.idea.vim.action.plugin.surround;
+
+/**
+ * @author dhleong
+ */
+class SurroundPair {
+  final String before, after;
+
+  SurroundPair(String before, String after) {
+    this.before = before;
+    this.after = after;
+  }
+
+  public SurroundPair(char before, char after) {
+    this(String.valueOf(before), String.valueOf(after));
+  }
+
+  @Override
+  public String toString() {
+    return "before=" + before + "  after=" + after;
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPlugin.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPlugin.java
@@ -1,0 +1,28 @@
+package com.maddyhome.idea.vim.action.plugin.surround;
+
+import com.maddyhome.idea.vim.action.plugin.Plugin;
+import com.maddyhome.idea.vim.command.Argument;
+import com.maddyhome.idea.vim.command.Command;
+import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.group.KeyGroup;
+import com.maddyhome.idea.vim.key.Shortcut;
+
+/**
+ * @author dhleong
+ */
+public class SurroundPlugin implements Plugin {
+
+  public static final String NAME = "surround";
+
+  @Override
+  public String getOptionName() {
+    return NAME;
+  }
+
+  @Override
+  public void registerActions(KeyGroup parser) {
+    System.out.println("REGISTER! ");
+    parser.registerAction(MappingMode.N, "VimSurroundMotion", Command.Type.CHANGE, Command.FLAG_OP_PEND,
+                          new Shortcut("ys"), Argument.Type.MOTION);
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPlugin.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPlugin.java
@@ -21,7 +21,6 @@ public class SurroundPlugin implements Plugin {
 
   @Override
   public void registerActions(KeyGroup parser) {
-    System.out.println("REGISTER! ");
     parser.registerAction(MappingMode.N, "VimSurroundMotion", Command.Type.CHANGE, Command.FLAG_OP_PEND,
                           new Shortcut("ys"), Argument.Type.MOTION);
   }

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPlugin.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPlugin.java
@@ -24,6 +24,8 @@ public class SurroundPlugin implements Plugin {
   public void registerActions(KeyGroup parser) {
     parser.registerAction(MappingMode.N, "VimSurroundMotion", Command.Type.CHANGE, Command.FLAG_OP_PEND,
                           new Shortcut("ys"), Argument.Type.MOTION);
+    parser.registerAction(MappingMode.N, "VimChangeSurrounding", Command.Type.DELETE,
+                          new Shortcut("cs"), Argument.Type.CHARACTER);
     parser.registerAction(MappingMode.N, "VimDeleteSurrounding", Command.Type.DELETE,
                           new Shortcut("ds"), Argument.Type.CHARACTER);
   }

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPlugin.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundPlugin.java
@@ -20,8 +20,11 @@ public class SurroundPlugin implements Plugin {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public void registerActions(KeyGroup parser) {
     parser.registerAction(MappingMode.N, "VimSurroundMotion", Command.Type.CHANGE, Command.FLAG_OP_PEND,
                           new Shortcut("ys"), Argument.Type.MOTION);
+    parser.registerAction(MappingMode.N, "VimDeleteSurrounding", Command.Type.DELETE,
+                          new Shortcut("ds"), Argument.Type.CHARACTER);
   }
 }

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundingChanger.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundingChanger.java
@@ -1,0 +1,148 @@
+package com.maddyhome.idea.vim.action.plugin.surround;
+
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.KeyHandler;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.common.Register;
+import com.maddyhome.idea.vim.helper.EditorDataContext;
+import com.maddyhome.idea.vim.helper.RunnableHelper;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.List;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * The SurroundingChanger works in three steps,
+ *    based on the original vim-surround:
+ *
+ *  1. Extract inner
+ *    Copy the contents "inside" the surrounding
+ *    indicated by the given key. This may be performed
+ *    by deleting them, but is not necessary
+ *
+ *  2. Remove outer
+ *    Delete the contents "outside" the surrounding
+ *    (in the vim sense, that is the "inside" plus
+ *    the surrounding).
+ *
+ *  3. Paste Surrounded
+ *    If desired, surround the copied "inside" contents
+ *    in some way, then paste it into place
+ *
+ * @author dhleong
+ */
+public abstract class SurroundingChanger {
+
+  static SurroundingChanger[] CHANGERS = {
+    new PunctualChanger()
+  };
+
+  /** Handles punctuation and xml tags */
+  static class PunctualChanger extends SurroundingChanger {
+
+    static final String ACCEPTS = "b()B{}r[]a<>`'\"t";
+
+    @Override
+    boolean handles(char chKey) {
+      return -1 != ACCEPTS.indexOf(chKey);
+    }
+
+    @Override
+    public List<KeyStroke> extractInner(Editor editor, char chKey) {
+      perform(editor, "\"" + REGISTER + "di" + chKey);
+      return getContentsOf(REGISTER);
+    }
+
+    @Override
+    public void removeOuter(Editor editor, char chKey) {
+      perform(editor, "\"" + REGISTER + "da" + chKey);
+    }
+
+    @Override
+    public void pasteSurrounded(Editor editor) {
+      perform(editor, "\"" + REGISTER + "P");
+    }
+  }
+
+  abstract boolean handles(char chKey);
+  public abstract List<KeyStroke> extractInner(Editor editor, char chKey);
+  public abstract void removeOuter(Editor editor, char chKey);
+  public abstract void pasteSurrounded(Editor editor);
+
+  private static void performChange(
+      final Editor editor, final char chKey, @Nullable final String surround,
+      final SurroundingChanger changer) {
+
+    RunnableHelper.runWriteCommand(editor.getProject(), new Runnable() {
+      @Override
+      public void run() {
+        // we take over the " register, so preserve it
+        final List<KeyStroke> oldValue = getContentsOf(REGISTER);
+
+        // extract inner
+        final List<KeyStroke> innerValue = changer.extractInner(editor, chKey);
+
+        // delete the surrounding
+        changer.removeOuter(editor, chKey);
+
+        // paste the innerValue
+        if (surround != null) {
+          List<KeyStroke> surrounding = parseKeys(surround);
+          innerValue.addAll(0, surrounding);
+          innerValue.addAll(surrounding);
+        }
+        setContentsOf(REGISTER, innerValue);
+        changer.pasteSurrounded(editor);
+
+        // restore the old value
+        setContentsOf(REGISTER, oldValue);
+      }
+    }, null, null);
+  }
+
+  static List<KeyStroke> getContentsOf(char register) {
+    final Register reg = VimPlugin.getRegister().getRegister(register);
+    if (reg == null) {
+      return null;
+    }
+    return reg.getKeys();
+  }
+
+  static void setContentsOf(char register, List<KeyStroke> keys) {
+    if (keys == null) {
+      return;
+    }
+
+    VimPlugin.getRegister().setKeys(register, keys);
+  }
+
+  static void perform(final Editor editor, final String sequence) {
+    final EditorDataContext dataContext =
+      new EditorDataContext(editor);
+    final KeyHandler keyHandler = KeyHandler.getInstance();
+    for (KeyStroke key : parseKeys(sequence)) {
+      keyHandler.handleKey(editor, key, dataContext, false);
+    }
+  }
+
+  /**
+   * Attempt to change the surroundings at the cursor
+   *
+   * @param chKey The type of surroundings to change
+   * @param surround The new surroundings, if any
+   * @return True if we were able to change, else false
+   */
+  public static boolean change(Editor editor, char chKey, @Nullable String surround) {
+    for (SurroundingChanger changer : CHANGERS) {
+      if (changer.handles(chKey)) {
+        performChange(editor, chKey, surround, changer);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static final char REGISTER = '"';
+}

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundingChanger.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundingChanger.java
@@ -3,6 +3,8 @@ package com.maddyhome.idea.vim.action.plugin.surround;
 import com.intellij.openapi.editor.Editor;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.Command;
+import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.common.Mark;
 import com.maddyhome.idea.vim.common.Register;
 import com.maddyhome.idea.vim.helper.EditorDataContext;
@@ -104,6 +106,11 @@ public abstract class SurroundingChanger {
       final Editor editor, final char chKey, @Nullable final SurroundPair surround,
       final SurroundingChanger changer) {
 
+    // save the current command (we don't want to override it)
+    final CommandState state = CommandState.getInstance(editor);
+    final Command currentCommand = state.getCommand();
+    final Command lastChangeCommand = state.getLastChangeCommand();
+
     // reset the KeyHandler state so we can perform our actions
     KeyHandler.getInstance().reset(editor);
 
@@ -131,6 +138,12 @@ public abstract class SurroundingChanger {
         setContentsOf(REGISTER, oldValue);
       }
     }, null, null);
+
+    // restore
+    if (currentCommand != null) {
+      state.setCommand(currentCommand);
+    }
+    state.saveLastChangeCommand(lastChangeCommand);
   }
 
   static List<KeyStroke> getContentsOf(char register) {

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundingChanger.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundingChanger.java
@@ -101,7 +101,7 @@ public abstract class SurroundingChanger {
   public abstract void pasteSurrounded(Editor editor);
 
   private static void performChange(
-      final Editor editor, final char chKey, @Nullable final String surround,
+      final Editor editor, final char chKey, @Nullable final SurroundPair surround,
       final SurroundingChanger changer) {
 
     RunnableHelper.runWriteCommand(editor.getProject(), new Runnable() {
@@ -118,9 +118,8 @@ public abstract class SurroundingChanger {
 
         // paste the innerValue
         if (surround != null) {
-          List<KeyStroke> surrounding = parseKeys(surround);
-          innerValue.addAll(0, surrounding);
-          innerValue.addAll(surrounding);
+          innerValue.addAll(0, parseKeys(surround.before));
+          innerValue.addAll(parseKeys(surround.after));
         }
         setContentsOf(REGISTER, innerValue);
         changer.pasteSurrounded(editor);
@@ -166,13 +165,13 @@ public abstract class SurroundingChanger {
    * Attempt to change the surroundings at the cursor
    *
    * @param chKey The type of surroundings to change
-   * @param surround The new surroundings, if any
+   * @param pair The new surroundings, if any
    * @return True if we were able to change, else false
    */
-  public static boolean change(Editor editor, char chKey, @Nullable String surround) {
+  public static boolean change(Editor editor, char chKey, @Nullable SurroundPair pair) {
     for (SurroundingChanger changer : CHANGERS) {
       if (changer.handles(chKey)) {
-        performChange(editor, chKey, surround, changer);
+        performChange(editor, chKey, pair, changer);
         return true;
       }
     }

--- a/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundingChanger.java
+++ b/src/com/maddyhome/idea/vim/action/plugin/surround/SurroundingChanger.java
@@ -104,6 +104,9 @@ public abstract class SurroundingChanger {
       final Editor editor, final char chKey, @Nullable final SurroundPair surround,
       final SurroundingChanger changer) {
 
+    // reset the KeyHandler state so we can perform our actions
+    KeyHandler.getInstance().reset(editor);
+
     RunnableHelper.runWriteCommand(editor.getProject(), new Runnable() {
       @Override
       public void run() {

--- a/src/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -349,7 +349,7 @@ public class KeyGroup {
     AnAction action = aMgr.getAction(actName);
     assert action != null;
 
-    Node node = base.getChild(key);
+    Node node = base.getExplicitChild(key);
     // Is this the first time we have seen this character at this point in the tree?
     if (node == null) {
       // If this is the last keystroke in the shortcut, and there is no argument, add a command node

--- a/src/com/maddyhome/idea/vim/handler/ChangeEditorActionHandler.java
+++ b/src/com/maddyhome/idea/vim/handler/ChangeEditorActionHandler.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  */
 public abstract class ChangeEditorActionHandler extends EditorActionHandlerBase {
+  @Override
   protected final boolean execute(@NotNull Editor editor, @NotNull DataContext context, @NotNull Command cmd) {
     boolean worked = execute(editor, context, cmd.getCount(), cmd.getRawCount(), cmd.getArgument());
     if (worked) {

--- a/src/com/maddyhome/idea/vim/key/ParentNode.java
+++ b/src/com/maddyhome/idea/vim/key/ParentNode.java
@@ -48,5 +48,19 @@ public abstract class ParentNode implements Node {
     return children.get(key);
   }
 
+  /**
+   * Returns the child not associated with the supplied key. Unlike
+   *  getChild(Object), this will only ever return a child explicitly
+   *  added with the given key.
+   *
+   * @param key
+   * @return
+   */
+  @Nullable
+  public final Node getExplicitChild(@NotNull Object key) {
+    return children.get(key);
+  }
+
   @NotNull protected final HashMap<Object, Node> children = new HashMap<Object, Node>();
+
 }

--- a/src/com/maddyhome/idea/vim/option/Options.java
+++ b/src/com/maddyhome/idea/vim/option/Options.java
@@ -20,6 +20,7 @@ package com.maddyhome.idea.vim.option;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.action.plugin.Plugin;
 import com.maddyhome.idea.vim.ex.ExOutputModel;
 import com.maddyhome.idea.vim.helper.EditorHelper;
 import com.maddyhome.idea.vim.helper.MessageHelper;
@@ -463,6 +464,10 @@ public class Options {
     addOption(new ToggleOption(NUMBER, "nu", false));
     addOption(new ToggleOption(RELATIVE_NUMBER, "rnu", false));
     addOption(new ListOption(CLIPBOARD, "cb", new String[]{"autoselect,exclude:cons\\|linux"}, null));
+
+    for (String option : Plugin.Registrar.getOptionNames()) {
+      addOption(new ToggleOption(option, option, false));
+    }
   }
 
   private void addOption(@NotNull Option option) {

--- a/src/com/maddyhome/idea/vim/option/Options.java
+++ b/src/com/maddyhome/idea/vim/option/Options.java
@@ -466,7 +466,7 @@ public class Options {
     addOption(new ListOption(CLIPBOARD, "cb", new String[]{"autoselect,exclude:cons\\|linux"}, null));
 
     for (String option : Plugin.Registrar.getOptionNames()) {
-      addOption(new ToggleOption(option, option, false));
+      addOption(new PluginOption(option));
     }
   }
 

--- a/src/com/maddyhome/idea/vim/option/PluginOption.java
+++ b/src/com/maddyhome/idea/vim/option/PluginOption.java
@@ -18,7 +18,7 @@ public class PluginOption extends ToggleOption {
   @Override
   public void set() {
     super.set();
-    Plugin.Registrar.registerActions(getName());
+    Plugin.Registrar.activate(getName());
   }
 
   @Override

--- a/src/com/maddyhome/idea/vim/option/PluginOption.java
+++ b/src/com/maddyhome/idea/vim/option/PluginOption.java
@@ -1,0 +1,28 @@
+package com.maddyhome.idea.vim.option;
+
+import com.maddyhome.idea.vim.action.plugin.Plugin;
+
+/**
+ * @author dhleong
+ */
+public class PluginOption extends ToggleOption {
+  /**
+   * Creates the option
+   *
+   * @param name   The option's name
+   */
+  PluginOption(String name) {
+    super(name, name, false);
+  }
+
+  @Override
+  public void set() {
+    super.set();
+    Plugin.Registrar.registerActions(getName());
+  }
+
+  @Override
+  public void reset() {
+    throw new UnsupportedOperationException("Plugins cannot yet be disabled at runtime");
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
@@ -1,0 +1,74 @@
+package org.jetbrains.plugins.ideavim.action.plugin.surround;
+
+import com.maddyhome.idea.vim.action.plugin.surround.SurroundPlugin;
+import com.maddyhome.idea.vim.option.Options;
+import com.maddyhome.idea.vim.option.ToggleOption;
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * @author dhleong
+ */
+public class SurroundPluginTest extends VimTestCase {
+
+  @Override
+  protected void setUp() throws Exception {
+    ToggleOption option = (ToggleOption) Options.getInstance()
+      .getOption(SurroundPlugin.NAME);
+    option.set();
+
+    super.setUp();
+  }
+
+  public void testSurroundWordParens() {
+    final String before =
+      "if <caret>condition {\n" +
+      "}\n";
+    final String after =
+      "if (condition) {\n" +
+      "}\n";
+
+    doTest(parseKeys("yseb"), before, after);
+    doTest(parseKeys("yse)"), before, after);
+    doTest(parseKeys("yse("), before,
+           "if ( condition ) {\n" +
+            "}\n");
+  }
+
+  public void testSurroundWORDBlock() {
+    final String before =
+      "if (condition) <caret>return;\n";
+    final String after =
+      "if (condition) {return;}\n";
+
+    doTest(parseKeys("ysEB"), before, after);
+    doTest(parseKeys("ysE}"), before, after);
+    doTest(parseKeys("ysE{"), before,
+           "if (condition) { return; }\n");
+  }
+
+  public void testSurroundWordArray() {
+    final String before =
+      "int foo = bar<caret>index;";
+    final String after =
+      "int foo = bar[index];";
+
+    doTest(parseKeys("yser"), before, after);
+    doTest(parseKeys("yse]"), before, after);
+    doTest(parseKeys("yse["), before,
+           "int foo = bar[ index ];");
+  }
+
+  public void testSurroundWordAngle() {
+    final String before =
+      "foo = new Bar<caret>Baz();";
+    final String after =
+      "foo = new Bar<Baz>();";
+
+    doTest(parseKeys("ysea"), before, after);
+    doTest(parseKeys("yse>"), before, after);
+    doTest(parseKeys("yse<"), before,
+           "foo = new Bar< Baz >();");
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
@@ -75,6 +75,16 @@ public class SurroundPluginTest extends VimTestCase {
            "foo = new Bar< Baz >();");
   }
 
+  public void testSurroundQuotes() {
+    final String before =
+      "foo = <caret>new Bar.Baz;";
+    final String after =
+      "foo = \"new Bar.Baz\";";
+
+    doTest(parseKeys("yst;\""), before, after);
+    doTest(parseKeys("ys4w\""), before, after);
+  }
+
   public void testRepeatSurroundWord() {
      final String before =
       "if <caret>condition {\n" +
@@ -87,7 +97,7 @@ public class SurroundPluginTest extends VimTestCase {
     doTest(parseKeys("ysiwbl."), before, after);
   }
 
-  // TODO quotes, tags, ...
+  // TODO tags, ...
 
   /* Delete surroundings */
 

--- a/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
@@ -14,11 +14,12 @@ public class SurroundPluginTest extends VimTestCase {
 
   @Override
   protected void setUp() throws Exception {
+    super.setUp();
+
     ToggleOption option = (ToggleOption) Options.getInstance()
       .getOption(SurroundPlugin.NAME);
     option.set();
 
-    super.setUp();
   }
 
   public void testSurroundWordParens() {

--- a/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
@@ -188,6 +188,6 @@ public class SurroundPluginTest extends VimTestCase {
     final String after =
       "foo[index][index2] = bar;";
 
-    doTest(parseKeys("csbrw."), before, after);
+    doTest(parseKeys("csbrE."), before, after);
   }
 }

--- a/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
@@ -73,6 +73,10 @@ public class SurroundPluginTest extends VimTestCase {
            "foo = new Bar< Baz >();");
   }
 
+  // TODO quotes, tags, ...
+
+  /* Delete surroundings */
+
   public void testDeleteSurroundingParens() {
     final String before =
       "if (<caret>condition) {\n" +
@@ -85,4 +89,38 @@ public class SurroundPluginTest extends VimTestCase {
     doTest(parseKeys("ds("), before, after);
     doTest(parseKeys("ds)"), before, after);
   }
+
+  public void testDeleteSurroundingBlock() {
+    final String before =
+      "if (condition) {<caret>return;}\n";
+    final String after =
+      "if (condition) return;\n";
+
+    doTest(parseKeys("dsB"), before, after);
+    doTest(parseKeys("ds}"), before, after);
+    doTest(parseKeys("ds{"), before, after);
+  }
+
+  public void testDeleteSurroundingArray() {
+    final String before =
+      "int foo = bar[<caret>index];";
+    final String after =
+      "int foo = barindex;";
+
+    doTest(parseKeys("dsr"), before, after);
+    doTest(parseKeys("ds]"), before, after);
+    doTest(parseKeys("ds["), before, after);
+  }
+
+  public void testDeleteSurroundingAngle() {
+    final String before =
+      "foo = new Bar<<caret>Baz>();";
+    final String after =
+      "foo = new BarBaz();";
+
+    doTest(parseKeys("dsa"), before, after);
+    doTest(parseKeys("ds>"), before, after);
+    doTest(parseKeys("ds<"), before, after);
+  }
+
 }

--- a/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
@@ -72,4 +72,17 @@ public class SurroundPluginTest extends VimTestCase {
     doTest(parseKeys("yse<"), before,
            "foo = new Bar< Baz >();");
   }
+
+  public void testDeleteSurroundingParens() {
+    final String before =
+      "if (<caret>condition) {\n" +
+      "}\n";
+    final String after =
+      "if condition {\n" +
+      "}\n";
+
+    doTest(parseKeys("dsb"), before, after);
+    doTest(parseKeys("ds("), before, after);
+    doTest(parseKeys("ds)"), before, after);
+  }
 }

--- a/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
@@ -22,6 +22,8 @@ public class SurroundPluginTest extends VimTestCase {
 
   }
 
+  /* surround */
+
   public void testSurroundWordParens() {
     final String before =
       "if <caret>condition {\n" +
@@ -71,6 +73,18 @@ public class SurroundPluginTest extends VimTestCase {
     doTest(parseKeys("yse>"), before, after);
     doTest(parseKeys("yse<"), before,
            "foo = new Bar< Baz >();");
+  }
+
+  public void testRepeatSurroundWord() {
+     final String before =
+      "if <caret>condition {\n" +
+      "}\n";
+    final String after =
+      "if ((condition)) {\n" +
+      "}\n";
+
+    doTest(parseKeys("yseb."), before, after);
+    doTest(parseKeys("ysiwbl."), before, after);
   }
 
   // TODO quotes, tags, ...
@@ -123,6 +137,17 @@ public class SurroundPluginTest extends VimTestCase {
     doTest(parseKeys("ds<"), before, after);
   }
 
+  public void testRepeatDeleteSurroundParens() {
+    final String before =
+      "if ((<caret>condition)) {\n" +
+      "}\n";
+    final String after =
+      "if condition {\n" +
+      "}\n";
+
+    doTest(parseKeys("dsb."), before, after);
+  }
+
   // TODO quotes, tags, ...
 
   /* Change surroundings */
@@ -147,5 +172,12 @@ public class SurroundPluginTest extends VimTestCase {
     doTest(parseKeys("csBb"), before, after);
   }
 
-  // TODO repeating deletes, surrounds, changes
+  public void testRepeatChangeSurroundingParens() {
+    final String before =
+      "foo(<caret>index)(index2) = bar;";
+    final String after =
+      "foo[index][index2] = bar;";
+
+    doTest(parseKeys("csbrw."), before, after);
+  }
 }

--- a/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/plugin/surround/SurroundPluginTest.java
@@ -123,4 +123,29 @@ public class SurroundPluginTest extends VimTestCase {
     doTest(parseKeys("ds<"), before, after);
   }
 
+  // TODO quotes, tags, ...
+
+  /* Change surroundings */
+
+  public void testChangeSurroundingParens() {
+    final String before =
+      "if (<caret>condition) {\n" +
+      "}\n";
+    final String after =
+      "if [condition] {\n" +
+      "}\n";
+
+    doTest(parseKeys("csbr"), before, after);
+  }
+
+  public void testChangeSurroundingBlock() {
+    final String before =
+      "if (condition) {<caret>return;}";
+    final String after =
+      "if (condition) (return;)";
+
+    doTest(parseKeys("csBb"), before, after);
+  }
+
+  // TODO repeating deletes, surrounds, changes
 }


### PR DESCRIPTION
This is an initial stab at defining semantics for replicating vim plugin behavior within IdeaVim, with some preliminary support for tpope's excellent [vim-surround](https://github.com/tpope/vim-surround) plugin.

I'm not sure if there's a more idiomatic way of doing stuff like this, but since I didn't hear back on my request for guidance I just went ahead and made something up.

I created a `Plugin` interface which contains a `Registrar` in which plugins register. Each plugin has an "option name" which is used to enable the plugin using the vim options syntax, eg:

```vim
  set surround
```

Plugins can be activated at runtime using this syntax, but I wasn't sure how to go about disabling them (I think we'd need a hook to register and de-register actions, or perhaps make a subclass of VimCommandAction that won't be automatically registered at init). I'm not sure that's a huge concern, though, as generally you set up your plugins once in your vimrc and just go.

Since plugin bindings are optional and are enabled after init via .ideavimrc, I slightly refactored `ParentNode` to be able to correctly handle adding new `BranchNode` onto a `BranchNode` that already has an `ArgumentNode`. This way, plugins can override built-in bindings as expected, as well as expand on them.

The included vim-surround port supports most of the core surroundings, but currently leaves xml/html tag support to future work, as well as (I'm sure) a few more obscure features that I wasn't aware of, but I wanted to get this PR up and get some feedback on the approach before I try to figure that one out.

Since the `ys` and `cs` motions take more than just a motion, I mimicked vim-surround's implementation and added a `getChar()` command to `KeyHandler`. While necessarily asynchronous, taking a callback, this does block other vim input processing, as expected. If there's a better way to deal with this sort of thing I'd love to hear it, but this seemed like it would prove helpful in porting other vim plugins in the future.

UPDATE: Repeat support via `.` for `cs` and `ys` is achieved by subclassing `Argument` and storing our extra arguments in it (ie, the `SurroundPair` object). I think this is the simplest way to support the more complex surrounds, such as that achieved by `ysiwtdiv>` to surround the inner word with `<div></div>` tags (which is not yet implemented, but I'm thinking ahead for when we figure that out).