### PR TITLE
Prioritise startup activity to initialise IdeaVim early

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -50,7 +50,10 @@
     <applicationService serviceImplementation="com.maddyhome.idea.vim.VimLocalConfig"/>
     <applicationService serviceImplementation="com.maddyhome.idea.vim.VimPlugin"/>
 
-    <postStartupActivity implementation="com.maddyhome.idea.vim.PluginStartup"/>
+    <!-- Initialise as early as possible so that we're ready to edit quickly. This is especially important for Rider,
+         which (at least for 2020.1) has some long running activities that block other startup extensions. None of the
+         core platform activities have IDs, so we can't use "before ID". We have to use "first" -->
+    <postStartupActivity implementation="com.maddyhome.idea.vim.PluginStartup" order="first"/>
 
     <editorFloatingToolbarProvider implementation="com.maddyhome.idea.vim.ui.ReloadFloatingToolbar"/>
   </extensions>


### PR DESCRIPTION
Initialise early in the post startup activities so that any open editors get Vim features as soon as possible. This is most important on Rider, which has a post startup activity that blocks until Rider's project model is ready. Unfortunately, it also blocks plugin startup activities.

All core startup activities are unordered and don't have IDs, so all we can do is go first.