### PR TITLE
={motion} implementation, == with count and fix for VIM-259

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -269,6 +269,7 @@
 
     <!-- Shift -->
     <action id="VimAutoIndentLines" class="com.maddyhome.idea.vim.action.change.shift.AutoIndentLinesAction" text="Auto Indent Lines"/>
+    <action id="VimAutoIndentMotion" class="com.maddyhome.idea.vim.action.change.shift.AutoIndentMotionAction" text="Auto Indent Lines"/>
     <action id="VimShiftLeftLines" class="com.maddyhome.idea.vim.action.change.shift.ShiftLeftLinesAction" text="Shift Lines Left"/>
     <action id="VimShiftLeftMotion" class="com.maddyhome.idea.vim.action.change.shift.ShiftLeftMotionAction" text="Shift Motion Left"/>
     <action id="VimShiftLeftVisual" class="com.maddyhome.idea.vim.action.change.shift.ShiftLeftVisualAction" text="Shift Visual Left"/>

--- a/src/com/maddyhome/idea/vim/RegisterActions.java
+++ b/src/com/maddyhome/idea/vim/RegisterActions.java
@@ -624,10 +624,10 @@ public class RegisterActions {
     });
 
     // Shift Actions
-    // TODO - add =
-    // TODO - == will ignore count and only auto-indent 1 lines
     parser.registerAction(MappingMode.N, "VimAutoIndentLines", Command.Type.CHANGE,
                           new Shortcut("=="));
+    parser.registerAction(MappingMode.N, "VimAutoIndentMotion", Command.Type.CHANGE, Command.FLAG_OP_PEND,
+                          new Shortcut('='), Argument.Type.MOTION);
     parser.registerAction(MappingMode.N, "VimShiftLeftLines", Command.Type.CHANGE,
                           new Shortcut("<<"));
     parser.registerAction(MappingMode.N, "VimShiftLeftMotion", Command.Type.CHANGE, Command.FLAG_OP_PEND,

--- a/src/com/maddyhome/idea/vim/action/change/change/AutoIndentLinesVisualAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/change/AutoIndentLinesVisualAction.java
@@ -43,7 +43,7 @@ public class AutoIndentLinesVisualAction extends VimCommandAction {
                                 @NotNull DataContext context,
                                 @NotNull Command cmd,
                                 @NotNull TextRange range) {
-        VimPlugin.getChange().autoIndentLines(context);
+        VimPlugin.getChange().autoIndentRange(editor, context, range);
         return true;
       }
     });

--- a/src/com/maddyhome/idea/vim/action/change/shift/AutoIndentMotionAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/shift/AutoIndentMotionAction.java
@@ -28,16 +28,23 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
+ * @author Aleksey Lagoshin
  */
-public class AutoIndentLinesAction extends EditorAction {
-  public AutoIndentLinesAction() {
+public class AutoIndentMotionAction extends EditorAction {
+  public AutoIndentMotionAction() {
     super(new Handler());
   }
 
   private static class Handler extends ChangeEditorActionHandler {
-    public boolean execute(@NotNull Editor editor, @NotNull DataContext context, int count, int rawCount, @Nullable Argument argument) {
-      VimPlugin.getChange().autoIndentLines(editor, context, count);
-      return true;
+    public boolean execute(@NotNull Editor editor, @NotNull DataContext context, int count, int rawCount,
+                           @Nullable Argument argument) {
+      if (argument != null) {
+        VimPlugin.getChange().autoIndentMotion(editor, context, count, rawCount, argument);
+        return true;
+      }
+      else {
+        return false;
+      }
     }
   }
 }

--- a/src/com/maddyhome/idea/vim/group/CopyGroup.java
+++ b/src/com/maddyhome/idea/vim/group/CopyGroup.java
@@ -370,8 +370,7 @@ public class CopyGroup {
     if (indent) {
       int startOff = editor.getDocument().getLineStartOffset(slp.line);
       int endOff = editor.getDocument().getLineEndOffset(elp.line);
-      editor.getSelectionModel().setSelection(startOff, endOff);
-      VimPlugin.getChange().autoIndentLines(context);
+      VimPlugin.getChange().autoIndentRange(editor, context, new TextRange(startOff, endOff));
     }
     /*
     boolean indented = false;

--- a/test/org/jetbrains/plugins/ideavim/action/AutoIndentTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/AutoIndentTest.java
@@ -1,0 +1,140 @@
+package org.jetbrains.plugins.ideavim.action;
+
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * @author Aleksey Lagoshin
+ */
+public class AutoIndentTest extends VimTestCase {
+  // VIM-256 |==|
+  public void testCaretPositionAfterAutoIndent() {
+    configureByJavaText("class C {\n" +
+                        "   int a;\n" +
+                        "   int <caret>b;\n" +
+                        "   int c;\n" +
+                        "}\n");
+    typeText(parseKeys("=="));
+    myFixture.checkResult("class C {\n" +
+                          "   int a;\n" +
+                          "    <caret>int b;\n" +
+                          "   int c;\n" +
+                          "}\n");
+  }
+
+  // |2==|
+  public void testAutoIndentWithCount() {
+    configureByJavaText("class C {\n" +
+                        "   int a;\n" +
+                        "   int <caret>b;\n" +
+                        "   int c;\n" +
+                        "   int d;\n" +
+                        "}\n");
+    typeText(parseKeys("2=="));
+    myFixture.checkResult("class C {\n" +
+                          "   int a;\n" +
+                          "    <caret>int b;\n" +
+                          "    int c;\n" +
+                          "   int d;\n" +
+                          "}\n");
+  }
+
+  // |=k|
+  public void testAutoIndentWithUpMotion() {
+    configureByJavaText("class C {\n" +
+                        "   int a;\n" +
+                        "   int b;\n" +
+                        "   int <caret>c;\n" +
+                        "   int d;\n" +
+                        "}\n");
+    typeText(parseKeys("=k"));
+    myFixture.checkResult("class C {\n" +
+                          "   int a;\n" +
+                          "    <caret>int b;\n" +
+                          "    int c;\n" +
+                          "   int d;\n" +
+                          "}\n");
+  }
+
+  // |=l|
+  public void testAutoIndentWithRightMotion() {
+    configureByJavaText("class C {\n" +
+                        "   int a;\n" +
+                        "   int <caret>b;\n" +
+                        "   int c;\n" +
+                        "}\n");
+    typeText(parseKeys("=l"));
+    myFixture.checkResult("class C {\n" +
+                          "   int a;\n" +
+                          "    <caret>int b;\n" +
+                          "   int c;\n" +
+                          "}\n");
+  }
+
+  // |2=j|
+  public void testAutoIndentWithCountsAndDownMotion() {
+    configureByJavaText("class C {\n" +
+                        "   int <caret>a;\n" +
+                        "   int b;\n" +
+                        "   int c;\n" +
+                        "   int d;\n" +
+                        "}\n");
+    typeText(parseKeys("2=j"));
+    myFixture.checkResult("class C {\n" +
+                          "    <caret>int a;\n" +
+                          "    int b;\n" +
+                          "    int c;\n" +
+                          "   int d;\n" +
+                          "}\n");
+  }
+
+  // |v| |l| |=|
+  public void testVisualAutoIndent() {
+    configureByJavaText("class C {\n" +
+                        "   int a;\n" +
+                        "   int <caret>b;\n" +
+                        "   int c;\n" +
+                        "}\n");
+    typeText(parseKeys("v", "l", "="));
+    myFixture.checkResult("class C {\n" +
+                          "   int a;\n" +
+                          "    <caret>int b;\n" +
+                          "   int c;\n" +
+                          "}\n");
+  }
+
+  // |v| |j| |=|
+  public void testVisualMultilineAutoIndent() {
+    configureByJavaText("class C {\n" +
+                        "   int a;\n" +
+                        "   int <caret>b;\n" +
+                        "   int c;\n" +
+                        "   int d;\n" +
+                        "}\n");
+    typeText(parseKeys("v", "j", "="));
+    myFixture.checkResult("class C {\n" +
+                          "   int a;\n" +
+                          "    <caret>int b;\n" +
+                          "    int c;\n" +
+                          "   int d;\n" +
+                          "}\n");
+  }
+
+  // |C-v| |j| |=|
+  public void testVisualBlockAutoIndent() {
+    configureByJavaText("class C {\n" +
+                        "   int a;\n" +
+                        "   int <caret>b;\n" +
+                        "   int c;\n" +
+                        "   int d;\n" +
+                        "}\n");
+    typeText(parseKeys("<C-V>", "j", "="));
+    myFixture.checkResult("class C {\n" +
+                          "   int a;\n" +
+                          "    <caret>int b;\n" +
+                          "    int c;\n" +
+                          "   int d;\n" +
+                          "}\n");
+  }
+}


### PR DESCRIPTION
This PR fixes VIM-259, allows using counts for == and adds ={motion} action.