### PR TITLE
Support end-of-line multi line percent match in visual mode

### DIFF
--- a/src/com/maddyhome/idea/vim/helper/SearchHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/SearchHelper.java
@@ -210,6 +210,13 @@ public class SearchHelper {
 
     int line = editor.getCaretModel().getLogicalPosition().line;
     int end = EditorHelper.getLineEndOffset(editor, line, true);
+
+    // To handle the case where visual mode allows the user to go past the end of the line,
+    // which will prevent loc from finding a pairable character below
+    if(pos > 0 && pos == end) {
+      pos = end - 1;
+    }
+
     CharSequence chars = editor.getDocument().getCharsSequence();
     int loc = -1;
     // Search the remainder of the current line for one of the candidate characters

--- a/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
@@ -766,6 +766,22 @@ public class MotionActionTest extends VimTestCase {
   }
 
   // |%|
+  public void testPercentVisualModeMatchMultiLineEndOfLine() {
+    typeTextInFile(parseKeys("v$%"),
+            "foo(\n" +
+                    ")");
+    assertOffset(5);
+  }
+
+  // |%|
+  public void testPercentVisualModeMatchFromStartMultiLineEndOfLine() {
+    typeTextInFile(parseKeys("v$%"),
+            "(\n" +
+                    ")");
+    assertOffset(2);
+  }
+
+  // |%|
   public void testPercentMatchParensInString() {
     typeTextInFile(parseKeys("%"),
                    "foo(bar, \"foo(bar\", <caret>baz)\n");


### PR DESCRIPTION
**Problem**

When in visual mode, the caret is allowed to go one past the end of the line, which is consistent with the behaviour in the real Vim editor. However, in this state, ideavim doesn't correctly respond to the *%* action to find a matching parenthesis or brace.  This issue comes up a lot when you use a language that typically has an open curly brace at the end of the line.

**Current Behaviour**

Pressing *v$%* to enter visual mode, go to the end of line, and then find the matching brace, should select the whole function in the example below. But since the caret is one character past the end of the line, ideavim doesn't recognize the newline as a pairable character, and nothing happens.

If you want to use *%* to find the matching curly brace, you currently must first press *h* to go back one character and then *%* will work as expected.

![Current Behaviour](https://d3uepj124s5rcx.cloudfront.net/items/3G2P1g210x3U2V3x313C/Screen%20Recording%202017-03-24%20at%2007.33%20AM.gif)


**Behaviour After Fix**

Pressing *v$%* now selects the entire function.

![Behaviour After Fix](https://d3uepj124s5rcx.cloudfront.net/items/2C3h3Q0c1w1y3l321I05/Screen%20Recording%202017-03-24%20at%2007.20%20AM.gif)

**Description of Work**
Based on my understanding of the code, I did the following:

In the case where the starting *pos* is equal to *end* (which, due to *allowEnd*=*true*, means it is actually past past the end of the line), then *loc* doesn't have a chance to see the open curly brace in order to begin the search for its pair.

So to fix this I simply decrement *pos* by 1, in this case where *pos* is at *end*. Given my limited familiarity with the code, I could not find a more suitable solution.

I also added 2 tests, *testPercentVisualModeMatchMultiLineEndOfLine* and *testPercentVisualModeMatchFromStartMultiLineEndOfLine*.

Thanks for the great project and apologies in advance for any mistakes - this is my first pull request.

**Version info**

IntelliJ IDEA 2017.1
Build #IC-171.3780.107, built on March 22, 2017
JRE: 1.8.0_112-release-736-b13 x86_64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Mac OS X 10.12.3

ideavim Version: 0.48
OS: macOS Sierra 10.12.3