### PR TITLE
 Fix issue VIM-1067: Repeat commands deletes End Of Line character when repeating "append to end of line" ('A') command.

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -445,7 +445,7 @@ public class ChangeGroup {
       document = editor.getDocument();
       documentListener = new InsertActionsDocumentListener();
       eventFacade.addDocumentListener(document, documentListener);
-      oldOffset = -1;
+      oldOffset = editor.getCaretModel().getOffset();
       setInsertEditorState(editor, mode == CommandState.Mode.INSERT);
       state.pushState(mode, CommandState.SubMode.NONE, MappingMode.INSERT);
 

--- a/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/ChangeActionTest.java
@@ -624,6 +624,36 @@ public class ChangeActionTest extends VimTestCase {
                           "}\n");
   }
 
+  // VIM-1067 |.|
+  public void testRepeatWithInsertAfterLineEnd() {
+    //Case 1
+    configureByText("<caret>- 1\n" +
+            "- 2\n" +
+            "- 3\n");
+    typeText(parseKeys("A", "<BS>", "<Esc>", "j", "."));
+    myFixture.checkResult("- \n" +
+            "- \n" +
+            "- 3\n");
+
+    //Case 2
+    configureByText("<caret>- 1\n" +
+            "- 2\n" +
+            "- 3\n");
+    typeText(parseKeys("A", "4", "<BS>", "<Esc>", "j", "."));
+    myFixture.checkResult("- 1\n" +
+            "- 2\n" +
+            "- 3\n");
+
+    //Case 3
+    configureByText("<caret>- 1\n" +
+            "- 2\n" +
+            "- 3\n");
+    typeText(parseKeys("A", "<BS>", "4",  "<Esc>", "j", "."));
+    myFixture.checkResult("- 4\n" +
+            "- 4\n" +
+            "- 3\n");
+  }
+
   // VIM-287 |zc| |O|
   public void testInsertAfterFold() {
     configureByJavaText("<caret>/**\n" +


### PR DESCRIPTION
The variable `ChangeGroup.oldOffset` should be initialized before every insertion action.

This fixes https://youtrack.jetbrains.com/issue/VIM-1067
