### PR TITLE
VIM-1473 Fixed incorrect selection type for unnamed registers

### DIFF
--- a/src/com/maddyhome/idea/vim/group/RegisterGroup.java
+++ b/src/com/maddyhome/idea/vim/group/RegisterGroup.java
@@ -22,8 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.util.containers.ContainerUtil;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.action.motion.mark.MotionGotoFileMarkAction;
 import com.maddyhome.idea.vim.action.motion.search.SearchAgainNextAction;
@@ -433,7 +431,11 @@ public class RegisterGroup {
   @Nullable
   private Register refreshClipboardRegister(char r) {
     final String text = ClipboardHandler.getClipboardText();
+    final Register currentRegister = registers.get(r);
     if (text != null) {
+      if (currentRegister != null && text.equals(currentRegister.getText())) {
+        return currentRegister;
+      }
       return new Register(r, guessSelectionType(text), text);
     }
     return null;
@@ -441,12 +443,7 @@ public class RegisterGroup {
 
   @NotNull
   private SelectionType guessSelectionType(@NotNull String text) {
-    final String[] lines = StringUtil.splitByLines(text);
-    final HashSet<Integer> lengths = new HashSet<>(ContainerUtil.map(lines, String::length));
-    if (lines.length > 1 && lengths.size() == 1) {
-      return SelectionType.BLOCK_WISE;
-    }
-    else if (text.endsWith("\n")) {
+    if (text.endsWith("\n")) {
       return SelectionType.LINE_WISE;
     }
     else {


### PR DESCRIPTION
While compiling [test cases](https://gist.github.com/thecodewarrior/7d766a97c377090470497c8af8e29527) for [VIM-1473](https://youtrack.jetbrains.com/issue/VIM-1473) I discovered that the unnamed registers (aka system clipboard) weren't retaining the selection type when yanked into and were making untrue assumptions as to what text copied in visual block mode would look like. 

In this PR I add a condition so the unnamed registers won't be overwritten unless the clipboard changes (thus they will retain the selection mode IDEAVim initially assigned them until someone copies different text) and removed visual block selections from guess function, as I can't think of any situation in which one would copy text outside of IDEA and want to paste it as if it were copied in visual block selection mode.

I have opened [IJSDK-475](https://youtrack.jetbrains.com/issue/IJSDK-475) regarding the misleading behavior of `StringUtil.splitByLines` as well.