### PR TITLE
Fix for VIM-964 along with other marks improvements

### DIFF
--- a/src/com/maddyhome/idea/vim/group/MarkGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MarkGroup.java
@@ -660,7 +660,7 @@ public class MarkGroup {
       if (!VimPlugin.isEnabled()) return;
 
       if (logger.isDebugEnabled()) logger.debug("MarkUpdater after, event = " + event);
-      if (event.getNewLength() == 0 || (event.getNewLength() == 1 && !event.getNewFragment().equals("\n"))) return;
+      if (event.getNewLength() == 0 || (event.getNewLength() == 1 && event.getNewFragment().charAt(0) != '\n')) return;
 
       Document doc = event.getDocument();
       updateMarkFromInsert(getAnEditor(doc), VimPlugin.getMark().getAllFileMarks(doc), event.getOffset(),

--- a/src/com/maddyhome/idea/vim/group/MarkGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MarkGroup.java
@@ -531,9 +531,9 @@ public class MarkGroup {
     // Skip all this work if there are no marks
     if (marks != null && marks.size() > 0 && editor != null) {
       // Calculate the logical position of the start and end of the deleted text
-      int delEndOff = delStartOff + delLength;
+      int delEndOff = delStartOff + delLength - 1;
       LogicalPosition delStart = editor.offsetToLogicalPosition(delStartOff);
-      LogicalPosition delEnd = editor.offsetToLogicalPosition(delEndOff);
+      LogicalPosition delEnd = editor.offsetToLogicalPosition(delEndOff + 1);
       if (logger.isDebugEnabled()) logger.debug("mark delete. delStart = " + delStart + ", delEnd = " + delEnd);
 
       // Now analyze each mark to determine if it needs to be updated or removed

--- a/test/org/jetbrains/plugins/ideavim/action/MarkTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MarkTest.java
@@ -83,6 +83,17 @@ public class MarkTest extends VimTestCase {
 
   // |m|
   public void testMarkIsMovedDownWhenLinesAreInsertedAbove() {
+    typeTextInFile(parseKeys("mY", "Obiff"), "foo\n" +
+                                             "ba<caret>r\n" +
+                                             "baz\n");
+    Mark mark = VimPlugin.getMark().getMark(myFixture.getEditor(), 'Y');
+    assertNotNull(mark);
+    assertEquals(2, mark.getLogicalLine());
+    assertEquals(2, mark.getCol());
+  }
+
+  // |m|
+  public void testMarkIsMovedDownWhenLinesAreInsertedAboveWithIndentation() {
     typeTextInFile(parseKeys("mY", "Obiff"), "    foo\n" +
                                              "    ba<caret>r\n" +
                                              "    baz\n");

--- a/test/org/jetbrains/plugins/ideavim/action/MarkTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MarkTest.java
@@ -51,6 +51,15 @@ public class MarkTest extends VimTestCase {
   }
 
   // |m|
+  public void testMarkIsNotDeletedWhenLineIsChanged() {
+    typeTextInFile(parseKeys("ma", "cc"), "    foo\n" +
+                                          "    ba<caret>r\n" +
+                                          "    baz\n");
+    Mark mark = VimPlugin.getMark().getMark(myFixture.getEditor(), 'a');
+    assertNotNull(mark);
+  }
+
+  // |m|
   public void testMarkIsMovedUpWhenLinesArePartiallyDeletedAbove() {
     typeTextInFile(parseKeys("mx", "2k", "dd", "0dw"), "    foo\n" +
                                                        "    bar\n" +

--- a/test/org/jetbrains/plugins/ideavim/action/MarkTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MarkTest.java
@@ -42,9 +42,29 @@ public class MarkTest extends VimTestCase {
   }
 
   // |m|
+  public void testMarkIsNotDeletedWhenLineIsOneCharAndReplaced() {
+    typeTextInFile(parseKeys("ma", "r1"), "foo\n" +
+                                          "<caret>0\n" +
+                                          "bar\n");
+    Mark mark = VimPlugin.getMark().getMark(myFixture.getEditor(), 'a');
+    assertNotNull(mark);
+  }
+
+  // |m|
+  public void testMarkIsMovedUpWhenLinesArePartiallyDeletedAbove() {
+    typeTextInFile(parseKeys("mx", "2k", "dd", "0dw"), "    foo\n" +
+                                                       "    bar\n" +
+                                                       "    ba<caret>z\n");
+    Mark mark = VimPlugin.getMark().getMark(myFixture.getEditor(), 'x');
+    assertNotNull(mark);
+    assertEquals(1, mark.getLogicalLine());
+    assertEquals(6, mark.getCol());
+  }
+
+  // |m|
   public void testMarkIsMovedUpWhenLinesAreDeletedAbove() {
     typeTextInFile(parseKeys("mx", "2k", "2dd"), "    foo\n" +
-                                                 "    ba<r\n" +
+                                                 "    bar\n" +
                                                  "    ba<caret>z\n");
     Mark mark = VimPlugin.getMark().getMark(myFixture.getEditor(), 'x');
     assertNotNull(mark);


### PR DESCRIPTION
This PR contains:
1. Fix for VIM-964. A mark got deleted if a whole content of a line (with that mark) is changed.
2. If a change was made (starting from the beginning of a line till some point on next lines), then marks on the first line were removed. Actually VIM doesn't remove such marks, because technically the first line still exists (even if subsequent lines got removed). So the second commit fixes this.
3. Marks were moved up incorrectly if you remove several lines before them in a text without leading spaces (without indentation). The third commit fixes that.
4. Tests for all these problems.