### PR TITLE
First stab at <Plug> mappings

### DIFF
--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -46,6 +46,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Stack;
 
@@ -54,6 +55,12 @@ import java.util.Stack;
  * actions. This is a singleton.
  */
 public class KeyHandler {
+
+  /**
+   * Special "key" for &lt;Plug&gt; mappings.
+   */
+  public static final char KEY_PLUG = KeyEvent.CHAR_UNDEFINED - 1;
+
   /**
    * Returns a reference to the singleton instance of this class
    *
@@ -233,6 +240,7 @@ public class KeyHandler {
 
     final KeyMapping mapping = VimPlugin.getKey().getKeyMapping(mappingMode);
     final MappingInfo mappingInfo = mapping.get(fromKeys);
+    final MappingInfo plugInfo = mapping.getPlug(fromKeys);
 
     if (mapping.isPrefix(fromKeys)) {
       mappingKeys.add(key);
@@ -249,46 +257,78 @@ public class KeyHandler {
     }
     else if (mappingInfo != null) {
       mappingKeys.clear();
-      final Application application = ApplicationManager.getApplication();
-      final Runnable handleMappedKeys = new Runnable() {
-        @Override
-        public void run() {
-          final List<KeyStroke> toKeys = mappingInfo.getToKeys();
-          final VimExtensionHandler extensionHandler = mappingInfo.getExtensionHandler();
-          if (toKeys != null) {
-            final boolean fromIsPrefix = isPrefix(mappingInfo.getFromKeys(), toKeys);
-            boolean first = true;
-            for (KeyStroke keyStroke : toKeys) {
-              final boolean recursive = mappingInfo.isRecursive() && !(first && fromIsPrefix);
-              handleKey(editor, keyStroke, new EditorDataContext(editor), recursive);
-              first = false;
-            }
-          }
-          else if (extensionHandler != null) {
-            RunnableHelper.runWriteCommand(editor.getProject(), new Runnable() {
-              @Override
-              public void run() {
-                extensionHandler.execute(editor, context);
-              }
-            }, "Vim " + extensionHandler.getClass().getSimpleName(), null);
-          }
-        }
-      };
-      if (application.isUnitTestMode()) {
-        handleMappedKeys.run();
-      }
-      else {
-        application.invokeLater(handleMappedKeys);
-      }
+      invokeMappingInfo(editor, context, mappingInfo,
+                        Collections.<KeyStroke>emptyList());
+      return true;
+    }
+    else if (plugInfo != null) {
+      mappingKeys.clear();
+
+      // NB: Ambiguous Plug mappings break if we do not add special handling,
+      //  because they cease to be prefixes would otherwise be executed in
+      //  the else branch without recursion
+      List<KeyStroke> extraKeys =
+        fromKeys.subList(plugInfo.getFromKeys().size(), fromKeys.size());
+      invokeMappingInfo(editor, context, plugInfo, extraKeys);
       return true;
     }
     else {
       final List<KeyStroke> unhandledKeys = new ArrayList<KeyStroke>(mappingKeys);
       mappingKeys.clear();
+
       for (KeyStroke keyStroke : unhandledKeys) {
         handleKey(editor, keyStroke, context, false);
       }
       return false;
+    }
+  }
+
+  private void invokeMappingInfo(@NotNull final Editor editor,
+                                 @NotNull final DataContext context,
+                                 @NotNull final MappingInfo mappingInfo,
+                                 @NotNull final List<KeyStroke> extraStrokes) {
+    final Application application = ApplicationManager.getApplication();
+    final Runnable handleMappedKeys = new Runnable() {
+      @Override
+      public void run() {
+        final List<KeyStroke> toKeys = mappingInfo.getToKeys();
+        final VimExtensionHandler extensionHandler = mappingInfo.getExtensionHandler();
+        if (toKeys != null) {
+          final boolean fromIsPrefix = isPrefix(mappingInfo.getFromKeys(), toKeys);
+          boolean first = true;
+          for (KeyStroke keyStroke : toKeys) {
+            final boolean recursive = mappingInfo.isRecursive() && !(first && fromIsPrefix);
+            handleKey(editor, keyStroke, new EditorDataContext(editor), recursive);
+            first = false;
+          }
+
+          for (KeyStroke keyStroke : extraStrokes) {
+            handleKey(editor, keyStroke, new EditorDataContext(editor), false);
+          }
+        }
+        else if (extensionHandler != null) {
+          final PlugInputModel model = PlugInputModel.getInstance(editor);
+          model.setPendingKeyStrokes(extraStrokes);
+
+          RunnableHelper.runWriteCommand(editor.getProject(), new Runnable() {
+            @Override
+            public void run() {
+              extensionHandler.execute(editor, context);
+            }
+          }, "Vim " + extensionHandler.getClass().getSimpleName(), null);
+
+          final List<KeyStroke> unused = model.removePendingKeyStrokes();
+          for (KeyStroke keyStroke : unused) {
+            handleKey(editor, keyStroke, new EditorDataContext(editor), false);
+          }
+        }
+      }
+    };
+    if (application.isUnitTestMode()) {
+      handleMappedKeys.run();
+    }
+    else {
+      application.invokeLater(handleMappedKeys);
     }
   }
 

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -76,10 +76,18 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
 
   @Override
   protected void initOnce() {
-    putExtensionHandlerMapping(MappingMode.N, parseKeys("ys"), new YSurroundHandler(), false);
-    putExtensionHandlerMapping(MappingMode.N, parseKeys("cs"), new CSurroundHandler(), false);
-    putExtensionHandlerMapping(MappingMode.N, parseKeys("ds"), new DSurroundHandler(), false);
-    putExtensionHandlerMapping(MappingMode.VO, parseKeys("S"), new VSurroundHandler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>YSurround"), new YSurroundHandler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>CSurround"), new CSurroundHandler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>DSurround"), new DSurroundHandler(), false);
+    putExtensionHandlerMapping(MappingMode.VO, parseKeys("<Plug>VSurround"), new VSurroundHandler(), false);
+
+    putKeyMapping(MappingMode.N, parseKeys("ys"), parseKeys("<Plug>YSurround"), true);
+    putKeyMapping(MappingMode.N, parseKeys("cs"), parseKeys("<Plug>CSurround"), true);
+    putKeyMapping(MappingMode.N, parseKeys("ds"), parseKeys("<Plug>DSurround"), true);
+    putKeyMapping(MappingMode.VO, parseKeys("S"), parseKeys("<Plug>VSurround"), true);
+
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>YSurroundMore"), new YSurroundHandler(), false);
+    putKeyMapping(MappingMode.N, parseKeys("gms"), parseKeys("<Plug>YSurroundMore"), true);
   }
 
   @Nullable

--- a/src/com/maddyhome/idea/vim/helper/EditorData.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorData.java
@@ -268,6 +268,7 @@ public class EditorData {
   private static final Key<ExOutputPanel> MORE_PANEL = new Key<ExOutputPanel>("IdeaVim.morePanel");
   private static final Key<ExOutputModel> EX_OUTPUT_MODEL = new Key<ExOutputModel>("IdeaVim.exOutputModel");
   private static final Key<TestInputModel> TEST_INPUT_MODEL = new Key<TestInputModel>("IdeaVim.testInputModel");
+  private static final Key<PlugInputModel> PLUG_INPUT_MODEL = new Key<PlugInputModel>("IdeaVim.plugInputModel");
 
   private static Key CONSOLE_VIEW_IN_EDITOR_VIEW = Key.create("CONSOLE_VIEW_IN_EDITOR_VIEW");
 
@@ -319,4 +320,14 @@ public class EditorData {
   public static void setTestInputModel(@NotNull Editor editor, @NotNull TestInputModel model) {
     editor.putUserData(TEST_INPUT_MODEL, model);
   }
+
+  @Nullable
+  public static PlugInputModel getPlugInputModel(@NotNull Editor editor) {
+    return editor.getUserData(PLUG_INPUT_MODEL);
+  }
+
+  public static void setPlugInputModel(@NotNull Editor editor, @NotNull PlugInputModel model) {
+    editor.putUserData(PLUG_INPUT_MODEL, model);
+  }
+
 }

--- a/src/com/maddyhome/idea/vim/helper/PlugInputModel.java
+++ b/src/com/maddyhome/idea/vim/helper/PlugInputModel.java
@@ -1,0 +1,56 @@
+package com.maddyhome.idea.vim.helper;
+
+import com.google.common.collect.Lists;
+import com.intellij.openapi.editor.Editor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author dhleong
+ */
+public class PlugInputModel {
+  @NotNull private final List<KeyStroke> myKeyStrokes = Lists.newArrayList();
+
+  private PlugInputModel() {}
+
+  public static PlugInputModel getInstance(@NotNull Editor editor) {
+    PlugInputModel model = EditorData.getPlugInputModel(editor);
+    if (model == null) {
+      model = new PlugInputModel();
+      EditorData.setPlugInputModel(editor, model);
+    }
+    return model;
+  }
+
+  /**
+   * Clear pending strokes state, removing
+   *  any that were not consumed
+   */
+  public List<KeyStroke> removePendingKeyStrokes() {
+    List<KeyStroke> unused = new ArrayList<KeyStroke>(myKeyStrokes);
+    myKeyStrokes.clear();
+    return unused;
+  }
+
+  public boolean hasPendingKeyStroke() {
+    return !myKeyStrokes.isEmpty();
+  }
+
+  public void setPendingKeyStrokes(@NotNull List<KeyStroke> keyStrokes) {
+    myKeyStrokes.clear();
+    myKeyStrokes.addAll(keyStrokes);
+  }
+
+  @Nullable
+  public KeyStroke nextKeyStroke() {
+    if (!myKeyStrokes.isEmpty()) {
+      return myKeyStrokes.remove(0);
+    }
+    return null;
+  }
+
+}

--- a/src/com/maddyhome/idea/vim/helper/StringHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/StringHelper.java
@@ -21,6 +21,7 @@ package com.maddyhome.idea.vim.helper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.intellij.openapi.util.text.StringUtil;
+import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment;
 import org.apache.commons.codec.binary.Base64;
 import org.jdom.Element;
@@ -71,6 +72,7 @@ public class StringHelper {
     .put("f10", VK_F10)
     .put("f11", VK_F11)
     .put("f12", VK_F12)
+    .put("plug", (int) KeyHandler.KEY_PLUG)
     .build();
   private static final Map<Integer, String> VIM_KEY_VALUES = invertMap(VIM_KEY_NAMES);
 
@@ -185,7 +187,7 @@ public class StringHelper {
               state = KeyParserState.INIT;
               final String specialKeyName = specialKeyBuilder.toString();
               final String lower = specialKeyName.toLowerCase();
-              if ("plug".equals(lower) || "sid".equals(lower)) {
+              if ("sid".equals(lower)) {
                 throw new IllegalArgumentException("<" + specialKeyName + "> is not supported");
               }
               if (!"nop".equals(lower)) {

--- a/src/com/maddyhome/idea/vim/key/KeyMapping.java
+++ b/src/com/maddyhome/idea/vim/key/KeyMapping.java
@@ -46,16 +46,20 @@ public class KeyMapping implements Iterable<List<KeyStroke>> {
   }
 
   /**
-   * Attempts to find a &lt;Plug&gt; mapping
+   * Attempts to find an extension mapping
+   *  (&lt;Plug&gt; or otherwise)
    *  with the longest subsequence of `sequence`
    */
   @Nullable
-  public MappingInfo getPlug(@NotNull List<KeyStroke> sequence) {
+  public MappingInfo getExtensionMapping(@NotNull List<KeyStroke> sequence) {
     ArrayList<KeyStroke> copy = new ArrayList<KeyStroke>(sequence);
     int size = copy.size();
     while (size > 0) {
       MappingInfo info = get(copy);
       if (info != null && info.hasExtensionHandler()) {
+        return info;
+      }
+      else if (info != null && info.mapsToPlug()) {
         return info;
       }
 

--- a/src/com/maddyhome/idea/vim/key/KeyMapping.java
+++ b/src/com/maddyhome/idea/vim/key/KeyMapping.java
@@ -45,6 +45,26 @@ public class KeyMapping implements Iterable<List<KeyStroke>> {
     return myKeys.get(ImmutableList.copyOf(keys));
   }
 
+  /**
+   * Attempts to find a &lt;Plug&gt; mapping
+   *  with the longest subsequence of `sequence`
+   */
+  @Nullable
+  public MappingInfo getPlug(@NotNull List<KeyStroke> sequence) {
+    ArrayList<KeyStroke> copy = new ArrayList<KeyStroke>(sequence);
+    int size = copy.size();
+    while (size > 0) {
+      MappingInfo info = get(copy);
+      if (info != null && info.hasExtensionHandler()) {
+        return info;
+      }
+
+      copy.remove(--size);
+    }
+
+    return null;
+  }
+
   public void put(@NotNull Set<MappingMode> mappingModes, @NotNull List<KeyStroke> fromKeys,
                   @Nullable List<KeyStroke> toKeys, @Nullable VimExtensionHandler extensionHandler, boolean recursive) {
     myKeys.put(ImmutableList.copyOf(fromKeys),

--- a/src/com/maddyhome/idea/vim/key/MappingInfo.java
+++ b/src/com/maddyhome/idea/vim/key/MappingInfo.java
@@ -82,6 +82,10 @@ public class MappingInfo implements Comparable<MappingInfo> {
     return myExtensionHandler;
   }
 
+  public boolean hasExtensionHandler() {
+    return myExtensionHandler != null;
+  }
+
   public boolean isRecursive() {
     return myRecursive;
   }
@@ -106,4 +110,5 @@ public class MappingInfo implements Comparable<MappingInfo> {
       return c1 - c2;
     }
   }
+
 }

--- a/src/com/maddyhome/idea/vim/key/MappingInfo.java
+++ b/src/com/maddyhome/idea/vim/key/MappingInfo.java
@@ -18,6 +18,7 @@
 
 package com.maddyhome.idea.vim.key;
 
+import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.command.MappingMode;
 import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import org.jetbrains.annotations.NotNull;
@@ -88,6 +89,12 @@ public class MappingInfo implements Comparable<MappingInfo> {
 
   public boolean isRecursive() {
     return myRecursive;
+  }
+
+  public boolean mapsToPlug() {
+    return myToKeys != null
+           && !myToKeys.isEmpty()
+           && myToKeys.get(0).getKeyCode() == KeyHandler.KEY_PLUG;
   }
 
   private int compareKeys(@NotNull KeyStroke key1, @NotNull KeyStroke key2) {

--- a/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
@@ -193,15 +193,6 @@ public class MapCommandTest extends VimTestCase {
     myFixture.checkResult("bcd\n");
   }
 
-  // VIM-672 |:map|
-  public void testIgnorePlugMappings() {
-    configureByText("<caret>foo bar\n");
-    typeText(commandToKeys("map w <Plug>abc"));
-    typeText(parseKeys("w"));
-    myFixture.checkResult("foo bar\n");
-    assertOffset(4);
-  }
-
   // VIM-676 |:map|
   public void testBackspaceCharacterInVimRc() {
     configureByText("\n");

--- a/test/org/jetbrains/plugins/ideavim/extension/PlugTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/PlugTest.java
@@ -1,0 +1,72 @@
+package org.jetbrains.plugins.ideavim.extension;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.command.SelectionType;
+import com.maddyhome.idea.vim.common.TextRange;
+import com.maddyhome.idea.vim.extension.VimExtensionHandler;
+import com.maddyhome.idea.vim.group.ChangeGroup;
+import com.maddyhome.idea.vim.key.OperatorFunction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+import static com.maddyhome.idea.vim.extension.VimExtensionFacade.*;
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * @author dhleong
+ */
+public class PlugTest extends VimTestCase {
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>More"), new Handler(), false);
+    putKeyMapping(MappingMode.N, parseKeys("gm"), parseKeys("<Plug>More"), true);
+  }
+
+  public void testPlugMapping() {
+    final String before =
+      "int foo = bar<caret>index;";
+    final String after =
+      "int foo = bar;";
+
+    //doTest(parseKeys("gme"), before, after);
+  }
+
+  public void testAmbiguousPlugMapping() {
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>MoreMagic"), new Handler(), false);
+    putKeyMapping(MappingMode.N, parseKeys("gn"), parseKeys("<Plug>MoreMagic"), true);
+
+    final String before =
+      "int foo = bar<caret>index;";
+    final String after =
+      "int foo = bar;";
+
+    //doTest(parseKeys("gne"), before, after);
+    doTest(parseKeys("gme"), before, after);
+  }
+
+  static class Handler implements VimExtensionHandler {
+    @Override
+    public void execute(@NotNull Editor editor, @NotNull DataContext context) {
+      setOperatorFunction(new Operator());
+      executeNormal(parseKeys("g@"), editor);
+    }
+
+  }
+  static class Operator implements OperatorFunction {
+    @Override
+    public boolean apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType) {
+      TextRange range = VimPlugin.getMark().getChangeMarks(editor);
+      if (range == null) return false;
+
+      final ChangeGroup change = VimPlugin.getChange();
+      change.deleteRange(editor, range, selectionType, true);
+      return true;
+    }
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/extension/PlugTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/PlugTest.java
@@ -82,6 +82,20 @@ public class PlugTest extends VimTestCase {
     doTest(parseKeys("gne"), before, after);
   }
 
+  public void testSuperAmbiguous() {
+    // put it all together now
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>MoreMagic"), new LineHandler(), false);
+    putKeyMapping(MappingMode.N, parseKeys("gmm"), parseKeys("<Plug>MoreMagic"), true);
+
+    final String before =
+      "int foo = bar<caret>index;";
+    final String after =
+      "int foo = bar;";
+
+    doTest(parseKeys("gmm"), before, "");
+    doTest(parseKeys("gme"), before, after);
+  }
+
   static class OperatorHandler implements VimExtensionHandler {
     @Override
     public void execute(@NotNull Editor editor, @NotNull DataContext context) {

--- a/test/org/jetbrains/plugins/ideavim/extension/PlugTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/PlugTest.java
@@ -24,7 +24,7 @@ public class PlugTest extends VimTestCase {
   protected void setUp() throws Exception {
     super.setUp();
 
-    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>More"), new Handler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>More"), new OperatorHandler(), false);
     putKeyMapping(MappingMode.N, parseKeys("gm"), parseKeys("<Plug>More"), true);
   }
 
@@ -34,11 +34,11 @@ public class PlugTest extends VimTestCase {
     final String after =
       "int foo = bar;";
 
-    //doTest(parseKeys("gme"), before, after);
+    doTest(parseKeys("gme"), before, after);
   }
 
   public void testAmbiguousPlugMapping() {
-    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>MoreMagic"), new Handler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>MoreMagic"), new OperatorHandler(), false);
     putKeyMapping(MappingMode.N, parseKeys("gn"), parseKeys("<Plug>MoreMagic"), true);
 
     final String before =
@@ -46,18 +46,50 @@ public class PlugTest extends VimTestCase {
     final String after =
       "int foo = bar;";
 
-    //doTest(parseKeys("gne"), before, after);
+    doTest(parseKeys("gne"), before, after);
     doTest(parseKeys("gme"), before, after);
   }
 
-  static class Handler implements VimExtensionHandler {
+  public void testAmbiguousKeyToPlugMapping() {
+    // this is a fairly common pattern of mappings;
+    //  you have a basic map that accepts an operator---
+    //  gm, in this case---then another mapping that
+    //  repeats the last character to operate on the
+    //  whole line.
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>Line"), new LineHandler(), false);
+    putKeyMapping(MappingMode.N, parseKeys("gmm"), parseKeys("<Plug>Line"), true);
+
+    final String before =
+      "int foo = bar<caret>index;";
+    final String after =
+      "int foo = bar;";
+
+    doTest(parseKeys("gmm"), before, "");
+    doTest(parseKeys("gme"), before, after);
+  }
+
+  public void testAmbiguousMapping() {
+    // direct extension mappings also need special care;
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("gn"), new OperatorHandler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("gnn"), new LineHandler(), false);
+
+    final String before =
+      "int foo = bar<caret>index;";
+    final String after =
+      "int foo = bar;";
+
+    doTest(parseKeys("gnn"), before, "");
+    doTest(parseKeys("gne"), before, after);
+  }
+
+  static class OperatorHandler implements VimExtensionHandler {
     @Override
     public void execute(@NotNull Editor editor, @NotNull DataContext context) {
       setOperatorFunction(new Operator());
       executeNormal(parseKeys("g@"), editor);
     }
-
   }
+
   static class Operator implements OperatorFunction {
     @Override
     public boolean apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType) {
@@ -67,6 +99,14 @@ public class PlugTest extends VimTestCase {
       final ChangeGroup change = VimPlugin.getChange();
       change.deleteRange(editor, range, selectionType, true);
       return true;
+    }
+  }
+
+  static class LineHandler implements VimExtensionHandler {
+    @Override
+    public void execute(@NotNull Editor editor, @NotNull DataContext context) {
+       final ChangeGroup change = VimPlugin.getChange();
+       change.deleteLine(editor, 1);
     }
   }
 }


### PR DESCRIPTION
Using a non-existent key stroke is great, but ambiguous
plug mappings aren't supported out of the box. Imagine you
have two mappings, both of which take a motion:

<Plug>More
<Plug>MoreMagic

You've mapped gmm to <Plug>More and gmc to <Plug>MoreMagic.

When you type gmc, the recursive mapping is available, and the
`else if (mappingInfo != null)` branch can feed the mapped keys
back into the system. Because these are fed as recursive, when
the keys come back through, they can get the mapping to MoreMagic
(which is no longer a prefix) and execute.

For gmm, when it feeds the keys for <Plug>More, it is still
a prefix; when a motion is inputted, it is no longer a prefix,
and so it would hit the `else` block, feeding the keys WITHOUT
recursion. So, we have to catch the case where we're no longer
a prefix, but can find a <Plug> mapping within the input. This
seems to work pretty well, but causes "recursive records found"
warnings in the console, and complaints about local history being
broken. I'm not entirely sure whether this is just an idiosyncrasy
of the unit test environment, or whether this would cause
significant problems in the live environment. I'm hoping you have
more experience here about whether that warning can be ignored,
and am open to suggestions otherwise.

Also included is some prep work for <Plug>-based repeat handling.
Extra input sequences past the <Plug> mapping are stored in a
PlugInputModel which is read from in preference to the
ModalInputDialog.