### PR TITLE
Support smooth scrolling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,9 +54,6 @@ _Available since 0.55.3 EAP:_
 * [VIM-434](https://youtrack.jetbrains.com/issue/VIM-434) Add `'showcmd'` support, on by default
 * `ReplaceWithRegister` plugin emulation ([ReplaceWithRegister](https://www.vim.org/scripts/script.php?script_id=2703))
 
-**Changes:**
-* Support IntelliJ's smooth scrolling. Use "Enable smooth scrolling" checkbox in _Preferences | Editor | General_ to disable.
-
 **Fixes:**
 * [VIM-570](https://youtrack.jetbrains.com/issue/VIM-570) Print non-ascii characters in ex panel
 * [VIM-926](https://youtrack.jetbrains.com/issue/VIM-926) Fix `<S-Space>` mapping

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,9 @@ _Available since 0.55.3 EAP:_
 * [VIM-434](https://youtrack.jetbrains.com/issue/VIM-434) Add `'showcmd'` support, on by default
 * `ReplaceWithRegister` plugin emulation ([ReplaceWithRegister](https://www.vim.org/scripts/script.php?script_id=2703))
 
+**Changes:**
+* Support IntelliJ's smooth scrolling. Use "Enable smooth scrolling" checkbox in _Preferences | Editor | General_ to disable.
+
 **Fixes:**
 * [VIM-570](https://youtrack.jetbrains.com/issue/VIM-570) Print non-ascii characters in ex panel
 * [VIM-926](https://youtrack.jetbrains.com/issue/VIM-926) Fix `<S-Space>` mapping

--- a/src/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -52,12 +52,10 @@ import java.util.List;
  */
 @State(name = "VimEditorSettings", storages = {@Storage(value = "$APP_CONFIG$/vim_settings.xml")})
 public class EditorGroup implements PersistentStateComponent<Element> {
-  private static final boolean ANIMATED_SCROLLING_VIM_VALUE = false;
   private static final boolean REFRAIN_FROM_SCROLLING_VIM_VALUE = true;
   public static final String EDITOR_STORE_ELEMENT = "editor";
 
   private boolean isBlockCursor = false;
-  private boolean isAnimatedScrolling = false;
   private boolean isRefrainFromScrolling = false;
   private Boolean isKeyRepeat = null;
 
@@ -244,7 +242,6 @@ public class EditorGroup implements PersistentStateComponent<Element> {
 
   public void editorCreated(@NotNull Editor editor) {
     isBlockCursor = editor.getSettings().isBlockCursor();
-    isAnimatedScrolling = editor.getSettings().isAnimatedScrolling();
     isRefrainFromScrolling = editor.getSettings().isRefrainFromScrolling();
     DocumentManager.INSTANCE.addListeners(editor.getDocument());
     VimPlugin.getKey().registerRequiredShortcutKeys(editor);
@@ -258,7 +255,6 @@ public class EditorGroup implements PersistentStateComponent<Element> {
       KeyHandler.getInstance().reset(editor);
     }
     editor.getSettings().setBlockCursor(!CommandStateHelper.inInsertMode(editor));
-    editor.getSettings().setAnimatedScrolling(ANIMATED_SCROLLING_VIM_VALUE);
     editor.getSettings().setRefrainFromScrolling(REFRAIN_FROM_SCROLLING_VIM_VALUE);
   }
 
@@ -267,7 +263,6 @@ public class EditorGroup implements PersistentStateComponent<Element> {
     UserDataManager.unInitializeEditor(editor);
     VimPlugin.getKey().unregisterShortcutKeys(editor);
     editor.getSettings().setBlockCursor(isBlockCursor);
-    editor.getSettings().setAnimatedScrolling(isAnimatedScrolling);
     editor.getSettings().setRefrainFromScrolling(isRefrainFromScrolling);
     DocumentManager.INSTANCE.removeListeners(editor.getDocument());
   }

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -259,7 +259,7 @@ public class MotionGroup {
   }
 
   private static int getScrollScreenTargetCaretVisualLine(final @NotNull Editor editor, int rawCount, boolean down) {
-    final Rectangle visibleArea = editor.getScrollingModel().getVisibleArea();
+    final Rectangle visibleArea = EditorHelper.getVisibleArea(editor);
     final int caretVisualLine = editor.getCaretModel().getVisualPosition().line;
     final int scrollOption = getScrollOption(rawCount);
 
@@ -890,7 +890,7 @@ public class MotionGroup {
   }
 
   private static void scrollColumnToLeftOfScreen(@NotNull Editor editor, int column) {
-    editor.getScrollingModel().scrollHorizontally(column * EditorHelper.getColumnWidth(editor));
+    EditorHelper.scrollHorizontally(editor, column * EditorHelper.getColumnWidth(editor));
   }
 
   public int moveCaretToMiddleColumn(@NotNull Editor editor, @NotNull Caret caret) {
@@ -1106,8 +1106,7 @@ public class MotionGroup {
       return false;
     }
 
-    final ScrollingModel scrollingModel = editor.getScrollingModel();
-    final Rectangle visibleArea = scrollingModel.getVisibleArea();
+    final Rectangle visibleArea = EditorHelper.getVisibleArea(editor);
 
     int targetCaretVisualLine = getScrollScreenTargetCaretVisualLine(editor, rawCount, down);
 
@@ -1128,7 +1127,7 @@ public class MotionGroup {
       }
       if (moved) {
         // We'll keep the caret at the same position, although that might not be the same line offset as previously
-        targetCaretVisualLine = editor.yToVisualLine(yInitialCaret + scrollingModel.getVisibleArea().y - yPrevious);
+        targetCaretVisualLine = editor.yToVisualLine(yInitialCaret + EditorHelper.getVisibleArea(editor).y - yPrevious);
       }
     }
     else {


### PR DESCRIPTION
Instead of maintaining state to enable/disable smooth scrolling per-editor, when IdeaVim is enabled/disabled, this PR means IdeaVim supports smooth scrolling. All scrolling such as `<C-F>`  will be handled correctly, and the page is animated, as when IdeaVim is disabled. The "Enable smooth scrolling" option in _Preferences | Editor | General_ is now correctly respected by IdeaVim.

