### PR TITLE
Framework for IdeaVim extensions + sketch of vim-surround port

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -372,6 +372,7 @@
     <action id="VimUndo" class="com.maddyhome.idea.vim.action.change.UndoAction" text="Undo"/>
 
     <!-- Keys -->
-    <action id="VimShortcutKeyAction" class="com.maddyhome.idea.vim.action.VimShortcutKeyAction" text="Vim Shortcuts"/>
+    <action id="VimShortcutKeyAction" class="com.maddyhome.idea.vim.action.VimShortcutKeyAction" text="Shortcuts"/>
+    <action id="VimOperatorAction" class="com.maddyhome.idea.vim.action.change.OperatorAction" text="Operator"/>
   </actions>
 </idea-plugin>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -78,9 +78,17 @@
     </component>
   </application-components>
 
+  <extensionPoints>
+    <extensionPoint qualifiedName="IdeaVIM.vimExtension" interface="com.maddyhome.idea.vim.extension.VimExtension"/>
+  </extensionPoints>
+
   <extensions defaultExtensionNs="com.intellij">
     <errorHandler implementation="com.intellij.diagnostic.ITNReporter"/>
     <applicationConfigurable instance="com.maddyhome.idea.vim.ui.VimEmulationConfigurable"/>
+  </extensions>
+
+  <extensions defaultExtensionNs="IdeaVIM">
+    <vimExtension implementation="com.maddyhome.idea.vim.extension.surround.VimSurroundExtension"/>
   </extensions>
 
   <actions>

--- a/resources/messages.properties
+++ b/resources/messages.properties
@@ -48,3 +48,4 @@ E385=E385: search hit BOTTOM without match for: {0}
 e_patnotf2=Pattern not found: {0}
 unkopt=Unknown option: {0}
 e_invarg=Invalid argument: {0}
+E774=E774: 'operatorfunc' is empty

--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -337,9 +337,7 @@ public class KeyHandler {
 
   private boolean isEditorReset(@NotNull KeyStroke key, @NotNull CommandState editorState) {
     return (editorState.getMode() == CommandState.Mode.COMMAND || state == State.COMMAND) &&
-           (key.getKeyCode() == KeyEvent.VK_ESCAPE ||
-            (key.getKeyCode() == KeyEvent.VK_C && (key.getModifiers() & KeyEvent.CTRL_MASK) != 0) ||
-            (key.getKeyCode() == '[' && (key.getModifiers() & KeyEvent.CTRL_MASK) != 0));
+           StringHelper.isCloseKeyStroke(key);
   }
 
   private void handleCharArgument(@NotNull KeyStroke key, char chKey) {

--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -33,6 +33,7 @@ import com.maddyhome.idea.vim.command.Argument;
 import com.maddyhome.idea.vim.command.Command;
 import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import com.maddyhome.idea.vim.group.RegisterGroup;
 import com.maddyhome.idea.vim.helper.*;
 import com.maddyhome.idea.vim.key.*;
@@ -252,12 +253,19 @@ public class KeyHandler {
       final Runnable handleMappedKeys = new Runnable() {
         @Override
         public void run() {
-          final boolean fromIsPrefix = isPrefix(mappingInfo.getFromKeys(), mappingInfo.getToKeys());
-          boolean first = true;
-          for (KeyStroke keyStroke : mappingInfo.getToKeys()) {
-            final boolean recursive = mappingInfo.isRecursive() && !(first && fromIsPrefix);
-            handleKey(editor, keyStroke, new EditorDataContext(editor), recursive);
-            first = false;
+          final List<KeyStroke> toKeys = mappingInfo.getToKeys();
+          final VimExtensionHandler extensionHandler = mappingInfo.getExtensionHandler();
+          if (toKeys != null) {
+            final boolean fromIsPrefix = isPrefix(mappingInfo.getFromKeys(), toKeys);
+            boolean first = true;
+            for (KeyStroke keyStroke : toKeys) {
+              final boolean recursive = mappingInfo.isRecursive() && !(first && fromIsPrefix);
+              handleKey(editor, keyStroke, new EditorDataContext(editor), recursive);
+              first = false;
+            }
+          }
+          else if (extensionHandler != null) {
+            extensionHandler.execute(editor, context);
           }
         }
       };

--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -265,7 +265,12 @@ public class KeyHandler {
             }
           }
           else if (extensionHandler != null) {
-            extensionHandler.execute(editor, context);
+            RunnableHelper.runWriteCommand(editor.getProject(), new Runnable() {
+              @Override
+              public void run() {
+                extensionHandler.execute(editor, context);
+              }
+            }, "Vim " + extensionHandler.getClass().getSimpleName(), null);
           }
         }
       };

--- a/src/com/maddyhome/idea/vim/action/change/OperatorAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/OperatorAction.java
@@ -1,0 +1,99 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.action.change;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.KeyHandler;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.action.VimCommandAction;
+import com.maddyhome.idea.vim.command.*;
+import com.maddyhome.idea.vim.common.TextRange;
+import com.maddyhome.idea.vim.group.MotionGroup;
+import com.maddyhome.idea.vim.handler.EditorActionHandlerBase;
+import com.maddyhome.idea.vim.helper.MessageHelper;
+import com.maddyhome.idea.vim.key.OperatorFunction;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author vlan
+ */
+public class OperatorAction extends VimCommandAction {
+  protected OperatorAction() {
+    super(new EditorActionHandlerBase() {
+      @Override
+      protected boolean execute(@NotNull Editor editor, @NotNull DataContext context, @NotNull Command cmd) {
+        final OperatorFunction operatorFunction = VimPlugin.getKey().getOperatorFunction();
+        if (operatorFunction != null) {
+          final Argument argument = cmd.getArgument();
+          if (argument != null) {
+            final Command motion = argument.getMotion();
+            if (motion != null) {
+              final TextRange range = MotionGroup.getMotionRange(editor, context, cmd.getCount(), cmd.getRawCount(),
+                                                                 argument, true);
+              if (range != null) {
+                VimPlugin.getMark().setChangeMarks(editor, range);
+                final SelectionType selectionType = SelectionType.fromCommandFlags(motion.getFlags());
+                KeyHandler.getInstance().reset(editor);
+                operatorFunction.apply(editor, context, selectionType);
+                return true;
+              }
+            }
+          }
+          return false;
+        }
+        VimPlugin.showMessage(MessageHelper.message("E774"));
+        return false;
+      }
+    });
+  }
+
+  @NotNull
+  @Override
+  public Set<MappingMode> getMappingModes() {
+    return MappingMode.N;
+  }
+
+  @NotNull
+  @Override
+  public Set<List<KeyStroke>> getKeyStrokesSet() {
+    return parseKeysSet("g@");
+  }
+
+  @NotNull
+  @Override
+  public Command.Type getType() {
+    return Command.Type.OTHER_READ_WRITE;
+  }
+
+  @NotNull
+  @Override
+  public Argument.Type getArgumentType() {
+    return Argument.Type.MOTION;
+  }
+
+  @Override
+  public int getFlags() {
+    return Command.FLAG_OP_PEND;
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/change/OperatorAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/OperatorAction.java
@@ -55,8 +55,7 @@ public class OperatorAction extends VimCommandAction {
                 VimPlugin.getMark().setChangeMarks(editor, range);
                 final SelectionType selectionType = SelectionType.fromCommandFlags(motion.getFlags());
                 KeyHandler.getInstance().reset(editor);
-                operatorFunction.apply(editor, context, selectionType);
-                return true;
+                return operatorFunction.apply(editor, context, selectionType);
               }
             }
           }

--- a/src/com/maddyhome/idea/vim/ex/handler/MapHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/MapHandler.java
@@ -96,7 +96,7 @@ public class MapHandler extends CommandHandler implements VimScriptCommandHandle
               throw new ExException("Unsupported map argument: " + unsupportedArgument);
             }
           }
-          VimPlugin.getKey().putKeyMapping(modes, arguments.getFromKeys(), arguments.getToKeys(),
+          VimPlugin.getKey().putKeyMapping(modes, arguments.getFromKeys(), arguments.getToKeys(), null,
                                            commandInfo.isRecursive());
           return true;
 

--- a/src/com/maddyhome/idea/vim/extension/VimExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtension.java
@@ -1,0 +1,36 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.extension;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author vlan
+ */
+public interface VimExtension {
+  @NotNull ExtensionPointName<VimExtension> EP_NAME = ExtensionPointName.create("IdeaVIM.vimExtension");
+
+  @NotNull
+  String getName();
+
+  void init();
+
+  void dispose();
+}

--- a/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
@@ -19,11 +19,13 @@
 package com.maddyhome.idea.vim.extension;
 
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.Ref;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.helper.TestInputModel;
 import com.maddyhome.idea.vim.key.OperatorFunction;
 import com.maddyhome.idea.vim.ui.ModalEntryDialog;
 import org.jetbrains.annotations.NotNull;
@@ -85,17 +87,23 @@ public class VimExtensionFacade {
    */
   @NotNull
   public static KeyStroke getKeyStroke(@NotNull Editor editor) {
-    final Ref<KeyStroke> ref = Ref.create();
-    final ModalEntryDialog dialog = new ModalEntryDialog(editor, "");
-    dialog.setEntryKeyListener(new KeyAdapter() {
-      @Override
-      public void keyTyped(KeyEvent e) {
-        ref.set(KeyStroke.getKeyStrokeForEvent(e));
-        dialog.dispose();
-      }
-    });
-    dialog.setVisible(true);
-    final KeyStroke key = ref.get();
+    final KeyStroke key;
+    if (ApplicationManager.getApplication().isUnitTestMode()) {
+      key = TestInputModel.getInstance(editor).nextKeyStroke();
+    }
+    else {
+      final Ref<KeyStroke> ref = Ref.create();
+      final ModalEntryDialog dialog = new ModalEntryDialog(editor, "");
+      dialog.setEntryKeyListener(new KeyAdapter() {
+        @Override
+        public void keyTyped(KeyEvent e) {
+          ref.set(KeyStroke.getKeyStrokeForEvent(e));
+          dialog.dispose();
+        }
+      });
+      dialog.setVisible(true);
+      key = ref.get();
+    }
     return key != null ? key : KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
   }
 }

--- a/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
@@ -20,13 +20,17 @@ package com.maddyhome.idea.vim.extension;
 
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.Ref;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.MappingMode;
 import com.maddyhome.idea.vim.key.OperatorFunction;
+import com.maddyhome.idea.vim.ui.ModalEntryDialog;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.util.List;
 import java.util.Set;
 
@@ -74,5 +78,24 @@ public class VimExtensionFacade {
     for (KeyStroke key : keys) {
       KeyHandler.getInstance().handleKey(editor, key, context);
     }
+  }
+
+  /**
+   * Returns a single key stroke from the user input similar to 'getchar()'.
+   */
+  @NotNull
+  public static KeyStroke getKeyStroke(@NotNull Editor editor) {
+    final Ref<KeyStroke> ref = Ref.create();
+    final ModalEntryDialog dialog = new ModalEntryDialog(editor, "");
+    dialog.setEntryKeyListener(new KeyAdapter() {
+      @Override
+      public void keyTyped(KeyEvent e) {
+        ref.set(KeyStroke.getKeyStrokeForEvent(e));
+        dialog.dispose();
+      }
+    });
+    dialog.setVisible(true);
+    final KeyStroke key = ref.get();
+    return key != null ? key : KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
   }
 }

--- a/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
@@ -1,0 +1,54 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.extension;
+
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.MappingMode;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Vim API facade that defines functions similar to the built-in functions and statements of the original Vim.
+ *
+ * See :help eval.
+ *
+ * @author vlan
+ */
+public class VimExtensionFacade {
+  private VimExtensionFacade() {}
+
+  /**
+   * The 'map' command for mapping keys to handlers defined in extensions.
+   */
+  public static void putExtensionHandlerMapping(@NotNull Set<MappingMode> modes, @NotNull List<KeyStroke> fromKeys,
+                                                @NotNull VimExtensionHandler extensionHandler, boolean recursive) {
+    VimPlugin.getKey().putKeyMapping(modes, fromKeys, null, extensionHandler, recursive);
+  }
+
+  /**
+   * The 'map' command for mapping keys to other keys.
+   */
+  public static void putKeyMapping(@NotNull Set<MappingMode> modes, @NotNull List<KeyStroke> fromKeys,
+                                   @NotNull List<KeyStroke> toKeys, boolean recursive) {
+    VimPlugin.getKey().putKeyMapping(modes, fromKeys, toKeys, null, recursive);
+  }
+}

--- a/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
@@ -18,8 +18,12 @@
 
 package com.maddyhome.idea.vim.extension;
 
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.key.OperatorFunction;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -50,5 +54,25 @@ public class VimExtensionFacade {
   public static void putKeyMapping(@NotNull Set<MappingMode> modes, @NotNull List<KeyStroke> fromKeys,
                                    @NotNull List<KeyStroke> toKeys, boolean recursive) {
     VimPlugin.getKey().putKeyMapping(modes, fromKeys, toKeys, null, recursive);
+  }
+
+  /**
+   * Sets the value of 'operatorfunc' to be used as the operator function in 'g@'.
+   */
+  public static void setOperatorFunction(@NotNull OperatorFunction function) {
+    VimPlugin.getKey().setOperatorFunction(function);
+  }
+
+  /**
+   * Runs normal mode commands similar to ':normal {commands}'.
+   *
+   * XXX: Currently it doesn't make the editor enter the normal mode, it doesn't recover from incomplete commands, it
+   * leaves the editor in the insert mode if it's been activated.
+   */
+  public static void executeNormal(@NotNull List<KeyStroke> keys, @NotNull Editor editor,
+                                   @NotNull DataContext context) {
+    for (KeyStroke key : keys) {
+      KeyHandler.getInstance().handleKey(editor, key, context);
+    }
   }
 }

--- a/src/com/maddyhome/idea/vim/extension/VimExtensionHandler.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtensionHandler.java
@@ -1,0 +1,30 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.extension;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author vlan
+ */
+public interface VimExtensionHandler {
+  void execute(@NotNull Editor editor, @NotNull DataContext context);
+}

--- a/src/com/maddyhome/idea/vim/extension/VimNonDisposableExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/VimNonDisposableExtension.java
@@ -18,6 +18,8 @@
 
 package com.maddyhome.idea.vim.extension;
 
+import com.intellij.openapi.application.ApplicationManager;
+
 /**
  * @author vlan
  */
@@ -26,9 +28,14 @@ public abstract class VimNonDisposableExtension implements VimExtension {
 
   @Override
   public final void init() {
-    if (!myInitialized) {
-      myInitialized = true;
+    if (ApplicationManager.getApplication().isUnitTestMode()) {
       initOnce();
+    }
+    else {
+      if (!myInitialized) {
+        myInitialized = true;
+        initOnce();
+      }
     }
   }
 

--- a/src/com/maddyhome/idea/vim/extension/VimNonDisposableExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/VimNonDisposableExtension.java
@@ -1,0 +1,40 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.extension;
+
+/**
+ * @author vlan
+ */
+public abstract class VimNonDisposableExtension implements VimExtension {
+  private boolean myInitialized = false;
+
+  @Override
+  public final void init() {
+    if (!myInitialized) {
+      myInitialized = true;
+      initOnce();
+    }
+  }
+
+  @Override
+  public final void dispose() {
+  }
+
+  protected abstract void initOnce();
+}

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -124,14 +124,18 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
   private static class VSurroundHandler implements VimExtensionHandler {
     @Override
     public void execute(@NotNull Editor editor, @NotNull DataContext context) {
+      final TextRange visualRange = VimPlugin.getMark().getVisualSelectionMarks(editor);
+      if (visualRange == null) {
+        return;
+      }
+
       // NB: Operator ignores SelectionType anyway
       new Operator().apply(editor, context, SelectionType.CHARACTER_WISE);
 
-      // jump back to visual start
-      executeNormal(parseKeys("`<"), editor);
-
       // leave visual mode
       executeNormal(parseKeys("<Esc>"), editor);
+
+      editor.getCaretModel().moveToOffset(visualRange.getStartOffset());
     }
   }
 

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -132,12 +132,7 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
       executeNormal(parseKeys("`<"), editor);
 
       // leave visual mode
-      executeNormal(
-        Collections.singletonList(
-          KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0)
-        ),
-        editor
-      );
+      parseKeys("<Esc>");
     }
   }
 

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -21,8 +21,8 @@ package com.maddyhome.idea.vim.extension.surround;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
-import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.extension.VimExtensionFacade;
 import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import com.maddyhome.idea.vim.extension.VimNonDisposableExtension;
 import org.jetbrains.annotations.NotNull;
@@ -47,7 +47,7 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
 
   @Override
   protected void initOnce() {
-    VimPlugin.getKey().putKeyMapping(MappingMode.N, parseKeys("ys"), null, new YSurroundHandler(), false);
+    VimExtensionFacade.putExtensionHandlerMapping(MappingMode.N, parseKeys("ys"), new YSurroundHandler(), false);
   }
 
   private static class YSurroundHandler implements VimExtensionHandler {

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -90,12 +90,11 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
       if (keyStroke.getKeyCode() == KeyEvent.VK_ESCAPE) {
         return true;
       }
-      // TODO: Handle `<` tags
       final char c = keyStroke.getKeyChar();
       if (c == KeyEvent.CHAR_UNDEFINED) {
         return false;
       }
-      final Pair<String, String> pair = getSurroundPair(c);
+      final Pair<String, String> pair = c == '<' || c == 't' ? inputTagPair(editor) : getSurroundPair(c);
       if (pair == null) {
         return false;
       }
@@ -108,6 +107,7 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
       final String leftSurround = pair.getFirst();
       change.insertText(editor, range.getStartOffset(), leftSurround);
       change.insertText(editor, range.getEndOffset() + leftSurround.length(), pair.getSecond());
+      // XXX: Should we move the caret to start offset?
       return true;
     }
 
@@ -133,6 +133,18 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
       else if (!Character.isLetter(c)) {
         final String s = String.valueOf(c);
         return Pair.create(s, s);
+      }
+      else {
+        return null;
+      }
+    }
+
+    @Nullable
+    private static Pair<String, String> inputTagPair(@NotNull Editor editor) {
+      final String tagInput = input(editor, "<");
+      if (tagInput.endsWith(">")) {
+        final String tagName = tagInput.substring(0, tagInput.length() - 1);
+        return Pair.create("<" + tagName + ">", "</" + tagName + ">");
       }
       else {
         return null;

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -1,0 +1,42 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.extension.surround;
+
+import com.maddyhome.idea.vim.extension.VimNonDisposableExtension;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Port of vim-surround.
+ *
+ * See https://github.com/tpope/vim-surround
+ *
+ * @author vlan
+ */
+public class VimSurroundExtension extends VimNonDisposableExtension {
+  @NotNull
+  @Override
+  public String getName() {
+    return "surround";
+  }
+
+  @Override
+  protected void initOnce() {
+    // TODO: Register key mappings via KeyGroup's new API for mapping to functions
+  }
+}

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -19,14 +19,15 @@
 package com.maddyhome.idea.vim.extension.surround;
 
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.maddyhome.idea.vim.command.MappingMode;
-import com.maddyhome.idea.vim.extension.VimExtensionFacade;
+import com.maddyhome.idea.vim.command.SelectionType;
 import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import com.maddyhome.idea.vim.extension.VimNonDisposableExtension;
+import com.maddyhome.idea.vim.key.OperatorFunction;
 import org.jetbrains.annotations.NotNull;
 
+import static com.maddyhome.idea.vim.extension.VimExtensionFacade.*;
 import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
 
 /**
@@ -37,8 +38,6 @@ import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
  * @author vlan
  */
 public class VimSurroundExtension extends VimNonDisposableExtension {
-  private static final Logger ourLogger = Logger.getInstance(VimSurroundExtension.class);
-
   @NotNull
   @Override
   public String getName() {
@@ -47,13 +46,21 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
 
   @Override
   protected void initOnce() {
-    VimExtensionFacade.putExtensionHandlerMapping(MappingMode.N, parseKeys("ys"), new YSurroundHandler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("ys"), new YSurroundHandler(), false);
   }
 
   private static class YSurroundHandler implements VimExtensionHandler {
     @Override
     public void execute(@NotNull Editor editor, @NotNull DataContext context) {
-      ourLogger.info("Executing Ysurround");
+      setOperatorFunction(new Operator());
+      executeNormal(parseKeys("g@"), editor, context);
+    }
+  }
+
+  private static class Operator implements OperatorFunction {
+    @Override
+    public void apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType) {
+      // TODO: Implement the surrounding action using the selected fragment
     }
   }
 }

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -99,6 +99,7 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
       if (pair == null) {
         return false;
       }
+      // XXX: Will it work with line-wise or block-wise selections?
       final TextRange range = getSurroundRange(editor);
       if (range == null) {
         return false;
@@ -117,6 +118,7 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
         case COMMAND:
           return VimPlugin.getMark().getChangeMarks(editor);
         case VISUAL:
+          // XXX: Untested code
           return VimPlugin.getMark().getVisualSelectionMarks(editor);
         default:
           return null;

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -20,6 +20,8 @@ package com.maddyhome.idea.vim.extension.surround;
 
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.command.MappingMode;
 import com.maddyhome.idea.vim.command.SelectionType;
 import com.maddyhome.idea.vim.extension.VimExtensionHandler;
@@ -27,8 +29,11 @@ import com.maddyhome.idea.vim.extension.VimNonDisposableExtension;
 import com.maddyhome.idea.vim.key.OperatorFunction;
 import org.jetbrains.annotations.NotNull;
 
+import javax.swing.*;
+
 import static com.maddyhome.idea.vim.extension.VimExtensionFacade.*;
 import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+import static com.maddyhome.idea.vim.helper.StringHelper.toKeyNotation;
 
 /**
  * Port of vim-surround.
@@ -60,7 +65,19 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
   private static class Operator implements OperatorFunction {
     @Override
     public void apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType) {
+      final KeyStroke keyStroke = getKeyStroke(editor);
       // TODO: Implement the surrounding action using the selected fragment
+      System.out.println(String.format("inputs:\n" +
+                                       "  mode: %s\n" +
+                                       "  selectionType: %s\n" +
+                                       "  changeRange: %s\n" +
+                                       "  visualRange: %s\n" +
+                                       "  keyStroke: %s\n",
+                                       CommandState.getInstance(editor).getMode(),
+                                       selectionType,
+                                       VimPlugin.getMark().getChangeMarks(editor),
+                                       VimPlugin.getMark().getVisualSelectionMarks(editor),
+                                       toKeyNotation(keyStroke)));
     }
   }
 }

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -79,7 +79,6 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
     putExtensionHandlerMapping(MappingMode.N, parseKeys("ys"), new YSurroundHandler(), false);
     putExtensionHandlerMapping(MappingMode.N, parseKeys("cs"), new CSurroundHandler(), false);
     putExtensionHandlerMapping(MappingMode.N, parseKeys("ds"), new DSurroundHandler(), false);
-
     putExtensionHandlerMapping(MappingMode.VO, parseKeys("S"), new VSurroundHandler(), false);
   }
 
@@ -132,7 +131,7 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
       executeNormal(parseKeys("`<"), editor);
 
       // leave visual mode
-      parseKeys("<Esc>");
+      executeNormal(parseKeys("<Esc>"), editor);
     }
   }
 
@@ -159,12 +158,6 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
 
     static void change(@NotNull Editor editor, char charFrom, @Nullable Pair<String, String> newSurround) {
 
-      if (charFrom == 't') {
-        // ideaVim doesn't currently support `dat` or `dit`,
-        //  so we can't support it here, either
-        return;
-      }
-
       // we take over the " register, so preserve it
       final List<KeyStroke> oldValue = getreg(REGISTER);
 
@@ -180,8 +173,8 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
 
       // insert the surrounding characters and paste
       if (newSurround != null) {
-        innerValue.addAll(0, parseKeys(newSurround.first));
-        innerValue.addAll(parseKeys(newSurround.second));
+        innerValue.addAll(0, parseKeys(escape(newSurround.first)));
+        innerValue.addAll(parseKeys(escape(newSurround.second)));
       }
       pasteSurround(innerValue, editor);
 
@@ -190,6 +183,10 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
 
       // jump back to start
       executeNormal(parseKeys("`["), editor);
+    }
+
+    private static String escape(String sequence) {
+      return sequence.replace("<", "\\<");
     }
 
     /** perform an action, storing the result in our register */

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -18,8 +18,16 @@
 
 package com.maddyhome.idea.vim.extension.surround;
 
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import com.maddyhome.idea.vim.extension.VimNonDisposableExtension;
 import org.jetbrains.annotations.NotNull;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
 
 /**
  * Port of vim-surround.
@@ -29,6 +37,8 @@ import org.jetbrains.annotations.NotNull;
  * @author vlan
  */
 public class VimSurroundExtension extends VimNonDisposableExtension {
+  private static final Logger ourLogger = Logger.getInstance(VimSurroundExtension.class);
+
   @NotNull
   @Override
   public String getName() {
@@ -37,6 +47,13 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
 
   @Override
   protected void initOnce() {
-    // TODO: Register key mappings via KeyGroup's new API for mapping to functions
+    VimPlugin.getKey().putKeyMapping(MappingMode.N, parseKeys("ys"), null, new YSurroundHandler(), false);
+  }
+
+  private static class YSurroundHandler implements VimExtensionHandler {
+    @Override
+    public void execute(@NotNull Editor editor, @NotNull DataContext context) {
+      ourLogger.info("Executing Ysurround");
+    }
   }
 }

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -335,7 +335,7 @@ public class ChangeGroup {
     CommandState state = CommandState.getInstance(editor);
 
     insertStart = editor.getCaretModel().getOffset();
-    VimPlugin.getMark().setMark(editor, '[', insertStart);
+    VimPlugin.getMark().setMark(editor, MarkGroup.MARK_CHANGE_START, insertStart);
 
     // If we are repeating the last insert/replace
     final Command cmd = state.getCommand();
@@ -538,8 +538,8 @@ public class ChangeGroup {
     final MarkGroup markGroup = VimPlugin.getMark();
     final int offset = editor.getCaretModel().getOffset();
     markGroup.setMark(editor, '^', offset);
-    markGroup.setMark(editor, ']', offset);
-    markGroup.setMark(editor, '.', offset);
+    markGroup.setMark(editor, MarkGroup.MARK_CHANGE_END, offset);
+    markGroup.setMark(editor, MarkGroup.MARK_CHANGE_POS, offset);
     CommandState.getInstance(editor).popState();
 
     if (!CommandState.inInsertMode(editor)) {
@@ -1456,7 +1456,7 @@ public class ChangeGroup {
     editor.getDocument().insertString(start, str);
     editor.getCaretModel().moveToOffset(start + str.length());
 
-    VimPlugin.getMark().setMark(editor, '.', start);
+    VimPlugin.getMark().setMark(editor, MarkGroup.MARK_CHANGE_POS, start);
   }
 
   /**
@@ -1484,9 +1484,8 @@ public class ChangeGroup {
 
       if (type != null) {
         int start = range.getStartOffset();
-        VimPlugin.getMark().setMark(editor, '.', start);
-        VimPlugin.getMark().setMark(editor, '[', start);
-        VimPlugin.getMark().setMark(editor, ']', start);
+        VimPlugin.getMark().setMark(editor, MarkGroup.MARK_CHANGE_POS, start);
+        VimPlugin.getMark().setChangeMarks(editor, range);
       }
 
       return true;
@@ -1506,9 +1505,9 @@ public class ChangeGroup {
   private void replaceText(@NotNull Editor editor, int start, int end, @NotNull String str) {
     editor.getDocument().replaceString(start, end, str);
 
-    VimPlugin.getMark().setMark(editor, '[', start);
-    VimPlugin.getMark().setMark(editor, ']', start + str.length());
-    VimPlugin.getMark().setMark(editor, '.', start + str.length());
+    final int newEnd = start + str.length();
+    VimPlugin.getMark().setChangeMarks(editor, new TextRange(start, newEnd));
+    VimPlugin.getMark().setMark(editor, MarkGroup.MARK_CHANGE_POS, newEnd);
   }
 
   /**

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -1485,7 +1485,7 @@ public class ChangeGroup {
       if (type != null) {
         int start = range.getStartOffset();
         VimPlugin.getMark().setMark(editor, MarkGroup.MARK_CHANGE_POS, start);
-        VimPlugin.getMark().setChangeMarks(editor, range);
+        VimPlugin.getMark().setChangeMarks(editor, new TextRange(start, start));
       }
 
       return true;

--- a/src/com/maddyhome/idea/vim/group/CopyGroup.java
+++ b/src/com/maddyhome/idea/vim/group/CopyGroup.java
@@ -439,9 +439,7 @@ public class CopyGroup {
         break;
     }
 
-    final MarkGroup markGroup = VimPlugin.getMark();
-    markGroup.setMark(editor, '[', offset);
-    markGroup.setMark(editor, ']', endOffset);
+    VimPlugin.getMark().setChangeMarks(editor, new TextRange(offset, endOffset));
   }
 
   private static final Logger logger = Logger.getInstance(CopyGroup.class.getName());

--- a/src/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -65,6 +65,7 @@ public class KeyGroup {
   @NotNull private final Set<KeyStroke> requiredShortcutKeys = new HashSet<KeyStroke>();
   @NotNull private final HashMap<MappingMode, RootNode> keyRoots = new HashMap<MappingMode, RootNode>();
   @NotNull private final Map<MappingMode, KeyMapping> keyMappings = new HashMap<MappingMode, KeyMapping>();
+  @Nullable private OperatorFunction operatorFunction = null;
 
   public void registerRequiredShortcutKeys(@NotNull Editor editor) {
     final Set<KeyStroke> requiredKeys = VimPlugin.getKey().getRequiredShortcutKeys();
@@ -123,6 +124,15 @@ public class KeyGroup {
         registerRequiredShortcutKeys(editor);
       }
     }
+  }
+
+  @Nullable
+  public OperatorFunction getOperatorFunction() {
+    return operatorFunction;
+  }
+
+  public void setOperatorFunction(@NotNull OperatorFunction function) {
+    operatorFunction = function;
   }
 
   public void saveData(@NotNull Element element) {

--- a/src/com/maddyhome/idea/vim/group/MarkGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MarkGroup.java
@@ -51,6 +51,9 @@ import java.util.*;
 public class MarkGroup {
   public static final char MARK_VISUAL_START = '<';
   public static final char MARK_VISUAL_END = '>';
+  public static final char MARK_CHANGE_START = '[';
+  public static final char MARK_CHANGE_END = ']';
+  public static final char MARK_CHANGE_POS = '.';
 
   /**
    * Creates the class
@@ -225,10 +228,25 @@ public class MarkGroup {
     setMark(editor, MARK_VISUAL_END, range.getEndOffset());
   }
 
+  public void setChangeMarks(@NotNull Editor editor, @NotNull TextRange range) {
+    setMark(editor, MARK_CHANGE_START, range.getStartOffset());
+    setMark(editor, MARK_CHANGE_END, range.getEndOffset());
+  }
+
+  @Nullable
+  public TextRange getChangeMarks(@NotNull Editor editor) {
+    return getMarksRange(editor, MARK_CHANGE_START, MARK_CHANGE_END);
+  }
+
   @Nullable
   public TextRange getVisualSelectionMarks(@NotNull Editor editor) {
-    final Mark start = getMark(editor, MARK_VISUAL_START);
-    final Mark end = getMark(editor, MARK_VISUAL_END);
+    return getMarksRange(editor, MARK_VISUAL_START, MARK_VISUAL_END);
+  }
+
+  @Nullable
+  private TextRange getMarksRange(@NotNull Editor editor, char startMark, char endMark) {
+    final Mark start = getMark(editor, startMark);
+    final Mark end = getMark(editor, endMark);
     if (start != null && end != null) {
       final int startOffset = EditorHelper.getOffset(editor, start.getLogicalLine(), start.getCol());
       final int endOffset = EditorHelper.getOffset(editor, end.getLogicalLine(), end.getCol());

--- a/src/com/maddyhome/idea/vim/group/RegisterGroup.java
+++ b/src/com/maddyhome/idea/vim/group/RegisterGroup.java
@@ -207,8 +207,7 @@ public class RegisterGroup {
     }
 
     if (start != -1) {
-      VimPlugin.getMark().setMark(editor, '[', start);
-      VimPlugin.getMark().setMark(editor, ']', Math.max(end - 1, 0));
+      VimPlugin.getMark().setChangeMarks(editor, new TextRange(start, Math.max(end - 1, 0)));
     }
 
     return true;

--- a/src/com/maddyhome/idea/vim/helper/EditorData.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorData.java
@@ -267,6 +267,7 @@ public class EditorData {
   public static final Key<Boolean> LINE_NUMBERS_SHOWN = new Key<Boolean>("lineNumbersShown");
   private static final Key<ExOutputPanel> MORE_PANEL = new Key<ExOutputPanel>("IdeaVim.morePanel");
   private static final Key<ExOutputModel> EX_OUTPUT_MODEL = new Key<ExOutputModel>("IdeaVim.exOutputModel");
+  private static final Key<TestInputModel> TEST_INPUT_MODEL = new Key<TestInputModel>("IdeaVim.testInputModel");
 
   private static Key CONSOLE_VIEW_IN_EDITOR_VIEW = Key.create("CONSOLE_VIEW_IN_EDITOR_VIEW");
 
@@ -308,5 +309,14 @@ public class EditorData {
   public static boolean isFileEditor(@NotNull Editor editor){
     final VirtualFile virtualFile = EditorData.getVirtualFile(editor);
     return virtualFile != null && !(virtualFile instanceof LightVirtualFile);
+  }
+
+  @Nullable
+  public static TestInputModel getTestInputModel(@NotNull Editor editor) {
+    return editor.getUserData(TEST_INPUT_MODEL);
+  }
+
+  public static void setTestInputModel(@NotNull Editor editor, @NotNull TestInputModel model) {
+    editor.putUserData(TEST_INPUT_MODEL, model);
   }
 }

--- a/src/com/maddyhome/idea/vim/helper/StringHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/StringHelper.java
@@ -314,6 +314,12 @@ public class StringHelper {
     return false;
   }
 
+  public static boolean isCloseKeyStroke(@NotNull KeyStroke key) {
+    return key.getKeyCode() == VK_ESCAPE ||
+           key.getKeyCode() == VK_C && (key.getModifiers() & CTRL_MASK) != 0 ||
+           key.getKeyCode() == '[' && (key.getModifiers() & CTRL_MASK) != 0;
+  }
+
   /**
    * Set the text of an XML element, safely encode it if needed.
    */

--- a/src/com/maddyhome/idea/vim/helper/TestInputModel.java
+++ b/src/com/maddyhome/idea/vim/helper/TestInputModel.java
@@ -1,0 +1,58 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.helper;
+
+import com.google.common.collect.Lists;
+import com.intellij.openapi.editor.Editor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.List;
+
+/**
+ * @author vlan
+ */
+public class TestInputModel {
+  @NotNull private final List<KeyStroke> myKeyStrokes = Lists.newArrayList();
+
+  private TestInputModel() {}
+
+  public static TestInputModel getInstance(@NotNull Editor editor) {
+    TestInputModel model = EditorData.getTestInputModel(editor);
+    if (model == null) {
+      model = new TestInputModel();
+      EditorData.setTestInputModel(editor, model);
+    }
+    return model;
+  }
+
+  public void setKeyStrokes(@NotNull List<KeyStroke> keyStrokes) {
+    myKeyStrokes.clear();
+    myKeyStrokes.addAll(keyStrokes);
+  }
+
+  @Nullable
+  public KeyStroke nextKeyStroke() {
+    if (!myKeyStrokes.isEmpty()) {
+      return myKeyStrokes.remove(0);
+    }
+    return null;
+  }
+}

--- a/src/com/maddyhome/idea/vim/key/KeyMapping.java
+++ b/src/com/maddyhome/idea/vim/key/KeyMapping.java
@@ -20,6 +20,7 @@ package com.maddyhome.idea.vim.key;
 
 import com.google.common.collect.ImmutableList;
 import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -45,8 +46,9 @@ public class KeyMapping implements Iterable<List<KeyStroke>> {
   }
 
   public void put(@NotNull Set<MappingMode> mappingModes, @NotNull List<KeyStroke> fromKeys,
-                  @NotNull List<KeyStroke> toKeys, boolean recursive) {
-    myKeys.put(ImmutableList.copyOf(fromKeys), new MappingInfo(mappingModes, fromKeys, toKeys, recursive));
+                  @Nullable List<KeyStroke> toKeys, @Nullable VimExtensionHandler extensionHandler, boolean recursive) {
+    myKeys.put(ImmutableList.copyOf(fromKeys),
+               new MappingInfo(mappingModes, fromKeys, toKeys, extensionHandler, recursive));
     List<KeyStroke> prefix = new ArrayList<KeyStroke>();
     final int prefixLength = fromKeys.size() - 1;
     for (int i = 0; i < prefixLength; i++) {

--- a/src/com/maddyhome/idea/vim/key/MappingInfo.java
+++ b/src/com/maddyhome/idea/vim/key/MappingInfo.java
@@ -19,7 +19,9 @@
 package com.maddyhome.idea.vim.key;
 
 import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.event.KeyEvent;
@@ -32,14 +34,17 @@ import java.util.Set;
 public class MappingInfo implements Comparable<MappingInfo> {
   @NotNull private final Set<MappingMode> myMappingModes;
   @NotNull private final List<KeyStroke> myFromKeys;
-  @NotNull private final List<KeyStroke> myToKeys;
+  @Nullable private final List<KeyStroke> myToKeys;
+  @Nullable private final VimExtensionHandler myExtensionHandler;
   private final boolean myRecursive;
 
   public MappingInfo(@NotNull Set<MappingMode> mappingModes, @NotNull List<KeyStroke> fromKeys,
-                     @NotNull List<KeyStroke> toKeys, boolean recursive) {
+                     @Nullable List<KeyStroke> toKeys, @Nullable VimExtensionHandler extensionHandler,
+                     boolean recursive) {
     myMappingModes = mappingModes;
     myFromKeys = fromKeys;
     myToKeys = toKeys;
+    myExtensionHandler = extensionHandler;
     myRecursive = recursive;
   }
 
@@ -67,9 +72,14 @@ public class MappingInfo implements Comparable<MappingInfo> {
     return myFromKeys;
   }
 
-  @NotNull
+  @Nullable
   public List<KeyStroke> getToKeys() {
     return myToKeys;
+  }
+
+  @Nullable
+  public VimExtensionHandler getExtensionHandler() {
+    return myExtensionHandler;
   }
 
   public boolean isRecursive() {

--- a/src/com/maddyhome/idea/vim/key/OperatorFunction.java
+++ b/src/com/maddyhome/idea/vim/key/OperatorFunction.java
@@ -27,5 +27,5 @@ import org.jetbrains.annotations.NotNull;
  * @author vlan
  */
 public interface OperatorFunction {
-  void apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType);
+  boolean apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType);
 }

--- a/src/com/maddyhome/idea/vim/key/OperatorFunction.java
+++ b/src/com/maddyhome/idea/vim/key/OperatorFunction.java
@@ -1,0 +1,31 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.key;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.command.SelectionType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author vlan
+ */
+public interface OperatorFunction {
+  void apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType);
+}

--- a/src/com/maddyhome/idea/vim/package-info.java
+++ b/src/com/maddyhome/idea/vim/package-info.java
@@ -89,6 +89,14 @@
  * |CTRL-W_bar|             TODO
  *
  *
+ * 2.4. Commands starting with 'g'
+ *
+ * tag                      action
+ * ---------------------------------------------------------------------------------------------------------------------
+ *
+ * |g@|                     {@link com.maddyhome.idea.vim.action.change.OperatorAction}
+ *
+ *
  * 3. Visual mode
  *
  * tag                      action

--- a/src/com/maddyhome/idea/vim/ui/ModalEntryDialog.java
+++ b/src/com/maddyhome/idea/vim/ui/ModalEntryDialog.java
@@ -1,0 +1,91 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.ui;
+
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.helper.UiHelper;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.KeyListener;
+
+/**
+ * @author vlan
+ */
+public class ModalEntryDialog extends JDialog {
+  @NotNull private final JTextField myEntry;
+  @NotNull private final JLabel myLabel;
+  @NotNull private final JComponent myParent;
+
+  public ModalEntryDialog(@NotNull Editor editor, @NotNull String prompt) {
+    super((Frame)null, true);
+    myParent = editor.getContentComponent();
+    myLabel = new JLabel(prompt);
+    myEntry = new JTextField();
+
+    myEntry.setBorder(null);
+
+    final Font font = UiHelper.getEditorFont();
+    myLabel.setFont(font);
+    myEntry.setFont(font);
+
+    setForeground(myEntry.getForeground());
+    setBackground(myEntry.getBackground());
+
+    myLabel.setForeground(myEntry.getForeground());
+    myLabel.setBackground(myEntry.getBackground());
+
+    GridBagLayout layout = new GridBagLayout();
+    GridBagConstraints gbc = new GridBagConstraints();
+
+    setLayout(layout);
+    gbc.gridx = 0;
+    layout.setConstraints(myLabel, gbc);
+    add(myLabel);
+    gbc.gridx = 1;
+    gbc.weightx = 1;
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    layout.setConstraints(myEntry, gbc);
+    add(myEntry);
+
+    setUndecorated(true);
+
+    final Container scroll = SwingUtilities.getAncestorOfClass(JScrollPane.class, myParent);
+    final int height = (int)getPreferredSize().getHeight();
+    if (scroll != null) {
+      final Rectangle bounds = scroll.getBounds();
+      bounds.translate(0, scroll.getHeight() - height);
+      bounds.height = height;
+      final JRootPane rootPane = SwingUtilities.getRootPane(myParent);
+      final Point pos = SwingUtilities.convertPoint(scroll.getParent(), bounds.getLocation(), rootPane);
+      final Window window = SwingUtilities.getWindowAncestor(myParent);
+      final Point windowPos = window.getLocation();
+      pos.translate(windowPos.x, windowPos.y);
+      final Insets windowInsets = window.getInsets();
+      pos.translate(windowInsets.left, windowInsets.top);
+      bounds.setLocation(pos);
+      setBounds(bounds);
+    }
+  }
+
+  public void setEntryKeyListener(@NotNull KeyListener listener) {
+    myEntry.addKeyListener(listener);
+  }
+}

--- a/src/com/maddyhome/idea/vim/ui/ModalEntryDialog.java
+++ b/src/com/maddyhome/idea/vim/ui/ModalEntryDialog.java
@@ -88,4 +88,9 @@ public class ModalEntryDialog extends JDialog {
   public void setEntryKeyListener(@NotNull KeyListener listener) {
     myEntry.addKeyListener(listener);
   }
+
+  @NotNull
+  public String getText() {
+    return myEntry.getText();
+  }
 }

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -21,7 +21,7 @@ public class VimSurroundExtensionTest extends VimTestCase {
       "if <caret>condition {\n" +
       "}\n";
     final String after =
-      "if (condition) {\n" +
+      "if <caret>(condition) {\n" +
       "}\n";
 
     doTest(parseKeys("yseb"), before, after);
@@ -80,6 +80,77 @@ public class VimSurroundExtensionTest extends VimTestCase {
     typeText(parseKeys("ysiw<em><Enter>"));
     myFixture.checkResult("Hello <em>World</em>!\n");
   }
+
+  /* Delete surroundings */
+
+  public void testDeleteSurroundingParens() {
+    final String before =
+      "if (<caret>condition) {\n" +
+      "}\n";
+    final String after =
+      "if condition {\n" +
+      "}\n";
+
+    doTest(parseKeys("dsb"), before, after);
+    doTest(parseKeys("ds("), before, after);
+    doTest(parseKeys("ds)"), before, after);
+  }
+
+  public void testDeleteSurroundingQuote() {
+    final String before =
+      "if (\"<caret>foo\".equals(foo)) {\n" +
+      "}\n";
+    final String after =
+      "if (<caret>foo.equals(foo)) {\n" +
+      "}\n";
+
+    doTest(parseKeys("ds\""), before, after);
+  }
+
+  public void testDeleteSurroundingBlock() {
+    final String before =
+      "if (condition) {<caret>return;}\n";
+    final String after =
+      "if (condition) return;\n";
+
+    doTest(parseKeys("dsB"), before, after);
+    doTest(parseKeys("ds}"), before, after);
+    doTest(parseKeys("ds{"), before, after);
+  }
+
+  public void testDeleteSurroundingArray() {
+    final String before =
+      "int foo = bar[<caret>index];";
+    final String after =
+      "int foo = barindex;";
+
+    doTest(parseKeys("dsr"), before, after);
+    doTest(parseKeys("ds]"), before, after);
+    doTest(parseKeys("ds["), before, after);
+  }
+
+  public void testDeleteSurroundingAngle() {
+    final String before =
+      "foo = new Bar<<caret>Baz>();";
+    final String after =
+      "foo = new BarBaz();";
+
+    doTest(parseKeys("dsa"), before, after);
+    doTest(parseKeys("ds>"), before, after);
+    doTest(parseKeys("ds<"), before, after);
+  }
+
+  // TODO if/when we add proper repeat support
+  //public void testRepeatDeleteSurroundParens() {
+  //  final String before =
+  //    "if ((<caret>condition)) {\n" +
+  //    "}\n";
+  //  final String after =
+  //    "if condition {\n" +
+  //    "}\n";
+  //
+  //  doTest(parseKeys("dsb."), before, after);
+  //}
 
   /* Change surroundings */
 

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -74,4 +74,10 @@ public class VimSurroundExtensionTest extends VimTestCase {
     doTest(parseKeys("yst;\""), before, after);
     doTest(parseKeys("ys4w\""), before, after);
   }
+
+  public void testSurroundTag() {
+    configureByText("Hello <caret>World!\n");
+    typeText(parseKeys("ysiw<em><Enter>"));
+    myFixture.checkResult("Hello <em>World</em>!\n");
+  }
 }

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -78,7 +78,7 @@ public class VimSurroundExtensionTest extends VimTestCase {
 
   public void testSurroundTag() {
     configureByText("Hello <caret>World!\n");
-    typeText(parseKeys("ysiw<em><Enter>"));
+    typeText(parseKeys("ysiw\\<em>"));
     myFixture.checkResult("Hello <em>World</em>!\n");
   }
 
@@ -161,6 +161,15 @@ public class VimSurroundExtensionTest extends VimTestCase {
     doTest(parseKeys("ds<"), before, after);
   }
 
+  public void testDeleteSurroundingTag() {
+     final String before =
+      "<div><p><caret>Foo</p></div>";
+    final String after =
+      "<div><caret>Foo</div>";
+
+    doTest(parseKeys("dst"), before, after);
+  }
+
   // TODO if/when we add proper repeat support
   //public void testRepeatDeleteSurroundParens() {
   //  final String before =
@@ -193,6 +202,24 @@ public class VimSurroundExtensionTest extends VimTestCase {
       "if (condition) (return;)";
 
     doTest(parseKeys("csBb"), before, after);
+  }
+
+  public void testChangeSurroundingTagSimple() {
+    final String before =
+      "<div><p><caret>Foo</p></div>";
+    final String after =
+      "<div><caret>(Foo)</div>";
+
+    doTest(parseKeys("cstb"), before, after);
+  }
+
+  public void testChangeSurroundingTagAnotherTag() {
+    final String before =
+      "<div><p><caret>Foo</p></div>";
+    final String after =
+      "<div><caret><b>Foo</b></div>";
+
+    doTest(parseKeys("cst\\<b>"), before, after);
   }
 
   // TODO if/when we add proper repeat support

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -1,6 +1,9 @@
 package org.jetbrains.plugins.ideavim.extension.surround;
 
+import com.maddyhome.idea.vim.command.CommandState;
 import org.jetbrains.plugins.ideavim.VimTestCase;
+
+import javax.jws.WebParam;
 
 import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
 
@@ -79,6 +82,26 @@ public class VimSurroundExtensionTest extends VimTestCase {
     configureByText("Hello <caret>World!\n");
     typeText(parseKeys("ysiw<em><Enter>"));
     myFixture.checkResult("Hello <em>World</em>!\n");
+  }
+
+  /* visual surround */
+
+  public void testVisualSurroundWordParens() {
+    final String before =
+      "if <caret>condition {\n" +
+      "}\n";
+    final String after =
+      "if <caret>(condition) {\n" +
+      "}\n";
+
+    doTest(parseKeys("veSb"), before, after);
+    assertMode(CommandState.Mode.COMMAND);
+    doTest(parseKeys("veS)"), before, after);
+    assertMode(CommandState.Mode.COMMAND);
+    doTest(parseKeys("veS("), before,
+           "if ( condition ) {\n" +
+           "}\n");
+    assertMode(CommandState.Mode.COMMAND);
   }
 
   /* Delete surroundings */

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -3,8 +3,6 @@ package org.jetbrains.plugins.ideavim.extension.surround;
 import com.maddyhome.idea.vim.command.CommandState;
 import org.jetbrains.plugins.ideavim.VimTestCase;
 
-import javax.jws.WebParam;
-
 import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
 
 /**

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -80,4 +80,36 @@ public class VimSurroundExtensionTest extends VimTestCase {
     typeText(parseKeys("ysiw<em><Enter>"));
     myFixture.checkResult("Hello <em>World</em>!\n");
   }
+
+  /* Change surroundings */
+
+  public void testChangeSurroundingParens() {
+    final String before =
+      "if (<caret>condition) {\n" +
+      "}\n";
+    final String after =
+      "if [condition] {\n" +
+      "}\n";
+
+    doTest(parseKeys("csbr"), before, after);
+  }
+
+  public void testChangeSurroundingBlock() {
+    final String before =
+      "if (condition) {<caret>return;}";
+    final String after =
+      "if (condition) (return;)";
+
+    doTest(parseKeys("csBb"), before, after);
+  }
+
+  // TODO if/when we add proper repeat support
+  //public void testRepeatChangeSurroundingParens() {
+  //  final String before =
+  //    "foo(<caret>index)(index2) = bar;";
+  //  final String after =
+  //    "foo[index][index2] = bar;";
+  //
+  //  doTest(parseKeys("csbrE."), before, after);
+  //}
 }

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -63,8 +63,6 @@ public class VimSurroundExtensionTest extends VimTestCase {
 
     doTest(parseKeys("ysea"), before, after);
     doTest(parseKeys("yse>"), before, after);
-    doTest(parseKeys("yse<"), before,
-           "foo = new Bar< Baz >();");
   }
 
   public void testSurroundQuotes() {

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -76,16 +76,4 @@ public class VimSurroundExtensionTest extends VimTestCase {
     doTest(parseKeys("yst;\""), before, after);
     doTest(parseKeys("ys4w\""), before, after);
   }
-
-  public void testRepeatSurroundWord() {
-     final String before =
-      "if <caret>condition {\n" +
-      "}\n";
-    final String after =
-      "if ((condition)) {\n" +
-      "}\n";
-
-    doTest(parseKeys("yseb."), before, after);
-    doTest(parseKeys("ysiwbl."), before, after);
-  }
 }

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -1,0 +1,91 @@
+package org.jetbrains.plugins.ideavim.extension.surround;
+
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * @author dhleong
+ */
+public class VimSurroundExtensionTest extends VimTestCase {
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    enableExtensions("surround");
+  }
+
+  /* surround */
+
+  public void testSurroundWordParens() {
+    final String before =
+      "if <caret>condition {\n" +
+      "}\n";
+    final String after =
+      "if (condition) {\n" +
+      "}\n";
+
+    doTest(parseKeys("yseb"), before, after);
+    doTest(parseKeys("yse)"), before, after);
+    doTest(parseKeys("yse("), before,
+           "if ( condition ) {\n" +
+            "}\n");
+  }
+
+  public void testSurroundWORDBlock() {
+    final String before =
+      "if (condition) <caret>return;\n";
+    final String after =
+      "if (condition) {return;}\n";
+
+    doTest(parseKeys("ysEB"), before, after);
+    doTest(parseKeys("ysE}"), before, after);
+    doTest(parseKeys("ysE{"), before,
+           "if (condition) { return; }\n");
+  }
+
+  public void testSurroundWordArray() {
+    final String before =
+      "int foo = bar<caret>index;";
+    final String after =
+      "int foo = bar[index];";
+
+    doTest(parseKeys("yser"), before, after);
+    doTest(parseKeys("yse]"), before, after);
+    doTest(parseKeys("yse["), before,
+           "int foo = bar[ index ];");
+  }
+
+  public void testSurroundWordAngle() {
+    final String before =
+      "foo = new Bar<caret>Baz();";
+    final String after =
+      "foo = new Bar<Baz>();";
+
+    doTest(parseKeys("ysea"), before, after);
+    doTest(parseKeys("yse>"), before, after);
+    doTest(parseKeys("yse<"), before,
+           "foo = new Bar< Baz >();");
+  }
+
+  public void testSurroundQuotes() {
+    final String before =
+      "foo = <caret>new Bar.Baz;";
+    final String after =
+      "foo = \"new Bar.Baz\";";
+
+    doTest(parseKeys("yst;\""), before, after);
+    doTest(parseKeys("ys4w\""), before, after);
+  }
+
+  public void testRepeatSurroundWord() {
+     final String before =
+      "if <caret>condition {\n" +
+      "}\n";
+    final String after =
+      "if ((condition)) {\n" +
+      "}\n";
+
+    doTest(parseKeys("yseb."), before, after);
+    doTest(parseKeys("ysiwbl."), before, after);
+  }
+}


### PR DESCRIPTION
I've added the following:

1. An extension point `IdeaVIM.vimExtension`. for registering IdeaVim extensions. See plugin.xml and `VimSurroundExtension` as an example. You have to add a `<vimExtension/>` tag into plugin.xml and inherit from `VimExtension` in order to get your plugin registered and get the `set <plguin-name>` option working.
2. The `VimExtensionFacade` contains the parts of the API for extension authors that is similar to Vim.
3. Extension actions are registered via `putExtensionHandlerMapping()` similar to `:map ... :call <your-extension-handler>` in Vim.
4. If your extension handler requires an argument, use `operatorfunc` (available as `setOperatorFunction()`) and `g@` as in Vim.
5. `getchar()` is implemented as a modal dialog that looks like Vim input line at the bottom of the editor, see `getKeyStroke()`
  * I'll add a unit-testable version of the modal dialog-based implementation

Next steps:

1. Add vim-surround commands with unit tests
2. Extend `VimExtensionFacade` according to the needs of the vim-surround port
