### PR TITLE
Vim 620 - Insert command while in Single Command SubMode (i_CTRL-O)

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -452,7 +452,9 @@ public class ChangeGroup {
       if (mode == CommandState.Mode.REPLACE) {
         processInsert(editor, context);
       }
-      state.pushState(mode, CommandState.SubMode.NONE, MappingMode.INSERT);
+      if (state.getSubMode() != CommandState.SubMode.SINGLE_COMMAND || mode != CommandState.Mode.INSERT) {
+        state.pushState(mode, CommandState.SubMode.NONE, MappingMode.INSERT);
+      }
 
       resetCursor(editor, true);
     }

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -29,6 +29,20 @@ public class ChangeActionTest extends VimTestCase {
            "}\n");
   }
 
+  // VIM-620 |i_CTRL-O|
+  public void testInsertSingleCommandAndInserting() {
+    doTest(parseKeys("i", "<C-O>", "a", "123", "<Esc>", "x"),
+            "abc<caret>d\n",
+            "abcd12\n");
+  }
+
+  // VIM-620 |i_CTRL-O|
+  public void testInsertSingleCommandAndNewLineInserting() {
+    doTest(parseKeys("i", "<C-O>", "o", "123", "<Esc>", "x"),
+           "abc<caret>d\n",
+           "abcd\n12\n");
+  }
+
   // VIM-311 |i_CTRL-O|
   public void testInsertSingleCommand() {
     doTest(parseKeys("i", "def", "<C-O>", "d2h", "x"),


### PR DESCRIPTION
The problem appears because of "additional" insert-mode-state in command states stack.

|Initial stack state       |     After pressing CTRL+O          |     After pressing insert command (E.g. "a")|  Stack depth  |
|-----------------------|------------------------------------|-----------------------------------------------|------|
| ...                              |     ...                                             |       ...                                                            |        |
|**INSERT_MODE**    |     **INSERT_MODE**                  |       **INSERT_MODE**                                 | (N ) |
|                                  |    **SINGLE_MODE_NORMAL**  |       **SINGLE_MODE_NORMAL**                |   (N+1)   |
|                                  |                                                    |       **INSERT_MODE**                                 | ( N+2 ) |

From a programming point of view, it's normal that (N+2) insert-mode should be finished before return to (N) insert-mode. But this approach requires 2 presses of "Esc" to enter normal mode. In this way, insert-mode entering became to be a kind of exception, when old **INSERT_MODE** should remain in the stack instead of adding a new one.

My proposal is not to push second insert-mode-state, but just perform cursor movement. **SINGLE_MODE_NORMAL** will be poped automatically and only (N) **INSERT_MODE** will remain in stack.