### PR TITLE
VIM-798 Arrow keys for window navigation commands

### DIFF
--- a/src/com/maddyhome/idea/vim/action/window/WindowDownAction.java
+++ b/src/com/maddyhome/idea/vim/action/window/WindowDownAction.java
@@ -54,7 +54,7 @@ public class WindowDownAction extends VimCommandAction {
   @NotNull
   @Override
   public Set<List<KeyStroke>> getKeyStrokesSet() {
-    return parseKeysSet("<C-W>j");
+    return parseKeysSet("<C-W>j", "<C-W><Down>");
   }
 
   @NotNull

--- a/src/com/maddyhome/idea/vim/action/window/WindowLeftAction.java
+++ b/src/com/maddyhome/idea/vim/action/window/WindowLeftAction.java
@@ -54,7 +54,7 @@ public class WindowLeftAction extends VimCommandAction {
   @NotNull
   @Override
   public Set<List<KeyStroke>> getKeyStrokesSet() {
-    return parseKeysSet("<C-W>h");
+    return parseKeysSet("<C-W>h", "<C-W><Left>");
   }
 
   @NotNull

--- a/src/com/maddyhome/idea/vim/action/window/WindowRightAction.java
+++ b/src/com/maddyhome/idea/vim/action/window/WindowRightAction.java
@@ -54,7 +54,7 @@ public class WindowRightAction extends VimCommandAction {
   @NotNull
   @Override
   public Set<List<KeyStroke>> getKeyStrokesSet() {
-    return parseKeysSet("<C-W>l");
+    return parseKeysSet("<C-W>l", "<C-W><Right>");
   }
 
   @NotNull

--- a/src/com/maddyhome/idea/vim/action/window/WindowUpAction.java
+++ b/src/com/maddyhome/idea/vim/action/window/WindowUpAction.java
@@ -54,7 +54,7 @@ public class WindowUpAction extends VimCommandAction {
   @NotNull
   @Override
   public Set<List<KeyStroke>> getKeyStrokesSet() {
-    return parseKeysSet("<C-W>k");
+    return parseKeysSet("<C-W>k", "<C-W><Up>");
   }
 
   @NotNull


### PR DESCRIPTION
Add new mappings to allow window navigation with arrow keys:
- ^W-left as ^W-h
- ^W-down as ^W-j
- ^W-up as ^W-k
- ^W-right as ^W-l

`package-info.java` already contains links to actions and doesn't require editing.