### PR TITLE
Fix the wrong email address

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -54,7 +54,7 @@ Contributors:
 * [John Lin](mailto:johnlinp@gmail.com)
 * [Alex Plate](mailto:alexpl292@gmail.com)
 * [Matt Ellis](mailto:m.t.ellis@gmail.com)
-* [John Grib](mailto:johngrib@woowahan.com)
+* [John Grib](mailto:johngrib82@gmail.com)
 * [Marcel Hild](mailto:hild@b4mad.net)
 
 If you are a contributor and your name is not listed here, feel free to


### PR DESCRIPTION
John Grib's email address recorded as johngrib@woowahan.com
is currently not valid.
I am currently using johngrib82@gmail.com.

You can see my merged PR and my recent email address
through the following two links.

* https://github.com/JetBrains/ideavim/pull/115
* https://github.com/johngrib