### PR TITLE
Fixed . reseting the last find movement 

### DIFF
--- a/src/com/maddyhome/idea/vim/action/change/RepeatChangeAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/RepeatChangeAction.java
@@ -41,6 +41,7 @@ public class RepeatChangeAction extends EditorAction {
     public boolean execute(@NotNull Editor editor, @NotNull DataContext context, @NotNull Command command) {
       CommandState state = CommandState.getInstance(editor);
       Command cmd = state.getLastChangeCommand();
+
       if (cmd != null) {
         if (command.getRawCount() > 0) {
           cmd.setCount(command.getCount());
@@ -53,6 +54,9 @@ public class RepeatChangeAction extends EditorAction {
           }
         }
         Command save = state.getCommand();
+        int lastFTCmd = VimPlugin.getMotion().getLastFTCmd();
+        char lastFTChar = VimPlugin.getMotion().getLastFTChar();
+
         state.setCommand(cmd);
         state.pushState(CommandState.Mode.REPEAT, CommandState.SubMode.NONE, MappingMode.NORMAL);
         char reg = VimPlugin.getRegister().getCurrentRegister();
@@ -67,6 +71,7 @@ public class RepeatChangeAction extends EditorAction {
         if (save != null) {
           state.setCommand(save);
         }
+        VimPlugin.getMotion().setLastFTCmd(lastFTCmd, lastFTChar);
         state.saveLastChangeCommand(cmd);
         VimPlugin.getRegister().selectRegister(reg);
 

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -1811,6 +1811,14 @@ public class MotionGroup {
     private int endOff;
   }
 
+  public int getLastFTCmd() {
+    return lastFTCmd;
+  }
+
+  public char getLastFTChar() {
+    return lastFTChar;
+  }
+
   private int lastFTCmd = 0;
   private char lastFTChar;
   private int visualStart;

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -572,4 +572,8 @@ public class ChangeActionTest extends VimTestCase {
                           "<caret>\n" +
                           "and some text after\n");
   }
+
+  public void testRepeatChangeWordDoesNotBreakNextRepeatFind() {
+    doTest(parseKeys("fXcfYPATATA<Esc>fX.;."), "<caret>aaaaXBBBBYaaaaaaaXBBBBYaaaaaaXBBBBYaaaaaaaa\n", "aaaaPATATAaaaaaaaPATATAaaaaaaPATATAaaaaaaaa\n");
+  }
 }


### PR DESCRIPTION
On the original vim when we repeat a change with . that also contain an find movement the last find that was typed before the repeat is the one used by the motion repeat ;. Before the commit the plugin would have reset the last movement to use the movement contained in the command that was repeated.

To solve this I took a simple approach where I save the last find motion before starting the repeat and then restoring it to its original value after the repeat is over. In order to access the find motion fields from RepeatChangeAction I created getters in MotionGroup for the movement type and character.

	modified:   src/com/maddyhome/idea/vim/action/change/RepeatChangeAction.java
	modified:   src/com/maddyhome/idea/vim/group/MotionGroup.java
	modified:   test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java