### PR TITLE
[VIM-1991] fix >0 number register not work

### DIFF
--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -563,7 +563,9 @@ public class KeyHandler {
   private boolean isCommandCountKey(char chKey, @NotNull CommandState editorState) {
     // Make sure to avoid handling '0' as the start of a count.
     final CommandBuilder commandBuilder = editorState.getCommandBuilder();
-    return (editorState.getMode() == CommandState.Mode.COMMAND || editorState.getMode() == CommandState.Mode.VISUAL)
+    return ((editorState.getMode() == CommandState.Mode.COMMAND
+             &&editorState.getSubMode()!=CommandState.SubMode.REGISTER_PENDING) 
+            || editorState.getMode() == CommandState.Mode.VISUAL)
       && commandBuilder.isExpectingCount() && Character.isDigit(chKey) && (commandBuilder.getCount() > 0 || chKey != '0');
   }
 


### PR DESCRIPTION
fix when use  >0  number register, treat it as a [count].but it is a  register.