### PR TITLE
argtextobj: support bracket pairs configuration via let g:argtextobj_pairs="..."

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,14 @@ Available extensions:
     * Commands: `gcc`, `gc + motion`, `v_gc`
 
 * argtextobj   [To Be Released]
-    * Setup: `set argtextobj`
+    * Setup:
+        * `set argtextobj`
+        * By default, only the arguments inside parenthesis are considered. To extend the functionality
+          to other types of brackets, set `g:argtextobj_pairs` variable to a comma-separated
+          list of colon-separated pairs (same as VIM's `matchpairs` option), like
+          `let g:argtextobj_pairs="(:),{:},<:>"`. The order of pairs matters when
+          handling symbols that can also be operators: `func(x << 5, 20) >> 17`. To handle
+          this syntax parenthesis, must come before angle brackets in the list.
     * Emulates [argtextobj.vim](https://www.vim.org/scripts/script.php?script_id=2699)
     * Additional text objects: `aa`, `ia`
 

--- a/test/org/jetbrains/plugins/ideavim/VimTestCase.java
+++ b/test/org/jetbrains/plugins/ideavim/VimTestCase.java
@@ -243,6 +243,10 @@ public abstract class VimTestCase extends UsefulTestCase {
     assertEquals(isError, VimPlugin.isError());
   }
 
+  public void assertPluginErrorMessageContains(@NotNull String message) {
+    assertTrue(VimPlugin.getMessage().contains(message));
+  }
+
   protected void assertCaretsColour() {
     Color selectionColour = myFixture.getEditor().getColorsScheme().getColor(EditorColors.SELECTION_BACKGROUND_COLOR);
     Color caretColour = myFixture.getEditor().getColorsScheme().getColor(EditorColors.CARET_COLOR);


### PR DESCRIPTION
argtextobj by default only handles arguments inside parenthesis. This is
very limiting when editing C++ source files. This change allows the list
of bracket pairs to be configurable via a global IdeaVim variable. The
variable takes effect immediately.