### PR TITLE
Get indent from PsiFile so formatting on shift is consistent (VIM-1231)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.java]
+indent_size = 2
+indent_style = space

--- a/src/com/maddyhome/idea/vim/common/IndentConfig.java
+++ b/src/com/maddyhome/idea/vim/common/IndentConfig.java
@@ -1,0 +1,80 @@
+package com.maddyhome.idea.vim.common;
+
+import com.intellij.application.options.CodeStyle;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+
+public class IndentConfig {
+
+  private final int indentSize;
+  private final int tabSize;
+  private final boolean useTabs;
+
+  private IndentConfig(CommonCodeStyleSettings.IndentOptions indentOptions) {
+    this.indentSize = indentOptions.INDENT_SIZE;
+    this.tabSize = indentOptions.TAB_SIZE;
+    this.useTabs = indentOptions.USE_TAB_CHARACTER;
+  }
+
+  public static IndentConfig create(Editor editor) {
+    return create(editor, editor.getProject());
+  }
+
+  public static IndentConfig create(Editor editor, DataContext context) {
+    return create(editor, PlatformDataKeys.PROJECT.getData(context));
+  }
+
+  public static IndentConfig create(Editor editor, Project project) {
+    CommonCodeStyleSettings.IndentOptions indentOptions;
+
+    if(project != null) {
+      indentOptions = CodeStyle.getIndentOptions(project, editor.getDocument());
+    } else {
+      indentOptions = CodeStyle.getDefaultSettings().getIndentOptions();
+
+      if(indentOptions == null) {
+        indentOptions = new CommonCodeStyleSettings.IndentOptions();
+      }
+    }
+
+    return new IndentConfig(indentOptions);
+  }
+
+  public int getIndentSize() {
+    return indentSize;
+  }
+
+  public int getTabSize() {
+    return tabSize;
+  }
+
+  public boolean isUseTabs() {
+    return useTabs;
+  }
+
+  public int getTotalIndent(int count) {
+    return indentSize * count;
+  }
+
+  public String createIndentByCount(int count) {
+    return createIndentBySize(getTotalIndent(count));
+  }
+
+  public String createIndentBySize(int size) {
+    final int tabCount;
+    final int spaceCount;
+    if (useTabs) {
+      tabCount = size / tabSize;
+      spaceCount = size % tabSize;
+    }
+    else {
+      tabCount = 0;
+      spaceCount = size;
+    }
+    return StringUtil.repeat("\t", tabCount) + StringUtil.repeat(" ", spaceCount);
+  }
+}

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -18,19 +18,13 @@
 
 package com.maddyhome.idea.vim.helper;
 
-import com.intellij.application.options.CodeStyle;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.editor.*;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.fileTypes.FileType;
-import com.intellij.openapi.fileTypes.FileTypeManager;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.maddyhome.idea.vim.common.CharacterPosition;
+import com.maddyhome.idea.vim.common.IndentConfig;
 import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.handler.CaretOrder;
 import org.jetbrains.annotations.NotNull;
@@ -551,22 +545,8 @@ public class EditorHelper {
     final int len = getLineLength(editor, line);
     if(len >= to) return "";
 
-    final VirtualFile virtualFile = EditorData.getVirtualFile(editor);
-    final Project project = PlatformDataKeys.PROJECT.getData(context);
     final int limit = to - len;
-    if (virtualFile != null) {
-      final FileType fileType = FileTypeManager.getInstance().getFileTypeByFile(virtualFile);
-      final CodeStyleSettings settings = project == null ? CodeStyle.getDefaultSettings() : CodeStyle.getSettings(project);
-      if (settings.useTabCharacter(fileType)) {
-        final int tabSize = settings.getTabSize(fileType);
-        final int tabsCnt = limit / tabSize;
-        final int spacesCnt = limit % tabSize;
-
-        return StringUtil.repeat("\t", tabsCnt) + StringUtil.repeat(" ", spacesCnt);
-      }
-    }
-
-    return StringUtil.repeat(" ", limit);
+    return IndentConfig.create(editor, context).createIndentBySize(limit);
   }
 
   /**


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.net/issue/VIM-1231

I wasn't sure what the difference was between `PlatformDataKeys.PROJECT.getData(context)` and `editor.getProject()`, so I opted to leave the current behavior (former) where `context` was available.