### PR TITLE
VIM-1970 | Working solution of plugin vim-highlightedyank

### DIFF
--- a/doc/emulated-plugins.md
+++ b/doc/emulated-plugins.md
@@ -69,3 +69,14 @@ Available extensions:
 * Emulates [vim-textobj-entire](https://github.com/kana/vim-textobj-entire)
 * Additional text objects: `ae`, `ie`
 * By [Alexandre Grison](https://github.com/agrison)
+
+## highlightedyank
+
+* Setup: 
+    * `set highlightedyank`
+    * if you want to optimize highlight duration, assign a time in milliseconds:  
+       `let g:highlightedyank_highlight_duration = "1000"`  
+       A negative number makes the highlight persistent.  
+       `let g:highlightedyank_highlight_duration = "-1"`
+* Emulates [vim-highlightedyank](https://github.com/machakann/vim-highlightedyank)
+* By [KostkaBrukowa](https://github.com/KostkaBrukowa)

--- a/doc/emulated-plugins.md
+++ b/doc/emulated-plugins.md
@@ -78,5 +78,7 @@ Available extensions:
        `let g:highlightedyank_highlight_duration = "1000"`  
        A negative number makes the highlight persistent.  
        `let g:highlightedyank_highlight_duration = "-1"`
+     * if you want to change background color of highlight you can provide the rgba of the color you want e.g.  
+       `let g:highlightedyank_highlight_color = "rgba(160, 160, 160, 155)"`
 * Emulates [vim-highlightedyank](https://github.com/machakann/vim-highlightedyank)
 * By [KostkaBrukowa](https://github.com/KostkaBrukowa)

--- a/doc/emulated-plugins.md
+++ b/doc/emulated-plugins.md
@@ -70,7 +70,7 @@ Available extensions:
 * Additional text objects: `ae`, `ie`
 * By [Alexandre Grison](https://github.com/agrison)
 
-## highlightedyank
+## highlightedyank [To Be Released]
 
 * Setup: 
     * `set highlightedyank`

--- a/resources/META-INF/includes/VimExtensions.xml
+++ b/resources/META-INF/includes/VimExtensions.xml
@@ -7,5 +7,6 @@
     <vimExtension implementation="com.maddyhome.idea.vim.extension.argtextobj.VimArgTextObjExtension"/>
     <vimExtension implementation="com.maddyhome.idea.vim.extension.replacewithregister.ReplaceWithRegister"/>
     <vimExtension implementation="com.maddyhome.idea.vim.extension.exchange.VimExchangeExtension"/>
+    <vimExtension implementation="com.maddyhome.idea.vim.extension.highlightedyank.VimHighlightedYank"/>
   </extensions>
 </idea-plugin>

--- a/src/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
+++ b/src/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
@@ -36,18 +36,14 @@ class VimHighlightedYank: VimExtension {
   override fun getName() = "highlightedyank"
 
   override fun init() {
-    println("init yank")
-
     Handler.highlightEnabled = true
   }
 
 
   override fun dispose() {
     super.dispose()
-    println("dispose yank")
     Handler.highlightEnabled = false
   }
-
 
   companion object {
     const val DEFAULT_HIGHLIGHT_DURATION: Long = 300
@@ -66,7 +62,6 @@ class VimHighlightedYank: VimExtension {
       highlightHandler.clearAllYankHighlighters(editor)
     }
   }
-
 
   private class HighlightHandler {
     private val yankHighlighters: MutableSet<RangeHighlighter> = mutableSetOf()

--- a/src/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
+++ b/src/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
@@ -22,19 +22,23 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.EffectType
 import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.editor.markup.HighlighterTargetArea
 import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.intellij.openapi.editor.markup.TextAttributes
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment
 import com.maddyhome.idea.vim.extension.VimExtension
+import java.awt.Font
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 private const val DEFAULT_HIGHLIGHT_DURATION: Long = 300
 private const val HIGHLIGHT_DURATION_VARIABLE_NAME = "g:highlightedyank_highlight_duration"
-private val DEFAULT_HIGHLIGHT_COLOR: TextAttributesKey = EditorColors.TEXT_SEARCH_RESULT_ATTRIBUTES
+private val DEFAULT_HIGHLIGHT_TEXT_ATTRIBUTES: TextAttributesKey = EditorColors.TEXT_SEARCH_RESULT_ATTRIBUTES
+
 
 /**
  * @author KostkaBrukowa (@kostkabrukowa)
@@ -104,12 +108,18 @@ class VimHighlightedYank: VimExtension {
     }
 
     private fun highlightSingleRange(editor: Editor, range: ClosedRange<Int>) {
-      val color = DEFAULT_HIGHLIGHT_COLOR
+      val textAttributes = TextAttributes(
+        DEFAULT_HIGHLIGHT_TEXT_ATTRIBUTES.defaultAttributes.foregroundColor,
+        DEFAULT_HIGHLIGHT_TEXT_ATTRIBUTES.defaultAttributes.backgroundColor,
+        editor.colorsScheme.getColor(EditorColors.CARET_COLOR),
+        EffectType.SEARCH_MATCH, Font.PLAIN
+      )
+
       val highlighter = editor.markupModel.addRangeHighlighter(
         range.start,
         range.endInclusive,
         HighlighterLayer.SELECTION - 1,
-        editor.colorsScheme.getAttributes(color),
+        textAttributes,
         HighlighterTargetArea.EXACT_RANGE
       )
 

--- a/src/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
+++ b/src/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
@@ -1,0 +1,142 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.extension.highlightedyank
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.colors.EditorColors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.HighlighterLayer
+import com.intellij.openapi.editor.markup.HighlighterTargetArea
+import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.common.TextRange
+import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment
+import com.maddyhome.idea.vim.extension.VimExtension
+import java.util.*
+import kotlin.concurrent.schedule
+
+class VimHighlightedYank: VimExtension {
+  override fun getName() = "highlightedyank"
+
+  override fun init() {
+    println("init yank")
+
+    Handler.highlightEnabled = true
+  }
+
+
+  override fun dispose() {
+    super.dispose()
+    println("dispose yank")
+    Handler.highlightEnabled = false
+  }
+
+
+  companion object {
+    const val DEFAULT_HIGHLIGHT_DURATION: Long = 300
+    val DEFAULT_HIGHLIGHT_COLOR: TextAttributesKey = EditorColors.TEXT_SEARCH_RESULT_ATTRIBUTES
+  }
+
+  object Handler {
+    var highlightEnabled: Boolean = false
+    private val highlightHandler = HighlightHandler()
+
+    fun highlightYankRange(editor: Editor, range: TextRange) {
+      highlightHandler.highlightYankRange(editor, range, highlightEnabled)
+    }
+
+    fun clearAllYankHighlighters(editor: Editor) {
+      highlightHandler.clearAllYankHighlighters(editor)
+    }
+  }
+
+
+  private class HighlightHandler {
+    private val yankHighlighters: MutableSet<RangeHighlighter> = mutableSetOf()
+
+    fun highlightYankRange(editor: Editor, range: TextRange, highlightEnabled: Boolean) {
+      if(!highlightEnabled) return
+
+      //from vim-highlightedyank docs: When a new text is yanked or user starts editing, the old highlighting would be deleted
+      clearAllYankHighlighters(editor)
+
+      if (range.isMultiple) {
+        for (i in 0 until range.size()) {
+          highlightSingleRange(editor, range.startOffsets[i]..range.endOffsets[i])
+        }
+      } else {
+        highlightSingleRange(editor, range.startOffset..range.endOffset)
+      }
+    }
+
+    fun clearAllYankHighlighters(editor: Editor) {
+      yankHighlighters.forEach { editor.markupModel.removeHighlighter(it) }
+      yankHighlighters.clear()
+    }
+
+    private fun highlightSingleRange(editor: Editor, range: ClosedRange<Int>) {
+      val color = DEFAULT_HIGHLIGHT_COLOR
+      val highlighter = editor.markupModel.addRangeHighlighter(
+        range.start,
+        range.endInclusive,
+        HighlighterLayer.SELECTION - 1,
+        editor.colorsScheme.getAttributes(color),
+        HighlighterTargetArea.EXACT_RANGE
+      )
+
+      yankHighlighters.add(highlighter)
+
+      setClearHighlightRangeTimer(editor, highlighter)
+    }
+
+
+    private fun setClearHighlightRangeTimer(editor: Editor, highlighter: RangeHighlighter) {
+      val timeout = extractHighlightDuration()
+
+      //from vim-highlightedyank docs: A negative number makes the highlight persistent.
+      if(timeout > 0) {
+        Timer("yankHighlight", false).schedule(timeout) {
+          ApplicationManager.getApplication().invokeLater {
+            editor.markupModel.removeHighlighter(highlighter)
+          }
+        }
+      }
+    }
+
+    private fun extractHighlightDuration(): Long {
+      val env = VimScriptGlobalEnvironment.getInstance()
+      val value = env.variables["g:highlightedyank_highlight_duration"]
+
+      if(value is String) {
+        return try {
+            value.toLong()
+        }
+        catch (e: NumberFormatException){
+          VimPlugin.showMessage("highlightedyank: Invalid value of g:highlightedyank_highlight_duration -- " + e.message)
+          VimPlugin.indicateError()
+
+          DEFAULT_HIGHLIGHT_DURATION
+        }
+      }
+
+      return DEFAULT_HIGHLIGHT_DURATION
+    }
+  }
+}

--- a/src/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
+++ b/src/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
@@ -29,8 +29,8 @@ import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment
 import com.maddyhome.idea.vim.extension.VimExtension
-import java.util.*
-import kotlin.concurrent.schedule
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 private const val DEFAULT_HIGHLIGHT_DURATION: Long = 300
 private const val HIGHLIGHT_DURATION_VARIABLE_NAME = "g:highlightedyank_highlight_duration"
@@ -122,12 +122,12 @@ class VimHighlightedYank: VimExtension {
       val timeout = extractHighlightDuration()
 
       //from vim-highlightedyank docs: A negative number makes the highlight persistent.
-      if(timeout > 0) {
-        Timer("yankHighlight", false).schedule(timeout) {
+      if(timeout >= 0) {
+        Executors.newSingleThreadScheduledExecutor().schedule({
           ApplicationManager.getApplication().invokeLater {
             editor.markupModel.removeHighlighter(highlighter)
           }
-        }
+        }, timeout, TimeUnit.MILLISECONDS)
       }
     }
 

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -55,6 +55,7 @@ import com.maddyhome.idea.vim.common.IndentConfig;
 import com.maddyhome.idea.vim.common.Register;
 import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.ex.ranges.LineRange;
+import com.maddyhome.idea.vim.extension.highlightedyank.VimHighlightedYank;
 import com.maddyhome.idea.vim.group.visual.VimSelection;
 import com.maddyhome.idea.vim.group.visual.VisualGroupKt;
 import com.maddyhome.idea.vim.group.visual.VisualModeHelperKt;
@@ -421,6 +422,8 @@ public class ChangeGroup {
 
       VisualGroupKt.updateCaretState(editor);
     }
+
+    VimHighlightedYank.Handler.INSTANCE.clearAllYankHighlighters(editor);
   }
 
   // Workaround for VIM-1546. Another solution is highly appreciated.

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -423,7 +423,7 @@ public class ChangeGroup {
       VisualGroupKt.updateCaretState(editor);
     }
 
-    VimHighlightedYank.Handler.INSTANCE.clearAllYankHighlighters(editor);
+    VimHighlightedYank.Companion.clearAllYankHighlighters();
   }
 
   // Workaround for VIM-1546. Another solution is highly appreciated.

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -46,6 +46,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.psi.util.PsiUtilBase;
 import com.intellij.util.ObjectUtils;
+import com.intellij.util.containers.ContainerUtil;
 import com.maddyhome.idea.vim.EventFacade;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.RegisterActions;
@@ -55,13 +56,13 @@ import com.maddyhome.idea.vim.common.IndentConfig;
 import com.maddyhome.idea.vim.common.Register;
 import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.ex.ranges.LineRange;
-import com.maddyhome.idea.vim.extension.highlightedyank.VimHighlightedYank;
 import com.maddyhome.idea.vim.group.visual.VimSelection;
 import com.maddyhome.idea.vim.group.visual.VisualGroupKt;
 import com.maddyhome.idea.vim.group.visual.VisualModeHelperKt;
 import com.maddyhome.idea.vim.handler.EditorActionHandlerBase;
 import com.maddyhome.idea.vim.helper.*;
 import com.maddyhome.idea.vim.listener.SelectionVimListenerSuppressor;
+import com.maddyhome.idea.vim.listener.VimInsertListener;
 import com.maddyhome.idea.vim.listener.VimListenerSuppressor;
 import com.maddyhome.idea.vim.option.BoundListOption;
 import com.maddyhome.idea.vim.option.OptionsManager;
@@ -92,6 +93,8 @@ public class ChangeGroup {
     ImmutableSet.of(VIM_MOTION_WORD_RIGHT, VIM_MOTION_BIG_WORD_RIGHT, VIM_MOTION_CAMEL_RIGHT);
 
   private @Nullable Command lastInsert;
+
+  private List<VimInsertListener> insertListeners = ContainerUtil.createLockFreeCopyOnWriteList();
 
   private void setInsertRepeat(int lines, int column, boolean append) {
     repeatLines = lines;
@@ -423,7 +426,7 @@ public class ChangeGroup {
       VisualGroupKt.updateCaretState(editor);
     }
 
-//    VimHighlightedYank.Companion.clearAllYankHighlighters();
+    notifyListeners(editor);
   }
 
   // Workaround for VIM-1546. Another solution is highly appreciated.
@@ -1969,6 +1972,18 @@ public class ChangeGroup {
     }
 
     return number;
+  }
+
+  public void addInsertListener(VimInsertListener listener) {
+    insertListeners.add(listener);
+  }
+
+  public void removeInsertListener(VimInsertListener listener) {
+    insertListeners.remove(listener);
+  }
+
+  private void notifyListeners(Editor editor) {
+    insertListeners.forEach(listener -> listener.insertModeStarted(editor));
   }
 
   private int oldOffset = -1;

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -423,7 +423,7 @@ public class ChangeGroup {
       VisualGroupKt.updateCaretState(editor);
     }
 
-    VimHighlightedYank.Companion.clearAllYankHighlighters();
+//    VimHighlightedYank.Companion.clearAllYankHighlighters();
   }
 
   // Workaround for VIM-1546. Another solution is highly appreciated.

--- a/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
@@ -173,7 +173,7 @@ class YankGroup {
                         startOffsets: Map<Caret, Int>?): Boolean {
     startOffsets?.forEach { caret, offset -> MotionGroup.moveCaret(editor, caret, offset) }
 
-    VimHighlightedYank.Handler.highlightYankRange(editor, range)
+    VimHighlightedYank.highlightYankRange(editor, range)
 
     return VimPlugin.getRegister().storeText(editor, range, type, false)
   }

--- a/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
@@ -19,25 +19,19 @@
 package com.maddyhome.idea.vim.group.copy
 
 import com.intellij.openapi.actionSystem.DataContext
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.colors.EditorColors
-import com.intellij.openapi.editor.colors.TextAttributesKey
-import com.intellij.openapi.editor.markup.HighlighterLayer
-import com.intellij.openapi.editor.markup.HighlighterTargetArea
-import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.action.motion.updown.MotionDownLess1FirstNonSpaceAction
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.SelectionType
 import com.maddyhome.idea.vim.common.TextRange
+import com.maddyhome.idea.vim.extension.highlightedyank.VimHighlightedYank
 import com.maddyhome.idea.vim.group.MotionGroup
 import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.fileSize
 import org.jetbrains.annotations.Contract
 import java.util.*
-import kotlin.concurrent.schedule
 import kotlin.math.min
 
 class YankGroup {
@@ -179,52 +173,9 @@ class YankGroup {
                         startOffsets: Map<Caret, Int>?): Boolean {
     startOffsets?.forEach { caret, offset -> MotionGroup.moveCaret(editor, caret, offset) }
 
-    highlightYankRange(editor, range, true)
+    VimHighlightedYank.Handler.highlightYankRange(editor, range)
 
     return VimPlugin.getRegister().storeText(editor, range, type, true)
   }
 
-  private fun highlightYankRange(editor: Editor, range: TextRange, highlightEnabled: Boolean) {
-    if(!highlightEnabled) return
-
-    val color = EditorColors.TEXT_SEARCH_RESULT_ATTRIBUTES
-    //from vim-highlightedyank docs: When a new text is yanked or user starts editing, the old highlighting would be deleted
-    yankHighlighters.forEach { editor.markupModel.removeHighlighter(it) }
-    yankHighlighters.clear()
-
-    if (range.isMultiple) {
-      for (i in 0 until range.size()) {
-        highlightSingleRange(editor, range.startOffsets[i]..range.endOffsets[i], color)
-      }
-    } else {
-      highlightSingleRange(editor, range.startOffset..range.endOffset, color)
-    }
-  }
-
-  private fun highlightSingleRange(editor: Editor, range: ClosedRange<Int>, color: TextAttributesKey) {
-    val highlighter = editor.markupModel.addRangeHighlighter(
-      range.start,
-      range.endInclusive,
-      HighlighterLayer.SELECTION - 1,
-      editor.colorsScheme.getAttributes(color),
-      HighlighterTargetArea.EXACT_RANGE
-    )
-
-    yankHighlighters.add(highlighter)
-
-    setClearHighlightRangeTimer(editor, highlighter, 1500)
-  }
-
-
-  private fun setClearHighlightRangeTimer(editor: Editor, highlighter: RangeHighlighter, timeout: Long) {
-    Timer("yankHighlight", false).schedule(timeout) {
-      ApplicationManager.getApplication().invokeLater {
-        editor.markupModel.removeHighlighter(highlighter)
-      }
-    }
-  }
-
-  companion object {
-    val yankHighlighters: MutableSet<RangeHighlighter> = mutableSetOf()
-  }
 }

--- a/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
@@ -21,6 +21,7 @@ package com.maddyhome.idea.vim.group.copy
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
+import com.intellij.util.containers.ContainerUtil
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.action.motion.updown.MotionDownLess1FirstNonSpaceAction
 import com.maddyhome.idea.vim.command.Argument
@@ -35,13 +36,13 @@ import java.util.*
 import kotlin.math.min
 
 class YankGroup {
-  private val listeners: MutableList<VimYankListener> = mutableListOf()
+  private val yankListeners: MutableList<VimYankListener> = ContainerUtil.createLockFreeCopyOnWriteList();
 
-  fun addListener(listener: VimYankListener) = listeners.add(listener)
+  fun addListener(listener: VimYankListener) = yankListeners.add(listener)
 
-  fun removeListener(listener: VimYankListener) = listeners.remove(listener)
+  fun removeListener(listener: VimYankListener) = yankListeners.remove(listener)
 
-  private fun notifyListeners(editor: Editor, textRange: TextRange) = listeners.forEach {
+  private fun notifyListeners(editor: Editor, textRange: TextRange) = yankListeners.forEach {
     it.yankPerformed(editor, textRange)
   }
 

--- a/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
@@ -179,7 +179,7 @@ class YankGroup {
                         startOffsets: Map<Caret, Int>?): Boolean {
     startOffsets?.forEach { caret, offset -> MotionGroup.moveCaret(editor, caret, offset) }
 
-    highlightYankRange(editor, range, false)
+    highlightYankRange(editor, range, true)
 
     return VimPlugin.getRegister().storeText(editor, range, type, true)
   }
@@ -190,6 +190,7 @@ class YankGroup {
     val color = EditorColors.TEXT_SEARCH_RESULT_ATTRIBUTES
     //from vim-highlightedyank docs: When a new text is yanked or user starts editing, the old highlighting would be deleted
     yankHighlighters.forEach { editor.markupModel.removeHighlighter(it) }
+    yankHighlighters.clear()
 
     if (range.isMultiple) {
       for (i in 0 until range.size()) {

--- a/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/copy/YankGroup.kt
@@ -175,7 +175,6 @@ class YankGroup {
 
     VimHighlightedYank.Handler.highlightYankRange(editor, range)
 
-    return VimPlugin.getRegister().storeText(editor, range, type, true)
+    return VimPlugin.getRegister().storeText(editor, range, type, false)
   }
-
 }

--- a/src/com/maddyhome/idea/vim/listener/VimInsertListener.kt
+++ b/src/com/maddyhome/idea/vim/listener/VimInsertListener.kt
@@ -1,0 +1,25 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.listener
+
+import com.intellij.openapi.editor.Editor
+
+interface VimInsertListener {
+  fun insertModeStarted(editor: Editor)
+}

--- a/src/com/maddyhome/idea/vim/listener/VimYankListener.kt
+++ b/src/com/maddyhome/idea/vim/listener/VimYankListener.kt
@@ -1,0 +1,26 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.listener
+
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.common.TextRange
+
+interface VimYankListener {
+  fun yankPerformed(editor: Editor, range: TextRange)
+}

--- a/test/org/jetbrains/plugins/ideavim/TestHelper.kt
+++ b/test/org/jetbrains/plugins/ideavim/TestHelper.kt
@@ -89,11 +89,7 @@ fun assertDoesntChange(timeInMillis: Int = 1000, condition: () -> Boolean) {
 }
 
 fun assertHappened(timeInMillis: Int = 1000, precision: Int, condition: () -> Boolean) {
-  assertDoesntChange(timeInMillis - precision) {
-    return@assertDoesntChange !condition()
-  }
+  assertDoesntChange(timeInMillis - precision) { !condition() }
 
-  waitAndAssert(precision * 2) {
-    return@waitAndAssert condition()
-  }
+  waitAndAssert(precision * 2) { condition() }
 }

--- a/test/org/jetbrains/plugins/ideavim/TestHelper.kt
+++ b/test/org/jetbrains/plugins/ideavim/TestHelper.kt
@@ -79,9 +79,21 @@ fun waitAndAssertMode(fixture: CodeInsightTestFixture, mode: CommandState.Mode, 
 fun assertDoesntChange(timeInMillis: Int = 1000, condition: () -> Boolean) {
   val end = System.currentTimeMillis() + timeInMillis
   while (end > System.currentTimeMillis()) {
-    if (!condition()) fail()
+    if (!condition()) {
+      fail()
+    }
 
     Thread.sleep(10)
     IdeEventQueue.getInstance().flushQueue()
+  }
+}
+
+fun assertHappened(timeInMillis: Int = 1000, precision: Int, condition: () -> Boolean) {
+  assertDoesntChange(timeInMillis - precision) {
+    return@assertDoesntChange !condition()
+  }
+
+  waitAndAssert(precision * 2) {
+    return@waitAndAssert condition()
   }
 }

--- a/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYank.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYank.kt
@@ -1,0 +1,123 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.highlightedyank
+
+import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.command.CommandState
+import com.maddyhome.idea.vim.helper.StringHelper
+import junit.framework.Assert
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+
+class VimHighlightedYankTest : VimTestCase() {
+  override fun setUp() {
+    super.setUp()
+    enableExtensions("highlightedyank")
+  }
+
+  fun `test highlighting whole line when whole line is yanked`() {
+    doTest("yy", code, code, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+
+    assertAllHighlightersCount(1)
+    assertHighlighterRange(1, 40, getFirstHighlighter())
+  }
+
+  fun `test highlighting single word when single word is yanked`() {
+    doTest("yiw", code, code, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+
+    assertAllHighlightersCount(1)
+    assertHighlighterRange(5, 8, getFirstHighlighter())
+  }
+
+  fun `test removing previous highlight when new range is yanked`() {
+    configureByJavaText(code)
+    typeText(StringHelper.parseKeys("yyjyy"))
+
+    assertAllHighlightersCount(1)
+    assertHighlighterRange(40, 59, getFirstHighlighter())
+  }
+
+  fun `test removing previous highlight entering insert mode`() {
+    configureByJavaText(code)
+    typeText(StringHelper.parseKeys("yyi"))
+
+    assertAllHighlightersCount(0)
+  }
+
+  fun `test indicating error when incorrect highlight duration was provided by user`() {
+    configureByJavaText(code)
+    typeText(StringHelper.parseKeys(":let g:highlightedyank_highlight_duration = \"500.15\"<CR>"))
+    typeText(StringHelper.parseKeys("yy"))
+
+    Assert.assertEquals(VimPlugin.getMessage(), "highlightedyank: Invalid value of g:highlightedyank_highlight_duration -- For input string: \"500.15\"")
+  }
+
+  fun `test not indicating error when correct highlight duration was provided by user`() {
+    configureByJavaText(code)
+    typeText(StringHelper.parseKeys(":let g:highlightedyank_highlight_duration = \"-1\"<CR>"))
+    typeText(StringHelper.parseKeys("yy"))
+
+    Assert.assertEquals(VimPlugin.getMessage(), "")
+  }
+
+  fun `test highlighting with multiple cursors`() {
+    configureByJavaText(codeWithMultipleCurors)
+    typeText(StringHelper.parseKeys("yiw"))
+
+    val highlighters = myFixture.editor.markupModel.allHighlighters
+    assertAllHighlightersCount(3)
+    assertHighlighterRange(12, 15, highlighters[1])
+    assertHighlighterRange(20, 23, highlighters[0])
+    assertHighlighterRange(28, 31, highlighters[2])
+  }
+
+  fun `test clearing all highlighters with multiple cursors`() {
+    configureByJavaText(codeWithMultipleCurors)
+    typeText(StringHelper.parseKeys("yiwi"))
+
+    assertAllHighlightersCount(0)
+  }
+
+  val code = """
+fun ${c}sum(x: Int, y: Int, z: Int): Int {
+  return x + y + z
+}
+"""
+
+  val codeWithMultipleCurors = """
+fun sum(x: ${c}Int, y: ${c}Int, z: ${c}Int): Int {
+  return x + y + z
+}
+"""
+
+
+  private fun assertHighlighterRange(start: Int, end: Int, highlighter: RangeHighlighter) {
+    assertEquals(start, highlighter.startOffset)
+    assertEquals(end, highlighter.endOffset)
+  }
+
+  private fun assertAllHighlightersCount(count: Int) {
+    Assert.assertEquals(count, myFixture.editor.markupModel.allHighlighters.size)
+  }
+
+  private fun getFirstHighlighter(): RangeHighlighter {
+    return myFixture.editor.markupModel.allHighlighters.first()
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
@@ -60,12 +60,12 @@ class VimHighlightedYankTest : VimTestCase() {
     assertHighlighterRange(40, 59, getFirstHighlighter())
   }
 
-//  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
-//  fun `test removing previous highlight when entering insert mode`() {
-//    doTest("yyi", code, code, CommandState.Mode.INSERT, CommandState.SubMode.NONE)
-//
-//    assertAllHighlightersCount(0)
-//  }
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test removing previous highlight when entering insert mode`() {
+    doTest("yyi", code, code, CommandState.Mode.INSERT, CommandState.SubMode.NONE)
+
+    assertAllHighlightersCount(0)
+  }
 
   fun `test indicating error when incorrect highlight duration was provided by user`() {
     configureByJavaText(code)
@@ -116,12 +116,12 @@ class VimHighlightedYankTest : VimTestCase() {
     assertHighlighterRange(28, 31, highlighters[2])
   }
 
-//  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
-//  fun `test clearing all highlighters with multiple cursors`() {
-//    doTest("yiwi", codeWithMultipleCurors, codeWithMultipleCurors, CommandState.Mode.INSERT, CommandState.SubMode.NONE)
-//
-//    assertAllHighlightersCount(0)
-//  }
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test clearing all highlighters with multiple cursors`() {
+    doTest("yiwi", codeWithMultipleCurors, codeWithMultipleCurors, CommandState.Mode.INSERT, CommandState.SubMode.NONE)
+
+    assertAllHighlightersCount(0)
+  }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
   fun `test highlighting for a correct default amount of time`() {

--- a/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
@@ -32,6 +32,14 @@ class VimHighlightedYankTest : VimTestCase() {
     enableExtensions("highlightedyank")
   }
 
+  override fun tearDown() {
+    super.tearDown()
+    for (t in Thread.getAllStackTraces().keys) {
+      if(t.name.contains("yankHighlight"))
+        t.interrupt()
+    }
+  }
+
   fun `test highlighting whole line when whole line is yanked`() {
     doTest("yy", code, code, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
 

--- a/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
@@ -67,13 +67,35 @@ class VimHighlightedYankTest : VimTestCase() {
 
     Assert.assertEquals(VimPlugin.getMessage(), "highlightedyank: Invalid value of g:highlightedyank_highlight_duration -- For input string: \"500.15\"")
   }
-
   fun `test not indicating error when correct highlight duration was provided by user`() {
+
     configureByJavaText(code)
     typeText(StringHelper.parseKeys(":let g:highlightedyank_highlight_duration = \"-1\"<CR>"))
     typeText(StringHelper.parseKeys("yy"))
 
     Assert.assertEquals(VimPlugin.getMessage(), "")
+  }
+
+  fun `test indicating error when incorrect highlight color was provided by user`() {
+    configureByJavaText(code)
+
+    listOf("rgba(1,2,3)", "rgba(1, 2, 3, 0.1)", "rgb(1,2,3)", "rgba(260, 2, 5, 6)").forEach { color ->
+      typeText(StringHelper.parseKeys(":let g:highlightedyank_highlight_color = \"$color\"<CR>"))
+      typeText(StringHelper.parseKeys("yy"))
+
+      Assert.assertTrue(color, VimPlugin.getMessage().contains("highlightedyank: Invalid value of g:highlightedyank_highlight_color"))
+    }
+  }
+
+  fun `test indicating error when correct highlight color was provided by user`() {
+    configureByJavaText(code)
+
+    listOf("rgba(1,2,3,5)", "rgba1, 2, 3, 1", "rgba(1, 2, 3, 4").forEach { color ->
+      typeText(StringHelper.parseKeys(":let g:highlightedyank_highlight_color = \"$color\"<CR>"))
+      typeText(StringHelper.parseKeys("yy"))
+
+      Assert.assertEquals("", VimPlugin.getMessage())
+    }
   }
 
   fun `test highlighting with multiple cursors`() {

--- a/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
@@ -32,14 +32,6 @@ class VimHighlightedYankTest : VimTestCase() {
     enableExtensions("highlightedyank")
   }
 
-  override fun tearDown() {
-    super.tearDown()
-    for (t in Thread.getAllStackTraces().keys) {
-      if(t.name.contains("yankHighlight"))
-        t.interrupt()
-    }
-  }
-
   fun `test highlighting whole line when whole line is yanked`() {
     doTest("yy", code, code, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
 

--- a/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/highlightedyank/VimHighlightedYankTest.kt
@@ -54,9 +54,8 @@ class VimHighlightedYankTest : VimTestCase() {
     assertHighlighterRange(40, 59, getFirstHighlighter())
   }
 
-  fun `test removing previous highlight entering insert mode`() {
-    configureByJavaText(code)
-    typeText(StringHelper.parseKeys("yyi"))
+  fun `test removing previous highlight when entering insert mode`() {
+    doTest("yyi", code, code, CommandState.Mode.INSERT, CommandState.SubMode.NONE)
 
     assertAllHighlightersCount(0)
   }
@@ -78,8 +77,7 @@ class VimHighlightedYankTest : VimTestCase() {
   }
 
   fun `test highlighting with multiple cursors`() {
-    configureByJavaText(codeWithMultipleCurors)
-    typeText(StringHelper.parseKeys("yiw"))
+    doTest("yiw", codeWithMultipleCurors, codeWithMultipleCurors, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
 
     val highlighters = myFixture.editor.markupModel.allHighlighters
     assertAllHighlightersCount(3)
@@ -89,8 +87,7 @@ class VimHighlightedYankTest : VimTestCase() {
   }
 
   fun `test clearing all highlighters with multiple cursors`() {
-    configureByJavaText(codeWithMultipleCurors)
-    typeText(StringHelper.parseKeys("yiwi"))
+    doTest("yiwi", codeWithMultipleCurors, codeWithMultipleCurors, CommandState.Mode.INSERT, CommandState.SubMode.NONE)
 
     assertAllHighlightersCount(0)
   }


### PR DESCRIPTION
Hey!
Before i go in I'd like to mention, that I've never contributed to any project before so if i did something wrong things please let me know :)
So, I've found issue ([VIM-1970](https://youtrack.jetbrains.com/issue/VIM-1970)) on plugin that is really simple but makes vim a little bit more pleasurable. This is vim-highlightedyank. I've been using it with Vim and it would be nice to have it in ideavim.
There was no response since that question and I decided to implement it myself.
Based on your advice (`or create a draft PR to indicate that you've started working`) I've created a draft PR to let you know that I've started working on this.

Right now I believe this draft is overall working version of the plugin. I was thinking if you have any thoughts on this solution.

It's still a draft and the next steps I would like to take are:
1. make it an extension and move this code to a different package
2. make this plugin optional (to make it possible to enable it via `set vim-highlightedyank`
3. make a duration of the highlight customizable (e.g. `let g:highlightedyank_highlight_duration = 1000`)
4. maybe make a highlight color customizable (don't know if it is possible)
5. of course write some tests to it.

What do you think about it?