### PR TITLE
Search actionlist by keyboard shortcuts which is assigned to action

### DIFF
--- a/src/com/maddyhome/idea/vim/ex/handler/ActionListHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/ActionListHandler.kt
@@ -39,13 +39,15 @@ class ActionListHandler : CommandHandler(
         val actionManager = ActionManager.getInstance()
 
         val actions = actionManager.getActionIds("")
-                .filter { actionName -> searchPattern.all { it in actionName.toLowerCase() } }
-                .sortedWith(String.CASE_INSENSITIVE_ORDER).joinToString(lineSeparator) { actionName ->
+                .sortedWith(String.CASE_INSENSITIVE_ORDER)
+                .map { actionName ->
                     val shortcuts = actionManager.getAction(actionName).shortcutSet.shortcuts.joinToString(" ") {
                         if (it is KeyboardShortcut) StringHelper.toKeyNotation(it.firstKeyStroke) else it.toString()
                     }
                     if (shortcuts.isBlank()) actionName else "${actionName.padEnd(50)} $shortcuts"
                 }
+                .filter { line -> searchPattern.all { it in line.toLowerCase() } }
+                .joinToString(lineSeparator)
 
 
         ExOutputModel.getInstance(editor).output("--- Actions ---$lineSeparator$actions")

--- a/test/org/jetbrains/plugins/ideavim/ex/ActionListCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/ActionListCommandTest.java
@@ -1,0 +1,43 @@
+package org.jetbrains.plugins.ideavim.ex;
+
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.maddyhome.idea.vim.ex.ExOutputModel;
+import org.jetbrains.plugins.ideavim.VimTestCase;
+
+/**
+ * @author Naoto Ikeno
+ */
+public class ActionListCommandTest extends VimTestCase {
+  public void testListAllActions() {
+    configureByText("\n");
+    typeText(commandToKeys("actionlist"));
+
+    String output = ExOutputModel.getInstance(myFixture.getEditor()).getText();
+    assert output != null;
+
+    // Header line
+    String[] displayedLines = output.split("\n");
+    assertEquals(displayedLines[0], "--- Actions ---");
+
+    // Action lines
+    int displayedActionNum = displayedLines.length - 1;
+    String[] actionIds = ActionManager.getInstance().getActionIds("");
+    assertEquals(displayedActionNum, actionIds.length);
+  }
+
+  // This test depends on default IntelliJ IDEA keymap
+  public void testSearchByActionName() {
+    configureByText("\n");
+    typeText(commandToKeys("actionlist quickimpl"));
+    assertExOutput("--- Actions ---\n" +
+                   "QuickImplementations                               <M-S-I>");
+  }
+
+  // This test depends on default IntelliJ IDEA keymap
+  public void testSearchByAssignedShortcutKey() {
+    configureByText("\n");
+    typeText(commandToKeys("actionlist <M-S-I>"));
+    assertExOutput("--- Actions ---\n" +
+                   "QuickImplementations                               <M-S-I>");
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/ex/ActionListCommandTest.java
+++ b/test/org/jetbrains/plugins/ideavim/ex/ActionListCommandTest.java
@@ -4,6 +4,8 @@ import com.intellij.openapi.actionSystem.ActionManager;
 import com.maddyhome.idea.vim.ex.ExOutputModel;
 import org.jetbrains.plugins.ideavim.VimTestCase;
 
+import java.util.Arrays;
+
 /**
  * @author Naoto Ikeno
  */
@@ -13,7 +15,7 @@ public class ActionListCommandTest extends VimTestCase {
     typeText(commandToKeys("actionlist"));
 
     String output = ExOutputModel.getInstance(myFixture.getEditor()).getText();
-    assert output != null;
+    assertNotNull(output);
 
     // Header line
     String[] displayedLines = output.split("\n");
@@ -25,19 +27,38 @@ public class ActionListCommandTest extends VimTestCase {
     assertEquals(displayedActionNum, actionIds.length);
   }
 
-  // This test depends on default IntelliJ IDEA keymap
   public void testSearchByActionName() {
     configureByText("\n");
     typeText(commandToKeys("actionlist quickimpl"));
-    assertExOutput("--- Actions ---\n" +
-                   "QuickImplementations                               <M-S-I>");
+
+    String[] displayedLines = parseActionListOutput();
+    for (int i = 0; i < displayedLines.length; i++) {
+      String line = displayedLines[i];
+      if (i == 0) {
+        assertEquals(line, "--- Actions ---");
+      }else {
+        assertTrue(line.toLowerCase().contains("quickimpl"));
+      }
+    }
   }
 
-  // This test depends on default IntelliJ IDEA keymap
   public void testSearchByAssignedShortcutKey() {
     configureByText("\n");
-    typeText(commandToKeys("actionlist <M-S-I>"));
-    assertExOutput("--- Actions ---\n" +
-                   "QuickImplementations                               <M-S-I>");
+    typeText(commandToKeys("actionlist <M-S-"));
+
+    String[] displayedLines = parseActionListOutput();
+    for (int i = 0; i < displayedLines.length; i++) {
+      String line = displayedLines[i];
+      if (i == 0) {
+        assertEquals(line, "--- Actions ---");
+      }else {
+        assertTrue(line.toLowerCase().contains("<m-s-"));
+      }
+    }
+  }
+
+  private String[] parseActionListOutput() {
+    String output = ExOutputModel.getInstance(myFixture.getEditor()).getText();
+    return output == null ? new String[]{} : output.split("\n");
   }
 }


### PR DESCRIPTION
So far, we can search an action by `:actionlist PartOfSomeActionName` command but there is no way to know action name of IntelliJ functions which we want to use as IdeaVim action.
So I think it is useful to search an action by keyboard shortcuts which is assigned to the action.

## Demo

![2018-09-10 20 04 46](https://user-images.githubusercontent.com/7638989/45294000-d5852600-b534-11e8-9226-1a3d414fc9ea.gif)

## Examples

When execute `:actionlist <M-I>`, the result is following.

```
--- Actions ---
ImplementMethods                                   <M-I>
MethodHierarchy.ImplementMethodAction              <M-I>
```

When execute `:actionlist <M-S-`, the result is following.

```
--- Actions ---
$Redo                                              <M-S-Z> <A-S-BS>
ActivateVersionControlToolWindow                   <M-9> <M-S-9>
ChangeTypeSignature                                <M-S-F6>
CloseActiveTab                                     <M-S-F4>
CollapseAllRegions                                 <M-S-m> <M-S-->
CollapseBlock                                      <M-S-.>
...
```