### PR TITLE
Implement TabOnlyHandler

### DIFF
--- a/src/com/maddyhome/idea/vim/ex/CommandParser.java
+++ b/src/com/maddyhome/idea/vim/ex/CommandParser.java
@@ -126,6 +126,7 @@ public class CommandParser {
     new ShellHandler();
     new NextTabHandler();
     new PreviousTabHandler();
+    new TabOnlyHandler();
 
     registered = true;
     //logger.debug("root=" + root);

--- a/src/com/maddyhome/idea/vim/ex/handler/TabOnlyHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/TabOnlyHandler.kt
@@ -1,0 +1,39 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.ex.handler
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.ex.CommandHandler
+import com.maddyhome.idea.vim.ex.CommandHandler.Flag.RANGE_OPTIONAL
+import com.maddyhome.idea.vim.ex.CommandHandler.Flag.RANGE_IS_COUNT
+import com.maddyhome.idea.vim.ex.ExCommand
+import com.maddyhome.idea.vim.ex.commands
+import com.maddyhome.idea.vim.ex.flags
+
+class TabOnlyHandler : CommandHandler(
+        commands("tabo[nly]"),
+        flags(RANGE_OPTIONAL, RANGE_IS_COUNT)
+) {
+    override fun execute(editor: Editor, context: DataContext, cmd: ExCommand): Boolean {
+        VimPlugin.getWindow().closeAllExceptCurrentTab(context)
+        return true
+    }
+}

--- a/src/com/maddyhome/idea/vim/group/WindowGroup.java
+++ b/src/com/maddyhome/idea/vim/group/WindowGroup.java
@@ -20,12 +20,14 @@ package com.maddyhome.idea.vim.group;
 
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx;
 import com.intellij.openapi.fileEditor.impl.EditorWindow;
 import com.intellij.openapi.fileEditor.impl.EditorWithProviderComposite;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.maddyhome.idea.vim.VimPlugin;
+import com.maddyhome.idea.vim.helper.EditorData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -54,6 +56,11 @@ public class WindowGroup {
         window.closeAllExcept(null);
       }
     }
+  }
+
+  public void closeAllExceptCurrentTab(@NotNull DataContext context) {
+    final EditorWindow currentWindow = getFileEditorManager(context).getCurrentWindow();
+    currentWindow.closeAllExcept(currentWindow.getSelectedFile());
   }
 
   public void closeAll(@NotNull DataContext context) {

--- a/test/org/jetbrains/plugins/ideavim/ex/handler/TabOnlyHandlerTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/ex/handler/TabOnlyHandlerTest.kt
@@ -1,0 +1,51 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.handler
+
+import junit.framework.TestCase
+import org.jetbrains.plugins.ideavim.VimFileEditorTestCase
+import javax.swing.SwingConstants
+
+/**
+ * @author Daniele Megna
+ */
+
+class TabOnlyHandlerTest : VimFileEditorTestCase() {
+    fun `test close not selected tabs`() {
+        val firstTabFile = myFixture.configureByText("A_Discovery", "I found it in a legendary land")
+        val secondTabFile = myFixture.configureByText("A_Legend", "I found it in a new land")
+        val thirdTabFile = myFixture.configureByText("A_Detection", "I found it in a that land")
+        fileManager.openFile(firstTabFile.virtualFile, false)
+        fileManager.openFile(secondTabFile.virtualFile, true)
+        fileManager.openFile(thirdTabFile.virtualFile, false)
+        fileManager.windows[0].tabbedPane!!.setSelectedIndex(1, true)
+
+        TestCase.assertEquals(1, fileManager.windows.size)
+        TestCase.assertEquals(3, fileManager.windows[0].files.size)
+        TestCase.assertEquals(3, fileManager.windows[0].tabCount)
+        TestCase.assertEquals(secondTabFile.virtualFile, fileManager.windows[0].selectedFile)
+
+        typeText(commandToKeys("tabonly"))
+
+        TestCase.assertEquals(1, fileManager.windows.size)
+        TestCase.assertEquals(1, fileManager.windows[0].files.size)
+        TestCase.assertEquals(1, fileManager.windows[0].tabCount)
+        TestCase.assertEquals(secondTabFile.virtualFile, fileManager.windows[0].selectedFile)
+    }
+}


### PR DESCRIPTION
Implement `:tabonly` command as described in [vim tab tips page](https://vim.fandom.com/wiki/Using_tab_pages).

_____

My congrats to maintainers, I found this repo very tidy and code very easy to browse and understand. :clap: 

This pull request has been developed during [Open Source Saturday #23](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/events/259527969/) meetup in Milan.