### PR TITLE
Fix alternative XDG path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ have `-Duser.home=/my/alternate/home` then IdeaVim will source
 `/my/alternate/home/.ideavimrc` instead of `~/.ideavimrc`.
 
 Alternatively, you can set up initialization commands using [XDG](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) standard.
-Put your settings to `$XDG_CONFIG_HOME$/ideavim/ideavimrc` file.
+Put your settings to `$XDG_CONFIG_HOME/ideavim/ideavimrc` file.
 
 
 Emulated Vim Plugins


### PR DESCRIPTION
README shows this path that follows XDG standart
```
$XDG_CONFIG_HOME$/ideavim/ideavimrc
```
It should be 
```
$XDG_CONFIG_HOME/ideavim/ideavimrc
```
Because be default **$XDG_CONFIG_HOME** points to $HOME/.config and I can to `cd $XDG_CONFIG_HOME` but `cd $XDG_CONFIG_HOME$`  will show this error `no such file or directory: /home/username/.config$`