### PR TITLE
Fix multiple cursors selection getting stuck with ignorecase

### DIFF
--- a/test/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionTest.kt
@@ -509,4 +509,24 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
     """.trimIndent())
     doTest(keys, before, after, CommandState.Mode.VISUAL, CommandState.SubMode.VISUAL_CHARACTER)
   }
+
+  fun `test multiple capitalized occurrences with ignorecase`() {
+    val before = """text ${c}Test text Test text Test text Test text"""
+    configureByText(before)
+
+    typeText(commandToKeys("set ignorecase"))
+    typeText(parseKeys("<A-n><A-n><A-n><A-n>"))
+    val after = """text ${s}Test${se} text ${s}Test${se} text ${s}Test${se} text ${s}Test${se} text"""
+    myFixture.checkResult(after)
+  }
+
+  fun `test multiple mixed case occurrences with ignorecase`() {
+    val before = """text ${c}Test text tesT text TEST text test text"""
+    configureByText(before)
+
+    typeText(commandToKeys("set ignorecase"))
+    typeText(parseKeys("<A-n><A-n><A-n><A-n>"))
+    val after = """text ${s}Test${se} text ${s}tesT${se} text ${s}TEST${se} text ${s}test${se} text"""
+    myFixture.checkResult(after)
+  }
 }


### PR DESCRIPTION
With `ignorecase` enabled, select next (`<A-n>`) would get stuck on the
second occurrence even though there are more occurrences to select. This
was happening because part of logic was still doing case sensitive
comparison against the current pattern. The fix is to use case
insensitive comparator everywhere the pattern is used, if `ignorecase`
option is set.