### PR TITLE
make offset work in normal search

### DIFF
--- a/src/com/maddyhome/idea/vim/group/SearchGroup.java
+++ b/src/com/maddyhome/idea/vim/group/SearchGroup.java
@@ -487,8 +487,13 @@ public class SearchGroup {
         pattern = p.substring(end.pointer() - p.pointer());
         if (logger.isDebugEnabled()) logger.debug("pattern=" + pattern);
         if (p.charAt() != type) {
-          logger.debug("no offset");
-          offset = "";
+          if (end.charAt() == type) {
+            end.inc();
+            offset = end.toString();
+          } else {
+            logger.debug("no offset");
+            offset = "";
+          }
         }
         else {
           p.inc();

--- a/test/org/jetbrains/plugins/ideavim/group/SearchGroupTest.java
+++ b/test/org/jetbrains/plugins/ideavim/group/SearchGroupTest.java
@@ -102,6 +102,13 @@ public class SearchGroupTest extends VimTestCase {
     assertOffset(4);
   }
 
+  // |/pattern/e|
+  public void testSearchMotionOffset() {
+    typeTextInFile(parseKeys("/", "two/e-1", "<Enter>"),
+                   "<caret>one two\n");
+    assertOffset(5);
+  }
+
   // |i_CTRL-K|
   public void testSearchDigraph() {
     typeTextInFile(parseKeys("/", "<C-K>O:", "<Enter>"),


### PR DESCRIPTION
fixes https://youtrack.jetbrains.com/issue/VIM-1119

makes `/two/e-1` work and the other implemented offsets

whats not working:
* search highlight  - once you are at the second `/` highlight stops
* `N` - `SearchAgainPreviousAction`

if you have pointers how to make that work, I'll give it a shot 