### PR TITLE
populate intelij navigation history together with ideavim jumplist

### DIFF
--- a/src/com/maddyhome/idea/vim/action/motion/mark/MotionMarkAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/mark/MotionMarkAction.kt
@@ -19,6 +19,7 @@ package com.maddyhome.idea.vim.action.motion.mark
 
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.ex.IdeDocumentHistory
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
@@ -31,6 +32,10 @@ class MotionMarkAction : VimActionHandler.SingleExecution() {
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     val argument = cmd.argument
+    if (editor.project != null) {
+      IdeDocumentHistory.getInstance(editor.project).includeCurrentCommandAsNavigation()
+    }
+
     return argument != null && VimPlugin.getMark().setMark(editor, argument.character)
   }
 }


### PR DESCRIPTION
Currently we keep intelij navigation history separate from ideavim jumplist.
This change will cause all updates to ideavim jumplist to be propagated to intelij navigaration history as well.

https://youtrack.jetbrains.com/issue/VIM-44