### PR TITLE
VIM-862 | Allow an optional Ex range for :action input

### DIFF
--- a/src/com/maddyhome/idea/vim/command/Argument.java
+++ b/src/com/maddyhome/idea/vim/command/Argument.java
@@ -47,7 +47,6 @@ public class Argument {
 
   /**
    * Creates a motion command argument
-   *
    * @param motionArg The motion command
    */
   public Argument(@Nullable Command motionArg) {

--- a/src/com/maddyhome/idea/vim/command/Argument.java
+++ b/src/com/maddyhome/idea/vim/command/Argument.java
@@ -47,6 +47,7 @@ public class Argument {
 
   /**
    * Creates a motion command argument
+   *
    * @param motionArg The motion command
    */
   public Argument(@Nullable Command motionArg) {

--- a/src/com/maddyhome/idea/vim/ex/CommandHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/CommandHandler.java
@@ -200,7 +200,7 @@ public abstract class CommandHandler {
   }
 
   /**
-   * Executes a command. The range and arugments are validated first.
+   * Executes a command. The range and arguments are validated first.
    *
    * @param editor  The editor to run the command in
    * @param context The data context

--- a/src/com/maddyhome/idea/vim/ex/handler/ActionHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/ActionHandler.java
@@ -44,12 +44,10 @@ public class ActionHandler extends CommandHandler {
                          @NotNull ExCommand cmd) throws ExException {
     final String actionName = cmd.getArgument().trim();
     final AnAction action = ActionManager.getInstance().getAction(actionName);
-
     if (action == null) {
       VimPlugin.showMessage("Action not found: " + actionName);
       return false;
     }
-
     final Application application = ApplicationManager.getApplication();
     if (application.isUnitTestMode()) {
       executeAction(action, context, actionName);

--- a/src/com/maddyhome/idea/vim/ex/handler/ActionHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/ActionHandler.java
@@ -26,14 +26,9 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
-import com.maddyhome.idea.vim.command.CommandState;
-import com.maddyhome.idea.vim.command.SelectionType;
-import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.ex.CommandHandler;
-import com.maddyhome.idea.vim.ex.CommandParser;
 import com.maddyhome.idea.vim.ex.ExCommand;
 import com.maddyhome.idea.vim.ex.ExException;
-import com.maddyhome.idea.vim.helper.EditorHelper;
 import com.maddyhome.idea.vim.helper.UiHelper;
 import org.jetbrains.annotations.NotNull;
 
@@ -54,18 +49,6 @@ public class ActionHandler extends CommandHandler {
       VimPlugin.showMessage("Action not found: " + actionName);
       return false;
     }
-
-    //////
-//    TextRange range = cmd.getTextRange(editor, context, false);
-//
-//    final ExCommand argumentCmd = CommandParser.getInstance().parse(cmd.getArgument());
-//    int line = argumentCmd.getRanges().getFirstLine(editor, context);
-//    final int offset = VimPlugin.getMotion().moveCaretToLineStart(editor, line + 1);
-//
-//    final String text = EditorHelper.getText(editor, range.getStartOffset(), range.getEndOffset());
-//    VimPlugin.getCopy().putText(editor, context, offset, text, SelectionType.LINE_WISE, 1, true,
-//        false, CommandState.SubMode.NONE);
-    //////
 
     final Application application = ApplicationManager.getApplication();
     if (application.isUnitTestMode()) {

--- a/src/com/maddyhome/idea/vim/ex/handler/ActionHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/ActionHandler.java
@@ -26,9 +26,14 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.command.CommandState;
+import com.maddyhome.idea.vim.command.SelectionType;
+import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.ex.CommandHandler;
+import com.maddyhome.idea.vim.ex.CommandParser;
 import com.maddyhome.idea.vim.ex.ExCommand;
 import com.maddyhome.idea.vim.ex.ExException;
+import com.maddyhome.idea.vim.helper.EditorHelper;
 import com.maddyhome.idea.vim.helper.UiHelper;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,17 +42,31 @@ import org.jetbrains.annotations.NotNull;
  */
 public class ActionHandler extends CommandHandler {
   public ActionHandler() {
-    super("action", "", RANGE_FORBIDDEN | DONT_REOPEN);
+    super("action", "", RANGE_OPTIONAL | DONT_REOPEN);
   }
 
   public boolean execute(@NotNull Editor editor, @NotNull final DataContext context,
                          @NotNull ExCommand cmd) throws ExException {
     final String actionName = cmd.getArgument().trim();
     final AnAction action = ActionManager.getInstance().getAction(actionName);
+
     if (action == null) {
       VimPlugin.showMessage("Action not found: " + actionName);
       return false;
     }
+
+    //////
+//    TextRange range = cmd.getTextRange(editor, context, false);
+//
+//    final ExCommand argumentCmd = CommandParser.getInstance().parse(cmd.getArgument());
+//    int line = argumentCmd.getRanges().getFirstLine(editor, context);
+//    final int offset = VimPlugin.getMotion().moveCaretToLineStart(editor, line + 1);
+//
+//    final String text = EditorHelper.getText(editor, range.getStartOffset(), range.getEndOffset());
+//    VimPlugin.getCopy().putText(editor, context, offset, text, SelectionType.LINE_WISE, 1, true,
+//        false, CommandState.SubMode.NONE);
+    //////
+
     final Application application = ApplicationManager.getApplication();
     if (application.isUnitTestMode()) {
       executeAction(action, context, actionName);

--- a/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
@@ -296,17 +296,35 @@ public class MapCommandTest extends VimTestCase {
     myFixture.checkResult("Hello!\n");
   }
 
-  public void testMapActionNormalMode() {
-    configureByText("World\n");
-    typeText(commandToKeys("map ,ff :action $Delete<CR>"));
-    typeText(parseKeys(",ff"));
-    myFixture.checkResult("orld\n");
-  }
-
-  public void testMapInVisualMode() {
+  // VIM-862
+  public void testActionMapWithVisualRangeOneChar() {
     configureByText("World\n");
     typeText(commandToKeys("map ,ff :action $Delete<CR>"));
     typeText(parseKeys("0", "v", ",ff"));
+    myFixture.checkResult("orld\n");
+  }
+
+  // VIM-862
+  public void testActionMapWithVisualRangeSegment() {
+    configureByText("World\n");
+    typeText(commandToKeys("map ,ff :action $Delete<CR>"));
+    typeText(parseKeys("0", "l", "v", "l", ",ff"));
+    myFixture.checkResult("Wld\n");
+  }
+
+  // VIM-862
+  public void testActionMapWithVisualRangeEntireLine() {
+    configureByText("World\n");
+    typeText(commandToKeys("map ,ff :action $Delete<CR>"));
+    typeText(parseKeys("0", "v", "$", ",ff"));
+    myFixture.checkResult("\n");
+  }
+
+  // VIM-862
+  public void testActionMapWithVisualRangeMultiLine() {
+    configureByText("World\nWorld\n");
+    typeText(commandToKeys("map ,ff :action $Delete<CR>"));
+    typeText(parseKeys("0", "v", "j", ",ff"));
     myFixture.checkResult("orld\n");
   }
 }

--- a/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/MapCommandTest.java
@@ -295,4 +295,18 @@ public class MapCommandTest extends VimTestCase {
     typeText(parseKeys(",fa!<Esc>"));
     myFixture.checkResult("Hello!\n");
   }
+
+  public void testMapActionNormalMode() {
+    configureByText("World\n");
+    typeText(commandToKeys("map ,ff :action $Delete<CR>"));
+    typeText(parseKeys(",ff"));
+    myFixture.checkResult("orld\n");
+  }
+
+  public void testMapInVisualMode() {
+    configureByText("World\n");
+    typeText(commandToKeys("map ,ff :action $Delete<CR>"));
+    typeText(parseKeys("0", "v", ",ff"));
+    myFixture.checkResult("orld\n");
+  }
 }


### PR DESCRIPTION
`ActionHandler` does not allow Ex ranges with its input, which leads to VIM-862 -- ranges given to an `:action` mapping are ignored. This branch changes `ActionHandler` to allow an optional range.
