### PR TITLE
VIM-862 Make :action commands work in visual mode

### DIFF
--- a/src/com/maddyhome/idea/vim/ex/handler/ActionHandler.java
+++ b/src/com/maddyhome/idea/vim/ex/handler/ActionHandler.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class ActionHandler extends CommandHandler {
   public ActionHandler() {
-    super("action", "", RANGE_FORBIDDEN | DONT_REOPEN);
+    super("action", "", RANGE_OPTIONAL | DONT_REOPEN);
   }
 
   public boolean execute(@NotNull Editor editor, @NotNull final DataContext context,
@@ -50,20 +50,24 @@ public class ActionHandler extends CommandHandler {
     }
     final Application application = ApplicationManager.getApplication();
     if (application.isUnitTestMode()) {
-      executeAction(action, context, actionName);
+      executeAction(editor, cmd,action, context, actionName);
     }
     else {
       UiHelper.runAfterGotFocus(new Runnable() {
         @Override
         public void run() {
-          executeAction(action, context, actionName);
+          executeAction(editor, cmd, action, context, actionName);
         }
       });
     }
     return true;
   }
 
-  private void executeAction(@NotNull AnAction action, @NotNull DataContext context, @NotNull String actionName) {
+  private void executeAction(@NotNull Editor editor, @NotNull ExCommand cmd, @NotNull AnAction action,
+                             @NotNull DataContext context, @NotNull String actionName) {
+    if (cmd.getRanges().size() > 0) {
+        VimPlugin.getMotion().swapVisualSelections(editor);
+    }
     try {
       KeyHandler.executeAction(action, context);
     }

--- a/test/org/jetbrains/plugins/ideavim/ex/VariousCommandsTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/VariousCommandsTest.java
@@ -8,6 +8,7 @@ import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
 /**
  * @author vlan
  */
+
 public class VariousCommandsTest extends VimTestCase {
   // VIM-550 |:put|
   public void testPutCreatesNewLine() {
@@ -37,5 +38,50 @@ public class VariousCommandsTest extends VimTestCase {
     assertMode(CommandState.Mode.COMMAND);
     myFixture.checkResult("f<caret>oo\n" +
                           "bar\n");
+  }
+
+  // VIM-862 |:action| in visual character mode
+  public void testExCommandInVisualCharacterMode() {
+    configureByJavaText("-----\n" +
+                        "1<caret>2345\n" +
+                        "abcde\n" +
+                        "-----");
+    typeText(parseKeys("vjl"));
+    typeText(commandToKeys("'<,'>action CommentByBlockComment"));
+    assertMode(CommandState.Mode.COMMAND);
+    myFixture.checkResult("-----\n" +
+                          "1/*2345\n" +
+                          "abc*/de\n" +
+                          "-----");
+  }
+
+  // VIM-862 |:action| in visual line mode
+  public void testExCommandInVisualLineMode() {
+    configureByJavaText("-----\n" +
+                        "1<caret>2345\n" +
+                        "abcde\n" +
+                        "-----");
+    typeText(parseKeys("Vj"));
+    typeText(commandToKeys("'<,'>action CommentByBlockComment"));
+    assertMode(CommandState.Mode.COMMAND);
+    myFixture.checkResult("-----\n" +
+                          "/*12345\n" +
+                          "abcde*/\n" +
+                          "-----");
+  }
+
+  // VIM-862 |:action| in visual block mode
+  public void testExCommandInVisualBlockMode() {
+    configureByJavaText("-----\n" +
+                        "1<caret>2345\n" +
+                        "abcde\n" +
+                        "-----");
+    typeText(parseKeys("<C-V>lj"));
+    typeText(commandToKeys("'<,'>action CommentByBlockComment"));
+    assertMode(CommandState.Mode.COMMAND);
+    myFixture.checkResult("-----\n" +
+                          "1/*23*/45\n" +
+                          "a/*bc*/de\n" +
+                          "-----");
   }
 }


### PR DESCRIPTION
Fixes the following issue VIM-862 ":action ExtractMethod doesn't work in visual mode".
https://youtrack.jetbrains.com/issue/VIM-862

Not only `:action ExtractMethod` works but also generic :action commands do. 
(e.g. `CommandByLineComment`, `CommandByBlockComment`, `ReformatCode`, ...)