### PR TITLE
Fix NPE in pattern search.

### DIFF
--- a/src/com/maddyhome/idea/vim/regexp/CharPointer.java
+++ b/src/com/maddyhome/idea/vim/regexp/CharPointer.java
@@ -357,6 +357,7 @@ public class CharPointer {
     return seq.charAt(pointer + 7);
   }
 
+  @Override
   public boolean equals(Object obj) {
     if (obj instanceof CharPointer) {
       CharPointer ptr = (CharPointer)obj;

--- a/src/com/maddyhome/idea/vim/regexp/RegExp.java
+++ b/src/com/maddyhome/idea/vim/regexp/RegExp.java
@@ -1319,7 +1319,7 @@ public class RegExp {
               regtail(lastbranch, br);
               /* connect all branches to the NOTHING
                                  * branch at the end */
-              for (br = ret.ref(0); br != lastnode; ) {
+              for (br = ret.ref(0); !br.equals(lastnode); ) {
                 if (br.OP() == BRANCH) {
                   regtail(br, lastbranch);
                   br = br.OPERAND();


### PR DESCRIPTION
This Pull request fixes a Null Pointer Exception inside Regex.java due to the conditional `br != lastnode` returning false on an optional sequence (`Magic.PERCENT` switch case)

Steps to reproduce: Perform a search or a search and replace with an optional atom like `\%[foo]bar`.
