### PR TITLE
VIM-714 Fixed down movement column after visual delete.

### DIFF
--- a/src/com/maddyhome/idea/vim/action/change/delete/DeleteVisualAction.java
+++ b/src/com/maddyhome/idea/vim/action/change/delete/DeleteVisualAction.java
@@ -21,12 +21,15 @@ package com.maddyhome.idea.vim.action.change.delete;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.action.VimCommandAction;
 import com.maddyhome.idea.vim.command.*;
 import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.handler.CaretOrder;
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler;
+import com.maddyhome.idea.vim.helper.CaretData;
+import com.maddyhome.idea.vim.helper.EditorData;
 import com.maddyhome.idea.vim.helper.EditorHelper;
 import org.jetbrains.annotations.NotNull;
 
@@ -51,7 +54,12 @@ public class DeleteVisualAction extends VimCommandAction {
           return VimPlugin.getChange().deleteRange(editor, caret, lineRange, SelectionType.fromSubMode(mode), false);
         }
         else {
-          return VimPlugin.getChange().deleteRange(editor, caret, range, SelectionType.fromSubMode(mode), false);
+          boolean isDeleted = VimPlugin.getChange().deleteRange(editor, caret, range, SelectionType.fromSubMode(mode), false);
+          if( isDeleted ) {
+            LogicalPosition start = editor.offsetToLogicalPosition(range.getStartOffset());
+            CaretData.setLastColumn(editor, caret, start.column);
+          }
+          return isDeleted;
         }
       }
     });

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -455,6 +455,25 @@ public class ChangeActionTest extends VimTestCase {
                           "ar\n");
   }
 
+  // VIM-714 |v|
+  public void testDeleteVisualColumnPositionOneLine() {
+    doTest(parseKeys("vwxj"),
+           "<caret>lorem ipsum dolor sit amet\n" +
+           "lorem ipsum dolor sit amet\n",
+           "psum dolor sit amet\n" +
+           "<caret>lorem ipsum dolor sit amet\n");
+  }
+
+  // VIM-714 |v|
+  public void testDeleteVisualColumnPositionMultiLine() {
+    doTest(parseKeys("v3wfixj"),
+           "gaganis <caret>gaganis gaganis\n" +
+           "gaganis gaganis gaganis\n" +
+           "gaganis gaganis gaganis\n",
+           "gaganis s gaganis\n" +
+           "gaganis <caret>gaganis gaganis\n");
+  }
+
   // |r|
   public void testReplaceOneChar() {
     doTest(parseKeys("rx"),


### PR DESCRIPTION
It seems that the movements that were done while in visual selection
mode were also moving the editor column information.

Despite the above it seems that original vim will use the column of the
position where the deletion is started, so this is what  I have
implemented to fix this.