### PR TITLE
VIM-1274 Fix StringHelper.containsUpperCase behavior

### DIFF
--- a/src/com/maddyhome/idea/vim/helper/StringHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/StringHelper.java
@@ -313,7 +313,7 @@ public class StringHelper {
 
   public static boolean containsUpperCase(@NotNull String text) {
     for (int i = 0; i < text.length(); i++) {
-      if (Character.isUpperCase(text.charAt(i)) && (i == 0 || text.charAt(i - 1) == '\\')) {
+      if (Character.isUpperCase(text.charAt(i)) && (i == 0 || text.charAt(i - 1) != '\\')) {
         return true;
       }
     }

--- a/test/org/jetbrains/plugins/ideavim/group/SearchGroupTest.java
+++ b/test/org/jetbrains/plugins/ideavim/group/SearchGroupTest.java
@@ -95,6 +95,20 @@ public class SearchGroupTest extends VimTestCase {
     assertEquals(-1, pos);
   }
 
+  public void testSmartCaseSearchCaseInsensitive() {
+    setIgnoreCaseAndSmartCase();
+    final int pos = search("tostring",
+                           "obj.toString();\n");
+    assertEquals(4, pos);
+  }
+
+  public void testSmartCaseSearchCaseSensitive() {
+    setIgnoreCaseAndSmartCase();
+    final int pos = search("toString",
+                           "obj.tostring();\nobj.toString();\n");
+    assertEquals(20, pos);
+  }
+
   // |/|
   public void testSearchMotion() {
     typeTextInFile(parseKeys("/", "two", "<Enter>"),
@@ -108,7 +122,7 @@ public class SearchGroupTest extends VimTestCase {
                    "<caret>Hello, Österreich!\n");
     assertOffset(7);
   }
-  
+
   private void setHighlightSearch() {
     final Options options = Options.getInstance();
     options.resetAllOptions();
@@ -116,6 +130,19 @@ public class SearchGroupTest extends VimTestCase {
     assertInstanceOf(option, ToggleOption.class);
     final ToggleOption highlightSearch = (ToggleOption)option;
     highlightSearch.set();
+  }
+
+  private void setIgnoreCaseAndSmartCase() {
+    final Options options = Options.getInstance();
+    options.resetAllOptions();
+    final Option ignoreCaseOption = options.getOption("ignorecase");
+    final Option smartCaseOption = options.getOption("smartcase");
+    assertInstanceOf(ignoreCaseOption, ToggleOption.class);
+    assertInstanceOf(smartCaseOption, ToggleOption.class);
+    final ToggleOption ignoreCase = (ToggleOption)ignoreCaseOption;
+    final ToggleOption smartCase = (ToggleOption)smartCaseOption;
+    ignoreCase.set();
+    smartCase.set();
   }
 
   private int search(final String pattern, String input) {


### PR DESCRIPTION
StringHelper.containsUpperCase should return true when one of
the character of the input string satisfies the following two
conditions:

1. The character is upper case.
2. The character is not prefixed with a backslash.

Before this fix, the second condition was incorrectly written.