### PR TITLE
VIM-1379 Changing visual block correctly handles short lines

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -1175,8 +1175,8 @@ public class ChangeGroup {
   }
 
   public boolean blockInsert(@NotNull Editor editor, @NotNull DataContext context, @NotNull TextRange range, boolean append) {
+    int lines = getLinesCountInVisualBlock(editor, range);
     LogicalPosition start = editor.offsetToLogicalPosition(range.getStartOffset());
-    int lines = range.size();
     int line = start.line;
     int col = start.column;
     if (!range.isMultiple()) {
@@ -1225,7 +1225,7 @@ public class ChangeGroup {
     int col = 0;
     int lines = 0;
     if (type == SelectionType.BLOCK_WISE) {
-      lines = range.size();
+      lines = getLinesCountInVisualBlock(editor, range);
       col = editor.offsetToLogicalPosition(range.getStartOffset()).column;
       if (EditorData.getLastColumn(editor) == MotionGroup.LAST_COLUMN) {
         col = MotionGroup.LAST_COLUMN;
@@ -1251,6 +1251,22 @@ public class ChangeGroup {
     }
 
     return res;
+  }
+
+  /**
+   * Counts number of lines in the visual block.
+   * <p>
+   * The result includes empty and short lines
+   * which does not have explicit start position (caret).
+   *
+   * @param editor  The editor the block was selected in
+   * @param range   The range corresponding to the selected block
+   * @return total number of lines
+   */
+  private static int getLinesCountInVisualBlock(@NotNull Editor editor, @NotNull TextRange range) {
+    LogicalPosition firstStart = editor.offsetToLogicalPosition(range.getStartOffsets()[0]);
+    LogicalPosition lastStart = editor.offsetToLogicalPosition(range.getStartOffsets()[range.size() - 1]);
+    return lastStart.line - firstStart.line + 1;
   }
 
   /**

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -377,6 +377,50 @@ public class ChangeActionTest extends VimTestCase {
            "br\n");
   }
 
+  // VIM-1379 |CTRL-V| |j| |v_b_I|
+  public void testInsertVisualBlockWithEmptyLineInTheMiddle() {
+    doTest(parseKeys("ll", "<C-V>", "jjI", "_quux_", "<Esc>"),
+            "foo\n" +
+            "\n" +
+            "bar\n",
+            "fo_quux_o\n" +
+            "\n" +
+            "ba_quux_r\n");
+  }
+
+  // VIM-1379 |CTRL-V| |j| |v_b_I|
+  public void testInsertVisualBlockWithShorterLineInTheMiddle() {
+    doTest(parseKeys("ll", "<C-V>", "jjI", "_quux_", "<Esc>"),
+            "foo\n" +
+            "x\n" +
+            "bar\n",
+            "fo_quux_o\n" +
+            "x\n" +
+            "ba_quux_r\n");
+  }
+
+  // VIM-1379 |CTRL-V| |j| |v_b_c|
+  public void testChangeVisualBlockWithEmptyLineInTheMiddle() {
+    doTest(parseKeys("ll", "<C-V>", "ljjc", "_quux_", "<Esc>"),
+            "foo foo\n" +
+            "\n" +
+            "bar bar\n",
+            "fo_quux_foo\n" +
+            "\n" +
+            "ba_quux_bar\n");
+  }
+
+  // VIM-1379 |CTRL-V| |j| |v_b_c|
+  public void testChangeVisualBlockWithShorterLineInTheMiddle() {
+    doTest(parseKeys("ll", "<C-V>", "ljjc", "_quux_", "<Esc>"),
+            "foo foo\n" +
+            "x\n" +
+            "bar bar\n",
+            "fo_quux_foo\n" +
+            "x\n" +
+            "ba_quux_bar\n");
+  }
+
   // VIM-845 |CTRL-V| |x|
   public void testDeleteVisualBlockOneCharWide() {
     configureByText("foo\n" +


### PR DESCRIPTION
`TextRange.size()` should be used only for iterating over starts/ends.

I am not sure that this is a proper fix. However it seems consistent with current implementation and passes all tests.