### PR TITLE
VIM-1720 Implement Ex command :delm[arks]

### DIFF
--- a/resources/messages.properties
+++ b/resources/messages.properties
@@ -67,4 +67,5 @@ E385=E385: search hit BOTTOM without match for: {0}
 e_patnotf2=Pattern not found: {0}
 unkopt=Unknown option: {0}
 e_invarg=Invalid argument: {0}
+E475=E475: Invalid argument: {0}
 E774=E774: 'operatorfunc' is empty

--- a/src/com/maddyhome/idea/vim/ex/CommandParser.java
+++ b/src/com/maddyhome/idea/vim/ex/CommandParser.java
@@ -53,6 +53,7 @@ public class CommandParser {
     new CopyTextHandler(),
     new DelCmdHandler(),
     new DeleteLinesHandler(),
+    new DeleteMarksHandler(),
     new DigraphHandler(),
     new DumpLineHandler(),
     new EditFileHandler(),

--- a/src/com/maddyhome/idea/vim/ex/handler/DeleteMarksHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/DeleteMarksHandler.kt
@@ -49,7 +49,7 @@ private const val DELETABLE_MARKS = DELETABLE_FILE_MARKS + DELETABLE_GLOBAL_MARK
  */
 class DeleteMarksHandler : CommandHandler.SingleExecution() {
   override val names = commands("delm[arks]")
-  override val argFlags = flags(RangeFlag.RANGE_FORBIDDEN, ArgumentFlag.ARGUMENT_REQUIRED)
+  override val argFlags = flags(RangeFlag.RANGE_FORBIDDEN, ArgumentFlag.ARGUMENT_REQUIRED, Access.READ_ONLY)
 
   override fun execute(editor: Editor, context: DataContext, cmd: ExCommand): Boolean {
     val processedArg = cmd.argument

--- a/src/com/maddyhome/idea/vim/ex/handler/DeleteMarksHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/DeleteMarksHandler.kt
@@ -1,0 +1,101 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.ex.handler
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.ex.CommandHandler
+import com.maddyhome.idea.vim.ex.ExCommand
+import com.maddyhome.idea.vim.ex.commands
+import com.maddyhome.idea.vim.ex.flags
+import com.maddyhome.idea.vim.group.MarkGroup
+import com.maddyhome.idea.vim.helper.MessageHelper
+import com.maddyhome.idea.vim.helper.Msg
+import kotlin.math.max
+
+
+private val VIML_COMMENT = Regex("(?<!\\\\)\".*")
+private val TRAILING_SPACES = Regex("\\s*$")
+private val ARGUMENT_DELETE_ALL_FILE_MARKS = Regex("^!$")
+
+private const val ESCAPED_QUOTE = "\\\""
+private const val UNESCAPED_QUOTE = "\""
+
+private const val ALPHA_LOWER = "abcdefghijklmnopqrstuvwxyz"
+private const val ALPHA_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+private const val NUMERICAL = "0123456789"
+
+private const val DELETABLE_FILE_MARKS = ".^[]\"$ALPHA_LOWER"
+private const val DELETABLE_GLOBAL_MARKS = "$NUMERICAL$ALPHA_UPPER"
+private const val DELETABLE_MARKS = DELETABLE_FILE_MARKS + DELETABLE_GLOBAL_MARKS
+
+class DeleteMarksHandler : CommandHandler.SingleExecution() {
+  override val names = commands("delm[arks]")
+  override val argFlags = flags(RangeFlag.RANGE_FORBIDDEN, ArgumentFlag.ARGUMENT_REQUIRED)
+
+  override fun execute(editor: Editor, context: DataContext, cmd: ExCommand): Boolean {
+    val processedArg = cmd.argument
+      .replace(VIML_COMMENT, "")
+      .replace(ESCAPED_QUOTE, UNESCAPED_QUOTE)
+      .replace(TRAILING_SPACES, "")
+      .replace(ARGUMENT_DELETE_ALL_FILE_MARKS, DELETABLE_FILE_MARKS)
+      .replaceRanges(ALPHA_LOWER)
+      .replaceRanges(ALPHA_UPPER)
+      .replaceRanges(NUMERICAL)
+
+    processedArg.indexOfFirst { !(" $DELETABLE_MARKS".contains(it)) }
+      .let { index ->
+        if (index != -1) {
+          val invalidIndex = max(0, if (processedArg[index] == '-') index - 1 else index)
+
+          VimPlugin.showMessage(MessageHelper.message(Msg.E475, processedArg.substring(invalidIndex)))
+          return false
+        }
+      }
+
+    processedArg
+      .forEach { character -> deleteMark(VimPlugin.getMark(), editor, character) }
+
+    return true
+  }
+}
+
+private fun deleteMark(marks: MarkGroup, editor: Editor, character: Char) {
+  if (character != ' ') {
+    marks.getMark(editor, character)
+      ?.let { mark -> marks.removeMark(character, mark, editor) }
+  }
+}
+
+private fun String.replaceRanges(range: String): String {
+  return Regex("[$range]-[$range]").replace(this) { match ->
+    val startChar = match.value[0]
+    val endChar = match.value[2]
+
+    val startIndex = range.indexOf(startChar)
+    val endIndex = range.indexOf(endChar)
+
+    if (startIndex >= 0 && endIndex >= 0 && startIndex <= endIndex) {
+      range.subSequence(startIndex, endIndex + 1)
+    } else {
+      match.value
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/ex/handler/DeleteMarksHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/DeleteMarksHandler.kt
@@ -25,6 +25,7 @@ import com.maddyhome.idea.vim.ex.CommandHandler
 import com.maddyhome.idea.vim.ex.ExCommand
 import com.maddyhome.idea.vim.ex.commands
 import com.maddyhome.idea.vim.ex.flags
+import com.maddyhome.idea.vim.group.MarkGroup.*
 import com.maddyhome.idea.vim.helper.MessageHelper
 import com.maddyhome.idea.vim.helper.Msg
 
@@ -35,14 +36,6 @@ private val ARGUMENT_DELETE_ALL_FILE_MARKS = Regex("^!$")
 
 private const val ESCAPED_QUOTE = "\\\""
 private const val UNESCAPED_QUOTE = "\""
-
-private const val ALPHA_LOWER = "abcdefghijklmnopqrstuvwxyz"
-private const val ALPHA_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-private const val NUMERICAL = "0123456789"
-
-private const val DELETABLE_FILE_MARKS = ".^[]\"$ALPHA_LOWER"
-private const val DELETABLE_GLOBAL_MARKS = "$NUMERICAL$ALPHA_UPPER"
-private const val DELETABLE_MARKS = DELETABLE_FILE_MARKS + DELETABLE_GLOBAL_MARKS
 
 /**
  * @author Jørgen Granseth
@@ -56,12 +49,12 @@ class DeleteMarksHandler : CommandHandler.SingleExecution() {
       .replace(VIML_COMMENT, "")
       .replace(ESCAPED_QUOTE, UNESCAPED_QUOTE)
       .replace(TRAILING_SPACES, "")
-      .replace(ARGUMENT_DELETE_ALL_FILE_MARKS, DELETABLE_FILE_MARKS)
-      .replaceRanges(ALPHA_LOWER)
-      .replaceRanges(ALPHA_UPPER)
-      .replaceRanges(NUMERICAL)
+      .replace(ARGUMENT_DELETE_ALL_FILE_MARKS, DEL_FILE_MARKS)
+      .replaceRanges(WR_REGULAR_FILE_MARKS)
+      .replaceRanges(WR_GLOBAL_MARKS)
+      .replaceRanges(RO_GLOBAL_MARKS)
 
-    processedArg.indexOfFirst { it !in " $DELETABLE_MARKS" }.let { index ->
+    processedArg.indexOfFirst { it !in " $DEL_MARKS" }.let { index ->
       if (index != -1) {
         val invalidIndex = if (processedArg[index] == '-') (index - 1).coerceAtLeast(0) else index
 

--- a/src/com/maddyhome/idea/vim/group/MarkGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MarkGroup.java
@@ -797,11 +797,19 @@ public class MarkGroup {
   private static final int SAVE_MARK_COUNT = 20;
   private static final int SAVE_JUMP_COUNT = 100;
 
-  private static final String WR_GLOBAL_MARKS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  private static final String WR_FILE_MARKS = "abcdefghijklmnopqrstuvwxyz'";
-  private static final String RO_GLOBAL_MARKS = "0123456789";
+  public static final String WR_GLOBAL_MARKS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  public static final String WR_REGULAR_FILE_MARKS = "abcdefghijklmnopqrstuvwxyz";
+  private static final String WR_FILE_MARKS = WR_REGULAR_FILE_MARKS + "'";
+
+  public static final String RO_GLOBAL_MARKS = "0123456789";
   private static final String RO_FILE_MARKS = ".[]<>^{}()";
-  private static final String SAVE_FILE_MARKS = WR_FILE_MARKS + ".^[]\"";
+
+  private static final String DEL_CONTEXT_FILE_MARKS = ".^[]\"";
+  public static final String DEL_FILE_MARKS = DEL_CONTEXT_FILE_MARKS + WR_REGULAR_FILE_MARKS;
+  private static final String DEL_GLOBAL_MARKS = RO_GLOBAL_MARKS + WR_GLOBAL_MARKS;
+  public static final String DEL_MARKS = DEL_FILE_MARKS + DEL_GLOBAL_MARKS;
+
+  private static final String SAVE_FILE_MARKS = WR_FILE_MARKS + DEL_CONTEXT_FILE_MARKS;
 
   private static final String GLOBAL_MARKS = WR_GLOBAL_MARKS + RO_GLOBAL_MARKS;
   private static final String FILE_MARKS = WR_FILE_MARKS + RO_FILE_MARKS;

--- a/src/com/maddyhome/idea/vim/group/MarkGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MarkGroup.java
@@ -325,7 +325,7 @@ public class MarkGroup {
     fileMarks.clear();
   }
 
-  private void removeMark(char ch, @NotNull Mark mark, @NotNull Editor editor) {
+  public void removeMark(char ch, @NotNull Mark mark, @NotNull Editor editor) {
     if (FILE_MARKS.indexOf(ch) >= 0) {
       HashMap fmarks = getFileMarks(mark.getFilename());
       fmarks.remove(ch);

--- a/src/com/maddyhome/idea/vim/helper/Msg.java
+++ b/src/com/maddyhome/idea/vim/helper/Msg.java
@@ -71,4 +71,5 @@ public interface Msg {
   String e_patnotf2 = "e_patnotf2";
   String unkopt = "unkopt";
   String e_invarg = "e_invarg";
+  String E475 = "E475";
 }

--- a/test/org/jetbrains/plugins/ideavim/ex/handler/DeleteMarksHandlerTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/ex/handler/DeleteMarksHandlerTest.kt
@@ -1,0 +1,151 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2019 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.handler
+
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.common.Mark
+import org.jetbrains.plugins.ideavim.VimTestCase
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * @author Jørgen Granseth
+ */
+class DeleteMarksHandlerTest : VimTestCase() {
+  private fun setUpMarks(marks: String) {
+    configureByText(
+      """I found it in a legendary land
+         all rocks and lavender and tufted grass,
+         where it was settled on some sodden sand
+         hard by the torrent of a mountain pass.
+         """.trimMargin()
+    )
+
+    marks.forEachIndexed { index, c ->
+      VimPlugin.getMark().setMark(myFixture.editor, c, index * 10)
+    }
+  }
+
+  private fun getMark(ch: Char): Mark? {
+    return VimPlugin.getMark().getMark(myFixture.editor, ch)
+  }
+
+  fun `test delete single mark`() {
+    setUpMarks("a")
+    typeText(commandToKeys("delmarks a"))
+
+    assertNull(getMark('a'), "Mark was not deleted")
+  }
+
+  fun `test delete multiple marks`() {
+    setUpMarks("abAB")
+    typeText(commandToKeys("delmarks Ab"))
+
+    arrayOf('A', 'b')
+      .forEach { ch -> assertNull(getMark(ch), "Mark $ch was not deleted") }
+
+    arrayOf('a', 'B')
+      .forEach { ch -> assertNotNull(getMark(ch), "Mark $ch was unexpectedly deleted") }
+  }
+
+  fun `test delete ranges (inclusive)`() {
+    setUpMarks("abcde")
+    typeText(commandToKeys("delmarks b-d"))
+
+    arrayOf('b', 'c', 'd')
+      .forEach { ch -> assertNull(getMark(ch), "Mark $ch was not deleted") }
+
+    arrayOf('a', 'e')
+      .forEach { ch -> assertNotNull(getMark(ch), "Mark $ch was unexpectedly deleted") }
+  }
+
+  fun `test delete multiple ranges and marks with whitespace`() {
+    setUpMarks("abcdeABCDE")
+    typeText(commandToKeys("delmarks b-dC-E a"))
+
+    arrayOf('a', 'b', 'c', 'd', 'C', 'D', 'E', 'a')
+      .forEach { ch -> assertNull(getMark(ch), "Mark $ch was not deleted") }
+
+    arrayOf('e', 'A', 'B')
+      .forEach { ch -> assertNotNull(getMark(ch), "Mark $ch was unexpectedly deleted") }
+  }
+
+  fun `test invalid range throws exception without deleting any marks`() {
+    setUpMarks("a")
+    typeText(commandToKeys("delmarks a-C"))
+    assertPluginError(true)
+
+    assertNotNull(getMark('a'), "Mark was deleted despite invalid command given")
+  }
+
+  fun `test invalid characters throws exception`() {
+    setUpMarks("a")
+    typeText(commandToKeys("delmarks bca# foo"))
+    assertPluginError(true)
+
+    assertNotNull(getMark('a'), "Mark was deleted despite invalid command given")
+  }
+
+  fun `test delmarks! with trailing spaces`() {
+    setUpMarks("aBcAbC")
+    typeText(commandToKeys("delmarks!"))
+
+    arrayOf('a', 'b', 'c')
+      .forEach { ch -> assertNull(getMark(ch), "Mark $ch was not deleted") }
+
+    arrayOf('A', 'B', 'C')
+      .forEach { ch -> assertNotNull(getMark(ch), "Global mark $ch was deleted by delmarks!") }
+  }
+
+  fun `test delmarks! with other arguments fails`() {
+    setUpMarks("aBcAbC")
+    typeText(commandToKeys("delmarks!a"))
+
+    assertPluginError(true)
+    arrayOf('a', 'b', 'c', 'A', 'B', 'C')
+      .forEach { ch -> assertNotNull(getMark(ch), "Mark $ch was deleted despite invalid command given") }
+  }
+
+  fun `test trailing spaces ignored`() {
+    setUpMarks("aBcAbC")
+    typeText(commandToKeys("delmarks!   "))
+
+    arrayOf('a', 'b', 'c')
+      .forEach { ch -> assertNull(getMark(ch), "Mark $ch was not deleted") }
+
+    arrayOf('A', 'B', 'C')
+      .forEach { ch -> assertNotNull(getMark(ch), "Global mark $ch was deleted by delmarks!") }
+  }
+
+  fun `test alias (delm)`() {
+    setUpMarks("a")
+    typeText(commandToKeys("delm a"))
+
+    assertNull(getMark('a'), "Mark was not deleted")
+
+    setUpMarks("aBcAbC")
+    typeText(commandToKeys("delm!"))
+
+    arrayOf('a', 'b', 'c')
+      .forEach { ch -> assertNull(getMark(ch), "Mark $ch was not deleted") }
+
+    arrayOf('A', 'B', 'C')
+      .forEach { ch -> assertNotNull(getMark(ch), "Global mark $ch was deleted by delm!") }
+  }
+}


### PR DESCRIPTION
Deletes existing marks. See
http://vimdoc.sourceforge.net/htmldoc/motion.html#:delmarks
for details.

[VIM-1720](https://youtrack.jetbrains.com/issue/VIM-1720)

Note that the `'` jump mark cannot be deleted with this command. This is why I decided to define the deletable marks separately from the constants already defined in `MarkGroup`, but I'd like some feedback on whether this is a good idea or not.

Similarly I've preprocessed the argument to account for all edge cases I could find. I imagine this is more readable than writing a parser, but if you'd prefer changes here I'm OK with changing it. A side effect of this choice is that an invalid command like `:delmarks %f-h` will throw the error message `E475: Invalid argument: %fgh` rather than `E475: Invalid argument: %f-h` (because it has already parsed the valid portion of the command). It has no functional side effect as far as I am aware: If the argument list is invalid no marks are deleted in Vim either.

Furthermore; for errors - what is preferable between the
```
          VimPlugin.showMessage(...)
          return false
```
pattern and throwing a suitable exception, and why?

On the topic of exceptions, I would like to know why messages from flag errors don't show. It seems the way these
https://github.com/JetBrains/ideavim/blob/master/src/com/maddyhome/idea/vim/ex/CommandHandler.kt#L129-L153
lines are written immediately replace the error messages with empty ones - is this intentional? It seems that moving the messages into the exceptions would give the desired behaviour.