### PR TITLE
More correct numbered registers behavior (fixes VIM-581)

### DIFF
--- a/src/com/maddyhome/idea/vim/group/RegisterGroup.java
+++ b/src/com/maddyhome/idea/vim/group/RegisterGroup.java
@@ -19,12 +19,22 @@
 package com.maddyhome.idea.vim.group;
 
 import com.google.common.collect.ImmutableList;
+import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
 import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.action.motion.mark.MotionGotoFileMarkAction;
+import com.maddyhome.idea.vim.action.motion.search.SearchAgainNextAction;
+import com.maddyhome.idea.vim.action.motion.search.SearchAgainPreviousAction;
+import com.maddyhome.idea.vim.action.motion.search.SearchEntryFwdAction;
+import com.maddyhome.idea.vim.action.motion.search.SearchEntryRevAction;
+import com.maddyhome.idea.vim.action.motion.text.*;
+import com.maddyhome.idea.vim.action.motion.updown.MotionPercentOrMatchAction;
+import com.maddyhome.idea.vim.command.Argument;
+import com.maddyhome.idea.vim.command.Command;
 import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.command.SelectionType;
 import com.maddyhome.idea.vim.common.Register;
@@ -182,22 +192,26 @@ public class RegisterGroup {
       if (logger.isDebugEnabled()) logger.debug("register '" + register + "' contains: \"" + text + "\"");
     }
 
-    // Deletes go into register 1. Old 1 goes to 2, etc. Old 8 to 9, old 9 is lost
     if (isDelete) {
-      for (char d = '8'; d >= '1'; d--) {
-        Register t = registers.get(new Character(d));
-        if (t != null) {
-          t.rename((char)(d + 1));
-          registers.put((char)(d + 1), t);
-        }
-      }
-      registers.put('1', new Register('1', type, text));
+      boolean smallInlineDeletion = type == SelectionType.CHARACTER_WISE &&
+                       editor.offsetToLogicalPosition(start).line == editor.offsetToLogicalPosition(end).line;
 
-      // Deletes small than one line also go the the - register
-      if (type == SelectionType.CHARACTER_WISE) {
-        if (editor.offsetToLogicalPosition(start).line == editor.offsetToLogicalPosition(end).line) {
-          registers.put('-', new Register('-', type, text));
+      // Deletes go into numbered registers only if text is smaller than a line, register is used or it's a special case
+      if (!smallInlineDeletion || register != defaultRegister || isSmallDeletionSpecialCase(editor)) {
+        // Old 1 goes to 2, etc. Old 8 to 9, old 9 is lost
+        for (char d = '8'; d >= '1'; d--) {
+          Register t = registers.get(d);
+          if (t != null) {
+            t.rename((char)(d + 1));
+            registers.put((char)(d + 1), t);
+          }
         }
+        registers.put('1', new Register('1', type, text));
+      }
+
+      // Deletes smaller than one line and without specified register go the the "-" register
+      if (smallInlineDeletion && register == defaultRegister) {
+        registers.put('-', new Register('-', type, text));
       }
     }
     // Yanks also go to register 0 if the default register was used
@@ -212,6 +226,26 @@ public class RegisterGroup {
     }
 
     return true;
+  }
+
+  private boolean isSmallDeletionSpecialCase(Editor editor) {
+    Command currentCommand = CommandState.getInstance(editor).getCommand();
+    if (currentCommand != null) {
+      Argument argument = currentCommand.getArgument();
+      if (argument != null) {
+        Command motionCommand = argument.getMotion();
+        if (motionCommand != null) {
+          AnAction action = motionCommand.getAction();
+          return action instanceof MotionPercentOrMatchAction || action instanceof MotionSentencePreviousStartAction
+            || action instanceof MotionSentenceNextStartAction || action instanceof MotionGotoFileMarkAction
+            || action instanceof SearchEntryFwdAction || action instanceof SearchEntryRevAction
+            || action instanceof SearchAgainNextAction || action instanceof SearchAgainPreviousAction
+            || action instanceof MotionParagraphNextAction || action instanceof MotionParagraphPreviousAction;
+        }
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/test/org/jetbrains/plugins/ideavim/action/SpecialRegistersTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/SpecialRegistersTest.java
@@ -1,0 +1,176 @@
+package org.jetbrains.plugins.ideavim.action;
+
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.common.Register;
+import com.maddyhome.idea.vim.group.RegisterGroup;
+import org.jetbrains.plugins.ideavim.VimTestCase;
+import org.junit.Assert;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+import static com.maddyhome.idea.vim.helper.StringHelper.stringToKeys;
+
+/**
+ * @author ayzen
+ */
+public class SpecialRegistersTest extends VimTestCase {
+
+  private static final String DUMMY_TEXT = "text";
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    final RegisterGroup registerGroup = VimPlugin.getRegister();
+    registerGroup.setKeys('a', stringToKeys(DUMMY_TEXT));
+    registerGroup.setKeys('-', stringToKeys(DUMMY_TEXT));
+    for (char c = '0'; c <= '9'; c++) {
+      registerGroup.setKeys(c, stringToKeys(DUMMY_TEXT));
+    }
+  }
+
+  // VIM-581
+  public void testSmallDelete() {
+    typeTextInFile(parseKeys("de"), "one <caret>two three\n");
+
+    assertEquals("two", getRegisterText('-'));
+    // Text smaller than line doesn't go to numbered registers (except special cases)
+    assertRegisterNotChanged('1');
+  }
+
+  // |d| |%| Special case for small delete
+  public void testSmallDeleteWithPercent() {
+    typeTextInFile(parseKeys("d%"), "(one<caret> two) three\n");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  // |d| |(| Special case for small delete
+  public void testSmallDeleteTillPrevSentence() {
+    typeTextInFile(parseKeys("d("), "One. Two<caret>. Three.\n");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  // |d| |)| Special case for small delete
+  public void testSmallDeleteTillNextSentence() {
+    typeTextInFile(parseKeys("d)"), "One. <caret>Two. Three.\n");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  // |d| |`| Special case for small delete
+  public void testSmallDeleteWithMark() {
+    typeTextInFile(parseKeys("ma", "b", "d`a"), "one two<caret> three\n");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  // |d| |/| Special case for small delete
+  public void testSmallDeleteWithSearch() {
+    typeTextInFile(parseKeys("d/", "o", "<Enter>"), "one <caret>two three\n");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  // |d| |?| Special case for small delete
+  public void testSmallDeleteWithBackSearch() {
+    typeTextInFile(parseKeys("d?", "t", "<Enter>"), "one two<caret> three\n");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  // |d| |n| Special case for small delete
+  public void testSmallDeleteWithSearchRepeat() {
+    typeTextInFile(parseKeys("/", "t", "<Enter>", "dn"), "<caret>one two three\n");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  // |d| |N| Special case for small delete
+  public void testSmallDeleteWithBackSearchRepeat() {
+    typeTextInFile(parseKeys("/", "t", "<Enter>", "dN"), "one tw<caret>o three\n");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  // |d| |{| Special case for small delete
+  public void testSmallDeleteTillPrevParagraph() {
+    typeTextInFile(parseKeys("d{"), "one<caret> two three");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  // |d| |}| Special case for small delete
+  public void testSmallDeleteTillNextParagraph() {
+    typeTextInFile(parseKeys("d}"), "one<caret> two three");
+
+    assertRegisterChanged('1');
+    assertRegisterChanged('-');
+  }
+
+  public void testSmallDeleteInRegister() {
+    typeTextInFile(parseKeys("\"ade"), "one <caret>two three\n");
+
+    // Small deletes (less than a line) with register specified go to that register and to numbered registers
+    assertRegisterChanged('a');
+    assertRegisterChanged('1');
+    assertRegisterNotChanged('-');
+  }
+
+  public void testLineDelete() {
+    typeTextInFile(parseKeys("dd"), "one <caret>two three\n");
+
+    assertRegisterChanged('1');
+    assertRegisterNotChanged('-');
+  }
+
+  public void testLineDeleteInRegister() {
+    typeTextInFile(parseKeys("\"add"), "one <caret>two three\n");
+
+    assertRegisterChanged('a');
+    assertRegisterChanged('1');
+  }
+
+  public void testNumberedRegistersShifting() {
+    configureByText("<caret>one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\n");
+
+    typeText(parseKeys("dd", "dd"));
+    assertEquals("one\n", getRegisterText('2'));
+    assertEquals("two\n", getRegisterText('1'));
+
+    typeText(parseKeys("dd", "dd", "dd"));
+    assertEquals("one\n", getRegisterText('5'));
+    assertEquals("four\n", getRegisterText('2'));
+
+    typeText(parseKeys("dd", "dd", "dd", "dd"));
+    assertEquals("one\n", getRegisterText('9'));
+  }
+
+  private void assertRegisterChanged(char registerName) {
+    String registerText = getRegisterText(registerName);
+    Assert.assertNotEquals(DUMMY_TEXT, registerText);
+  }
+
+  private void assertRegisterNotChanged(char registerName) {
+    String registerText = getRegisterText(registerName);
+    assertEquals(DUMMY_TEXT, registerText);
+  }
+
+  private String getRegisterText(char registerName) {
+    final RegisterGroup registerGroup = VimPlugin.getRegister();
+    final Register register = registerGroup.getRegister(registerName);
+    assertNotNull(register);
+
+    return register.getText();
+  }
+
+}


### PR DESCRIPTION
The original behavior slightly differs from VIM. This caused the root problem of [VIM-581](https://youtrack.jetbrains.com/issue/VIM-581) (it turned out that it's not a macro problem).

Changes:
* Only multiline deletes (a line or more) go to registers "1"-"9", unless a register is specified or it's a special case (details can be found in VIM docs, registers topic).
* Small deletes (less than a line) go to the register "-" only if no registers were specified.
* Added tests to cover numbered registers (including "0") and "-" logic.