### PR TITLE
VIM-2114 Do not override registers when deleting empty range

### DIFF
--- a/src/com/maddyhome/idea/vim/group/RegisterGroup.java
+++ b/src/com/maddyhome/idea/vim/group/RegisterGroup.java
@@ -179,6 +179,11 @@ public class RegisterGroup implements PersistentStateComponent<Element> {
 
     int start = range.getStartOffset();
     int end = range.getEndOffset();
+
+    if (isDelete && start == end) {
+      return true;
+    }
+
     // Normalize the start and end
     if (start > end) {
       int t = start;

--- a/test/org/jetbrains/plugins/ideavim/action/CopyActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/CopyActionTest.java
@@ -218,4 +218,16 @@ public class CopyActionTest extends VimTestCase {
     typeTextInFile(parseKeys("\"ap"), "");
     myFixture.checkResult("test");
   }
+
+  public void testOverridingRegisterWithEmptyTag() {
+    configureByText("<root>\n" +
+                    "<a><caret>value</a>\n" +
+                    "<b></b>\n" +
+                    "</root>\n");
+    typeText(parseKeys("dit", "j", "cit", "<C-R>\""));
+    myFixture.checkResult("<root>\n" +
+                          "<a></a>\n" +
+                          "<b>value</b>\n" +
+                          "</root>\n");
+  }
 }


### PR DESCRIPTION
I'm not all that confident about the fix -- it's quite hard to follow Vim code here -- but it results in behavior matching Vim and all tests still pass.

Note that it depends on #249 due to another bug in this simple scenario.