### PR TITLE
 Support f and F surround commands (function name)

### DIFF
--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -128,8 +128,34 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
   }
 
   @Nullable
+  private static Pair<String, String> inputFunctionName(
+    @NotNull Editor editor,
+    boolean withInternalSpaces
+  ) {
+    final String functionNameInput = inputString(editor, "function: ");
+
+    if (functionNameInput.isEmpty()) {
+      return null;
+    }
+
+    return withInternalSpaces
+      ? Pair.create(functionNameInput + "( ", " )")
+      : Pair.create(functionNameInput + "(", ")");
+  }
+
+  @Nullable
   private static Pair<String, String> getOrInputPair(char c, @NotNull Editor editor) {
-    return c == '<' || c == 't' ? inputTagPair(editor) : getSurroundPair(c);
+    switch (c) {
+      case '<':
+      case 't':
+        return inputTagPair(editor);
+      case 'f':
+        return inputFunctionName(editor, false);
+      case 'F':
+        return inputFunctionName(editor, true);
+      default:
+        return getSurroundPair(c);
+    }
   }
 
   private static char getChar(@NotNull Editor editor) {

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.java
@@ -77,6 +77,7 @@ public class VimSurroundExtension extends VimNonDisposableExtension {
     .put(']', Pair.create("[", "]"))
     .put('a', Pair.create("<", ">"))
     .put('>', Pair.create("<", ">"))
+    .put('s', Pair.create(" ", ""))
     .build();
 
   @NotNull

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
@@ -102,6 +102,24 @@ class VimSurroundExtensionTest : VimTestCase() {
     myFixture.checkResult("<div class = \"container\"><p>Hello</p></div>")
   }
 
+  fun testSurroundFunctionName() {
+    configureByText("foo = ${c}bar")
+    typeText(parseKeys("ysiwfbaz"))
+    myFixture.checkResult("foo = baz(bar)")
+  }
+
+  fun testSurroundFunctionNameDoesNothingIfInputIsEmpty() {
+    configureByText("foo = ${c}bar")
+    typeText(parseKeys("ysiwf"))
+    myFixture.checkResult("foo = bar")
+  }
+
+  fun testSurroundFunctionNameWithInnerSpacing() {
+    configureByText("foo = ${c}bar")
+    typeText(parseKeys("ysiwFbaz"))
+    myFixture.checkResult("foo = baz( bar )")
+  }
+
   /* visual surround */
 
   fun testVisualSurroundWordParens() {

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
@@ -109,19 +109,21 @@ class VimSurroundExtensionTest : VimTestCase() {
   }
 
   fun testSurroundFunctionNameDoesNothingIfInputIsEmpty() {
-    configureByText("foo = ${c}bar")
+    // The cursor does not move. This is different from Vim
+    // where the cursor moves to the beginning of the text object.
+    configureByText("foo = b${c}ar")
     typeText(parseKeys("ysiwf"))
-    myFixture.checkResult("foo = bar")
+    myFixture.checkResult("foo = b${c}ar")
   }
 
   fun testSurroundFunctionNameWithInnerSpacing() {
-    configureByText("foo = ${c}bar")
+    configureByText("foo = b${c}ar")
     typeText(parseKeys("ysiwFbaz"))
     myFixture.checkResult("foo = ${c}baz( bar )")
   }
 
   fun testSurroundSpace() {
-    configureByText("foo(${c}bar)")
+    configureByText("foo(b${c}ar)")
     typeText(parseKeys("csbs"))
     myFixture.checkResult("foo${c} bar")
   }

--- a/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
@@ -103,9 +103,9 @@ class VimSurroundExtensionTest : VimTestCase() {
   }
 
   fun testSurroundFunctionName() {
-    configureByText("foo = ${c}bar")
+    configureByText("foo = b${c}ar")
     typeText(parseKeys("ysiwfbaz"))
-    myFixture.checkResult("foo = baz(bar)")
+    myFixture.checkResult("foo = ${c}baz(bar)")
   }
 
   fun testSurroundFunctionNameDoesNothingIfInputIsEmpty() {
@@ -117,7 +117,13 @@ class VimSurroundExtensionTest : VimTestCase() {
   fun testSurroundFunctionNameWithInnerSpacing() {
     configureByText("foo = ${c}bar")
     typeText(parseKeys("ysiwFbaz"))
-    myFixture.checkResult("foo = baz( bar )")
+    myFixture.checkResult("foo = ${c}baz( bar )")
+  }
+
+  fun testSurroundSpace() {
+    configureByText("foo(${c}bar)")
+    typeText(parseKeys("csbs"))
+    myFixture.checkResult("foo${c} bar")
   }
 
   /* visual surround */


### PR DESCRIPTION
https://github.com/tpope/vim-surround/blob/master/doc/surround.txt#L138

I noticed that this was missing from IdeaVim, and it seems very useful and not all that complicated, so I gave it a go.

... and it turned out to be somewhat complicated after all since `<C-F>` keystrokes are not caught by the current extension (which is based on pure characters, so `<C-F>` is ignored). I made an attempt to implement that as well here:
https://github.com/JetBrains/ideavim/compare/master...jorgengranseth:attempt-at-ctrl-f

While the test passes, it doesn't work in the IDE since `<C-F>` gets hijacked by IdeaVim as the page-down motion. Setting the key mapping to undefined didn't work - I'm not sure if this is a bug - but I am also not sure if this is the right approach since I haven't looked into other possible side effects by allowing `<C-F>` at random times in the surround plugin.

Do you have any thoughts on how we can implement the `<C-F>` part of `vim-surround`? It is the equivalent of the `f` command for ML-like languages, so I would personally find it useful to have available. On the other hand I'd rather have `f` and `F` than nothing at all.