### PR TITLE
vim-repeat Extension

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -63,6 +63,7 @@
     <vimExtension implementation="com.maddyhome.idea.vim.extension.surround.VimSurroundExtension"/>
     <vimExtension implementation="com.maddyhome.idea.vim.extension.multiplecursors.VimMultipleCursorsExtension"/>
     <vimExtension implementation="com.maddyhome.idea.vim.extension.commentary.CommentaryExtension"/>
+    <vimExtension implementation="com.maddyhome.idea.vim.extension.repeat.VimRepeat"/>
   </extensions>
 
   <actions>

--- a/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
@@ -21,6 +21,7 @@ package com.maddyhome.idea.vim.extension;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.Ref;
+import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.Argument;
 import com.maddyhome.idea.vim.command.Command;
@@ -32,7 +33,6 @@ import com.maddyhome.idea.vim.helper.StringHelper;
 import com.maddyhome.idea.vim.helper.TestInputModel;
 import com.maddyhome.idea.vim.key.OperatorFunction;
 import com.maddyhome.idea.vim.ui.ExEntryPanel;
-import com.maddyhome.idea.vim.ui.InputQueue;
 import com.maddyhome.idea.vim.ui.ModalEntry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,6 +42,8 @@ import java.awt.event.KeyEvent;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+
+import static com.maddyhome.idea.vim.ui.InputQueue.dequeue;
 
 /**
  * Vim API facade that defines functions similar to the built-in functions and statements of the original Vim.
@@ -84,8 +86,10 @@ public class VimExtensionFacade {
    */
   public static void executeNormal(@NotNull List<KeyStroke> keys, @NotNull Editor editor) {
     final EditorDataContext context = new EditorDataContext(editor);
-    InputQueue.insert(keys);
-    InputQueue.executeNormal(editor, context);
+
+    for (KeyStroke key : keys) {
+      KeyHandler.getInstance().handleKey(editor, key, context);
+    }
   }
 
   /**
@@ -93,7 +97,7 @@ public class VimExtensionFacade {
    */
   @NotNull
   public static KeyStroke inputKeyStroke(@NotNull Editor editor) {
-    final KeyStroke enqueued = InputQueue.dequeue();
+    final KeyStroke enqueued = dequeue();
     if (enqueued != null) {
       return enqueued;
     }

--- a/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
@@ -22,6 +22,9 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.Ref;
 import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.Argument;
+import com.maddyhome.idea.vim.command.Command;
+import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.command.MappingMode;
 import com.maddyhome.idea.vim.common.Register;
 import com.maddyhome.idea.vim.helper.EditorDataContext;
@@ -168,5 +171,18 @@ public class VimExtensionFacade {
    */
   public static void setRegister(char register, @Nullable List<KeyStroke> keys) {
     VimPlugin.getRegister().setKeys(register, keys != null ? keys : Collections.emptyList());
+  }
+
+  public static List<KeyStroke> getMotionKeys(Editor editor) {
+    Command command = CommandState.getInstance(editor).getCommand();
+    if (command == null) return Collections.emptyList();
+
+    Argument arg = command.getArgument();
+    if (arg == null) return Collections.emptyList();
+
+    Command motion = arg.getMotion();
+    if (motion == null) return Collections.emptyList();
+
+    return motion.getKeys();
   }
 }

--- a/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
@@ -43,8 +43,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import static com.maddyhome.idea.vim.ui.InputQueue.dequeue;
-
 /**
  * Vim API facade that defines functions similar to the built-in functions and statements of the original Vim.
  *
@@ -97,11 +95,6 @@ public class VimExtensionFacade {
    */
   @NotNull
   public static KeyStroke inputKeyStroke(@NotNull Editor editor) {
-    final KeyStroke enqueued = dequeue();
-    if (enqueued != null) {
-      return enqueued;
-    }
-
     final KeyStroke key;
     if (ApplicationManager.getApplication().isUnitTestMode()) {
       key = TestInputModel.getInstance(editor).nextKeyStroke();

--- a/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
+++ b/src/com/maddyhome/idea/vim/extension/VimExtensionFacade.java
@@ -21,7 +21,6 @@ package com.maddyhome.idea.vim.extension;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.Ref;
-import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.MappingMode;
 import com.maddyhome.idea.vim.common.Register;
@@ -30,6 +29,7 @@ import com.maddyhome.idea.vim.helper.StringHelper;
 import com.maddyhome.idea.vim.helper.TestInputModel;
 import com.maddyhome.idea.vim.key.OperatorFunction;
 import com.maddyhome.idea.vim.ui.ExEntryPanel;
+import com.maddyhome.idea.vim.ui.InputQueue;
 import com.maddyhome.idea.vim.ui.ModalEntry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -81,9 +81,8 @@ public class VimExtensionFacade {
    */
   public static void executeNormal(@NotNull List<KeyStroke> keys, @NotNull Editor editor) {
     final EditorDataContext context = new EditorDataContext(editor);
-    for (KeyStroke key : keys) {
-      KeyHandler.getInstance().handleKey(editor, key, context);
-    }
+    InputQueue.insert(keys);
+    InputQueue.executeNormal(editor, context);
   }
 
   /**
@@ -91,6 +90,11 @@ public class VimExtensionFacade {
    */
   @NotNull
   public static KeyStroke inputKeyStroke(@NotNull Editor editor) {
+    final KeyStroke enqueued = InputQueue.dequeue();
+    if (enqueued != null) {
+      return enqueued;
+    }
+
     final KeyStroke key;
     if (ApplicationManager.getApplication().isUnitTestMode()) {
       key = TestInputModel.getInstance(editor).nextKeyStroke();

--- a/src/com/maddyhome/idea/vim/extension/repeat/VimRepeat.java
+++ b/src/com/maddyhome/idea/vim/extension/repeat/VimRepeat.java
@@ -9,12 +9,14 @@ import com.maddyhome.idea.vim.command.CommandState;
 import com.maddyhome.idea.vim.command.MappingMode;
 import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import com.maddyhome.idea.vim.extension.VimNonDisposableExtension;
+import com.maddyhome.idea.vim.ui.InputQueue;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.List;
 
-import static com.maddyhome.idea.vim.extension.VimExtensionFacade.*;
+import static com.maddyhome.idea.vim.extension.VimExtensionFacade.putExtensionHandlerMapping;
+import static com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMapping;
 import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
 
 /**
@@ -47,7 +49,7 @@ public class VimRepeat extends VimNonDisposableExtension {
       final Command newLastChange =
         CommandState.getInstance(editor).getLastChangeCommand();
       if (repeatSequence != null && newLastChange == repeatChangeCommand) {
-        executeNormal(repeatSequence, editor);
+        InputQueue.executeNormal(repeatSequence, editor);
       } else {
         KeyStroke repeatStroke = parseKeys(".").get(0);
         KeyHandler.getInstance().handleKey(editor, repeatStroke, context, false);

--- a/src/com/maddyhome/idea/vim/extension/repeat/VimRepeat.java
+++ b/src/com/maddyhome/idea/vim/extension/repeat/VimRepeat.java
@@ -1,0 +1,63 @@
+package com.maddyhome.idea.vim.extension.repeat;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.maddyhome.idea.vim.KeyHandler;
+import com.maddyhome.idea.vim.command.Command;
+import com.maddyhome.idea.vim.command.CommandState;
+import com.maddyhome.idea.vim.command.MappingMode;
+import com.maddyhome.idea.vim.extension.VimExtensionHandler;
+import com.maddyhome.idea.vim.extension.VimNonDisposableExtension;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.List;
+
+import static com.maddyhome.idea.vim.extension.VimExtensionFacade.*;
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * @author dhleong
+ */
+public class VimRepeat extends VimNonDisposableExtension {
+
+  static List<KeyStroke> repeatSequence;
+  static Command repeatChangeCommand;
+
+  @NotNull
+  @Override
+  public String getName() {
+    return "repeat";
+  }
+
+  @Override
+  protected void initOnce() {
+    putExtensionHandlerMapping(MappingMode.N, parseKeys("<Plug>(RepeatDot)"), new RepeatDotHandler(), false);
+
+    putKeyMapping(MappingMode.N, parseKeys("."), parseKeys("<Plug>(RepeatDot)"), true);
+  }
+
+  private static class RepeatDotHandler implements VimExtensionHandler {
+    @Override
+    public void execute(@NotNull Editor editor, @NotNull DataContext context) {
+      Project proj = editor.getProject();
+      if (proj == null) return;
+
+      final Command newLastChange =
+        CommandState.getInstance(editor).getLastChangeCommand();
+      if (repeatSequence != null && newLastChange == repeatChangeCommand) {
+        executeNormal(repeatSequence, editor);
+      } else {
+        KeyStroke repeatStroke = parseKeys(".").get(0);
+        KeyHandler.getInstance().handleKey(editor, repeatStroke, context, false);
+      }
+    }
+  }
+
+  public static void set(Editor editor, List<KeyStroke> sequence) {
+    repeatChangeCommand =
+      CommandState.getInstance(editor).getLastChangeCommand();
+    repeatSequence = sequence;
+  }
+}

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -43,7 +43,6 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -271,7 +270,7 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
   private static class Operator implements OperatorFunction {
     @Override
     public boolean apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType) {
-      List<KeyStroke> operatorMotion = getMotionKeys(editor);
+      final List<KeyStroke> operatorMotion = getMotionKeys(editor);
 
       final char c = getChar(editor);
       if (c == 0) {
@@ -304,19 +303,6 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
         VimRepeat.set(editor, keys);
       });
       return true;
-    }
-
-    private List<KeyStroke> getMotionKeys(Editor editor) {
-      Command command = CommandState.getInstance(editor).getCommand();
-      if (command == null) return Collections.emptyList();
-
-      Argument arg = command.getArgument();
-      if (arg == null) return Collections.emptyList();
-
-      Command motion = arg.getMotion();
-      if (motion == null) return Collections.emptyList();
-
-      return motion.getKeys();
     }
 
     @Nullable

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -213,6 +213,12 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
 
       // Jump back to start
       executeNormal(parseKeys("`["), editor);
+
+      if (newSurround == null) {
+        VimRepeat.set(editor, parseKeys("<Plug>DSurround" + charFrom));
+      } else {
+        VimRepeat.set(editor, parseKeys("<Plug>CSurround" + charFrom + newSurround.first));
+      }
     }
 
     @NotNull

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -25,13 +25,12 @@ import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.Pair;
 import com.maddyhome.idea.vim.VimPlugin;
-import com.maddyhome.idea.vim.command.CommandState;
-import com.maddyhome.idea.vim.command.MappingMode;
-import com.maddyhome.idea.vim.command.SelectionType;
+import com.maddyhome.idea.vim.command.*;
 import com.maddyhome.idea.vim.common.Mark;
 import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import com.maddyhome.idea.vim.extension.VimNonDisposableExtension;
+import com.maddyhome.idea.vim.extension.repeat.VimRepeat;
 import com.maddyhome.idea.vim.group.ChangeGroup;
 import com.maddyhome.idea.vim.helper.EditorHelper;
 import com.maddyhome.idea.vim.key.OperatorFunction;
@@ -44,6 +43,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -271,6 +271,8 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
   private static class Operator implements OperatorFunction {
     @Override
     public boolean apply(@NotNull Editor editor, @NotNull DataContext context, @NotNull SelectionType selectionType) {
+      List<KeyStroke> operatorMotion = getMotionKeys(editor);
+
       final char c = getChar(editor);
       if (c == 0) {
         return true;
@@ -295,8 +297,26 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
 
         // Jump back to start
         executeNormal(parseKeys("`["), editor);
+
+        List<KeyStroke> keys = parseKeys("<Plug>YSurround");
+        keys.addAll(operatorMotion);
+        keys.addAll(parseKeys(String.valueOf(c)));
+        VimRepeat.set(editor, keys);
       });
       return true;
+    }
+
+    private List<KeyStroke> getMotionKeys(Editor editor) {
+      Command command = CommandState.getInstance(editor).getCommand();
+      if (command == null) return Collections.emptyList();
+
+      Argument arg = command.getArgument();
+      if (arg == null) return Collections.emptyList();
+
+      Command motion = arg.getMotion();
+      if (motion == null) return Collections.emptyList();
+
+      return motion.getKeys();
     }
 
     @Nullable

--- a/src/com/maddyhome/idea/vim/helper/TestInputModel.java
+++ b/src/com/maddyhome/idea/vim/helper/TestInputModel.java
@@ -20,6 +20,7 @@ package com.maddyhome.idea.vim.helper;
 
 import com.google.common.collect.Lists;
 import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.ui.InputQueue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,6 +51,12 @@ public class TestInputModel {
 
   @Nullable
   public KeyStroke nextKeyStroke() {
+
+    KeyStroke enqueued = InputQueue.dequeue();
+    if (enqueued != null) {
+      return enqueued;
+    }
+
     if (!myKeyStrokes.isEmpty()) {
       return myKeyStrokes.remove(0);
     }

--- a/src/com/maddyhome/idea/vim/ui/InputQueue.java
+++ b/src/com/maddyhome/idea/vim/ui/InputQueue.java
@@ -61,13 +61,6 @@ public class InputQueue {
     instance.queue.addAll(strokes);
   }
 
-  public static void insert(List<KeyStroke> keys) {
-    final int size = keys.size();
-    for (int i = size-1; i >= 0; i--) {
-      instance.queue.addFirst(keys.get(i));
-    }
-  }
-
   static class DrainTask implements Runnable {
 
     private final Editor myEditor;

--- a/src/com/maddyhome/idea/vim/ui/InputQueue.java
+++ b/src/com/maddyhome/idea/vim/ui/InputQueue.java
@@ -1,0 +1,86 @@
+package com.maddyhome.idea.vim.ui;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.KeyHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.ArrayDeque;
+import java.util.List;
+
+/**
+ * @author dhleong
+ */
+public class InputQueue {
+
+  private static InputQueue instance = new InputQueue();
+
+  private ArrayDeque<KeyStroke> queue = new ArrayDeque<KeyStroke>();
+
+  private InputQueue() {}
+
+  public static @Nullable KeyStroke dequeue() {
+    if (instance.queue.isEmpty()) {
+      return null;
+    }
+    return instance.queue.pop();
+  }
+
+  /**
+   * Execute every KeyStroke enqueued as if in normal mode
+   */
+  public static void executeNormal(@NotNull Editor editor, @NotNull DataContext context) {
+    if (ApplicationManager.getApplication().isUnitTestMode()) {
+
+      KeyStroke key;
+      while ((key = dequeue()) != null) {
+        KeyHandler.getInstance().handleKey(editor, key, context);
+      }
+
+    } else {
+
+      // when not in a Test, we need to invokeLater each
+      //  instance of handleKey, so that any mapping actions
+      //  can appropriately happen "before" the extra strokes.
+      //  NB: Multiple recursive mappings might still break....
+      new DrainTask(editor, context).run();
+    }
+  }
+
+  public static void enqueue(@NotNull List<KeyStroke> strokes) {
+    instance.queue.addAll(strokes);
+  }
+
+  public static void insert(List<KeyStroke> keys) {
+    final int size = keys.size();
+    for (int i = size-1; i >= 0; i--) {
+      instance.queue.addFirst(keys.get(i));
+    }
+  }
+
+  static class DrainTask implements Runnable {
+
+    private final Editor myEditor;
+    private final DataContext myContext;
+
+    public DrainTask(Editor editor, DataContext context) {
+      myEditor = editor;
+      myContext = context;
+    }
+
+    @Override
+    public void run() {
+      KeyStroke key = dequeue();
+      if (key != null) {
+        KeyHandler.getInstance().handleKey(myEditor, key, myContext);
+
+        final Application application = ApplicationManager.getApplication();
+        application.invokeLater(this);
+      }
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/ui/ModalEntry.java
+++ b/src/com/maddyhome/idea/vim/ui/ModalEntry.java
@@ -36,6 +36,17 @@ public final class ModalEntry {
    * Activates modal entry mode, passing all received key strokes to the processor until it returns false.
    */
   public static void activate(@NotNull final Processor<KeyStroke> processor) {
+    while (true) {
+      KeyStroke enqueued = InputQueue.dequeue();
+      if (enqueued == null) {
+        break;
+      }
+      else if (!processor.process(enqueued)) {
+        // done processing
+        return;
+      }
+    }
+
     final EventQueue systemQueue = Toolkit.getDefaultToolkit().getSystemEventQueue();
     final SecondaryLoop loop = systemQueue.createSecondaryLoop();
 

--- a/test/org/jetbrains/plugins/ideavim/JavaVimTestCase.java
+++ b/test/org/jetbrains/plugins/ideavim/JavaVimTestCase.java
@@ -20,6 +20,7 @@ package org.jetbrains.plugins.ideavim;
 
 import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileTypes.PlainTextFileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.testFramework.fixtures.JavaCodeInsightFixtureTestCase;
 import com.maddyhome.idea.vim.KeyHandler;
@@ -66,6 +67,12 @@ public abstract class JavaVimTestCase extends JavaCodeInsightFixtureTestCase {
       assert option != null;
       option.set();
     }
+  }
+
+  @NotNull
+  protected Editor configureByText(@NotNull String content) {
+    myFixture.configureByText(PlainTextFileType.INSTANCE, content);
+    return myFixture.getEditor();
   }
 
   @NotNull

--- a/test/org/jetbrains/plugins/ideavim/extension/repeat/VimRepeatExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/repeat/VimRepeatExtensionTest.java
@@ -1,0 +1,32 @@
+package org.jetbrains.plugins.ideavim.extension.repeat;
+
+import org.jetbrains.plugins.ideavim.JavaVimTestCase;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+/**
+ * @author dhleong
+ */
+public class VimRepeatExtensionTest extends JavaVimTestCase {
+
+  public void testRepeatSurround() {
+    enableExtensions("surround", "repeat");
+
+    configureByText("ffoo\n");
+    typeText(parseKeys("x")); // set some initial repeat-able
+
+    typeText(parseKeys("ysiwb"));
+    myFixture.checkResult("<caret>(foo)\n");
+
+    typeText(parseKeys("w."));
+    myFixture.checkResult("(<caret>(foo))\n");
+
+    typeText(parseKeys("hx"));
+    myFixture.checkResult("<caret>(foo))\n");
+
+    // this repeat should do the default
+    typeText(parseKeys("."));
+    myFixture.checkResult("<caret>foo))\n");
+  }
+
+}

--- a/test/org/jetbrains/plugins/ideavim/extension/repeat/VimRepeatExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/repeat/VimRepeatExtensionTest.java
@@ -69,25 +69,25 @@ public class VimRepeatExtensionTest extends JavaVimTestCase {
     myFixture.checkResult("'foo' <caret>ar'\n");
   }
 
-  //public void testRepeatChangeSurroundTag() {
-  //  enableExtensions("surround", "repeat");
-  //
-  //  configureByText("<<a>foo</a> <i>bar</i>\n");
-  //  typeText(parseKeys("x")); // set some initial repeat-able
-  //
-  //  typeText(parseKeys("cst<div>"));
-  //  myFixture.checkResult("<caret><div>foo</div> <i>bar</i>\n");
-  //
-  //  typeText(parseKeys("fb."));
-  //  myFixture.checkResult("<div>foo</div> <caret><div>bar</div>\n");
-  //
-  //  typeText(parseKeys("x"));
-  //  myFixture.checkResult("div>foo</div> <caret><div>bar</div>\n");
-  //
-  //  // this repeat should do the default
-  //  typeText(parseKeys("."));
-  //  myFixture.checkResult("iv>foo</div> <caret><div>bar</div>\n");
-  //}
+  public void testRepeatChangeSurroundTag() {
+    enableExtensions("surround", "repeat");
+
+    configureByText("<<a>foo</a> <i>bar</i>\n");
+    typeText(parseKeys("x")); // set some initial repeat-able
+
+    typeText(parseKeys("cst<div>"));
+    myFixture.checkResult("<caret><div>foo</div> <i>bar</i>\n");
+
+    typeText(parseKeys("fb."));
+    myFixture.checkResult("<div>foo</div> <caret><div>bar</div>\n");
+
+    typeText(parseKeys("x"));
+    myFixture.checkResult("<div>foo</div> <caret>div>bar</div>\n");
+
+    // this repeat should do the default
+    typeText(parseKeys("."));
+    myFixture.checkResult("<div>foo</div> <caret>iv>bar</div>\n");
+  }
 
   /*
    * Repeating comments

--- a/test/org/jetbrains/plugins/ideavim/extension/repeat/VimRepeatExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/repeat/VimRepeatExtensionTest.java
@@ -29,4 +29,43 @@ public class VimRepeatExtensionTest extends JavaVimTestCase {
     myFixture.checkResult("<caret>foo))\n");
   }
 
+  public void testRepeatLineComment() {
+    enableExtensions("commentary", "repeat");
+    configureByJavaText("ffoo\n");
+    typeText(parseKeys("x")); // set some initial repeat-able
+
+    typeText(parseKeys("gcc"));
+    myFixture.checkResult("<caret>//foo\n");
+
+    // repeat the comment
+    typeText(parseKeys("."));
+    myFixture.checkResult("<caret>foo\n");
+
+    typeText(parseKeys("x"));
+    myFixture.checkResult("<caret>oo\n");
+
+    // this repeat should do the default
+    typeText(parseKeys("."));
+    myFixture.checkResult("<caret>o\n");
+  }
+
+  public void testRepeatMotionComment() {
+    enableExtensions("commentary", "repeat");
+    configureByJavaText("ffoo\n");
+    typeText(parseKeys("x")); // set some initial repeat-able
+
+    typeText(parseKeys("gcap"));
+    myFixture.checkResult("<caret>//foo\n");
+
+    // repeat the comment
+    typeText(parseKeys("."));
+    myFixture.checkResult("<caret>foo\n");
+
+    typeText(parseKeys("x"));
+    myFixture.checkResult("<caret>oo\n");
+
+    // this repeat should do the default
+    typeText(parseKeys("."));
+    myFixture.checkResult("<caret>o\n");
+  }
 }

--- a/test/org/jetbrains/plugins/ideavim/extension/repeat/VimRepeatExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/repeat/VimRepeatExtensionTest.java
@@ -29,6 +29,70 @@ public class VimRepeatExtensionTest extends JavaVimTestCase {
     myFixture.checkResult("<caret>foo))\n");
   }
 
+  public void testRepeatDeleteSurround() {
+    enableExtensions("surround", "repeat");
+
+    configureByText("(((foo))\n");
+    typeText(parseKeys("x")); // set some initial repeat-able
+
+    typeText(parseKeys("dsb"));
+    myFixture.checkResult("<caret>(foo)\n");
+
+    typeText(parseKeys("."));
+    myFixture.checkResult("<caret>foo\n");
+
+    typeText(parseKeys("x"));
+    myFixture.checkResult("<caret>oo\n");
+
+    // this repeat should do the default
+    typeText(parseKeys("."));
+    myFixture.checkResult("<caret>o\n");
+  }
+
+  public void testRepeatChangeSurround() {
+    enableExtensions("surround", "repeat");
+
+    configureByText("((foo) (bar)\n");
+    typeText(parseKeys("x")); // set some initial repeat-able
+
+    typeText(parseKeys("csb'"));
+    myFixture.checkResult("<caret>'foo' (bar)\n");
+
+    typeText(parseKeys("W."));
+    myFixture.checkResult("'foo' <caret>'bar'\n");
+
+    typeText(parseKeys("x"));
+    myFixture.checkResult("'foo' <caret>bar'\n");
+
+    // this repeat should do the default
+    typeText(parseKeys("."));
+    myFixture.checkResult("'foo' <caret>ar'\n");
+  }
+
+  //public void testRepeatChangeSurroundTag() {
+  //  enableExtensions("surround", "repeat");
+  //
+  //  configureByText("<<a>foo</a> <i>bar</i>\n");
+  //  typeText(parseKeys("x")); // set some initial repeat-able
+  //
+  //  typeText(parseKeys("cst<div>"));
+  //  myFixture.checkResult("<caret><div>foo</div> <i>bar</i>\n");
+  //
+  //  typeText(parseKeys("fb."));
+  //  myFixture.checkResult("<div>foo</div> <caret><div>bar</div>\n");
+  //
+  //  typeText(parseKeys("x"));
+  //  myFixture.checkResult("div>foo</div> <caret><div>bar</div>\n");
+  //
+  //  // this repeat should do the default
+  //  typeText(parseKeys("."));
+  //  myFixture.checkResult("iv>foo</div> <caret><div>bar</div>\n");
+  //}
+
+  /*
+   * Repeating comments
+   */
+
   public void testRepeatLineComment() {
     enableExtensions("commentary", "repeat");
     configureByJavaText("ffoo\n");


### PR DESCRIPTION
This PR refactors some input handling for Extensions to be able to feed input in a vim-like way, enabling a [vim-repeat](https://github.com/tpope/vim-repeat)-style interface for supporting repeat from extension functions. This is another that may not be merged right away, but I'm submitting to open the dialog about how best to go about this. 

I introduce here a global `InputQueue` (should it rather be per-editor, like the `TestInputModel`?) so we can more closely simulate vim's `execute` command with input queued up and processed in-order. The queue accessed indirectly for `inputKeyStroke` and `inputString` (via `ModalEntry` and `TestInputModel`), so it is transparent to the Extensions. 

Since we're _not_ actually vim, it may not be necessary to support this sort of input feeding (we could instead save some executable object that performs the repeat) and indeed it does bring up some weirdness in implementation. Specifically, the `VimRepeat` class uses the `InputQueue` directly to perform a sort of lazy/delayed run through the input queue, but other plugins need to use the regular `VimExtensionFacade#executeNormal`. This interplay seems to work, but it might open the door to potential bugs in the future, if there are particularly complicated extensions.

I originally had the Facade call the `InputQueue` always so it would be more symmetrical, but this introduces a weird timing condition when repeating `gcip`, for example. Since `gc` triggers the "lazy" execution of `g@`, that `g` would execute _before_ the `i`, and the `@` would execute _before_ the `p`, causing you to enter insert mode unexpectedly. As it is now, all the Extension's intended executions and execute atomically, with the rest of the enqueued input happening after, as expected. Again, though, it's easy to imagine a situation where this would not be sufficient. 

Included is repeat support for `surround` and the proposed `commentary` extension from #109, with tests that ensure the repeating cleans up when another change command is executed. Future extensions should probably test their own repeat-ability.

Let me know what you think!

(This PR addresses VIM-1118)
