### PR TITLE
Properly reset when pressing Esc in the middle of command

### DIFF
--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -212,13 +212,15 @@ public class KeyHandler {
     handleKeyRecursionCount++;
 
     try {
+      if (isEditorReset(key, editorState)) {
+        handleEditorReset(editor, key, context, editorState);
+      }
+
       if (!allowKeyMappings || !handleKeyMapping(editor, key, context)) {
         if (isCommandCountKey(chKey, editorState)) {
           commandBuilder.addCountCharacter(key);
         } else if (isDeleteCommandCountKey(key, editorState)) {
           commandBuilder.deleteCountCharacter();
-        } else if (isEditorReset(key, editorState)) {
-          handleEditorReset(editor, key, context, editorState);
         }
         // If we got this far the user is entering a command or supplying an argument to an entered command.
         // First let's check to see if we are at the point of expecting a single character argument to a command.

--- a/test/org/jetbrains/plugins/ideavim/action/ResetModeActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/ResetModeActionTest.kt
@@ -18,12 +18,18 @@
 
 package org.jetbrains.plugins.ideavim.action
 
+import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.CommandState
+import com.maddyhome.idea.vim.command.MappingMode
 import com.maddyhome.idea.vim.helper.StringHelper
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.key.MappingOwner
 import junit.framework.TestCase
 import org.jetbrains.plugins.ideavim.VimTestCase
 
 class ResetModeActionTest : VimTestCase() {
+  private val owner = MappingOwner.Plugin.get("ResetModeActionTest")
+
   fun `test reset from normal mode`() {
     val keys = StringHelper.parseKeys("<C-\\><C-N>")
     val before = "A Discovery"
@@ -63,4 +69,48 @@ class ResetModeActionTest : VimTestCase() {
     doTest(keys, before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
     TestCase.assertFalse(myFixture.editor.selectionModel.hasSelection())
   }
+
+  fun `test delete command after resetting operator-pending mode`() {
+    val keys = StringHelper.parseKeys("d", "<C-\\><C-N>", "dw")
+    val before = "A Discovery"
+    val after = "Discovery"
+    doTest(keys, before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+    TestCase.assertFalse(myFixture.editor.selectionModel.hasSelection())
+  }
+
+  fun `test delete command after resetting operator-pending mode with esc`() {
+    val keys = StringHelper.parseKeys("d", "<Esc>", "dw")
+    val before = "A Discovery"
+    val after = "Discovery"
+    doTest(keys, before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+    TestCase.assertFalse(myFixture.editor.selectionModel.hasSelection())
+  }
+
+  fun `test delete command after resetting operator-pending mode with ctrl open bracket`() {
+    val keys = StringHelper.parseKeys("d", "<C-[>", "dw")
+    val before = "A Discovery"
+    val after = "Discovery"
+    doTest(keys, before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+    TestCase.assertFalse(myFixture.editor.selectionModel.hasSelection())
+  }
+
+  fun `test delete command after resetting operator-pending mode with mapping`() {
+    VimPlugin.getKey()
+      .putKeyMapping(MappingMode.NVO, parseKeys("<C-D>"), owner, parseKeys("<Esc>"), false)
+
+    val keys = StringHelper.parseKeys("d", "<C-D>", "dw")
+    val before = "A Discovery"
+    val after = "Discovery"
+    doTest(keys, before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+    TestCase.assertFalse(myFixture.editor.selectionModel.hasSelection())
+  }
+
+  fun `test non-delete commands after resetting operator-pending mode`() {
+    val keys = StringHelper.parseKeys("c", "<C-\\><C-N>", "another")
+    val before = "A Discovery"
+    val after = "Another Discovery"
+    doTest(keys, before, after, CommandState.Mode.INSERT, CommandState.SubMode.NONE)
+    TestCase.assertFalse(myFixture.editor.selectionModel.hasSelection())
+  }
+
 }


### PR DESCRIPTION
This is a continuation on Adriafarres pull request (#237) since that PR has been idle for the past month and this bug really annoys me. I'll just quote the previous issue description:

> Suppose we have the text "|Hello, world", with | being the position of
the cursor. Pressing d<Esc>dw simply moves the cursor on top of the
comma instead of leaving the text as ", world".
>
> This fixes issue VIM-1421

I've added some more test cases based on the last comment in the other PR.
Please let me know what you think :) 