### PR TITLE
VIM-1615 Fix handling of so=999

### DIFF
--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -910,10 +910,18 @@ public class MotionGroup {
   }
 
   public boolean scrollLine(@NotNull Editor editor, int lines) {
-    int visualLine = EditorHelper.getVisualLineAtTopOfScreen(editor);
+    assert lines != 0 : "lines cannot be 0";
 
-    visualLine = EditorHelper.normalizeVisualLine(editor, visualLine + lines);
-    EditorHelper.scrollVisualLineToTopOfScreen(editor, visualLine);
+    if (lines > 0) {
+      int visualLine = EditorHelper.getVisualLineAtTopOfScreen(editor);
+      visualLine = EditorHelper.normalizeVisualLine(editor, visualLine + lines);
+      EditorHelper.scrollVisualLineToTopOfScreen(editor, visualLine);
+    }
+    else if (lines < 0) {
+      int visualLine = EditorHelper.getVisualLineAtBottomOfScreen(editor);
+      visualLine = EditorHelper.normalizeVisualLine(editor, visualLine + lines);
+      EditorHelper.scrollVisualLineToBottomOfScreen(editor, visualLine);
+    }
 
     moveCaretToView(editor);
 

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -1385,7 +1385,8 @@ public class MotionGroup {
     final int visualLine = position.line;
     final int column = position.column;
 
-    int scrollOffset = getNormalizedScrollOffset(editor);
+    // We need the non-normalised value here, so we can handle cases such as so=999 to keep the current line centred
+    int scrollOffset = ((NumberOption) Options.getInstance().getOption("scrolloff")).value();
 
     int scrollJumpSize = 0;
     if (scrollJump) {
@@ -1393,7 +1394,7 @@ public class MotionGroup {
     }
 
     int visualTop = topVisualLine + scrollOffset;
-    int visualBottom = bottomVisualLine - scrollOffset;
+    int visualBottom = bottomVisualLine - scrollOffset + 1;
     if (visualTop == visualBottom) {
       visualBottom++;
     }
@@ -1403,16 +1404,20 @@ public class MotionGroup {
       diff = visualLine - visualTop;
       scrollJumpSize = -scrollJumpSize;
     } else {
-      diff = Math.max(0, visualLine - visualBottom);
+      diff = Math.max(0, visualLine - visualBottom + 1);
     }
 
     if (diff != 0) {
 
-      // If we need to move the top line more than a half screen worth then we just center the cursor line.
-      // Block inlays mean that this half screen height isn't a consistent pixel height, and might be larger than line
-      // height multiplied by number of lines, but it's still a good heuristic to use here
+      // If we need to scroll the current line more than half a screen worth of lines then we just centre the new
+      // current line. This mimics vim behaviour of e.g. 100G in a 300 line file with a screen size of 25 centering line
+      // 100. It also handles so=999 keeping the current line centred.
+      // It doesn't handle keeping the line centred when scroll offset is less than a full page height, as the new line
+      // might be within e.g. top + scroll offset, so we test for that separately.
+      // Note that block inlays means that the pixel height we are scrolling can be larger than half the screen, even if
+      // the number of lines is less. I'm not sure what impact this has.
       int height = bottomVisualLine - topVisualLine + 1;
-      if (Math.abs(diff) > height / 2) {
+      if (Math.abs(diff) > height / 2 || scrollOffset > height / 2) {
         EditorHelper.scrollVisualLineToMiddleOfScreen(editor, visualLine);
       }
       else {

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -711,21 +711,7 @@ public class EditorHelper {
 
     Rectangle visibleArea = scrollingModel.getVisibleArea();
 
-    // For consistency, we always try to scroll to keep a whole line (with inlays) aligned at the top of the screen.
-    // This is inexact, and means we can bounce around, most visibly when the caret is on the last line and we're moving
-    // down (j) or the caret is on the last line and we're scrolling up (CTRL-Y)
-    // If we want it to be simpler: scrollingModel.scrollVertically(y - visibleArea.height + height);
-
-    int topVisualLine = editor.yToVisualLine(y - visibleArea.height + height);
-    int topLineInlayHeight = getHeightOfVisualLineInlays(editor, topVisualLine, true);
-    int topY = editor.visualLineToY(topVisualLine);
-    if (topY - topLineInlayHeight + visibleArea.height < y + height) {
-      // There's a pathological edge case here, if topVisualLine has a HUGE inlay, then topVisualLine+1 won't put our
-      // given line at the bottom of the screen
-      scrollVisualLineToTopOfScreen(editor, topVisualLine + 1);
-    } else {
-      scrollingModel.scrollVertically(topY - topLineInlayHeight);
-    }
+    scrollingModel.scrollVertically(y - visibleArea.height + height);
 
     return verticalPos != scrollingModel.getVerticalScrollOffset();
   }


### PR DESCRIPTION
This PR will fix handling of `scrolloff` being larger than half the height of the screen, and will keep the current line centred in the screen.

- [x] Fix issue which caused the position of the current line to shift up and down when pressing `h` and `l` ([VIM-1615](https://youtrack.jetbrains.com/issue/VIM-1615)) 
- [x] Fix centring of current line when `scrolloff` is larger than half the height of the screen but less than the full height
- [x] Fix centring of current line when block inlays are enabled (e.g. Rider)
- [x] Keeps the bottom line aligned to the bottom of the screen when scrolling text up (e.g. `j` at the bottom of the screen) and the top line aligned to the top when scrolling text down (`k` at top of screen)