### PR TITLE
Fix findBlockRange

### DIFF
--- a/src/com/maddyhome/idea/vim/helper/SearchHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/SearchHelper.java
@@ -139,7 +139,7 @@ public class SearchHelper {
         int inQuoteStart = findBlockLocation(subSequence, close, type, -1, inQuotePos, count);
         if (inQuoteStart != -1) {
           startPosInStringFound = true;
-          int inQuoteEnd = findBlockLocation(subSequence, type, close, 1, inQuoteStart + 1, 1);
+          int inQuoteEnd = findBlockLocation(subSequence, type, close, 1, inQuoteStart, 1);
           if (inQuoteEnd != -1) {
             bstart = inQuoteStart + startOffset;
             bend = inQuoteEnd + startOffset;
@@ -151,7 +151,7 @@ public class SearchHelper {
     if (!startPosInStringFound) {
       bstart = findBlockLocation(chars, close, type, -1, pos, count);
       if (bstart != -1) {
-        bend = findBlockLocation(chars, type, close, 1, bstart + 1, 1);
+        bend = findBlockLocation(chars, type, close, 1, bstart, 1);
       }
     }
 

--- a/test/org/jetbrains/plugins/ideavim/helper/SearchHelperTest.java
+++ b/test/org/jetbrains/plugins/ideavim/helper/SearchHelperTest.java
@@ -3,6 +3,8 @@ package org.jetbrains.plugins.ideavim.helper;
 import com.maddyhome.idea.vim.helper.SearchHelper;
 import org.jetbrains.plugins.ideavim.VimTestCase;
 
+import static com.maddyhome.idea.vim.helper.StringHelper.parseKeys;
+
 public class SearchHelperTest extends VimTestCase {
   public void testFindNextWord() {
     String text = "first second";
@@ -51,5 +53,10 @@ public class SearchHelperTest extends VimTestCase {
     int previousWordPosition = SearchHelper.findNextWord(text, text.length(), text.length(), -1, true, false);
 
     assertEquals(previousWordPosition, text.indexOf("second"));
+  }
+
+  public void testMotionOuterWordAction() {
+    typeTextInFile(parseKeys("v", "a("), "((int) nu<caret>m)");
+    myFixture.checkResult("<selection>((int) num)</selection>");
   }
 }


### PR DESCRIPTION
In insert mode, "a(" to
`((int) nu<caret>m)`
should cover the whole block, but it covers only `(int)`.
I fixed the bug.