### PR TITLE
Fix vim 1287

### DIFF
--- a/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
@@ -306,6 +306,12 @@ public class MotionActionTest extends VimTestCase {
     myFixture.checkResult("foo = [];\n");
   }
 
+  // VIM-1287 |d| |v_i(|
+  public void testSelectInsideForStringLiteral() {
+    typeTextInFile(parseKeys("di("), "(text \"with quotes(and <caret>braces)\")");
+    myFixture.checkResult("(text \"with quotes()\")");
+  }
+
   // |d| |v_i>|
   public void testDeleteInnerAngleBracketBlock() {
     typeTextInFile(parseKeys("di>"),


### PR DESCRIPTION
Add support for commands like "yi(" or "di{" when caret and braces are inside the string