### PR TITLE
Check if project is disposed when editorDeinit

### DIFF
--- a/src/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -73,7 +73,7 @@ public class EditorGroup implements PersistentStateComponent<Element> {
   }
 
   private void deinitLineNumbers(@NotNull Editor editor, boolean isReleasing) {
-    if (!supportsVimLineNumbers(editor) || !UserDataManager.getVimEditorGroup(editor)) {
+    if (isProjectDisposed(editor) || !supportsVimLineNumbers(editor) || !UserDataManager.getVimEditorGroup(editor)) {
       return;
     }
 
@@ -95,6 +95,10 @@ public class EditorGroup implements PersistentStateComponent<Element> {
     // We only support line numbers in editors that are file based, and that aren't for diffs, which control their
     // own line numbers, often using EditorGutter#setLineNumberConverter
     return EditorHelper.isFileEditor(editor) && !EditorHelper.isDiffEditor(editor);
+  }
+
+  private static boolean isProjectDisposed(final @NotNull Editor editor) {
+    return editor.getProject() == null || editor.getProject().isDisposed();
   }
 
   private static void updateLineNumbers(final @NotNull Editor editor) {


### PR DESCRIPTION
This is a fix for an `AlreadyDisposedException` in idea.log, unfortunately there was no repro case for this exception. The origin log is as follow:

```
2020-08-03 05:57:22,291 [57156550]  ERROR - tellij.openapi.util.ObjectTree - Cannot create com.intellij.ui.EditorNotifications because container is already disposed: Project(name=myproject, containerState=DISPOSE_COMPLETED, componentStore=<path-to-project>) 
com.intellij.serviceContainer.AlreadyDisposedException: Cannot create com.intellij.ui.EditorNotifications because container is already disposed: Project(name=myproject, containerState=DISPOSE_COMPLETED, componentStore=<path-to-project>)
	at com.intellij.serviceContainer.ComponentManagerImpl.throwContainerIsAlreadyDisposed(ComponentManagerImpl.kt:445)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:421)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:393)
	at com.intellij.ui.EditorNotifications.getInstance(EditorNotifications.java:61)
	at com.intellij.openapi.editor.impl.EditorImpl.reinitSettings(EditorImpl.java:1011)
	at com.intellij.openapi.editor.impl.EditorImpl.reinitSettings(EditorImpl.java:959)
	at com.intellij.openapi.editor.impl.SettingsImpl.fireEditorRefresh(SettingsImpl.java:715)
	at com.intellij.openapi.editor.impl.SettingsImpl.setLineNumbersShown(SettingsImpl.java:201)
	at com.maddyhome.idea.vim.group.EditorGroup.setBuiltinLineNumbers(EditorGroup.java:132)
	at com.maddyhome.idea.vim.group.EditorGroup.deinitLineNumbers(EditorGroup.java:90)
	at com.maddyhome.idea.vim.group.EditorGroup.editorDeinit(EditorGroup.java:221)
	at com.maddyhome.idea.vim.listener.VimListenerManager$EditorListeners.remove(ListenerManager.kt:180)
	at com.maddyhome.idea.vim.listener.VimListenerManager$EditorListeners.removeAll(ListenerManager.kt:149)
	at com.maddyhome.idea.vim.listener.VimListenerManager.turnOff(ListenerManager.kt:93)
	at com.maddyhome.idea.vim.VimPlugin.turnOffPlugin(VimPlugin.java:376)
	at com.maddyhome.idea.vim.VimPlugin.dispose(VimPlugin.java:129)
	at com.intellij.openapi.util.ObjectNode.lambda$execute$0(ObjectNode.java:111)
	at com.intellij.openapi.util.ObjectTree.executeActionWithRecursiveGuard(ObjectTree.java:189)
	at com.intellij.openapi.util.ObjectNode.execute(ObjectNode.java:71)
	at com.intellij.openapi.util.ObjectNode.lambda$execute$0(ObjectNode.java:95)
	at com.intellij.openapi.util.ObjectTree.executeActionWithRecursiveGuard(ObjectTree.java:189)
	at com.intellij.openapi.util.ObjectNode.execute(ObjectNode.java:71)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:137)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:121)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:111)
	at com.intellij.serviceContainer.ComponentManagerImpl.dispose(ComponentManagerImpl.kt:878)
	at com.intellij.openapi.application.impl.ApplicationImpl.dispose(ApplicationImpl.java:362)
	at com.intellij.openapi.util.ObjectNode.lambda$execute$0(ObjectNode.java:111)
	at com.intellij.openapi.util.ObjectTree.executeActionWithRecursiveGuard(ObjectTree.java:189)
	at com.intellij.openapi.util.ObjectNode.execute(ObjectNode.java:71)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:137)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:121)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:111)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$disposeContainer$3(ApplicationImpl.java:195)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:980)
	at com.intellij.openapi.application.impl.ApplicationImpl.disposeContainer(ApplicationImpl.java:193)
	at com.intellij.openapi.application.impl.ApplicationImpl.disposeSelf(ApplicationImpl.java:214)
	at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:609)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:579)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:568)
	at com.intellij.openapi.application.ex.ApplicationEx.exit(ApplicationEx.java:101)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.lambda$initMacApplication$3(MacOSApplicationProvider.java:84)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.lambda$submit$7(MacOSApplicationProvider.java:175)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:201)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:802)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$invokeLater$4(ApplicationImpl.java:322)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:84)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:132)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:47)
	at com.intellij.openapi.application.impl.FlushQueue$FlushNow.run(FlushQueue.java:188)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:776)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:727)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:746)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:967)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:839)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:450)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:744)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$9(IdeEventQueue.java:449)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:802)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:497)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
2020-08-03 05:57:22,291 [57156550]  ERROR - tellij.openapi.util.ObjectTree - IntelliJ IDEA 2020.2  Build #IU-202.6397.94 
2020-08-03 05:57:22,291 [57156550]  ERROR - tellij.openapi.util.ObjectTree - JDK: 11.0.7; VM: OpenJDK 64-Bit Server VM; Vendor: JetBrains s.r.o. 
2020-08-03 05:57:22,291 [57156550]  ERROR - tellij.openapi.util.ObjectTree - OS: Mac OS X 
2020-08-03 05:57:22,291 [57156550]  ERROR - tellij.openapi.util.ObjectTree - Plugin to blame: IdeaVim version: 0.58 
2020-08-03 05:57:22,294 [57156553]   INFO -        #com.intellij.idea.Main - ------------------------------------------------------ IDE SHUTDOWN ------------------------------------------------------ 

```