### PR TITLE
Fixed Bug: VIM-1569 - Surrounding visually selected text with tag + attributes

### DIFF
--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -106,17 +106,19 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
     }
   }
 
-  @Nullable
-  private static Pair<String, String> inputTagPair(@NotNull Editor editor) {
-    final String tagInput = inputString(editor, "<");
-    if (tagInput.endsWith(">")) {
-      final String tagName = tagInput.substring(0, tagInput.length() - 1);
-      return Pair.create("<" + tagName + ">", "</" + tagName + ">");
-    }
-    else {
-      return null;
-    }
-  }
+      @Nullable
+      private static Pair<String, String> inputTagPair(@NotNull Editor editor) {
+        final String tagInput = inputString(editor, "<");
+        if (tagInput.endsWith(">")) {
+          final int propertiesBegin = tagInput.indexOf(' ') == -1 ? tagInput.length() - 1 : tagInput.indexOf(' ');
+          final String tagName = tagInput.substring(0, propertiesBegin);
+          final String tagProperties = tagInput.substring(propertiesBegin, tagInput.length() - 1);
+
+          return Pair.create("<" + tagName + tagProperties + ">", "</" + tagName + ">");
+        } else {
+          return null;
+        }
+      }
 
   @Nullable
   private static Pair<String, String> getOrInputPair(char c, @NotNull Editor editor) {

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.java
@@ -253,6 +253,12 @@ public class VimSurroundExtensionTest extends VimTestCase {
     doTest(parseKeys("cst\\<b>"), before, after);
   }
 
+   public void testAddSurroundingTagWithProperties(){
+    final String before = "<p><caret>Hello</p>";
+    final String after = "<div class = \"container\"><p>Hello</p></div>";
+    doTest(parseKeys("VS<div class = \"container\">"), before, after);
+  }
+
   // TODO if/when we add proper repeat support
   //public void testRepeatChangeSurroundingParens() {
   //  final String before =


### PR DESCRIPTION
Fixed the bug :O
Added a test to the test file.

Note: 
Typing VS<div class = "container"> while on e.g. "Hello" will result in 
<div class = "container">Hello
</div>
and not in:
<div class="container">
<p>Hello txt</p>
</div>
as it is in normal vim.
But inserting a LF (\n) after "container"> results in failed tests.
I think inserting a LF at the end depends on the tag, which is to be inserted?

I hope i didn't do to much wrong. First pull request :)