### PR TITLE
Fix VIM-636 Broken behavior with shift-s to substitute line

### DIFF
--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -642,8 +642,45 @@ public class ChangeActionTest extends VimTestCase {
                           "and some text after\n");
   }
 
+  // VIM-1216 |f| |.| |;|
   public void testRepeatChangeWordDoesNotBreakNextRepeatFind() {
     doTest(parseKeys("fXcfYPATATA<Esc>fX.;."), "<caret>aaaaXBBBBYaaaaaaaXBBBBYaaaaaaXBBBBYaaaaaaaa\n", "aaaaPATATAaaaaaaaPATATAaaaaaaPATATAaaaaaaaa\n");
+  }
+
+  // VIM-636 |S| |cc|
+  public void testLineSubstitutionEmptyFile() {
+    doTest(parseKeys("S"),
+           "",
+           "\n");
+    assertOffset(0);
+    assertMode(CommandState.Mode.INSERT);
+  }
+
+  // VIM-636 |S| |cc|
+  public void testLineSubstitutionOneLineBlankFile() {
+    doTest(parseKeys("S"),
+           "\n",
+           "\n");
+    assertOffset(0);
+    assertMode(CommandState.Mode.INSERT);
+  }
+
+  // VIM-636 |S| |cc|
+  public void testLineSubstitutionThreeLineBlankFile() {
+    doTest(parseKeys("S"),
+           "\n<caret>\n\n",
+           "\n<caret>\n\n");
+    assertOffset(1);
+    assertMode(CommandState.Mode.INSERT);
+  }
+
+  // VIM-636 |S| |cc|
+  public void testLineSubstitutionFourLineBlankFile() {
+    doTest(parseKeys("S"),
+           "\n<caret>\n\n\n",
+           "\n<caret>\n\n\n");
+    assertOffset(1);
+    assertMode(CommandState.Mode.INSERT);
   }
 
   // VIM-1110 |CTRL-V| |v_b_i| |zc|


### PR DESCRIPTION
|S| aka |cc| was not behaving properly on files that were empty or
contained 1 to 3 blank lines.

I have found the problem for the 2 and 3 line files to be not counting
newlines when getting of the file size in deleteLine. I have given it
some thought and we are comparing to an offset which includes newlines.
So I am pretty confident that using getFileSize(editor, true) is more
accurate regardless of the fix.

For the empty and one blank line problems I have added special case
checks. I did it this way because I was able to confine the change only
for change line thus minimizing the breakage risk.