### PR TITLE
Fix VIM-987

### DIFF
--- a/src/com/maddyhome/idea/vim/action/VimShortcutKeyAction.java
+++ b/src/com/maddyhome/idea/vim/action/VimShortcutKeyAction.java
@@ -235,7 +235,16 @@ public class VimShortcutKeyAction extends AnAction implements DumbAware {
     final InputEvent inputEvent = e.getInputEvent();
     if (inputEvent instanceof KeyEvent) {
       final KeyEvent keyEvent = (KeyEvent)inputEvent;
-      return KeyStroke.getKeyStrokeForEvent(keyEvent);
+      if (keyEvent.getKeyCode() == keyEvent.getExtendedKeyCode()) {
+        return KeyStroke.getKeyStrokeForEvent(keyEvent);
+      }
+      else {
+        int id = keyEvent.getID();
+        boolean isReleased = keyEvent.getID() == KeyEvent.KEY_RELEASED;
+        if (id == KeyEvent.KEY_PRESSED || isReleased) {
+          return KeyStroke.getKeyStroke(keyEvent.getExtendedKeyCode(), keyEvent.getModifiers(), isReleased);
+        }
+      }
     }
     return null;
   }


### PR DESCRIPTION
This is my attempt to fix [VIM-987](https://youtrack.jetbrains.com/issue/VIM-987).

The IDE itself does something slightly different at the moment (see [here](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-impl/src/com/intellij/ui/KeyStrokeAdapter.java#L85-L126)) while `JComponent#processKeyBindings(KeyEvent, boolean)` falls back on the "normal" key code when it finds no matching binding (I'd like to link the source here, but it seems to be only available as scrs.zip).

Because I don't know if I break something else with this change and I want to see if I get a response on  [IDEA-197762](https://youtrack.jetbrains.com/issue/IDEA-197762), I prefaced this with WIP.
I the meantime I am testing this change on my system.

Any feedback would be appreciated.