### PR TITLE
Fix block insert with parameter hint

### DIFF
--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -641,7 +641,7 @@ public class ChangeGroup {
             repeatInsertText(editor, context, started ? (i == 0 ? count : count + 1) : count);
           }
           else if (EditorHelper.getVisualLineLength(editor, visualLine + i) >= repeatColumn) {
-            caret.moveToVisualPosition(new VisualPosition(visualLine + i, repeatColumn));
+            caret.moveToLogicalPosition(new LogicalPosition(logicalLine + i, repeatColumn));
             repeatInsertText(editor, context, started ? (i == 0 ? count : count + 1) : count);
           }
         }


### PR DESCRIPTION
I found a bug about block insert with parameter hint.

Given parameter hint is active like below.
function(hint: "str1")
function(hint: "str1")
Then you try to change two "str1" into "str_1" with block insert (e.g. ctrl-v j I _ <esc>), they become like below.
function(hint: "str_1")
function(hint: "st_r1")

I fixed the bug by using logicalPosition instead of VisualPosition.

I searched for this bug in youtrack and wasn't able to find any issue.