### PR TITLE
VIM-1061 Explicitly register shortcuts for digraphs

### DIFF
--- a/src/com/maddyhome/idea/vim/RegisterActions.java
+++ b/src/com/maddyhome/idea/vim/RegisterActions.java
@@ -774,5 +774,13 @@ class RegisterActions {
                           new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_D, KeyEvent.CTRL_MASK)));
     parser.registerAction(MappingMode.I, "VimShiftRightLines", Command.Type.INSERT, EnumSet.of(CommandFlags.FLAG_SAVE_STROKE),
                           new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_T, KeyEvent.CTRL_MASK)));
+
+    // Digraph shortcuts are handled directly by KeyHandler#handleKey, so they don't have an action. But we still need to
+    // register the shortcuts or the editor will swallow them. Technically, the shortcuts will be registered as part of
+    // other commands, but it's best to be explicit
+    parser.registerShortcutWithoutAction(new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_K, KeyEvent.CTRL_MASK)));
+    parser.registerShortcutWithoutAction(new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_Q, KeyEvent.CTRL_MASK)));
+    parser.registerShortcutWithoutAction(new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_V, KeyEvent.CTRL_MASK)));
+    parser.registerShortcutWithoutAction(new Shortcut(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0)));
   }
 }

--- a/src/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -246,6 +246,19 @@ public class KeyGroup {
     return res;
   }
 
+  /**
+   * Registers a shortcut that is handled by KeyHandler#handleKey directly, rather than by an action
+   *
+   * <p>
+   * Digraphs are handled directly by KeyHandler#handleKey instead of via an action, but we need to still make sure the
+   * shortcuts are registered, or the key handler won't see them
+   * </p>
+   * @param shortcut The shortcut to register
+   */
+  public void registerShortcutWithoutAction(Shortcut shortcut) {
+    registerRequiredShortcut(shortcut);
+  }
+
   public void registerCommandAction(@NotNull VimCommandAction commandAction, @NotNull String actionId) {
     final List<Shortcut> shortcuts = new ArrayList<>();
     for (List<KeyStroke> keyStrokes : commandAction.getKeyStrokesSet()) {
@@ -329,15 +342,19 @@ public class KeyGroup {
   public void registerAction(@NotNull Set<MappingMode> mappingModes, @NotNull String actName, @NotNull Command.Type cmdType, EnumSet<CommandFlags> cmdFlags, @NotNull Shortcut[] shortcuts,
                              @NotNull Argument.Type argType) {
     for (Shortcut shortcut : shortcuts) {
-      final KeyStroke[] keys = shortcut.getKeys();
-      for (KeyStroke key : keys) {
-        if (key.getKeyChar() == KeyEvent.CHAR_UNDEFINED) {
-          requiredShortcutKeys.add(key);
-        }
-      }
-      //noinspection deprecation
+      final KeyStroke[] keys = registerRequiredShortcut(shortcut);
       registerAction(mappingModes, actName, cmdType, cmdFlags, keys, argType);
     }
+  }
+
+  private KeyStroke[] registerRequiredShortcut(@NotNull Shortcut shortcut) {
+    final KeyStroke[] keys = shortcut.getKeys();
+    for (KeyStroke key : keys) {
+      if (key.getKeyChar() == KeyEvent.CHAR_UNDEFINED) {
+        requiredShortcutKeys.add(key);
+      }
+    }
+    return keys;
   }
 
   /**


### PR DESCRIPTION
Ensures that the keyboard shortcuts required for digraphs (`<C-K>`, `<C-V>`, `<C-Q>` and `<BS>`) are all explicitly registered. 

Digraphs are handled directly by the key handler, so there is no action that can provide keys to be registered. If the keys aren't registered, the key stroke doesn't get to the key handler and digraphs don't work. 

Technically, these shortcuts are already registered by other actions, but it is better to be explicit, as [VIM-1061](https://youtrack.jetbrains.com/issue/VIM-1061) demonstrates. Digraphs with `<C-K>` were broken in 0.51, but fixed by accident by #194, which included the key sequence `<C-W><C-K>`, meaning `<C-K>` is registered.

Tests are not possible for this change as it affects the IDE event loop and the tests invoke `handleKey` directly,