### PR TITLE
Add rudimentary command support

### DIFF
--- a/src/com/maddyhome/idea/vim/ex/CommandParser.java
+++ b/src/com/maddyhome/idea/vim/ex/CommandParser.java
@@ -17,6 +17,12 @@
  */
 package com.maddyhome.idea.vim.ex;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
@@ -24,16 +30,64 @@ import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.SelectionType;
 import com.maddyhome.idea.vim.common.Register;
 import com.maddyhome.idea.vim.common.TextRange;
-import com.maddyhome.idea.vim.ex.handler.*;
+import com.maddyhome.idea.vim.ex.handler.ActionHandler;
+import com.maddyhome.idea.vim.ex.handler.ActionListHandler;
+import com.maddyhome.idea.vim.ex.handler.AsciiHandler;
+import com.maddyhome.idea.vim.ex.handler.CmdFilterHandler;
+import com.maddyhome.idea.vim.ex.handler.CommandCommandHandler;
+import com.maddyhome.idea.vim.ex.handler.CopyTextHandler;
+import com.maddyhome.idea.vim.ex.handler.DeleteLinesHandler;
+import com.maddyhome.idea.vim.ex.handler.DigraphHandler;
+import com.maddyhome.idea.vim.ex.handler.DumpLineHandler;
+import com.maddyhome.idea.vim.ex.handler.EchoHandler;
+import com.maddyhome.idea.vim.ex.handler.EditFileHandler;
+import com.maddyhome.idea.vim.ex.handler.ExitHandler;
+import com.maddyhome.idea.vim.ex.handler.FindClassHandler;
+import com.maddyhome.idea.vim.ex.handler.FindFileHandler;
+import com.maddyhome.idea.vim.ex.handler.FindSymbolHandler;
+import com.maddyhome.idea.vim.ex.handler.GotoCharacterHandler;
+import com.maddyhome.idea.vim.ex.handler.GotoLineHandler;
+import com.maddyhome.idea.vim.ex.handler.HelpHandler;
+import com.maddyhome.idea.vim.ex.handler.HistoryHandler;
+import com.maddyhome.idea.vim.ex.handler.JoinLinesHandler;
+import com.maddyhome.idea.vim.ex.handler.JumpsHandler;
+import com.maddyhome.idea.vim.ex.handler.LetHandler;
+import com.maddyhome.idea.vim.ex.handler.MapHandler;
+import com.maddyhome.idea.vim.ex.handler.MarkHandler;
+import com.maddyhome.idea.vim.ex.handler.MarksHandler;
+import com.maddyhome.idea.vim.ex.handler.MoveTextHandler;
+import com.maddyhome.idea.vim.ex.handler.NextFileHandler;
+import com.maddyhome.idea.vim.ex.handler.NoHLSearchHandler;
+import com.maddyhome.idea.vim.ex.handler.OnlyHandler;
+import com.maddyhome.idea.vim.ex.handler.PreviousFileHandler;
+import com.maddyhome.idea.vim.ex.handler.PromptFindHandler;
+import com.maddyhome.idea.vim.ex.handler.PromptReplaceHandler;
+import com.maddyhome.idea.vim.ex.handler.PutLinesHandler;
+import com.maddyhome.idea.vim.ex.handler.QuitHandler;
+import com.maddyhome.idea.vim.ex.handler.RedoHandler;
+import com.maddyhome.idea.vim.ex.handler.RegistersHandler;
+import com.maddyhome.idea.vim.ex.handler.RepeatHandler;
+import com.maddyhome.idea.vim.ex.handler.SelectFileHandler;
+import com.maddyhome.idea.vim.ex.handler.SelectFirstFileHandler;
+import com.maddyhome.idea.vim.ex.handler.SelectLastFileHandler;
+import com.maddyhome.idea.vim.ex.handler.SetHandler;
+import com.maddyhome.idea.vim.ex.handler.ShiftLeftHandler;
+import com.maddyhome.idea.vim.ex.handler.ShiftRightHandler;
+import com.maddyhome.idea.vim.ex.handler.SortHandler;
+import com.maddyhome.idea.vim.ex.handler.SourceHandler;
+import com.maddyhome.idea.vim.ex.handler.SplitHandler;
+import com.maddyhome.idea.vim.ex.handler.SubstituteHandler;
+import com.maddyhome.idea.vim.ex.handler.UndoHandler;
+import com.maddyhome.idea.vim.ex.handler.WriteAllHandler;
+import com.maddyhome.idea.vim.ex.handler.WriteHandler;
+import com.maddyhome.idea.vim.ex.handler.WriteNextFileHandler;
+import com.maddyhome.idea.vim.ex.handler.WritePreviousFileHandler;
+import com.maddyhome.idea.vim.ex.handler.WriteQuitHandler;
+import com.maddyhome.idea.vim.ex.handler.YankLinesHandler;
 import com.maddyhome.idea.vim.ex.range.AbstractRange;
 import com.maddyhome.idea.vim.group.HistoryGroup;
 import com.maddyhome.idea.vim.helper.MessageHelper;
 import com.maddyhome.idea.vim.helper.Msg;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Maintains a tree of Ex commands based on the required and optional parts of the command names. Parses and
@@ -70,6 +124,7 @@ public class CommandParser {
   public void registerHandlers() {
     if (registered) return;
 
+    new CommandCommandHandler();
     new ActionListHandler();
     new AsciiHandler();
     new CmdFilterHandler();

--- a/src/com/maddyhome/idea/vim/ex/handler/CommandCommandHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/CommandCommandHandler.java
@@ -1,0 +1,93 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2016 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.ex.handler;
+
+import java.util.List;
+
+import org.bouncycastle.util.Strings;
+import org.jetbrains.annotations.NotNull;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Editor;
+import com.maddyhome.idea.vim.KeyHandler;
+import com.maddyhome.idea.vim.ex.CommandHandler;
+import com.maddyhome.idea.vim.ex.CommandParser;
+import com.maddyhome.idea.vim.ex.ExCommand;
+import com.maddyhome.idea.vim.ex.ExException;
+import com.maddyhome.idea.vim.helper.UiHelper;
+
+/**
+ * @author smartbomb
+ */
+public class CommandCommandHandler extends CommandHandler {
+  public CommandCommandHandler() {
+    super("command", "", RANGE_FORBIDDEN | DONT_REOPEN | ARGUMENT_REQUIRED);
+  }
+
+
+  public static CommandHandler createCommandWrapper(String commandName, String wrappedCommand) {
+    return new CommandHandler(commandName, "", ARGUMENT_OPTIONAL) {
+      @Override
+      public boolean execute(@NotNull Editor editor, @NotNull DataContext context, @NotNull ExCommand cmd) throws ExException {
+
+        CommandParser.getInstance().processCommand(editor, context, wrappedCommand, 1);
+        return false;
+      }
+    };
+  }
+
+  public boolean execute(@NotNull Editor editor, @NotNull final DataContext context,
+                         @NotNull ExCommand cmd) throws ExException {
+    final String actionName = cmd.getArgument().trim();
+    final String cmdToExecute = cmd.getArgument().trim();
+    List<String> strings = Lists.newArrayList(Strings.split(cmdToExecute, ' '));
+    String excmd = strings.get(0);
+    strings.remove(0);
+    String args = Joiner.on(' ').join(strings);
+    final Application application = ApplicationManager.getApplication();
+    if (application.isUnitTestMode()) {
+      //executeAction(action, context, actionName);
+    }
+    else {
+      UiHelper.runAfterGotFocus(new Runnable() {
+        @Override
+        public void run() {
+          //executeAction(action, context, actionName);
+          CommandParser.getInstance().addHandler(createCommandWrapper(excmd, args));
+        }
+      });
+    }
+    return true;
+  }
+
+  private void executeAction(@NotNull AnAction action, @NotNull DataContext context, @NotNull String actionName) {
+    try {
+      KeyHandler.executeAction(action, context);
+    }
+    catch (RuntimeException e) {
+      // TODO: Find out if any runtime exceptions may happen here
+      assert false : "Error while executing :action " + actionName + " (" + action + "): " + e;
+    }
+  }
+}


### PR DESCRIPTION
Experimenting with a simple ":command" interface. Allows mapping intellij custom actions to shorter commands as desired. For example  ":command shell action openTerminal"  to open shell instead of requiring a custom action in java code.

No unit test (as of yet). Would appreciate initial comments.
