### PR TITLE
Improve relative line numbers and VCS annotations

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -28,7 +28,7 @@
   <version>SNAPSHOT</version>
   <vendor>JetBrains</vendor>
 
-  <idea-version since-build="183.2940.10"/>
+  <idea-version since-build="183.4284.148"/>
 
   <!-- Mark the plugin as compatible with RubyMine and other products based on the IntelliJ platform -->
   <depends>com.intellij.modules.lang</depends>

--- a/src/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.editor.event.CaretEvent;
 import com.intellij.openapi.editor.event.CaretListener;
 import com.intellij.openapi.editor.event.EditorFactoryEvent;
 import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.editor.ex.EditorGutterComponentEx;
 import com.intellij.openapi.project.Project;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
@@ -38,6 +39,7 @@ import com.maddyhome.idea.vim.option.OptionChangeListener;
 import com.maddyhome.idea.vim.option.OptionsManager;
 import kotlin.text.StringsKt;
 import org.jdom.Element;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -59,8 +61,9 @@ public class EditorGroup {
 
   private final CaretListener myLineNumbersCaretListener = new CaretListener() {
     @Override
-    public void caretPositionChanged(CaretEvent e) {
-      updateLineNumbers(e.getEditor());
+    public void caretPositionChanged(@NotNull CaretEvent e) {
+      final boolean requiresRepaint = e.getNewPosition().line != e.getOldPosition().line;
+      updateLineNumbers(e.getEditor(), requiresRepaint);
     }
   };
 
@@ -70,9 +73,7 @@ public class EditorGroup {
     setRefrainFromScrolling(REFRAIN_FROM_SCROLLING_VIM_VALUE);
 
     for (Editor editor : EditorFactory.getInstance().getAllEditors()) {
-      if (!UserDataManager.getVimEditorGroup(editor)) {
-        initLineNumbers(editor);
-      }
+      initLineNumbers(editor);
     }
   }
 
@@ -82,55 +83,105 @@ public class EditorGroup {
     setRefrainFromScrolling(isRefrainFromScrolling);
 
     for (Editor editor : EditorFactory.getInstance().getAllEditors()) {
-      deinitLineNumbers(editor);
+      deinitLineNumbers(editor, false);
     }
   }
 
   private void initLineNumbers(@NotNull final Editor editor) {
-    editor.getCaretModel().addCaretListener(myLineNumbersCaretListener);
-    UserDataManager.setVimEditorGroup(editor, true);
-
-    final EditorSettings settings = editor.getSettings();
-    UserDataManager.setVimLineNumbersShown(editor, settings.isLineNumbersShown());
-    updateLineNumbers(editor);
-  }
-
-  private void deinitLineNumbers(@NotNull Editor editor) {
-    editor.getCaretModel().removeCaretListener(myLineNumbersCaretListener);
-    UserDataManager.setVimEditorGroup(editor, false);
-
-    editor.getGutter().closeAllAnnotations();
-
-    final Project project = editor.getProject();
-    if (project == null || project.isDisposed()) return;
-
-    editor.getSettings().setLineNumbersShown(UserDataManager.getVimLineNumbersShown(editor));
-  }
-
-  private static void updateLineNumbers(@NotNull Editor editor) {
-    if (!EditorHelper.isFileEditor(editor)) {
+    if (!supportsVimLineNumbers(editor) || UserDataManager.getVimEditorGroup(editor)) {
       return;
     }
 
+    editor.getCaretModel().addCaretListener(myLineNumbersCaretListener);
+    UserDataManager.setVimEditorGroup(editor, true);
+
+    UserDataManager.setVimLineNumbersInitialState(editor, editor.getSettings().isLineNumbersShown());
+    updateLineNumbers(editor, true);
+  }
+
+  private void deinitLineNumbers(@NotNull Editor editor, boolean isReleasing) {
+    if (!supportsVimLineNumbers(editor) || !UserDataManager.getVimEditorGroup(editor)) {
+      return;
+    }
+
+    editor.getCaretModel().removeCaretListener(myLineNumbersCaretListener);
+    UserDataManager.setVimEditorGroup(editor, false);
+
+    removeRelativeLineNumbers(editor);
+
+    // Don't reset the built in line numbers if we're releasing the editor. If we do, EditorSettings.setLineNumbersShown
+    // can cause the editor to refresh settings and can call into FileManagerImpl.getCachedPsiFile AFTER FileManagerImpl
+    // has been disposed (Closing the project with a Find Usages result showing a preview panel is a good repro case).
+    // See IDEA-184351 and VIM-1671
+    if (!isReleasing) {
+      setBuiltinLineNumbers(editor, UserDataManager.getVimLineNumbersInitialState(editor));
+    }
+  }
+
+  private static boolean supportsVimLineNumbers(@NotNull final Editor editor) {
+    // We only support line numbers in editors that are file based, and that aren't for diffs, which control their
+    // own line numbers, often using EditorGutterComponentEx#setLineNumberConvertor
+    return EditorHelper.isFileEditor(editor) && !EditorHelper.isDiffEditor(editor);
+  }
+
+  private static void updateLineNumbers(@NotNull final Editor editor, final boolean requiresRepaint) {
     final boolean relativeLineNumber = OptionsManager.INSTANCE.getRelativenumber().isSet();
-    final boolean lineNumber = OptionsManager.INSTANCE.getNumber().isSet();
+    final boolean number = OptionsManager.INSTANCE.getNumber().isSet();
+
+    final boolean showBuiltinEditorLineNumbers = (UserDataManager.getVimLineNumbersInitialState(editor) || number)
+      && !relativeLineNumber;
 
     final EditorSettings settings = editor.getSettings();
-    final boolean showEditorLineNumbers = (UserDataManager.getVimLineNumbersShown(editor) || lineNumber) && !relativeLineNumber;
-
-    if (settings.isLineNumbersShown() ^ showEditorLineNumbers) {
+    if (settings.isLineNumbersShown() ^ showBuiltinEditorLineNumbers) {
       // Update line numbers later since it may be called from a caret listener
       // on the caret move and it may move the caret internally
       ApplicationManager.getApplication().invokeLater(() -> {
         if (editor.isDisposed()) return;
-        settings.setLineNumbersShown(showEditorLineNumbers);
+        setBuiltinLineNumbers(editor, showBuiltinEditorLineNumbers);
       });
     }
 
     if (relativeLineNumber) {
-      final EditorGutter gutter = editor.getGutter();
-      gutter.closeAllAnnotations();
-      gutter.registerTextAnnotation(LineNumbersGutterProvider.INSTANCE);
+      if (!hasRelativeLineNumbersInstalled(editor)) {
+        installRelativeLineNumbers(editor);
+      }
+      else if (requiresRepaint) {
+        repaintRelativeLineNumbers(editor);
+      }
+    }
+    else if (hasRelativeLineNumbersInstalled(editor)) {
+      removeRelativeLineNumbers(editor);
+    }
+  }
+
+  private static void setBuiltinLineNumbers(@NotNull final Editor editor, boolean show) {
+    editor.getSettings().setLineNumbersShown(show);
+  }
+
+  private static boolean hasRelativeLineNumbersInstalled(@NotNull final Editor editor) {
+    return UserDataManager.getVimHasLineNumberGutterProvider(editor);
+  }
+
+  private static void installRelativeLineNumbers(@NotNull final Editor editor) {
+    if (!hasRelativeLineNumbersInstalled(editor)) {
+      editor.getGutter().registerTextAnnotation(new RelativeLineNumberGutterProvider(editor));
+      UserDataManager.setVimHasLineNumberGutterProvider(editor, true);
+    }
+  }
+
+  private static void removeRelativeLineNumbers(@NotNull final Editor editor) {
+    if (hasRelativeLineNumbersInstalled(editor)) {
+      // TODO: When we move up to 192, we can close just our provider
+      editor.getGutter().closeAllAnnotations();
+      UserDataManager.setVimHasLineNumberGutterProvider(editor, false);
+    }
+  }
+
+  private static void repaintRelativeLineNumbers(@NotNull final Editor editor) {
+    final EditorGutter gutter = editor.getGutter();
+    final EditorGutterComponentEx gutterComponent = gutter instanceof EditorGutterComponentEx ? (EditorGutterComponentEx) gutter : null;
+    if (gutterComponent != null) {
+      gutterComponent.repaint();
     }
   }
 
@@ -220,7 +271,7 @@ public class EditorGroup {
 
   public void editorReleased(@NotNull EditorFactoryEvent event) {
     final Editor editor = event.getEditor();
-    deinitLineNumbers(editor);
+    deinitLineNumbers(editor, true);
     UserDataManager.unInitializeEditor(editor);
     VimPlugin.getKey().unregisterShortcutKeys(editor);
     editor.getSettings().setAnimatedScrolling(isAnimatedScrolling);
@@ -228,55 +279,52 @@ public class EditorGroup {
     DocumentManager.getInstance().removeListeners(editor.getDocument());
   }
 
-  public static class NumberChangeListener implements OptionChangeListener {
-    public static NumberChangeListener INSTANCE = new NumberChangeListener();
-    private NumberChangeListener() {
-    }
-    @Override
-    public void valueChange(OptionChangeEvent event) {
-      for (Editor editor : EditorFactory.getInstance().getAllEditors()) {
-        updateLineNumbers(editor);
-      }
-    }
-  }
-
   public void notifyIdeaJoin(@Nullable Project project) {
     if (VimPlugin.getVimState().isIdeaJoinNotified() || OptionsManager.INSTANCE.getIdeajoin().isSet()) return;
 
     VimPlugin.getVimState().setIdeaJoinNotified(true);
-
     VimPlugin.getNotifications(project).notifyAboutIdeaJoin();
   }
 
-  private static class LineNumbersGutterProvider implements TextAnnotationGutterProvider {
+  public static class NumberChangeListener implements OptionChangeListener {
+    public static NumberChangeListener INSTANCE = new NumberChangeListener();
 
-    public static LineNumbersGutterProvider INSTANCE = new LineNumbersGutterProvider();
+    @Contract(pure = true)
+    private NumberChangeListener() {
+    }
+
+    @Override
+    public void valueChange(OptionChangeEvent event) {
+      for (Editor editor : EditorFactory.getInstance().getAllEditors()) {
+        if (UserDataManager.getVimEditorGroup(editor) && supportsVimLineNumbers(editor)) {
+          updateLineNumbers(editor, true);
+        }
+      }
+    }
+  }
+
+  private static class RelativeLineNumberGutterProvider implements TextAnnotationGutterProvider {
+    @NotNull
+    private final Editor editor;
+
+    @Contract(pure = true)
+    RelativeLineNumberGutterProvider(@NotNull final Editor editor) {
+      this.editor = editor;
+    }
 
     @Nullable
     @Override
     public String getLineText(int line, @NotNull Editor editor) {
-      if (VimPlugin.isEnabled() && EditorHelper.isFileEditor(editor)) {
-        final boolean relativeLineNumber = OptionsManager.INSTANCE.getRelativenumber().isSet();
-        final boolean lineNumber = OptionsManager.INSTANCE.getNumber().isSet();
-        if (editor.getDocument().getLineCount() == 0) {
-          return null;
-        }
-        else if (relativeLineNumber && lineNumber && isCaretLine(line, editor)) {
-          return lineNumberToString(getLineNumber(line), editor);
-        }
-        else if (relativeLineNumber) {
-          return lineNumberToString(getRelativeLineNumber(line, editor), editor);
-        }
+      final boolean number = OptionsManager.INSTANCE.getNumber().isSet();
+      if (number && isCaretLine(line, editor)) {
+        return lineNumberToString(line + 1, editor, true);
+      } else {
+        return lineNumberToString(getRelativeLineNumber(line, editor), editor, false);
       }
-      return null;
     }
 
     private boolean isCaretLine(int line, @NotNull Editor editor) {
       return line == editor.getCaretModel().getLogicalPosition().line;
-    }
-
-    private int getLineNumber(int line) {
-      return line + 1;
     }
 
     private int getRelativeLineNumber(int line, @NotNull Editor editor) {
@@ -286,10 +334,12 @@ public class EditorGroup {
       return Math.abs(currentVisualLine - visualLine);
     }
 
-    private String lineNumberToString(int lineNumber, @NotNull Editor editor) {
+    private String lineNumberToString(int lineNumber, @NotNull Editor editor, boolean leftJustify) {
       final int lineCount = editor.getDocument().getLineCount();
-      final int digitsCount = (int)Math.ceil(Math.log10(lineCount));
-      return StringsKt.padEnd("" + lineNumber, digitsCount, ' ');
+      final int digitsCount = lineCount == 0 ? 1 : (int)Math.ceil(Math.log10(lineCount));
+      return leftJustify
+        ? StringsKt.padEnd(Integer.toString(lineNumber), digitsCount, ' ')
+        : StringsKt.padStart(Integer.toString(lineNumber), digitsCount, ' ');
     }
 
     @Nullable
@@ -300,13 +350,13 @@ public class EditorGroup {
 
     @Override
     public EditorFontType getStyle(int line, Editor editor) {
-      return null;
+      return isCaretLine(line, editor) ? EditorFontType.BOLD: null;
     }
 
     @Nullable
     @Override
     public ColorKey getColor(int line, Editor editor) {
-      return EditorColors.LINE_NUMBERS_COLOR;
+      return isCaretLine(line, editor) ? EditorColors.LINE_NUMBER_ON_CARET_ROW_COLOR : EditorColors.LINE_NUMBERS_COLOR;
     }
 
     @Nullable
@@ -322,6 +372,7 @@ public class EditorGroup {
 
     @Override
     public void gutterClosed() {
+      UserDataManager.setVimHasLineNumberGutterProvider(this.editor, false);
     }
   }
 }

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -831,4 +831,11 @@ public class EditorHelper {
     final VirtualFile virtualFile = getVirtualFile(editor);
     return virtualFile != null && !(virtualFile instanceof LightVirtualFile);
   }
+
+  /**
+   * Checks if the editor is a diff window
+   */
+  public static boolean isDiffEditor(@NotNull Editor editor) {
+    return editor.getEditorKind() == EditorKind.DIFF;
+  }
 }

--- a/src/com/maddyhome/idea/vim/helper/UserDataManager.kt
+++ b/src/com/maddyhome/idea/vim/helper/UserDataManager.kt
@@ -89,7 +89,7 @@ var Editor.vimChangeGroup: Boolean by userDataOr { false }
 var Editor.vimMotionGroup: Boolean by userDataOr { false }
 var Editor.vimEditorGroup: Boolean by userDataOr { false }
 var Editor.vimLineNumbersInitialState: Boolean by userDataOr { false }
-var Editor.vimHasLineNumberGutterProvider: Boolean by userDataOr { false }
+var Editor.vimHasRelativeLineNumbersInstalled: Boolean by userDataOr { false }
 var Editor.vimMorePanel: ExOutputPanel? by userData()
 var Editor.vimExOutput: ExOutputModel? by userData()
 var Editor.vimTestInputModel: TestInputModel? by userData()

--- a/src/com/maddyhome/idea/vim/helper/UserDataManager.kt
+++ b/src/com/maddyhome/idea/vim/helper/UserDataManager.kt
@@ -88,7 +88,8 @@ var Editor.vimCommandState: CommandState? by userData()
 var Editor.vimChangeGroup: Boolean by userDataOr { false }
 var Editor.vimMotionGroup: Boolean by userDataOr { false }
 var Editor.vimEditorGroup: Boolean by userDataOr { false }
-var Editor.vimLineNumbersShown: Boolean by userDataOr { false }
+var Editor.vimLineNumbersInitialState: Boolean by userDataOr { false }
+var Editor.vimHasLineNumberGutterProvider: Boolean by userDataOr { false }
 var Editor.vimMorePanel: ExOutputPanel? by userData()
 var Editor.vimExOutput: ExOutputModel? by userData()
 var Editor.vimTestInputModel: TestInputModel? by userData()


### PR DESCRIPTION
This PR makes relative line numbers play (mostly) nice with VCS annotations. The current implementation is a `TextAnnotationGutterProvider`, which is a core platform API, but only really implemented by the VCS subsystem. 

The main problem today (notably [VIM-1032](https://youtrack.jetbrains.com/issue/VIM-1032)) is that the VCS subsystem doesn't expect other annotation providers, and incorrectly shows annotations as enabled when they're not. Toggling (twice) will show the VCS annotations, but moving the caret closes them and shows the relative line numbers again.

There isn't a solution that perfectly fixes everything, but this PR gives the best implementation, by firstly improving the presentation and behaviour of the gutter provider and secondly replacing it with a line number converter function, falling back in the unlikely event that converters aren't available.

For gutter providers:
* They no longer close VCS annotations when the caret moves
* In 183 and 191, the "VCS | Git Annotate…" toggle action is still incorrectly enabled. Toggling hides the relative numbers provider. Toggling again shows the VCS annotations. Moving the caret will now re-show the relative line numbers and leave the VCS annotations visible.
* In 192, the "VCS | Git Annotate…" toggle works correctly, and is only shown when the VCS annotations are visible. Toggling this does not affect the relative numbers provider.
* `:set nornu` closes all annotation provides, including VCS. 192 has an API that fixes this, but we're still targeting 183
* The presentation of the gutter provider is improved, but doesn't exactly match Vim - soft wrapped lines have a repeated line number on each wrapped line, while Vim only shows the number on the first line

For line number converters:
* Uses the built in line number presentation, just provides a different number to display. This is the same mechanism used by the diff views
* Does not affect VCS annotations at all
* Soft wrapped line numbers are shown the same as in Vim
* Technically, it is possible that another plugin could overwrite the line number converter. API watcher shows that no other plugins are using this API
* In the (very) unlikely event that the `EditorGutter` instance can't be downcast to `EditorGutterCopmonentEx`, the code will fall back to the gutter annotation providers.
* Minor issue: If `'number'` is not set, the current line number is shown as blank instead of "0". If `:set number` is added, the current line number is correctly displayed. This is an API decision, and unlikely to change in the platform (see [IDEA-211165](https://youtrack.jetbrains.com/issue/IDEA-211165))

So, the upshot is that gutter annotation providers work great if we're targeting 192 (and can use the proper 'close' API), although soft wrapped lines are not presented in the same way as Vim. They are ok, but not great in 183 and 191.

Line number converters work well in all versions, although `:set nonumber` can leave a blank current line.

IMHO, line number converters are the best solution.

This PR also:

* Sets the `since-build` in `plugin.xml` to the build of 2018.3 RTM, which is needed to allow use of `EditorColors.LINE_NUMBER_ON_CARET_ROW`
* Shows the current line number in the correct colour - [VIM-1762](https://youtrack.jetbrains.com/issue/VIM-1762)
* Avoids an exception when closing a project with a preview panel open in Find Usages that is showing relative line numbers - [VIM-1671](https://youtrack.jetbrains.com/issue/VIM-1671) (and see also [IDEA-184351](https://youtrack.jetbrains.com/issue/IDEA-184351))
* Does not replace line number behaviour in diff windows, which normally provide their own line numbers. This affects both relative and non-relative line numbers. This also only affects line numbers in editable diff panes, as historical diffs were already excluded because they're not backed by a virtual file. The diff views now always provide their own line numbers. The main reason behind this change was that diff views also use line number converters, and avoiding them avoids any chance of clashing.