### PR TITLE
VIM-1187: Fix performance issue with relative line numbers + large files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-ideaVersion IC-2018.2.5
+ideaVersion IC-2018.3
 downloadIdeaSources true
 instrumentPluginCode true
 version SNAPSHOT

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -22,6 +22,7 @@ import com.intellij.application.options.CodeStyle;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.editor.*;
+import com.intellij.openapi.editor.impl.EditorImpl;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileTypes.FileType;
@@ -223,6 +224,9 @@ public class EditorHelper {
    * @return The visual line number
    */
   public static int logicalLineToVisualLine(@NotNull final Editor editor, final int line) {
+    if (editor instanceof EditorImpl) {
+      return ((EditorImpl) editor).offsetToVisualLine(editor.getDocument().getLineStartOffset(line));
+    }
     return editor.logicalToVisualPosition(new LogicalPosition(line, 0)).line;
   }
 


### PR DESCRIPTION
Fixes [VIM-1187](https://youtrack.jetbrains.com/issue/VIM-1187), which is a performance issue with large files and the `relativenumber` option. The fix uses the alternative API as specified in [this comment](https://youtrack.jetbrains.com/issue/VIM-1187#focus=streamItem-27-3057288-0-0). However, this also means bumping required IJ version to 2018.3.