### PR TITLE
Delete "octal" from default nrformats config

### DIFF
--- a/src/com/maddyhome/idea/vim/option/Options.java
+++ b/src/com/maddyhome/idea/vim/option/Options.java
@@ -452,7 +452,7 @@ public class Options {
     addOption(new ToggleOption("ignorecase", "ic", false));
     addOption(new ListOption("matchpairs", "mps", new String[]{"(:)", "{:}", "[:]"}, ".:."));
     addOption(new ToggleOption("more", "more", true));
-    addOption(new BoundListOption("nrformats", "nf", new String[]{"octal", "hex"}, new String[]{"octal", "hex", "alpha"}));
+    addOption(new BoundListOption("nrformats", "nf", new String[]{"hex"}, new String[]{"octal", "hex", "alpha"}));
     addOption(new NumberOption("scroll", "scr", 0));
     addOption(new NumberOption("scrolljump", "sj", 1));
     addOption(new NumberOption("scrolloff", "so", 0));


### PR DESCRIPTION
So as not to confuse the Ctrl+A's behavior described in https://youtrack.jetbrains.com/issue/VIM-1418