### PR TITLE
(VIM-1105) Adding support for command aliasing.

### DIFF
--- a/src/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/com/maddyhome/idea/vim/VimPlugin.java
@@ -102,6 +102,7 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
 
   @NotNull private final MotionGroup motion;
   @NotNull private final ChangeGroup change;
+  @NotNull private final CommandGroup command;
   @NotNull private final CopyGroup copy;
   @NotNull private final MarkGroup mark;
   @NotNull private final RegisterGroup register;
@@ -118,6 +119,7 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
   public VimPlugin() {
     motion = new MotionGroup();
     change = new ChangeGroup();
+    command = new CommandGroup();
     copy = new CopyGroup();
     mark = new MarkGroup();
     register = new RegisterGroup();
@@ -236,6 +238,9 @@ public class VimPlugin implements ApplicationComponent, PersistentStateComponent
   public static ChangeGroup getChange() {
     return getInstance().change;
   }
+
+  @NotNull
+  public static CommandGroup getCommand() { return getInstance().command; }
 
   @NotNull
   public static CopyGroup getCopy() {

--- a/src/com/maddyhome/idea/vim/common/Alias.kt
+++ b/src/com/maddyhome/idea/vim/common/Alias.kt
@@ -1,0 +1,62 @@
+
+package com.maddyhome.idea.vim.common
+
+import com.maddyhome.idea.vim.VimPlugin
+
+/**
+ * @author Elliot Courant
+ */
+class Alias(
+        var minimumNumberOfArguments: Int,
+        var maximumNumberOfArguments: Int,
+        var name: String,
+        var command: String
+) {
+    private companion object {
+        const val LessThan = "<lt>"
+        const val Count = "<count>"
+        const val Arguments = "<args>"
+        const val QuotedArguments = "<q-args>"
+    }
+
+    fun getNumberOfArguments(): String {
+        if (this.minimumNumberOfArguments == 0 && this.maximumNumberOfArguments == 0) {
+            return "0" // No arguments
+        } else if (this.minimumNumberOfArguments == 0 && this.maximumNumberOfArguments == -1) {
+            return "*" // Any number of arguments
+        } else if (this.minimumNumberOfArguments == 0 && this.maximumNumberOfArguments == 1) {
+            return "?" // Zero or one argument
+        } else if (this.minimumNumberOfArguments == 1 && this.maximumNumberOfArguments == -1) {
+            return "+" // One or more arguments
+        }
+        return this.minimumNumberOfArguments.toString() // Specified number of arguments
+    }
+
+    fun getCommand(input: String, count: Int): String {
+        if (this.maximumNumberOfArguments == 0 && this.maximumNumberOfArguments == 0) {
+            return this.command
+        }
+        var compiledCommand = this.command
+        val cleanedInput = input.trim().removePrefix(name).trim()
+        if (minimumNumberOfArguments > 0 && cleanedInput.isEmpty()) {
+            VimPlugin.showMessage("E471: Argument required")
+            VimPlugin.indicateError()
+            return ""
+        }
+        for (symbol in arrayOf(Count, Arguments, QuotedArguments)) {
+            compiledCommand = compiledCommand.replace(symbol, when(symbol) {
+                Count -> arrayOf(count.toString())
+                Arguments -> arrayOf(cleanedInput)
+                QuotedArguments ->  arrayOf("'$cleanedInput'")
+                else -> emptyArray()
+            }.joinToString(", "))
+        }
+
+        // We want to escape <lt> after we've dropped in all of our args, if they are
+        // using <lt> its because they are escaping something that we don't want to handle
+        // yet.
+        compiledCommand = compiledCommand.replace(LessThan, "<")
+
+        return compiledCommand
+    }
+}

--- a/src/com/maddyhome/idea/vim/common/Alias.kt
+++ b/src/com/maddyhome/idea/vim/common/Alias.kt
@@ -1,3 +1,20 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 package com.maddyhome.idea.vim.common
 
@@ -7,29 +24,25 @@ import com.maddyhome.idea.vim.VimPlugin
  * @author Elliot Courant
  */
 class Alias(
-        var minimumNumberOfArguments: Int,
-        var maximumNumberOfArguments: Int,
-        var name: String,
-        var command: String
+        private val minimumNumberOfArguments: Int,
+        private val maximumNumberOfArguments: Int,
+        val name: String,
+        val command: String
 ) {
+    val numberOfArguments =
+            when {
+                this.minimumNumberOfArguments == 0 && this.maximumNumberOfArguments == 0 -> "0" // No arguments
+                this.minimumNumberOfArguments == 0 && this.maximumNumberOfArguments == -1 -> "*" // Any number of arguments
+                this.minimumNumberOfArguments == 0 && this.maximumNumberOfArguments == 1 -> "?" // Zero or one argument
+                this.minimumNumberOfArguments == 1 && this.maximumNumberOfArguments == -1 -> "+" // One or more arguments
+                else -> this.minimumNumberOfArguments.toString() // Specified number of arguments
+            }
+
     private companion object {
         const val LessThan = "<lt>"
         const val Count = "<count>"
         const val Arguments = "<args>"
         const val QuotedArguments = "<q-args>"
-    }
-
-    fun getNumberOfArguments(): String {
-        if (this.minimumNumberOfArguments == 0 && this.maximumNumberOfArguments == 0) {
-            return "0" // No arguments
-        } else if (this.minimumNumberOfArguments == 0 && this.maximumNumberOfArguments == -1) {
-            return "*" // Any number of arguments
-        } else if (this.minimumNumberOfArguments == 0 && this.maximumNumberOfArguments == 1) {
-            return "?" // Zero or one argument
-        } else if (this.minimumNumberOfArguments == 1 && this.maximumNumberOfArguments == -1) {
-            return "+" // One or more arguments
-        }
-        return this.minimumNumberOfArguments.toString() // Specified number of arguments
     }
 
     fun getCommand(input: String, count: Int): String {
@@ -44,10 +57,10 @@ class Alias(
             return ""
         }
         for (symbol in arrayOf(Count, Arguments, QuotedArguments)) {
-            compiledCommand = compiledCommand.replace(symbol, when(symbol) {
+            compiledCommand = compiledCommand.replace(symbol, when (symbol) {
                 Count -> arrayOf(count.toString())
                 Arguments -> arrayOf(cleanedInput)
-                QuotedArguments ->  arrayOf("'$cleanedInput'")
+                QuotedArguments -> arrayOf("'$cleanedInput'")
                 else -> emptyArray()
             }.joinToString(", "))
         }

--- a/src/com/maddyhome/idea/vim/ex/handler/CmdClearHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/CmdClearHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.maddyhome.idea.vim.ex.handler
 
 import com.intellij.openapi.actionSystem.DataContext
@@ -8,8 +26,7 @@ import com.maddyhome.idea.vim.ex.ExCommand
 import com.maddyhome.idea.vim.ex.commands
 import com.maddyhome.idea.vim.ex.flags
 
-class
-CmdClearHandler : CommandHandler(
+class CmdClearHandler : CommandHandler(
         commands("comc[lear]"),
         flags(RangeFlag.RANGE_FORBIDDEN, ArgumentFlag.ARGUMENT_FORBIDDEN)
 ) {

--- a/src/com/maddyhome/idea/vim/ex/handler/CmdClearHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/CmdClearHandler.kt
@@ -1,0 +1,20 @@
+package com.maddyhome.idea.vim.ex.handler
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.ex.CommandHandler
+import com.maddyhome.idea.vim.ex.ExCommand
+import com.maddyhome.idea.vim.ex.commands
+import com.maddyhome.idea.vim.ex.flags
+
+class
+CmdClearHandler : CommandHandler(
+        commands("comc[lear]"),
+        flags(RangeFlag.RANGE_FORBIDDEN, ArgumentFlag.ARGUMENT_FORBIDDEN)
+) {
+    override fun execute(editor: Editor, context: DataContext, cmd: ExCommand): Boolean {
+        VimPlugin.getCommand().resetAliases()
+        return true
+    }
+}

--- a/src/com/maddyhome/idea/vim/ex/handler/CmdHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/CmdHandler.kt
@@ -1,0 +1,160 @@
+package com.maddyhome.idea.vim.ex.handler
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.common.Alias
+import com.maddyhome.idea.vim.ex.*
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptCommandHandler
+
+/**
+ * @author Elliot Courant
+ */
+class CmdHandler : CommandHandler(
+        commands("com[mand]"),
+        flags(RangeFlag.RANGE_FORBIDDEN, ArgumentFlag.ARGUMENT_OPTIONAL, Flag.DONT_REOPEN)
+), VimScriptCommandHandler {
+    // Static definitions needed for aliases.
+    private companion object {
+        const val overridePrefix = "!"
+        const val argsPrefix = "-nargs"
+        val blacklistedAliases = arrayOf("X", "Next", "Print")
+
+        const val anyNumberOfArguments = "*"
+        const val zeroOrOneArguments = "?"
+        const val moreThanZeroArguments = "+"
+
+        const val errorInvalidNumberOfArguments = "E176: Invalid number of arguments"
+        const val errorCannotStartWithLowercase = "E183: User defined commands must start with an uppercase letter"
+        const val errorReservedName = "E841: Reserved name, cannot be used for user defined command"
+        const val errorCommandAlreadyExists = "E174: Command already exists: add ! to replace it"
+    }
+
+    override fun execute(cmd: ExCommand) {
+        this.addAlias(cmd, null)
+    }
+
+    override fun execute(editor: Editor, context: DataContext, cmd: ExCommand): Boolean {
+        if (cmd.argument.trim().isEmpty()) {
+            return this.listAlias(editor, "")
+        }
+        return this.addAlias(cmd, editor)
+    }
+
+    private fun listAlias(editor: Editor, filter: String): Boolean {
+        val lineSeparator = System.lineSeparator()
+        val allAliases = VimPlugin.getCommand().listAliases()
+        val aliases = allAliases.filter {
+            (filter.isEmpty() || it.key.startsWith(filter))
+        }.map {
+            "${it.key.padEnd(12)}${it.value.getNumberOfArguments().padEnd(11)}${it.value.command}"
+        }.sortedWith(String.CASE_INSENSITIVE_ORDER).joinToString(lineSeparator)
+        ExOutputModel.getInstance(editor).output("Name        Args       Definition$lineSeparator$aliases")
+        return true
+    }
+
+    private fun addAlias(cmd: ExCommand, editor: Editor?): Boolean {
+        var argument = cmd.argument.trim()
+
+        // Handle overwriting of aliases
+        val overrideAlias = argument.startsWith(overridePrefix)
+        if (overrideAlias) {
+            argument = argument.removePrefix(overridePrefix).trim()
+        }
+
+        // Handle alias arguments
+        val hasArguments = argument.startsWith(argsPrefix)
+        var minNumberOfArgs = 0
+        var maxNumberOfArgs = 0
+        if (hasArguments) {
+            // Extract the -nargs that's part of this execution, it's possible that -nargs is
+            // in the actual alias being created, and we don't want to parse that one.
+            val trimmedInput = argument.takeWhile { it != ' ' }
+            val pattern = Regex("(?>-nargs=((|[-])\\d+|[?]|[+]|[*]))").find(trimmedInput)
+            if (pattern == null) {
+                VimPlugin.showMessage(errorInvalidNumberOfArguments)
+                return false
+            }
+            val nargForTrim = pattern.groupValues[0]
+            val argumentValue = pattern.groups[1]!!.value
+            val argNum = argumentValue.toIntOrNull()
+            if (argNum == null) { // If the argument number is null then it is not a number.
+                // Make sure the argument value is a valid symbol that we can handle.
+                when (argumentValue) {
+                    anyNumberOfArguments -> {
+                        minNumberOfArgs = 0
+                        maxNumberOfArgs = -1
+                    }
+                    zeroOrOneArguments -> maxNumberOfArgs = 1
+                    moreThanZeroArguments -> {
+                        minNumberOfArgs = 1
+                        maxNumberOfArgs = -1
+                    }
+                    else -> {
+                        // Technically this should never be reached, but is here just in case
+                        // I missed something, since the regex limits the value to be ? + * or
+                        // a valid number, its not possible (as far as I know) to have another value
+                        // that regex would accept that is not valid.
+                        VimPlugin.showMessage(errorInvalidNumberOfArguments)
+                        return false
+                    }
+                }
+            } else {
+                // Not sure why this isn't documented, but if you try to create a command in vim
+                // with an explicit number of arguments greater than 1 it returns this error.
+                if (argNum > 1 || argNum < 0) {
+                    VimPlugin.showMessage(errorInvalidNumberOfArguments)
+                    return false
+                }
+                minNumberOfArgs = argNum
+                maxNumberOfArgs = argNum
+            }
+            argument = argument.removePrefix(nargForTrim).trim()
+        }
+
+        // We want to trim off any "!" at the beginning of the arguments.
+        // This will also remove any extra spaces.
+        argument = argument.trim()
+
+        // We want to get the first character sequence in the arguments.
+        // eg. command! Wq wq
+        // We want to extract the Wq only, and then just use the rest of
+        // the argument as the alias result.
+        val alias = argument.split(" ")[0]
+        argument = argument.removePrefix(alias).trim()
+
+        // User-aliases need to begin with an uppercase character.
+        if (!alias[0].isUpperCase()) {
+            VimPlugin.showMessage(errorCannotStartWithLowercase)
+            return false
+        }
+
+        if (blacklistedAliases.contains(alias)) {
+            VimPlugin.showMessage(errorReservedName)
+            return false
+        }
+
+        if (argument.isEmpty()) {
+            if (editor == null) {
+                // If there is no editor then we can't list aliases, just return false.
+                // No message should be shown either, since there is no editor.
+                return false
+            }
+            return this.listAlias(editor, alias)
+        }
+
+        // If we are not over-writing existing aliases, and an alias with the same command
+        // already exists then we want to do nothing.
+        if (!overrideAlias && VimPlugin.getCommand().hasAlias(alias)) {
+            VimPlugin.showMessage(errorCommandAlreadyExists)
+            return false
+        }
+
+        // Store the alias and the command. We don't need to parse the argument
+        // at this time, if the syntax is wrong an error will be returned when
+        // the alias is executed.
+        VimPlugin.getCommand().setAlias(alias, Alias(minNumberOfArgs, maxNumberOfArgs, alias, argument))
+
+        return true
+    }
+}

--- a/src/com/maddyhome/idea/vim/ex/handler/DelCmdHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/DelCmdHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.maddyhome.idea.vim.ex.handler
 
 import com.intellij.openapi.actionSystem.DataContext

--- a/src/com/maddyhome/idea/vim/ex/handler/DelCmdHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/DelCmdHandler.kt
@@ -1,0 +1,24 @@
+package com.maddyhome.idea.vim.ex.handler
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.ex.CommandHandler
+import com.maddyhome.idea.vim.ex.ExCommand
+import com.maddyhome.idea.vim.ex.commands
+import com.maddyhome.idea.vim.ex.flags
+
+class DelCmdHandler : CommandHandler(
+        commands("delc[ommand]"),
+        flags(RangeFlag.RANGE_FORBIDDEN, ArgumentFlag.ARGUMENT_REQUIRED)
+) {
+    override fun execute(editor: Editor, context: DataContext, cmd: ExCommand): Boolean {
+        if (!VimPlugin.getCommand().hasAlias(cmd.argument)) {
+            VimPlugin.showMessage("E184: No such user-defined command: ${cmd.argument}")
+            return false
+        }
+
+        VimPlugin.getCommand().removeAlias(cmd.argument)
+        return true
+    }
+}

--- a/src/com/maddyhome/idea/vim/group/CommandGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/CommandGroup.kt
@@ -1,3 +1,21 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.maddyhome.idea.vim.group
 
 import com.maddyhome.idea.vim.common.Alias
@@ -6,9 +24,9 @@ import com.maddyhome.idea.vim.common.Alias
  * @author Elliot Courant
  */
 class CommandGroup {
-    private companion object {
-        const val overridePrefix = "!"
-        val blacklistedAliases = arrayOf("X", "Next", "Print")
+    companion object {
+        val BLACKLISTED_ALIASES = arrayOf("X", "Next", "Print")
+        private const val overridePrefix = "!"
     }
     private var aliases = HashMap<String, Alias>()
 
@@ -21,9 +39,7 @@ class CommandGroup {
         }
 
         // If the input is blacklisted, then it is not an alias.
-        if (blacklistedAliases.any {
-            name == it
-        }) {
+        if (name in BLACKLISTED_ALIASES) {
             return false
         }
 
@@ -31,7 +47,7 @@ class CommandGroup {
     }
 
     fun hasAlias(name: String): Boolean {
-        return this.aliases.containsKey(name)
+        return name in this.aliases
     }
 
     fun getAlias(name: String): Alias {

--- a/src/com/maddyhome/idea/vim/group/CommandGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/CommandGroup.kt
@@ -1,0 +1,68 @@
+package com.maddyhome.idea.vim.group
+
+import com.maddyhome.idea.vim.common.Alias
+
+/**
+ * @author Elliot Courant
+ */
+class CommandGroup {
+    private companion object {
+        const val overridePrefix = "!"
+        val blacklistedAliases = arrayOf("X", "Next", "Print")
+    }
+    private var aliases = HashMap<String, Alias>()
+
+    fun isAlias(command: String): Boolean {
+        val name = this.getAliasName(command)
+        // If the first letter is not uppercase then it cannot be an alias
+        // and reject immediately.
+        if (!name[0].isUpperCase()) {
+            return false
+        }
+
+        // If the input is blacklisted, then it is not an alias.
+        if (blacklistedAliases.any {
+            name == it
+        }) {
+            return false
+        }
+
+        return this.hasAlias(name)
+    }
+
+    fun hasAlias(name: String): Boolean {
+        return this.aliases.containsKey(name)
+    }
+
+    fun getAlias(name: String): Alias {
+        return this.aliases[name]!!
+    }
+
+    fun getAliasCommand(command: String, count: Int): String {
+        return this.getAlias(this.getAliasName(command)).getCommand(command, count)
+    }
+
+    fun setAlias(name: String, alias: Alias) {
+        this.aliases[name] = alias
+    }
+
+    fun removeAlias(name: String) {
+        this.aliases.remove(name)
+    }
+
+    fun listAliases(): Set<Map.Entry<String, Alias>> {
+        return this.aliases.entries
+    }
+
+    fun resetAliases() {
+        this.aliases.clear()
+    }
+
+    private fun getAliasName(command: String): String {
+        val items = command.split(" ")
+        if (items.count() > 1) {
+            return items[0].removeSuffix(overridePrefix)
+        }
+        return command.removeSuffix(overridePrefix)
+    }
+}

--- a/src/com/maddyhome/idea/vim/package-info.java
+++ b/src/com/maddyhome/idea/vim/package-info.java
@@ -602,9 +602,9 @@
  * |:quitall|             {@link com.maddyhome.idea.vim.ex.handler.ExitHandler}
  * |:wqall|               {@link com.maddyhome.idea.vim.ex.handler.ExitHandler}
  * |:xall|                {@link com.maddyhome.idea.vim.ex.handler.ExitHandler}
- * |:command|             {@link com.maddyhome.idea.vim.ex.handler.CmdHandler}
- * |:delcommand|          {@link com.maddyhome.idea.vim.ex.handler.DelCmdHandler}
- * |:comclear|            {@link com.maddyhome.idea.vim.ex.handler.CmdClearHandler}
+ * |:command|             {@link com.maddyhome.idea.vim.ex.handler.CmdHandler} [To Be Released]
+ * |:delcommand|          {@link com.maddyhome.idea.vim.ex.handler.DelCmdHandler} [To Be Released]
+ * |:comclear|            {@link com.maddyhome.idea.vim.ex.handler.CmdClearHandler} [To Be Released]
  * ...
  *
  * The list of supported Ex commands is incomplete.

--- a/src/com/maddyhome/idea/vim/package-info.java
+++ b/src/com/maddyhome/idea/vim/package-info.java
@@ -602,6 +602,9 @@
  * |:quitall|             {@link com.maddyhome.idea.vim.ex.handler.ExitHandler}
  * |:wqall|               {@link com.maddyhome.idea.vim.ex.handler.ExitHandler}
  * |:xall|                {@link com.maddyhome.idea.vim.ex.handler.ExitHandler}
+ * |:command|             {@link com.maddyhome.idea.vim.ex.handler.CmdHandler}
+ * |:delcommand|          {@link com.maddyhome.idea.vim.ex.handler.DelCmdHandler}
+ * |:comclear|            {@link com.maddyhome.idea.vim.ex.handler.CmdClearHandler}
  * ...
  *
  * The list of supported Ex commands is incomplete.

--- a/test/org/jetbrains/plugins/ideavim/ex/handler/CmdClearHandlerTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/ex/handler/CmdClearHandlerTest.kt
@@ -1,0 +1,57 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.handler
+import com.maddyhome.idea.vim.VimPlugin
+import org.jetbrains.plugins.ideavim.VimFileEditorTestCase
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+/**
+ * @author Elliot Courant
+ */
+class CmdClearHandlerTest : VimFileEditorTestCase() {
+    fun `test clear aliases`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command"))
+        assertPluginError(false)
+        assertExOutput("Name        Args       Definition\n") // There should not be any aliases.
+
+        typeText(VimTestCase.commandToKeys("command Vs vs"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command Wq wq"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command WQ wq"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command"))
+        assertPluginError(false)
+        // The added alias should be listed
+        assertExOutput("""Name        Args       Definition
+            |Vs          0          vs
+            |Wq          0          wq
+            |WQ          0          wq
+        """.trimMargin())
+
+        // Delete all of the aliases and then list aliases again.
+        typeText(VimTestCase.commandToKeys("comclear"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command"))
+        assertPluginError(false)
+        assertExOutput("Name        Args       Definition\n") // There should not be any aliases.
+    }
+}

--- a/test/org/jetbrains/plugins/ideavim/ex/handler/CmdHandlerTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/ex/handler/CmdHandlerTest.kt
@@ -1,0 +1,207 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.handler
+
+import com.maddyhome.idea.vim.VimPlugin
+import org.jetbrains.plugins.ideavim.VimFileEditorTestCase
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+/**
+ * @author Elliot Courant
+ */
+class CmdHandlerTest : VimFileEditorTestCase() {
+    fun `test recursive`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command Recur1 Recur2"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command Recur2 Recur1"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("Recur1"))
+        assertPluginError(true) // Recursive command should error.
+    }
+
+    fun `test list aliases`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command"))
+        assertPluginError(false)
+        assertExOutput("Name        Args       Definition\n") // There should not be any aliases.
+
+        typeText(VimTestCase.commandToKeys("command Vs vs"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command Wq wq"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command WQ wq"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command-nargs=* Test1 echo"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command-nargs=? Test2 echo"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command-nargs=+ Test3 echo"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command-nargs=1 Test4 echo"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command"))
+        assertPluginError(false)
+        // The added alias should be listed
+        assertExOutput("""Name        Args       Definition
+            |Test1       *          echo
+            |Test2       ?          echo
+            |Test3       +          echo
+            |Test4       1          echo
+            |Vs          0          vs
+            |Wq          0          wq
+            |WQ          0          wq
+        """.trimMargin())
+
+        typeText(VimTestCase.commandToKeys("command W"))
+        assertPluginError(false)
+        // The filtered aliases should be listed
+        assertExOutput("""Name        Args       Definition
+            |Wq          0          wq
+            |WQ          0          wq
+        """.trimMargin())
+    }
+
+    fun `test bad alias`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("Vs"))
+        assertPluginError(true)
+        typeText(VimTestCase.commandToKeys("command Vs vs"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("Vs"))
+        assertPluginError(false)
+    }
+
+    fun `test lowercase should fail`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command lowercase vs"))
+        assertPluginError(true)
+    }
+
+    fun `test blacklisted alias should fail`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command X vs"))
+        assertPluginError(true)
+        typeText(VimTestCase.commandToKeys("command Next vs"))
+        assertPluginError(true)
+        typeText(VimTestCase.commandToKeys("command Print vs"))
+        assertPluginError(true)
+    }
+
+    fun `test add an existing alias and overwrite`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command Existing1 vs"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command Existing1 wq"))
+        assertPluginError(true)
+        typeText(VimTestCase.commandToKeys("command! Existing1 wq"))
+        assertPluginError(false)
+    }
+
+    fun `test add command with arguments`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command -nargs=* Error echo <args>"))
+        assertPluginError(false)
+    }
+
+    fun `test add command with arguments short`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command-nargs=* Error echo <args>"))
+        assertPluginError(false)
+    }
+
+    fun `test add command with arguments even shorter`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("com-nargs=* Error echo <args>"))
+        assertPluginError(false)
+    }
+
+    fun `test add command with various arguments`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command! -nargs=0 Error echo <args>"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command! -nargs=1 Error echo <args>"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command! -nargs=* Error echo <args>"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command! -nargs=? Error echo <args>"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command! -nargs=+ Error echo <args>"))
+        assertPluginError(false)
+    }
+
+    fun `test add command with invalid arguments`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command! -nargs= Error echo <args>"))
+        assertPluginError(true)
+        typeText(VimTestCase.commandToKeys("command! -nargs=-1 Error echo <args>"))
+        assertPluginError(true)
+        typeText(VimTestCase.commandToKeys("command! -nargs=# Error echo <args>"))
+        assertPluginError(true)
+    }
+
+    fun `test run command with arguments`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("let test = \"Hello!\""))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command! -nargs=1 Error echo <args>"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("Error test"))
+        assertPluginError(false)
+        assertExOutput("Hello!\n")
+
+        typeText(VimTestCase.commandToKeys("command! -nargs=1 Error echo <q-args>"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("Error test message"))
+        assertPluginError(false)
+        assertExOutput("test message\n")
+    }
+
+    fun `test run command that creates another command`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command! -nargs=1 CreateCommand command -nargs=1 <args> <lt>q-args>"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("CreateCommand Show echo"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("Show test"))
+        assertPluginError(false)
+        assertExOutput("test\n")
+    }
+
+    fun `test run command missing required argument`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command! -nargs=1 Error echo <q-args>"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("Error"))
+    }
+}

--- a/test/org/jetbrains/plugins/ideavim/ex/handler/DelCmdHandlerTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/ex/handler/DelCmdHandlerTest.kt
@@ -1,0 +1,75 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.handler
+import com.maddyhome.idea.vim.VimPlugin
+import org.jetbrains.plugins.ideavim.VimFileEditorTestCase
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+/**
+ * @author Elliot Courant
+ */
+class DelCmdHandlerTest : VimFileEditorTestCase() {
+    fun `test remove alias`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("command"))
+        assertPluginError(false)
+        assertExOutput("Name        Args       Definition\n") // There should not be any aliases.
+
+        typeText(VimTestCase.commandToKeys("command Vs vs"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command Wq wq"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command WQ wq"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command"))
+        assertPluginError(false)
+        // The added alias should be listed
+        assertExOutput("""Name        Args       Definition
+            |Vs          0          vs
+            |Wq          0          wq
+            |WQ          0          wq
+        """.trimMargin())
+
+        typeText(VimTestCase.commandToKeys("command W"))
+        assertPluginError(false)
+        // The filtered aliases should be listed
+        assertExOutput("""Name        Args       Definition
+            |Wq          0          wq
+            |WQ          0          wq
+        """.trimMargin())
+
+        // Delete one of the aliases and then list all aliases again.
+        typeText(VimTestCase.commandToKeys("delcommand Wq"))
+        assertPluginError(false)
+        typeText(VimTestCase.commandToKeys("command"))
+        assertPluginError(false)
+        assertExOutput("""Name        Args       Definition
+            |Vs          0          vs
+            |WQ          0          wq
+        """.trimMargin())
+    }
+
+    fun `test remove non-existant alias`() {
+        VimPlugin.getCommand().resetAliases()
+        configureByText("\n")
+        typeText(VimTestCase.commandToKeys("delcommand VS"))
+        assertPluginError(true)
+    }
+}


### PR DESCRIPTION
Commands `command`, `comclear` and `delcommand` have been added. `command` also
supports -nargs, allowing arguments to be passed to the aliased command.
Symbols supported for -nargs are: `<args> <q-args> <count> <lt>`.

For example:
```vim
command WQ wq
```
Will allow `WQ` to be used as an alias for `wq`.

Documentation: http://vimdoc.sourceforge.net/htmldoc/map.html#:command

- [x] `:command {cmd}` support.
- [x] `!` flag.
- [x] `:com[mand]` support (shorter version).
- [x] Listing added aliases.
- [x] `:delc[ommand]` support.
- [x] Do not allow defining ":X", ":Next" and ":Print"
- [x] Tests

Please give me some feedback. 

Fixes [VIM-1105](https://youtrack.jetbrains.com/issue/VIM-1105)

Example:
![ideavimcommand](https://user-images.githubusercontent.com/17016423/54787629-4ef38480-4bfa-11e9-8a31-8f4bda11fc99.gif)

@AlexPl292 This was just easier than trying to fix my fork that I broke when I tried to rebase.
