### PR TITLE
Another attempt at comment motion extension

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -79,6 +79,7 @@
   <extensions defaultExtensionNs="IdeaVIM">
     <vimExtension implementation="com.maddyhome.idea.vim.extension.surround.VimSurroundExtension"/>
     <vimExtension implementation="com.maddyhome.idea.vim.extension.multiplecursors.VimMultipleCursorsExtension"/>
+    <vimExtension implementation="com.maddyhome.idea.vim.extension.commentary.CommentaryExtension"/>
   </extensions>
 
   <actions>

--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -300,7 +300,12 @@ public class KeyHandler {
                                      "Vim " + extensionHandler.getClass().getSimpleName(),
                                      null);
           }
-          if (prevMappingInfo != null) {
+
+          // NB: mappingInfo MUST be non-null here, so if equal
+          //  then prevMappingInfo is also non-null; this also
+          //  means that the prev mapping was a prefix, but the
+          //  next key typed (`key`) was not part of that
+          if (prevMappingInfo == mappingInfo) {
             handleKey(editor, key, currentContext);
           }
         }

--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -309,12 +309,7 @@ public class KeyHandler {
             // post to end of queue so it's handled AFTER
             //  an <Plug> mapping is invoked (since that
             //  will also get posted)
-            Runnable handleRemainingKey = new Runnable() {
-              @Override
-              public void run() {
-                handleKey(editor, key, currentContext);
-              }
-            };
+            Runnable handleRemainingKey = () -> handleKey(editor, key, currentContext);
 
             if (application.isUnitTestMode()) {
               handleRemainingKey.run();

--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -306,7 +306,22 @@ public class KeyHandler {
           //  means that the prev mapping was a prefix, but the
           //  next key typed (`key`) was not part of that
           if (prevMappingInfo == mappingInfo) {
-            handleKey(editor, key, currentContext);
+            // post to end of queue so it's handled AFTER
+            //  an <Plug> mapping is invoked (since that
+            //  will also get posted)
+            Runnable handleRemainingKey = new Runnable() {
+              @Override
+              public void run() {
+                handleKey(editor, key, currentContext);
+              }
+            };
+
+            if (application.isUnitTestMode()) {
+              handleRemainingKey.run();
+            }
+            else {
+              application.invokeLater(handleRemainingKey);
+            }
           }
         }
       };

--- a/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
@@ -100,8 +100,10 @@ public class CommentaryExtension extends VimNonDisposableExtension {
           handler.invoke(editor.getProject(), editor, editor.getCaretModel().getCurrentCaret(), file);
           handler.postInvoke();
 
-          // Jump back to start
-          executeNormal(parseKeys("`["), editor);
+          // Jump back to start if in block mode
+          if (selectionType == SelectionType.CHARACTER_WISE) {
+            executeNormal(parseKeys("`["), editor);
+          }
           return true;
         } finally {
           // remove the selection

--- a/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
@@ -19,9 +19,7 @@ import com.maddyhome.idea.vim.key.OperatorFunction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static com.maddyhome.idea.vim.extension.VimExtensionFacade.executeNormal;
-import static com.maddyhome.idea.vim.extension.VimExtensionFacade.putExtensionHandlerMapping;
-import static com.maddyhome.idea.vim.extension.VimExtensionFacade.setOperatorFunction;
+import static com.maddyhome.idea.vim.extension.VimExtensionFacade.*;
 import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
 
 /**
@@ -37,17 +35,17 @@ public class CommentaryExtension extends VimNonDisposableExtension {
 
   @Override
   protected void initOnce() {
-    //putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>(CommentMotion)"), new CommentMotionHandler(), false);
-    //putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>(CommentLine)"), new CommentLineHandler(), false);
-    //putExtensionHandlerMapping(MappingMode.VO, parseKeys("<Plug>(CommentMotionV)"), new CommentMotionHandler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>(CommentMotion)"), new CommentMotionHandler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>(CommentLine)"), new CommentLineHandler(), false);
+    putExtensionHandlerMapping(MappingMode.VO, parseKeys("<Plug>(CommentMotionV)"), new CommentMotionHandler(), false);
 
-    //putKeyMapping(MappingMode.N, parseKeys("gc"), parseKeys("<Plug>(CommentMotion)"), true);
-    //putKeyMapping(MappingMode.N, parseKeys("gcc"), parseKeys("<Plug>(CommentLine)"), true);
-    //putKeyMapping(MappingMode.VO, parseKeys("gc"), parseKeys("<Plug>(CommentMotionV)"), true);
+    putKeyMapping(MappingMode.N, parseKeys("gc"), parseKeys("<Plug>(CommentMotion)"), true);
+    putKeyMapping(MappingMode.N, parseKeys("gcc"), parseKeys("<Plug>(CommentLine)"), true);
+    putKeyMapping(MappingMode.VO, parseKeys("gc"), parseKeys("<Plug>(CommentMotionV)"), true);
 
-    putExtensionHandlerMapping(MappingMode.N, parseKeys("gc"), new CommentMotionHandler(), false);
-    putExtensionHandlerMapping(MappingMode.N, parseKeys("gcc"), new CommentLineHandler(), false);
-    putExtensionHandlerMapping(MappingMode.VO, parseKeys("gc"), new CommentMotionHandler(), false);
+    //putExtensionHandlerMapping(MappingMode.N, parseKeys("gc"), new CommentMotionHandler(), false);
+    //putExtensionHandlerMapping(MappingMode.N, parseKeys("gcc"), new CommentLineHandler(), false);
+    //putExtensionHandlerMapping(MappingMode.VO, parseKeys("gc"), new CommentMotionHandler(), false);
   }
 
   private static class CommentMotionHandler implements VimExtensionHandler {

--- a/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
@@ -1,0 +1,121 @@
+package com.maddyhome.idea.vim.extension.commentary;
+
+import com.intellij.codeInsight.actions.MultiCaretCodeInsightActionHandler;
+import com.intellij.codeInsight.generation.CommentByBlockCommentHandler;
+import com.intellij.codeInsight.generation.CommentByLineCommentHandler;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiFile;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.CommandState;
+import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.command.SelectionType;
+import com.maddyhome.idea.vim.common.TextRange;
+import com.maddyhome.idea.vim.extension.VimExtensionHandler;
+import com.maddyhome.idea.vim.extension.VimNonDisposableExtension;
+import com.maddyhome.idea.vim.key.OperatorFunction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static com.maddyhome.idea.vim.extension.VimExtensionFacade.executeNormal;
+import static com.maddyhome.idea.vim.extension.VimExtensionFacade.putExtensionHandlerMapping;
+import static com.maddyhome.idea.vim.extension.VimExtensionFacade.setOperatorFunction;
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * @author dhleong
+ */
+public class CommentaryExtension extends VimNonDisposableExtension {
+
+  @NotNull
+  @Override
+  public String getName() {
+    return "commentary";
+  }
+
+  @Override
+  protected void initOnce() {
+    //putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>(CommentMotion)"), new CommentMotionHandler(), false);
+    //putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>(CommentLine)"), new CommentLineHandler(), false);
+    //putExtensionHandlerMapping(MappingMode.VO, parseKeys("<Plug>(CommentMotionV)"), new CommentMotionHandler(), false);
+
+    //putKeyMapping(MappingMode.N, parseKeys("gc"), parseKeys("<Plug>(CommentMotion)"), true);
+    //putKeyMapping(MappingMode.N, parseKeys("gcc"), parseKeys("<Plug>(CommentLine)"), true);
+    //putKeyMapping(MappingMode.VO, parseKeys("gc"), parseKeys("<Plug>(CommentMotionV)"), true);
+
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("gc"), new CommentMotionHandler(), false);
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("gcc"), new CommentLineHandler(), false);
+    putExtensionHandlerMapping(MappingMode.VO, parseKeys("gc"), new CommentMotionHandler(), false);
+  }
+
+  private static class CommentMotionHandler implements VimExtensionHandler {
+    @Override
+    public void execute(@NotNull Editor editor, @NotNull DataContext context) {
+      setOperatorFunction(new Operator());
+      executeNormal(parseKeys("g@"), editor);
+    }
+  }
+
+  private static class Operator implements OperatorFunction {
+    @Override
+    public boolean apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType) {
+      final TextRange range = getCommentRange(editor);
+      if (range == null) return false;
+
+      if (CommandState.getInstance(editor).getMode() != CommandState.Mode.VISUAL) {
+        editor.getSelectionModel().setSelection(range.getStartOffset(), range.getEndOffset());
+      }
+
+      final MultiCaretCodeInsightActionHandler handler =
+        selectionType == SelectionType.CHARACTER_WISE
+          ? new CommentByBlockCommentHandler()
+          : new CommentByLineCommentHandler();
+
+      try {
+        Project proj = editor.getProject();
+        if (proj == null) return false;
+
+        PsiFile file = PsiDocumentManager.getInstance(proj).getPsiFile(editor.getDocument());
+        if (file == null) return false;
+
+        handler.invoke(editor.getProject(), editor, editor.getCaretModel().getCurrentCaret(), file);
+        handler.postInvoke();
+        return true;
+      } catch (RuntimeException e) {
+        e.printStackTrace(); // ???
+      } finally {
+        // remove the selection
+        editor.getSelectionModel().removeSelection();
+      }
+
+      return true;
+    }
+
+    @Nullable
+    private TextRange getCommentRange(@NotNull Editor editor) {
+      final CommandState.Mode mode = CommandState.getInstance(editor).getMode();
+      switch (mode) {
+        case COMMAND:
+          return VimPlugin.getMark().getChangeMarks(editor);
+        case VISUAL:
+          return VimPlugin.getMark().getVisualSelectionMarks(editor);
+        default:
+          return null;
+      }
+    }
+  }
+
+  private static class CommentLineHandler implements VimExtensionHandler {
+    @Override
+    public void execute(@NotNull Editor editor, @NotNull DataContext context) {
+      final int offset = editor.getCaretModel().getOffset();
+      final int line = editor.getDocument().getLineNumber(offset);
+      final int lineStart = editor.getDocument().getLineStartOffset(line);
+      final int lineEnd = editor.getDocument().getLineEndOffset(line);
+      VimPlugin.getMark().setChangeMarks(editor, new TextRange(lineStart, lineEnd));
+      new Operator().apply(editor, context, SelectionType.LINE_WISE);
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
@@ -100,14 +100,10 @@ public class CommentaryExtension extends VimNonDisposableExtension {
         // Jump back to start
         executeNormal(parseKeys("`["), editor);
         return true;
-      } catch (RuntimeException e) {
-        e.printStackTrace(); // ???
       } finally {
         // remove the selection
         editor.getSelectionModel().removeSelection();
       }
-
-      return true;
     }
 
     @Nullable

--- a/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
@@ -80,6 +80,9 @@ public class CommentaryExtension extends VimNonDisposableExtension {
 
         handler.invoke(editor.getProject(), editor, editor.getCaretModel().getCurrentCaret(), file);
         handler.postInvoke();
+
+        // Jump back to start
+        executeNormal(parseKeys("`["), editor);
         return true;
       } catch (RuntimeException e) {
         e.printStackTrace(); // ???

--- a/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
@@ -37,7 +37,7 @@ public class CommentaryExtension extends VimNonDisposableExtension {
   protected void initOnce() {
     putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>(CommentMotion)"), new CommentMotionHandler(), false);
     putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>(CommentLine)"), new CommentLineHandler(), false);
-    putExtensionHandlerMapping(MappingMode.VO, parseKeys("<Plug>(CommentMotionV)"), new CommentMotionHandler(), false);
+    putExtensionHandlerMapping(MappingMode.VO, parseKeys("<Plug>(CommentMotionV)"), new CommentMotionVHandler(), false);
 
     putKeyMapping(MappingMode.N, parseKeys("gc"), parseKeys("<Plug>(CommentMotion)"), true);
     putKeyMapping(MappingMode.N, parseKeys("gcc"), parseKeys("<Plug>(CommentLine)"), true);
@@ -49,6 +49,26 @@ public class CommentaryExtension extends VimNonDisposableExtension {
     public void execute(@NotNull Editor editor, @NotNull DataContext context) {
       setOperatorFunction(new Operator());
       executeNormal(parseKeys("g@"), editor);
+    }
+  }
+
+  private static class CommentMotionVHandler implements VimExtensionHandler {
+    @Override
+    public void execute(@NotNull Editor editor, @NotNull DataContext context) {
+      final TextRange visualRange = VimPlugin.getMark().getVisualSelectionMarks(editor);
+      if (visualRange == null) {
+        return;
+      }
+
+      // always use line-wise comments
+      if (!new Operator().apply(editor, context, SelectionType.LINE_WISE)) {
+        return;
+      }
+
+      // Leave visual mode
+      executeNormal(parseKeys("<Esc>"), editor);
+
+      editor.getCaretModel().moveToOffset(visualRange.getStartOffset());
     }
   }
 

--- a/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.java
@@ -42,10 +42,6 @@ public class CommentaryExtension extends VimNonDisposableExtension {
     putKeyMapping(MappingMode.N, parseKeys("gc"), parseKeys("<Plug>(CommentMotion)"), true);
     putKeyMapping(MappingMode.N, parseKeys("gcc"), parseKeys("<Plug>(CommentLine)"), true);
     putKeyMapping(MappingMode.VO, parseKeys("gc"), parseKeys("<Plug>(CommentMotionV)"), true);
-
-    //putExtensionHandlerMapping(MappingMode.N, parseKeys("gc"), new CommentMotionHandler(), false);
-    //putExtensionHandlerMapping(MappingMode.N, parseKeys("gcc"), new CommentLineHandler(), false);
-    //putExtensionHandlerMapping(MappingMode.VO, parseKeys("gc"), new CommentMotionHandler(), false);
   }
 
   private static class CommentMotionHandler implements VimExtensionHandler {

--- a/test/org/jetbrains/plugins/ideavim/JavaVimTestCase.java
+++ b/test/org/jetbrains/plugins/ideavim/JavaVimTestCase.java
@@ -1,0 +1,99 @@
+package org.jetbrains.plugins.ideavim;
+
+import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase;
+import com.maddyhome.idea.vim.KeyHandler;
+import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.CommandState;
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment;
+import com.maddyhome.idea.vim.helper.EditorDataContext;
+import com.maddyhome.idea.vim.helper.RunnableHelper;
+import com.maddyhome.idea.vim.helper.TestInputModel;
+import com.maddyhome.idea.vim.option.Options;
+import com.maddyhome.idea.vim.option.ToggleOption;
+import com.maddyhome.idea.vim.ui.ExEntryPanel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.List;
+
+/**
+ * NB: We need to extend from JavaCodeInsightFixtureTestCase so we
+ *  can create PsiFiles with proper Java Language type
+ * @author dhleong
+ */
+public abstract class JavaVimTestCase extends JavaCodeInsightFixtureTestCase {
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    KeyHandler.getInstance().fullReset(myFixture.getEditor());
+    Options.getInstance().resetAllOptions();
+    VimPlugin.getKey().resetKeyMappings();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    ExEntryPanel.getInstance().deactivate(false);
+    VimScriptGlobalEnvironment.getInstance().getVariables().clear();
+    super.tearDown();
+  }
+
+  protected void enableExtensions(@NotNull String... extensionNames) {
+    for (String name : extensionNames) {
+      ToggleOption option = (ToggleOption)Options.getInstance().getOption(name);
+      option.set();
+    }
+  }
+
+  @NotNull
+  protected Editor configureByJavaText(@NotNull String content) {
+    myFixture.configureByText(JavaFileType.INSTANCE, content);
+    return myFixture.getEditor();
+  }
+
+  public void doTest(final List<KeyStroke> keys, String before, String after) {
+    configureByJavaText(before);
+    typeText(keys);
+    myFixture.checkResult(after);
+  }
+
+  @NotNull
+  protected Editor typeText(@NotNull List<KeyStroke> keys) {
+    final Editor editor = myFixture.getEditor();
+    final KeyHandler keyHandler = KeyHandler.getInstance();
+    final EditorDataContext dataContext = new EditorDataContext(editor);
+    final Project project = myFixture.getProject();
+    TestInputModel.getInstance(editor).setKeyStrokes(keys);
+    RunnableHelper.runWriteCommand(project, new Runnable() {
+      @Override
+      public void run() {
+        final TestInputModel inputModel = TestInputModel.getInstance(editor);
+        for (KeyStroke key = inputModel.nextKeyStroke(); key != null; key = inputModel.nextKeyStroke()) {
+          final ExEntryPanel exEntryPanel = ExEntryPanel.getInstance();
+          if (exEntryPanel.isActive()) {
+            exEntryPanel.handleKey(key);
+          }
+          else {
+            keyHandler.handleKey(editor, key, dataContext);
+          }
+        }
+      }
+    }, null, null);
+    return editor;
+  }
+
+  public void assertMode(@NotNull CommandState.Mode expectedMode) {
+    final CommandState.Mode mode = CommandState.getInstance(myFixture.getEditor()).getMode();
+    assertEquals(expectedMode, mode);
+  }
+
+  public void assertSelection(@Nullable String expected) {
+    final String selected = myFixture.getEditor().getSelectionModel().getSelectedText();
+    assertEquals(expected, selected);
+  }
+
+}

--- a/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
@@ -293,17 +293,29 @@ public class MapCommandTest extends VimTestCase {
   public void testAmbiguousMapping() {
     configureByText("\n");
     typeText(commandToKeys("nmap ,f iHello<Esc>"));
-    typeText(commandToKeys("nmap ,f2 iBye<Esc>"));
+    typeText(commandToKeys("nmap ,fc iBye<Esc>"));
     typeText(parseKeys(",fh"));
     myFixture.checkResult("Hello\n");
+
+    typeText(parseKeys("diw"));
+    myFixture.checkResult("\n");
+
+    typeText(parseKeys(",fch"));
+    myFixture.checkResult("Bye\n");
   }
 
   public void testLongAmbiguousMapping() {
     configureByText("\n");
     typeText(commandToKeys("nmap ,foo iHello<Esc>"));
-    typeText(commandToKeys("nmap ,foo2 iBye<Esc>"));
+    typeText(commandToKeys("nmap ,fooc iBye<Esc>"));
     typeText(parseKeys(",fooh"));
     myFixture.checkResult("Hello\n");
+
+    typeText(parseKeys("diw"));
+    myFixture.checkResult("\n");
+
+    typeText(parseKeys(",fooch"));
+    myFixture.checkResult("Bye\n");
   }
 
   public void testPlugMapping() {

--- a/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
@@ -294,8 +294,8 @@ public class MapCommandTest extends VimTestCase {
     configureByText("\n");
     typeText(commandToKeys("nmap ,f iHello<Esc>"));
     typeText(commandToKeys("nmap ,fc iBye<Esc>"));
-    typeText(parseKeys(",fh"));
-    myFixture.checkResult("Hello\n");
+    typeText(parseKeys(",fdh"));
+    myFixture.checkResult("Helo\n");
 
     typeText(parseKeys("diw"));
     myFixture.checkResult("\n");
@@ -308,8 +308,8 @@ public class MapCommandTest extends VimTestCase {
     configureByText("\n");
     typeText(commandToKeys("nmap ,foo iHello<Esc>"));
     typeText(commandToKeys("nmap ,fooc iBye<Esc>"));
-    typeText(parseKeys(",fooh"));
-    myFixture.checkResult("Hello\n");
+    typeText(parseKeys(",foodh"));
+    myFixture.checkResult("Helo\n");
 
     typeText(parseKeys("diw"));
     myFixture.checkResult("\n");

--- a/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
@@ -1,0 +1,109 @@
+package org.jetbrains.plugins.ideavim.extension.commentary;
+
+import org.jetbrains.plugins.ideavim.JavaVimTestCase;
+
+import static com.maddyhome.idea.vim.command.CommandState.Mode.COMMAND;
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * @author dhleong
+ */
+public class CommentaryExtensionTest extends JavaVimTestCase {
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    enableExtensions("commentary");
+  }
+
+  // |gc| |iw|
+  public void testBlockCommentInnerWord() {
+    doTest(parseKeys("gciw"),
+           "<caret>if (condition) {\n" + "}\n",
+           "/*if*/ (condition) {\n" + "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
+  }
+
+  // |gc| |iw|
+  public void testBlockCommentTillForward() {
+    doTest(parseKeys("gct{"),
+           "<caret>if (condition) {\n" + "}\n",
+           "/*if (condition) */{\n" + "}\n");
+  }
+
+  // |gc| |ab|
+  public void testBlockCommentOuterParens() {
+    doTest(parseKeys("gcab"),
+           "if (<caret>condition) {\n" + "}\n",
+           "if /*(condition)*/ {\n" + "}\n");
+  }
+
+  /*
+   * NB: linewise motions become linewise comments;
+   *  otherwise, they are incredibly difficult to undo
+   */
+
+  // |gc| |j|
+  public void testLineCommentDown() {
+    doTest(parseKeys("gcj"),
+           "<caret>if (condition) {\n" + "}\n",
+           "//if (condition) {\n" +
+           "//}\n");
+  }
+
+  // |gc| |ip|
+  public void testLineCommentInnerParagraph() {
+    doTest(parseKeys("gcip"),
+           "<caret>if (condition) {\n" + "}\n",
+           "//if (condition) {\n" +
+           "//}\n");
+  }
+
+  // |gc| |ip|
+  public void testLineCommentSingleLineInnerParagraph() {
+    doTest(parseKeys("gcip"),
+           "<caret>if (condition) {}",
+           "//if (condition) {}");
+  }
+
+  /* Ensure uncommenting works as well */
+
+  // |gc| |ip|
+  public void testLineUncommentInnerParagraph() {
+    doTest(parseKeys("gcip"),
+           "<caret>//if (condition) {\n" + "//}\n",
+           "if (condition) {\n" +
+           "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
+  }
+
+  // |gc| |ip|
+  public void testLineUncommentSingleLineInnerParagraph() {
+    doTest(parseKeys("gcip"),
+           "<caret>//if (condition) {}",
+           "if (condition) {}");
+  }
+
+  /* Special shortcut gcc is always linewise */
+
+  // |gcc|
+  public void testLineCommentShortcut() {
+    doTest(parseKeys("gcc"),
+           "<caret>if (condition) {\n" + "}\n",
+           "//if (condition) {\n" +
+           "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
+  }
+
+  // |gcc|
+  public void testLineUncommentShortcut() {
+    doTest(parseKeys("gcc"),
+           "<caret>//if (condition) {\n" + "}\n",
+           "if (condition) {\n" + "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
@@ -96,6 +96,27 @@ public class CommentaryExtensionTest extends JavaVimTestCase {
            "if (condition) {}");
   }
 
+  /* Visual mode */
+
+  // |gc| |ip|
+  public void testLineCommentVisualInnerParagraph() {
+    doTest(parseKeys("vipgc"),
+           "<caret>if (condition) {\n" + "}\n",
+           "//if (condition) {\n" +
+           "//}\n");
+  }
+
+  // |gc| |ip|
+  public void testLineUncommentVisualInnerParagraph() {
+    doTest(parseKeys("vipgc"),
+           "<caret>//if (condition) {\n" + "//}\n",
+           "if (condition) {\n" +
+           "}\n");
+  }
+
+
+
+
   /* Special shortcut gcc is always linewise */
 
   // |gcc|

--- a/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
@@ -47,7 +47,7 @@ public class CommentaryExtensionTest extends JavaVimTestCase {
   public void testBlockCommentOuterParens() {
     doTest(parseKeys("gcab"),
            "if (<caret>condition) {\n" + "}\n",
-           "if /*(condition)*/ {\n" + "}\n");
+           "if <caret>/*(condition)*/ {\n" + "}\n");
   }
 
   /*
@@ -126,6 +126,15 @@ public class CommentaryExtensionTest extends JavaVimTestCase {
            "<caret>if (condition) {\n" + "}\n",
            "//if (condition) {\n" +
            "<caret>}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
+  }
+
+  // |gcc|
+  public void testLineCommentShortcutPreservesCaret() {
+    doTest(parseKeys("gcc"),
+           "if (<caret>condition) {\n" + "}\n",
+           "//if (<caret>condition) {\n" + "}\n");
     assertMode(COMMAND);
     assertSelection(null);
   }

--- a/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
@@ -112,8 +112,8 @@ public class CommentaryExtensionTest extends JavaVimTestCase {
   public void testLineUncommentShortcut() {
     doTest(parseKeys("gcc"),
            "<caret>//if (condition) {\n" + "}\n",
-           "if (condition) {\n" +
-           "<caret>}\n");
+           "<caret>if (condition) {\n" +
+           "}\n");
     assertMode(COMMAND);
     assertSelection(null);
   }

--- a/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
@@ -16,11 +16,21 @@ public class CommentaryExtensionTest extends JavaVimTestCase {
     enableExtensions("commentary");
   }
 
+  // |gc| |l|
+  public void testBlockCommentSingle() {
+    doTest(parseKeys("gcll"),
+           "<caret>if (condition) {\n" + "}\n",
+           "/<caret>*i*/f (condition) {\n" + "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
+  }
+
+
   // |gc| |iw|
   public void testBlockCommentInnerWord() {
     doTest(parseKeys("gciw"),
            "<caret>if (condition) {\n" + "}\n",
-           "/*if*/ (condition) {\n" + "}\n");
+           "<caret>/*if*/ (condition) {\n" + "}\n");
     assertMode(COMMAND);
     assertSelection(null);
   }
@@ -29,7 +39,7 @@ public class CommentaryExtensionTest extends JavaVimTestCase {
   public void testBlockCommentTillForward() {
     doTest(parseKeys("gct{"),
            "<caret>if (condition) {\n" + "}\n",
-           "/*if (condition) */{\n" + "}\n");
+           "<caret>/*if (condition) */{\n" + "}\n");
   }
 
   // |gc| |ab|
@@ -90,10 +100,10 @@ public class CommentaryExtensionTest extends JavaVimTestCase {
 
   // |gcc|
   public void testLineCommentShortcut() {
-    doTest(parseKeys("gcc"),
+    doTest(parseKeys("gccj"),
            "<caret>if (condition) {\n" + "}\n",
            "//if (condition) {\n" +
-           "}\n");
+           "<caret>}\n");
     assertMode(COMMAND);
     assertSelection(null);
   }
@@ -102,7 +112,8 @@ public class CommentaryExtensionTest extends JavaVimTestCase {
   public void testLineUncommentShortcut() {
     doTest(parseKeys("gcc"),
            "<caret>//if (condition) {\n" + "}\n",
-           "if (condition) {\n" + "}\n");
+           "if (condition) {\n" +
+           "<caret>}\n");
     assertMode(COMMAND);
     assertSelection(null);
   }

--- a/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.java
@@ -1,5 +1,6 @@
 package org.jetbrains.plugins.ideavim.extension.commentary;
 
+import com.intellij.ide.highlighter.HtmlFileType;
 import org.jetbrains.plugins.ideavim.JavaVimTestCase;
 
 import static com.maddyhome.idea.vim.command.CommandState.Mode.COMMAND;
@@ -135,6 +136,15 @@ public class CommentaryExtensionTest extends JavaVimTestCase {
            "<caret>//if (condition) {\n" + "}\n",
            "<caret>if (condition) {\n" +
            "}\n");
+    assertMode(COMMAND);
+    assertSelection(null);
+  }
+
+  // |gcc|
+  public void testHTMLCommentShortcut() {
+    myFixture.configureByText(HtmlFileType.INSTANCE, "<div />");
+    typeText(parseKeys("gcc"));
+    myFixture.checkResult("<!--<div />-->");
     assertMode(COMMAND);
     assertSelection(null);
   }


### PR DESCRIPTION
@vlasovskikh Thanks for your work on #105. Here's another try at an extension for providing motion-based comment actions, based off the latest master. This PR will initially serve as more discussion, however, as trying to use the `<Plug>` support is causing some issues that I haven't had time to fully investigate. Basically, the PR mostly works as-is, but without `<Plug>` maps.  When I uncomment the `<Plug>` maps, it seems to want an extra operator before performing the action. 

More concretely, when using the `<Plug>` map indirection: 
- `gcc` works as expected, but it seems to also add an extra `c` as input, such that then hitting `j` will delete the current and next lines and enter insert mode)
- `gcl` to do a block comment around one letter will appear to only accept the `l` to move the cursor. A subsequent `l` will do the comment (but of course at this point it will be one character to the right of the one you actually wanted to comment). In fact, at this point you can enter any motion and it'll "work."
- `gcip` will enter insert mode and paste `g@p`

When directly mapping the keys to the extension handlers:
- The `gc` + motion in normal word works as expected
- `gc` in visual mode doesn't seem to do anything
- `gcc` behaves the same as when using `<Plug>`

The tests, however, all pass. These were observed by using the `runIdea` gradle command from within IntelliJ. The `vim-surround` support seems to work just fine, though, so it could be some problem in my code rather than the extension framework....

Wanted to get this up so we can start looking into the causes of these behaviors, since they'll probably need to be addressed before other extensions can be developed.
