### PR TITLE
Reset operator-pending commands on escape

### DIFF
--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -212,13 +212,15 @@ public class KeyHandler {
     handleKeyRecursionCount++;
 
     try {
+      if (isEditorReset(key, editorState)) {
+        handleEditorReset(editor, key, context, editorState);
+      }
+
       if (!allowKeyMappings || !handleKeyMapping(editor, key, context)) {
         if (isCommandCountKey(chKey, editorState)) {
           commandBuilder.addCountCharacter(key);
         } else if (isDeleteCommandCountKey(key, editorState)) {
           commandBuilder.deleteCountCharacter();
-        } else if (isEditorReset(key, editorState)) {
-          handleEditorReset(editor, key, context, editorState);
         }
         // If we got this far the user is entering a command or supplying an argument to an entered command.
         // First let's check to see if we are at the point of expecting a single character argument to a command.
@@ -564,7 +566,7 @@ public class KeyHandler {
     // Make sure to avoid handling '0' as the start of a count.
     final CommandBuilder commandBuilder = editorState.getCommandBuilder();
     return ((editorState.getMode() == CommandState.Mode.COMMAND
-             &&editorState.getSubMode()!=CommandState.SubMode.REGISTER_PENDING) 
+             &&editorState.getSubMode()!=CommandState.SubMode.REGISTER_PENDING)
             || editorState.getMode() == CommandState.Mode.VISUAL)
       && commandBuilder.isExpectingCount() && Character.isDigit(chKey) && (commandBuilder.getCount() > 0 || chKey != '0');
   }

--- a/test/org/jetbrains/plugins/ideavim/action/ResetModeActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/ResetModeActionTest.kt
@@ -63,4 +63,12 @@ class ResetModeActionTest : VimTestCase() {
     doTest(keys, before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
     TestCase.assertFalse(myFixture.editor.selectionModel.hasSelection())
   }
+
+  fun `test reset from operator-pending mode with delete`() {
+    val keys = StringHelper.parseKeys("d<Esc>dw")
+    val before = "A Discovery"
+    val after = "Discovery"
+    doTest(keys, before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+    TestCase.assertFalse(myFixture.editor.selectionModel.hasSelection())
+  }
 }


### PR DESCRIPTION
Suppose we have the text "|Hello, world", with | being the position of
the cursor. Pressing `d<Esc>dw` simply moves the cursor on top of the
comma instead of leaving the text as ", world".

This fixes issue VIM-1421.

I'm creating the pull request again, since on rebasing I apparently messed up the history.