### PR TITLE
FIX VIM-1154 too many lines affected by multiline indent

### DIFF
--- a/src/com/maddyhome/idea/vim/action/change/shift/ShiftLeftLinesAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/shift/ShiftLeftLinesAction.java
@@ -36,7 +36,7 @@ public class ShiftLeftLinesAction extends EditorAction {
 
   private static class Handler extends ChangeEditorActionHandler {
     public boolean execute(@NotNull Editor editor, @NotNull DataContext context, int count, int rawCount, @Nullable Argument argument) {
-      VimPlugin.getChange().indentLines(editor, context, count, -1);
+      VimPlugin.getChange().indentLines(editor, context, count, 1, -1);
 
       return true;
     }

--- a/src/com/maddyhome/idea/vim/action/change/shift/ShiftRightLinesAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/shift/ShiftRightLinesAction.java
@@ -36,7 +36,7 @@ public class ShiftRightLinesAction extends EditorAction {
 
   private static class Handler extends ChangeEditorActionHandler {
     public boolean execute(@NotNull Editor editor, @NotNull DataContext context, int count, int rawCount, @Nullable Argument argument) {
-      VimPlugin.getChange().indentLines(editor, context, count, 1);
+      VimPlugin.getChange().indentLines(editor, context, count, 1, 1);
 
       return true;
     }

--- a/src/com/maddyhome/idea/vim/ex/ExCommand.java
+++ b/src/com/maddyhome/idea/vim/ex/ExCommand.java
@@ -67,7 +67,7 @@ public class ExCommand {
     return ranges.getTextRange(editor, context, count);
   }
 
-  protected int getCountArgument() {
+  public int getCountArgument() {
     try {
       return Integer.parseInt(argument);
     }

--- a/src/com/maddyhome/idea/vim/ex/handler/ShiftLeftHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/ShiftLeftHandler.java
@@ -35,10 +35,12 @@ public class ShiftLeftHandler extends CommandHandler {
   }
 
   public boolean execute(@NotNull Editor editor, @NotNull DataContext context, @NotNull ExCommand cmd) {
-    TextRange range = cmd.getTextRange(editor, context, true);
+    int count = cmd.getCountArgument();
+    if ( count == -1 ) {
+      count = 1;
+    }
 
-    VimPlugin.getChange().indentRange(editor, context, range, cmd.getCommand().length(), -1);
-
+    VimPlugin.getChange().indentLines(editor, context, count, cmd.getCommand().length(), -1);
     return true;
   }
 }

--- a/src/com/maddyhome/idea/vim/ex/handler/ShiftRightHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/ShiftRightHandler.java
@@ -35,10 +35,12 @@ public class ShiftRightHandler extends CommandHandler {
   }
 
   public boolean execute(@NotNull Editor editor, @NotNull DataContext context, @NotNull ExCommand cmd) {
-    TextRange range = cmd.getTextRange(editor, context, true);
+    int count = cmd.getCountArgument();
+    if ( count == -1 ) {
+      count = 1;
+    }
 
-    VimPlugin.getChange().indentRange(editor, context, range, cmd.getCommand().length(), 1);
-
+    VimPlugin.getChange().indentLines(editor, context, count, cmd.getCommand().length(), 1);
     return true;
   }
 }

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -1340,10 +1340,10 @@ public class ChangeGroup {
     KeyHandler.executeAction("ReformatCode", context);
   }
 
-  public void indentLines(@NotNull Editor editor, @NotNull DataContext context, int lines, int dir) {
+  public void indentLines(@NotNull Editor editor, @NotNull DataContext context, int lines, int count, int dir) {
     int start = editor.getCaretModel().getOffset();
     int end = VimPlugin.getMotion().moveCaretToLineEndOffset(editor, lines - 1, false);
-    indentRange(editor, context, new TextRange(start, end), 1, dir);
+    indentRange(editor, context, new TextRange(start, end), count, dir);
   }
 
   public void indentMotion(@NotNull Editor editor, @NotNull DataContext context, int count, int rawCount, @NotNull Argument argument, int dir) {

--- a/test/org/jetbrains/plugins/ideavim/action/ShiftLeftLinesActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ShiftLeftLinesActionTest.java
@@ -1,0 +1,22 @@
+package org.jetbrains.plugins.ideavim.action;
+
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
+
+public class ShiftLeftLinesActionTest extends VimTestCase {
+
+  public void testShiftShiftsSingleLine() {
+    myFixture.configureByText("a.txt", "        <caret>w\n");
+    typeText(parseKeys("<<"));
+    myFixture.checkResult("    w\n");
+  }
+
+  public void testShiftShiftsMultiLine() {
+    myFixture.configureByText("a.txt", "Hello\n        <caret>w\nWorld");
+    typeText(parseKeys("<<"));
+    myFixture.checkResult("Hello\n    w\nWorld");
+  }
+
+}

--- a/test/org/jetbrains/plugins/ideavim/ex/ShiftCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/ShiftCommandTest.java
@@ -1,0 +1,73 @@
+package org.jetbrains.plugins.ideavim.ex;
+
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+public class ShiftCommandTest extends VimTestCase {
+
+  // VIM-1154 |:>|
+  public void testShiftRightSingleLine() {
+    myFixture.configureByText("a.txt", "ABC\n" +
+                                       "<caret>DEF\n" +
+                                       "GHI");
+    typeText(commandToKeys(">"));
+    myFixture.checkResult("ABC\n" +
+                          "    <caret>DEF\n" +
+                          "GHI");
+  }
+
+  // VIM-1154 |:>>|
+  public void testShiftRightSingleLineTwoCount() {
+    myFixture.configureByText("a.txt", "ABC\n" +
+            "<caret>DEF\n" +
+            "GHI");
+    typeText(commandToKeys(">>"));
+    myFixture.checkResult("ABC\n" +
+            "        <caret>DEF\n" +
+            "GHI");
+  }
+
+  // VIM-1154 |2:>|
+  public void testShiftRightMultipleLine() {
+    myFixture.configureByText("a.txt",  "ABC\n" +
+                                        "<caret>DEF\n" +
+                                        "GHI");
+    typeText(commandToKeys(">2"));
+    myFixture.checkResult("ABC\n" +
+                          "    <caret>DEF\n" +
+                          "    GHI");
+  }
+
+  // VIM-1154 |:<|
+  public void testShiftLeftSingleLine() {
+    myFixture.configureByText("a.txt", "ABC\n" +
+            "        <caret>DEF\n" +
+            "GHI");
+    typeText(commandToKeys("<"));
+    myFixture.checkResult("ABC\n" +
+            "    <caret>DEF\n" +
+            "GHI");
+  }
+
+  // VIM-1154 |:<<|
+  public void testShiftLeftSingleLineTwoCount() {
+    myFixture.configureByText("a.txt", "ABC\n" +
+            "        <caret>DEF\n" +
+            "GHI");
+    typeText(commandToKeys("<<"));
+    myFixture.checkResult("ABC\n" +
+            "<caret>DEF\n" +
+            "GHI");
+  }
+
+  // VIM-1154 |2:<|
+  public void testShiftLeftMultipleLine() {
+    myFixture.configureByText("a.txt", "ABC\n" +
+            "    <caret>DEF\n" +
+            "    GHI");
+    typeText(commandToKeys("<2"));
+    myFixture.checkResult("ABC\n" +
+            "<caret>DEF\n" +
+            "GHI");
+  }
+
+}


### PR DESCRIPTION
a fix for the VIM-1154 issue: too many lines affected by multiline indent.

Unexpectedly, following code return next line number.

```
    int eline = editor.offsetToLogicalPosition(range.getEndOffset()).line;
```

range.getEndOffset() return newline position, but editor.offsetToLocaPosition() intepret newline position as being in next line.
