### PR TITLE
add support for putting & editing macros

### DIFF
--- a/src/com/maddyhome/idea/vim/action/copy/PutTextAction.kt
+++ b/src/com/maddyhome/idea/vim/action/copy/PutTextAction.kt
@@ -25,6 +25,7 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.group.copy.PutData
 import com.maddyhome.idea.vim.group.copy.PutData.TextData
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
+import com.maddyhome.idea.vim.helper.StringHelper
 
 sealed class PutTextBaseAction(
   private val insertTextBeforeCaret: Boolean,
@@ -35,7 +36,7 @@ sealed class PutTextBaseAction(
 
   override fun execute(editor: Editor, context: DataContext, count: Int, rawCount: Int, argument: Argument?): Boolean {
     val lastRegister = VimPlugin.getRegister().lastRegister
-    val textData = if (lastRegister != null) TextData(lastRegister.text, lastRegister.type, lastRegister.transferableData) else null
+    val textData = if (lastRegister != null) TextData(lastRegister.text ?: StringHelper.toKeyNotation(lastRegister.keys), lastRegister.type, lastRegister.transferableData) else null
     val putData = PutData(textData, null, count, insertTextBeforeCaret, indent, caretAfterInsertedText, -1)
     return VimPlugin.getPut().putText(editor, context, putData)
   }

--- a/src/com/maddyhome/idea/vim/ex/handler/PutLinesHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/PutLinesHandler.kt
@@ -26,6 +26,7 @@ import com.maddyhome.idea.vim.ex.CommandHandler
 import com.maddyhome.idea.vim.ex.ExCommand
 import com.maddyhome.idea.vim.ex.flags
 import com.maddyhome.idea.vim.group.copy.PutData
+import com.maddyhome.idea.vim.helper.StringHelper
 
 class PutLinesHandler : CommandHandler.SingleExecution() {
   override val argFlags = flags(RangeFlag.RANGE_OPTIONAL, ArgumentFlag.ARGUMENT_OPTIONAL, Access.READ_ONLY)
@@ -35,14 +36,15 @@ class PutLinesHandler : CommandHandler.SingleExecution() {
 
     val registerGroup = VimPlugin.getRegister()
     val arg = cmd.argument
-    if (arg.isNotEmpty() && !registerGroup.selectRegister(arg[0])) {
-      return false
+    if (arg.isNotEmpty()) {
+      if(!registerGroup.selectRegister(arg[0]))
+        return false
     } else {
       registerGroup.selectRegister(registerGroup.defaultRegister)
     }
 
     val line = if (cmd.ranges.size() == 0) -1 else cmd.getLine(editor)
-    val textData = registerGroup.lastRegister?.let { PutData.TextData(it.text, SelectionType.LINE_WISE, it.transferableData) }
+    val textData = registerGroup.lastRegister?.let { PutData.TextData(it.text ?: StringHelper.toKeyNotation(it.keys), SelectionType.LINE_WISE, it.transferableData) }
     val putData = PutData(textData, null, 1, insertTextBeforeCaret = false, _indent = false, caretAfterInsertedText = false, putToLine = line)
     return VimPlugin.getPut().putText(editor, context, putData)
   }

--- a/src/com/maddyhome/idea/vim/ex/handler/RegistersHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/RegistersHandler.kt
@@ -38,7 +38,7 @@ class RegistersHandler : CommandHandler.SingleExecution() {
           SelectionType.CHARACTER_WISE -> "c"
           SelectionType.BLOCK_WISE -> "b"
         }
-        "  $type  \"${reg.name}   ${StringHelper.toPrintableCharacters(reg.keys).take(200)}"
+        "  $type  \"${reg.name}   ${StringHelper.toKeyNotation(reg.keys).take(200)}"
       }
 
     ExOutputModel.getInstance(editor).output(regs)

--- a/src/com/maddyhome/idea/vim/group/MacroGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MacroGroup.java
@@ -27,6 +27,7 @@ import com.intellij.openapi.project.Project;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.common.Register;
+import com.maddyhome.idea.vim.helper.StringHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -57,8 +58,13 @@ public class MacroGroup {
     if (register == null) {
       return false;
     }
-
-    List<KeyStroke> keys = register.getKeys();
+    List<KeyStroke> keys;
+    if (register.getRawText() == null) {
+      keys = register.getKeys();
+    }
+    else {
+      keys = StringHelper.parseKeys(register.getRawText());
+    }
     playbackKeys(editor, context, project, keys, 0, 0, count);
 
     lastRegister = reg;

--- a/test/org/jetbrains/plugins/ideavim/ex/handler/RegistersHandlerTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/ex/handler/RegistersHandlerTest.kt
@@ -88,7 +88,7 @@ class RegistersHandlerTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput("""Type Name Content
-                     |  c  "a   ^IHello World^J^[
+                     |  c  "a   <Tab>Hello World<CR><Esc>
       """.trimMargin())
   }
 


### PR DESCRIPTION
Add support for putting and editing a macros
https://youtrack.jetbrains.com/issue/VIM-2059

Currently we can't edit a recorded marco just like what we can do in classic vim.

What this PR does:

1. put a recorded macro to current buffer by converting key strokes to printable characters with `p` or `:put`
2. convert text to a collection of key strokes while playing back a macro

Effects :
1. can put recorded macro as printable character
2. support for editing macro (put from and yank to register)
3. can play back any register as a macro even if it's not a recorded macro, eg from yanking

I'm a idea & vim fanatic, ideavim saved my days! Thank you guys!