### PR TITLE
VIM-1287 fix di,cs TextObject processing when carret is inside "string"

### DIFF
--- a/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
@@ -182,12 +182,41 @@ public class MotionActionTest extends VimTestCase {
     myFixture.checkResult("{}\n");
   }
 
-  // |d| |v_iB|
+  //VIM-1287 |d| |v_iB|
   public void testDeleteInnerCyrlyBraceBlockWithCarretInsideString() {
     typeTextInFile(parseKeys("di{"),
                    "{\"{foo, \"<caret>bar\", baz}\"}\n");
     myFixture.checkResult("{\"{}\"}\n");
   }
+
+  //VIM-1287 |d| |v_iB|
+  public void testDeleteInnerCyrlyBraceBlockWithCarretInsideStringAndBracesUnbalanced() {
+    typeTextInFile(parseKeys("di{"),
+                   "{\"{foo, <caret>bar\", baz}}\n");
+    myFixture.checkResult("{\"{foo, bar\", baz}}\n");
+  }
+
+  //VIM-1287 |d| |v_iB|
+  public void testDeleteInnerCyrlyBraceBlockWithCarretInsideCharAndBracesUnbalanced() {
+    typeTextInFile(parseKeys("di{"),
+                   "{'{foo, <caret>bar', baz}}\n");
+    myFixture.checkResult("{'{}}\n");
+  }
+
+  //VIM-1287 |d| |v_iB|
+  public void testDeleteInnerCyrlyBraceBlockNestedScenario() {
+    typeTextInFile(parseKeys("di{"),
+                   "{'{foo, '{'{<caret>bar'}', baz}'}");
+    myFixture.checkResult("{'{foo, '{'{}'}");
+  }
+
+  //VIM-1287 |d| |v_iB|
+  public void testDeleteInnerCyrlyBraceBlockWithCarretInsideChar() {
+    typeTextInFile(parseKeys("di{"),
+                   "{'{foo, '<caret>bar', baz}'}\n");
+    myFixture.checkResult("{'{}'}\n");
+  }
+
 
   // |d| |v_aB|
   public void testDeleteOuterCurlyBraceBlock() {

--- a/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
@@ -182,6 +182,13 @@ public class MotionActionTest extends VimTestCase {
     myFixture.checkResult("{}\n");
   }
 
+  // |d| |v_iB|
+  public void testDeleteInnerCyrlyBraceBlockWithCarretInsideString() {
+    typeTextInFile(parseKeys("di{"),
+                   "{\"{foo, \"<caret>bar\", baz}\"}\n");
+    myFixture.checkResult("{\"{}\"}\n");
+  }
+
   // |d| |v_aB|
   public void testDeleteOuterCurlyBraceBlock() {
     typeTextInFile(parseKeys("da{"),

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -235,6 +235,15 @@ public class VimSurroundExtensionTest extends VimTestCase {
     doTest(parseKeys("csBb"), before, after);
   }
 
+  public void testChangeSurroundingBlockInString() {
+    final String before =
+      "if (condition) {return \"<caret>foo\";}";
+    final String after =
+      "if (condition) (return \"foo\";)";
+
+    doTest(parseKeys("csBb"), before, after);
+  }
+
   public void testChangeSurroundingTagSimple() {
     final String before =
       "<div><p><caret>Foo</p></div>";


### PR DESCRIPTION
This align behavior with VIM of di and cs inside strings. 
Without this invoking di on: 
`{"{foo, "<caret>bar", baz}"}`
Wiil result in only: 
`{}`
When in VIM version result is:
`{"{}"}`
Same behavior is observed in surround plugin processing.  

This is not elegant fix but it is minimal. 
Please let me know if anything should be done additionally. 
Also, thank you for maintaining such amazing project.