### PR TITLE
VIM-1569: Strip tag attributes from closing tag for Vim-Surround

### DIFF
--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -43,6 +43,7 @@ import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.*;
 
 import static com.maddyhome.idea.vim.extension.VimExtensionFacade.*;
 import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
@@ -109,9 +110,13 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
   @Nullable
   private static Pair<String, String> inputTagPair(@NotNull Editor editor) {
     final String tagInput = inputString(editor, "<");
-    if (tagInput.endsWith(">")) {
-      final String tagName = tagInput.substring(0, tagInput.length() - 1);
-      return Pair.create("<" + tagName + ">", "</" + tagName + ">");
+    final Pattern tagNameAndAttributesCapturePattern = Pattern.compile("(\\w+)([^>]*)>");
+    final Matcher matcher = tagNameAndAttributesCapturePattern.matcher(tagInput);
+
+    if (matcher.find()) {
+      final String tagName = matcher.group(1);
+      final String tagAttributes = matcher.group(2);
+      return Pair.create("<" + tagName + tagAttributes + ">", "</" + tagName + ">");
     }
     else {
       return null;

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -82,6 +82,12 @@ public class VimSurroundExtensionTest extends VimTestCase {
     myFixture.checkResult("Hello <em>World</em>!\n");
   }
 
+  public void testSurroundTagWithAttributes() {
+    configureByText("Hello <caret>World!");
+    typeText(parseKeys("ysiw\\<span class=\"important\" data-foo=\"bar\">"));
+    myFixture.checkResult("Hello <span class=\"important\" data-foo=\"bar\">World</span>!");
+  }
+
   /* visual surround */
 
   public void testVisualSurroundWordParens() {


### PR DESCRIPTION
Fixes [VIM-1569](https://youtrack.jetbrains.com/issue/VIM-1569) - Surrounding visually selected text adds class attribute to end tag

There appears to be an additional issue - that the selected text is not surrounded by line breaks in Visual-Line mode.