### PR TITLE
Fix ideajoin examples URL

### DIFF
--- a/doc/set-commands.md
+++ b/doc/set-commands.md
@@ -76,7 +76,7 @@ The following `:set` commands can appear in `~/.ideavimrc` or be set manually in
     `ideajoin`      `ideajoin` Boolean (default false)     - IdeaVim ONLY
     
                   If true, join command will be performed via IDE
-                  See ideajoin-examples.md
+                  See wiki/`ideajoin` examples
     
     'sidescroll'     'ss'        minimum number of columns to scroll horizontally
     'sidescrolloff'  'siso'      min. number of columns to left and right of cursor

--- a/src/com/maddyhome/idea/vim/group/NotificationService.kt
+++ b/src/com/maddyhome/idea/vim/group/NotificationService.kt
@@ -188,7 +188,7 @@ class NotificationService(private val project: Project?) {
     const val IDEAVIM_STICKY_NOTIFICATION_ID = "ideavim-sticky"
     const val IDEAVIM_NOTIFICATION_ID = "ideavim"
     const val IDEAVIM_NOTIFICATION_TITLE = "IdeaVim"
-    const val ideajoinExamplesUrl = "https://github.com/JetBrains/ideavim/blob/master/doc/ideajoin-examples.md"
+    const val ideajoinExamplesUrl = "https://github.com/JetBrains/ideavim/wiki/%60ideajoin%60-examples"
     const val selectModeUrl = "https://vimhelp.org/visual.txt.html#Select-mode"
   }
 }


### PR DESCRIPTION
Recent commit d06f2a2d181e46c7737c2919fff9d7171d444f3b moved ideajoin examples page from doc/ to wiki.