### PR TITLE
Fixes for scrolling

### DIFF
--- a/resources/META-INF/includes/VimActions.xml
+++ b/resources/META-INF/includes/VimActions.xml
@@ -150,6 +150,7 @@
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.scroll.MotionScrollLastScreenColumnAction" mappingModes="NXO" keys="ze"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.scroll.MotionScrollColumnLeftAction" mappingModes="NXO" keys="zl,z«Right»"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.scroll.MotionScrollColumnRightAction" mappingModes="NXO" keys="zh,z«Left»"/>
+    <vimAction implementation="com.maddyhome.idea.vim.action.motion.scroll.MotionScrollHalfWidthLeftAction" mappingModes="NXO" keys="zL"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.updown.MotionShiftDownAction" mappingModes="NV" keys="«S-Down»"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.updown.MotionShiftUpAction" mappingModes="NV" keys="«S-Up»"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.leftright.MotionShiftRightAction" mappingModes="NV" keys="«S-Right»"/>

--- a/resources/META-INF/includes/VimActions.xml
+++ b/resources/META-INF/includes/VimActions.xml
@@ -151,6 +151,7 @@
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.scroll.MotionScrollColumnLeftAction" mappingModes="NXO" keys="zl,z«Right»"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.scroll.MotionScrollColumnRightAction" mappingModes="NXO" keys="zh,z«Left»"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.scroll.MotionScrollHalfWidthLeftAction" mappingModes="NXO" keys="zL"/>
+    <vimAction implementation="com.maddyhome.idea.vim.action.motion.scroll.MotionScrollHalfWidthRightAction" mappingModes="NXO" keys="zH"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.updown.MotionShiftDownAction" mappingModes="NV" keys="«S-Down»"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.updown.MotionShiftUpAction" mappingModes="NV" keys="«S-Up»"/>
     <vimAction implementation="com.maddyhome.idea.vim.action.motion.leftright.MotionShiftRightAction" mappingModes="NV" keys="«S-Right»"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -78,7 +78,8 @@
     </action>
 
     <!-- Internal -->
-    <action id="VimInternalAddInlays" class="com.maddyhome.idea.vim.action.internal.AddInlaysAction" text="Add Test Inlays | IdeaVim Internal" internal="true"/>
+    <action id="VimInternalAddBlockInlays" class="com.maddyhome.idea.vim.action.internal.AddBlockInlaysAction" text="Add Test Block Inlays | IdeaVim Internal" internal="true"/>
+    <action id="VimInternalAddInlineInlays" class="com.maddyhome.idea.vim.action.internal.AddInlineInlaysAction" text="Add Test Inline Inlays | IdeaVim Internal" internal="true"/>
 
     <action id="VimShortcutKeyAction" class="com.maddyhome.idea.vim.action.VimShortcutKeyAction"/>
     <action id="VimActions" class="com.maddyhome.idea.vim.ui.VimActions"/>

--- a/src/com/maddyhome/idea/vim/action/internal/AddBlockInlaysAction.kt
+++ b/src/com/maddyhome/idea/vim/action/internal/AddBlockInlaysAction.kt
@@ -41,7 +41,7 @@ import java.util.*
 import javax.swing.UIManager
 import kotlin.math.max
 
-class AddInlaysAction : AnAction() {
+class AddBlockInlaysAction : AnAction() {
   override fun actionPerformed(e: AnActionEvent) {
     val dataContext = e.dataContext
     val editor = getEditor(dataContext) ?: return

--- a/src/com/maddyhome/idea/vim/action/internal/AddBlockInlaysAction.kt
+++ b/src/com/maddyhome/idea/vim/action/internal/AddBlockInlaysAction.kt
@@ -111,7 +111,7 @@ class AddBlockInlaysAction : AnAction() {
       return if (text == null) 0 else fontMetrics.stringWidth(text)
     }
 
-    private inner class MyFontMetrics internal constructor(editor: Editor, familyName: String?, size: Int) {
+    private inner class MyFontMetrics(editor: Editor, familyName: String?, size: Int) {
       val metrics: FontMetrics
       fun isActual(editor: Editor, familyName: String, size: Int): Boolean {
         val font = metrics.font

--- a/src/com/maddyhome/idea/vim/action/internal/AddInlineInlaysAction.kt
+++ b/src/com/maddyhome/idea/vim/action/internal/AddInlineInlaysAction.kt
@@ -48,7 +48,7 @@ class AddInlineInlaysAction : AnAction() {
       // We don't need a custom renderer, just use the standard parameter hint renderer
       inlayModel.addInlineElement(offset, relatesToPrecedingText, HintRenderer(if (relatesToPrecedingText) ":$text" else "$text:"))
       // Every 20 chars +/- 5 chars
-      i+= 20 + (random.nextInt(10) - 5)
+      i += 20 + (random.nextInt(10) - 5)
     }
   }
 

--- a/src/com/maddyhome/idea/vim/action/internal/AddInlineInlaysAction.kt
+++ b/src/com/maddyhome/idea/vim/action/internal/AddInlineInlaysAction.kt
@@ -1,0 +1,58 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.action.internal
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.VisualPosition
+import com.maddyhome.idea.vim.helper.EditorHelper
+import java.util.*
+import kotlin.math.max
+
+class AddInlineInlaysAction : AnAction() {
+  companion object {
+    private val random = Random()
+  }
+
+  override fun actionPerformed(e: AnActionEvent) {
+    val dataContext = e.dataContext
+    val editor = getEditor(dataContext) ?: return
+    val inlayModel = editor.inlayModel
+    val currentVisualLine = editor.caretModel.primaryCaret.visualPosition.line
+    var i = random.nextInt(10)
+    val lineLength = EditorHelper.getLineLength(editor, EditorHelper.visualLineToLogicalLine(editor, currentVisualLine))
+    while (i < lineLength) {
+      val relatesToPrecedingText = random.nextInt(10) > 7
+      val text = "a".repeat(max(1, random.nextInt(7)))
+      val offset = EditorHelper.visualPositionToOffset(editor, VisualPosition(currentVisualLine, i))
+      // We don't need a custom renderer, just use the standard parameter hint renderer
+      inlayModel.addInlineElement(offset, relatesToPrecedingText, HintRenderer(if (relatesToPrecedingText) ":$text" else "$text:"))
+      // Every 20 chars +/- 5 chars
+      i+= 20 + (random.nextInt(10) - 5)
+    }
+  }
+
+  private fun getEditor(dataContext: DataContext): Editor? {
+    return CommonDataKeys.EDITOR.getData(dataContext)
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollColumnLeftAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollColumnLeftAction.kt
@@ -32,6 +32,6 @@ class MotionScrollColumnLeftAction : VimActionHandler.SingleExecution() {
   override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SIDE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
-    return VimPlugin.getMotion().scrollColumn(editor, cmd.count)
+    return VimPlugin.getMotion().scrollColumns(editor, cmd.count)
   }
 }

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollColumnRightAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollColumnRightAction.kt
@@ -31,6 +31,6 @@ class MotionScrollColumnRightAction : VimActionHandler.SingleExecution() {
   override val flags: EnumSet<CommandFlags> = EnumSet.of(CommandFlags.FLAG_IGNORE_SIDE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
-    return VimPlugin.getMotion().scrollColumn(editor, -cmd.count)
+   return VimPlugin.getMotion().scrollColumns(editor, -cmd.count)
   }
 }

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenColumnAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenColumnAction.kt
@@ -27,6 +27,6 @@ class MotionScrollFirstScreenColumnAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
-    return VimPlugin.getMotion().scrollColumnToFirstScreenColumn(editor)
+    return VimPlugin.getMotion().scrollCaretColumnToFirstScreenColumn(editor)
   }
 }

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLineAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLineAction.kt
@@ -21,10 +21,15 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollFirstScreenLineAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollLineToFirstScreenLine(editor, cmd.rawCount, false)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLinePageStartAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLinePageStartAction.kt
@@ -21,11 +21,16 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.EditorHelper
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollFirstScreenLinePageStartAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     var line = cmd.rawCount

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLinePageStartAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLinePageStartAction.kt
@@ -33,11 +33,12 @@ class MotionScrollFirstScreenLinePageStartAction : VimActionHandler.SingleExecut
   override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
-    var line = cmd.rawCount
-    if (line == 0) {
-      val nextVisualLine = EditorHelper.getVisualLineAtBottomOfScreen(editor) + 1
-      line = EditorHelper.visualLineToLogicalLine(editor, nextVisualLine) + 1 // rawCount is 1 based
+    var rawCount = cmd.rawCount
+    if (rawCount == 0) {
+      val nextVisualLine = EditorHelper.normalizeVisualLine(editor,
+        EditorHelper.getVisualLineAtBottomOfScreen(editor) + 1)
+      rawCount = EditorHelper.visualLineToLogicalLine(editor, nextVisualLine) + 1 // rawCount is 1 based
     }
-    return VimPlugin.getMotion().scrollLineToFirstScreenLine(editor, line, true)
+    return VimPlugin.getMotion().scrollLineToFirstScreenLine(editor, rawCount, true)
   }
 }

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLineStartAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLineStartAction.kt
@@ -21,10 +21,15 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollFirstScreenLineStartAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollLineToFirstScreenLine(editor, cmd.rawCount, true)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollHalfPageDownAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollHalfPageDownAction.kt
@@ -21,10 +21,15 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollHalfPageDownAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollScreen(editor, cmd.rawCount, true)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollHalfWidthLeftAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollHalfWidthLeftAction.kt
@@ -1,0 +1,53 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.action.motion.scroll
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
+import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.EditorHelper
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
+
+/*
+For the following four commands the cursor follows the screen.  If the
+character that the cursor is on is moved off the screen, the cursor is moved
+to the closest character that is on the screen.  The value of 'sidescroll' is
+not used.
+
+                                                       *zH*
+zH                      Move the view on the text half a screenwidth to the
+                        left, thus scroll the text half a screenwidth to the
+                        right.  This only works when 'wrap' is off.
+
+[count] is used but undocumented.
+ */
+class MotionScrollHalfWidthLeftAction : VimActionHandler.SingleExecution() {
+  override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SIDE_SCROLL_JUMP)
+
+  override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
+    // Vim's screen width is the full screen width, including columns used for gutters.
+    return VimPlugin.getMotion().scrollColumns(editor, cmd.count * (EditorHelper.getApproximateScreenWidth(editor) / 2));
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollHalfWidthRightAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollHalfWidthRightAction.kt
@@ -1,0 +1,53 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.action.motion.scroll
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
+import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.EditorHelper
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
+
+/*
+For the following four commands the cursor follows the screen.  If the
+character that the cursor is on is moved off the screen, the cursor is moved
+to the closest character that is on the screen.  The value of 'sidescroll' is
+not used.
+
+                                                       *zH*
+zH                      Move the view on the text half a screenwidth to the
+                        left, thus scroll the text half a screenwidth to the
+                        right.  This only works when 'wrap' is off.
+
+[count] is used but undocumented.
+ */
+class MotionScrollHalfWidthRightAction : VimActionHandler.SingleExecution() {
+  override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SIDE_SCROLL_JUMP)
+
+  override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
+    // Vim's screen width is the full screen width, including columns used for gutters.
+    return VimPlugin.getMotion().scrollColumns(editor, -cmd.count * (EditorHelper.getApproximateScreenWidth(editor) / 2));
+  }
+}

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenColumnAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenColumnAction.kt
@@ -27,6 +27,6 @@ class MotionScrollLastScreenColumnAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
-    return VimPlugin.getMotion().scrollColumnToLastScreenColumn(editor)
+    return VimPlugin.getMotion().scrollCaretColumnToLastScreenColumn(editor)
   }
 }

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLineAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLineAction.kt
@@ -21,10 +21,15 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollLastScreenLineAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollLineToLastScreenLine(editor, cmd.rawCount, false)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLinePageStartAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLinePageStartAction.kt
@@ -21,28 +21,37 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.EditorHelper
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollLastScreenLinePageStartAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
 
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
+
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     val motion = VimPlugin.getMotion()
-    var line = cmd.rawCount
-    if (line == 0) {
-      val prevVisualLine = EditorHelper.getVisualLineAtTopOfScreen(editor) - 1
-      line = EditorHelper.visualLineToLogicalLine(editor, prevVisualLine) + 1 // rawCount is 1 based
-      return motion.scrollLineToLastScreenLine(editor, line, true)
+
+    // Without [count]: Redraw with the line just above the window at the bottom of the window. Put the cursor in that
+    // line, at the first non-blank in the line.
+    if (cmd.rawCount == 0) {
+      val prevVisualLine = EditorHelper.normalizeVisualLine(editor,
+        EditorHelper.getVisualLineAtTopOfScreen(editor) - 1)
+      val logicalLine = EditorHelper.visualLineToLogicalLine(editor, prevVisualLine)
+      return motion.scrollLineToLastScreenLine(editor, logicalLine + 1, true)
     }
+
     // [count]z^ first scrolls [count] to the bottom of the window, then moves the caret to the line that is now at
     // the top, and then move that line to the bottom of the window
-    line = EditorHelper.normalizeLine(editor, line)
-    if (motion.scrollLineToLastScreenLine(editor, line, true)) {
-      line = EditorHelper.getVisualLineAtTopOfScreen(editor)
-      line = EditorHelper.visualLineToLogicalLine(editor, line) + 1 // rawCount is 1 based
-      return motion.scrollLineToLastScreenLine(editor, line, true)
+    var logicalLine = EditorHelper.normalizeLine(editor, cmd.rawCount - 1)
+    if (motion.scrollLineToLastScreenLine(editor, logicalLine + 1, false)) {
+      logicalLine = EditorHelper.visualLineToLogicalLine(editor, EditorHelper.getVisualLineAtTopOfScreen(editor))
+      return motion.scrollLineToLastScreenLine(editor, logicalLine + 1, true)
     }
+
     return false
   }
 }

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLineStartAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLineStartAction.kt
@@ -21,10 +21,15 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollLastScreenLineStartAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollLineToLastScreenLine(editor, cmd.rawCount, true)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLineDownAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLineDownAction.kt
@@ -21,10 +21,15 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollLineDownAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollLine(editor, cmd.count)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLineUpAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLineUpAction.kt
@@ -21,10 +21,15 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollLineUpAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollLine(editor, -cmd.count)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollMiddleScreenLineAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollMiddleScreenLineAction.kt
@@ -21,10 +21,15 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollMiddleScreenLineAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollLineToMiddleScreenLine(editor, cmd.rawCount, false)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollMiddleScreenLineStartAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollMiddleScreenLineStartAction.kt
@@ -21,10 +21,15 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.*
 
 class MotionScrollMiddleScreenLineStartAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollLineToMiddleScreenLine(editor, cmd.rawCount, true)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageDownAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageDownAction.kt
@@ -44,8 +44,6 @@ class MotionScrollPageDownInsertModeAction : VimActionHandler.SingleExecution(),
 
   override val keyStrokesSet: Set<List<KeyStroke>> = setOf(
     listOf(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN, 0)),
-    listOf(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.CTRL_DOWN_MASK)),
-    listOf(KeyStroke.getKeyStroke(KeyEvent.VK_KP_DOWN, KeyEvent.CTRL_DOWN_MASK)),
     listOf(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.SHIFT_DOWN_MASK)),
     listOf(KeyStroke.getKeyStroke(KeyEvent.VK_KP_DOWN, KeyEvent.SHIFT_DOWN_MASK))
   )

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageDownAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageDownAction.kt
@@ -35,6 +35,8 @@ class MotionScrollPageDownAction : VimActionHandler.SingleExecution() {
 
   override val type: Command.Type = Command.Type.OTHER_READONLY
 
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
+
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollFullPage(editor, cmd.count)
   }
@@ -50,7 +52,7 @@ class MotionScrollPageDownInsertModeAction : VimActionHandler.SingleExecution(),
 
   override val type: Command.Type = Command.Type.OTHER_READONLY
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_CLEAR_STROKES)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP, CommandFlags.FLAG_CLEAR_STROKES)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollFullPage(editor, cmd.count)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageUpAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageUpAction.kt
@@ -35,6 +35,8 @@ class MotionScrollPageUpAction : VimActionHandler.SingleExecution() {
 
   override val type: Command.Type = Command.Type.OTHER_READONLY
 
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP)
+
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollFullPage(editor, -cmd.count)
   }
@@ -50,7 +52,7 @@ class MotionScrollPageUpInsertModeAction : VimActionHandler.SingleExecution(), C
 
   override val type: Command.Type = Command.Type.OTHER_READONLY
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_CLEAR_STROKES)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_IGNORE_SCROLL_JUMP, CommandFlags.FLAG_CLEAR_STROKES)
 
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     return VimPlugin.getMotion().scrollFullPage(editor, -cmd.count)

--- a/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageUpAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageUpAction.kt
@@ -44,8 +44,6 @@ class MotionScrollPageUpInsertModeAction : VimActionHandler.SingleExecution(), C
 
   override val keyStrokesSet: Set<List<KeyStroke>> = setOf(
     listOf(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_UP, 0)),
-    listOf(KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.CTRL_DOWN_MASK)),
-    listOf(KeyStroke.getKeyStroke(KeyEvent.VK_KP_UP, KeyEvent.CTRL_DOWN_MASK)),
     listOf(KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.SHIFT_DOWN_MASK)),
     listOf(KeyStroke.getKeyStroke(KeyEvent.VK_KP_UP, KeyEvent.SHIFT_DOWN_MASK))
   )

--- a/src/com/maddyhome/idea/vim/action/motion/select/SelectEnableBlockModeAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/select/SelectEnableBlockModeAction.kt
@@ -23,6 +23,7 @@ import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandState
+import com.maddyhome.idea.vim.helper.moveToInlayAwareOffset
 import com.maddyhome.idea.vim.group.visual.vimSetSystemSelectionSilently
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.EditorHelper
@@ -41,7 +42,7 @@ class SelectEnableBlockModeAction : VimActionHandler.SingleExecution() {
     val lineEnd = EditorHelper.getLineEndForOffset(editor, editor.caretModel.primaryCaret.offset)
     editor.caretModel.primaryCaret.run {
       vimSetSystemSelectionSilently(offset, (offset + 1).coerceAtMost(lineEnd))
-      moveToOffset((offset + 1).coerceAtMost(lineEnd))
+      moveToInlayAwareOffset((offset + 1).coerceAtMost(lineEnd))
       vimLastColumn = visualPosition.column
     }
     return VimPlugin.getVisualMotion().enterSelectMode(editor, CommandState.SubMode.VISUAL_BLOCK)

--- a/src/com/maddyhome/idea/vim/action/motion/select/SelectEnableCharacterModeAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/select/SelectEnableCharacterModeAction.kt
@@ -23,6 +23,7 @@ import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandState
+import com.maddyhome.idea.vim.helper.moveToInlayAwareOffset
 import com.maddyhome.idea.vim.group.visual.vimSetSystemSelectionSilently
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.EditorHelper
@@ -41,7 +42,7 @@ class SelectEnableCharacterModeAction : VimActionHandler.SingleExecution() {
       val lineEnd = EditorHelper.getLineEndForOffset(editor, caret.offset)
       caret.run {
         vimSetSystemSelectionSilently(offset, (offset + 1).coerceAtMost(lineEnd))
-        moveToOffset((offset + 1).coerceAtMost(lineEnd))
+        moveToInlayAwareOffset((offset + 1).coerceAtMost(lineEnd))
         vimLastColumn = visualPosition.column
       }
     }

--- a/src/com/maddyhome/idea/vim/action/motion/select/SelectToggleVisualMode.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/select/SelectToggleVisualMode.kt
@@ -23,6 +23,7 @@ import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandState
+import com.maddyhome.idea.vim.helper.moveToInlayAwareOffset
 import com.maddyhome.idea.vim.group.visual.updateCaretState
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.commandState
@@ -45,7 +46,7 @@ class SelectToggleVisualMode : VimActionHandler.SingleExecution() {
       if (subMode != CommandState.SubMode.VISUAL_LINE) {
         editor.caretModel.runForEachCaret {
           if (it.offset + VimPlugin.getVisualMotion().selectionAdj == it.selectionEnd) {
-            it.moveToOffset(it.offset + VimPlugin.getVisualMotion().selectionAdj)
+            it.moveToInlayAwareOffset(it.offset + VimPlugin.getVisualMotion().selectionAdj)
           }
         }
       }
@@ -54,7 +55,7 @@ class SelectToggleVisualMode : VimActionHandler.SingleExecution() {
       if (subMode != CommandState.SubMode.VISUAL_LINE) {
         editor.caretModel.runForEachCaret {
           if (it.offset == it.selectionEnd && it.visualLineStart <= it.offset - VimPlugin.getVisualMotion().selectionAdj) {
-            it.moveToOffset(it.offset - VimPlugin.getVisualMotion().selectionAdj)
+            it.moveToInlayAwareOffset(it.offset - VimPlugin.getVisualMotion().selectionAdj)
           }
         }
       }

--- a/src/com/maddyhome/idea/vim/command/CommandFlags.kt
+++ b/src/com/maddyhome/idea/vim/command/CommandFlags.kt
@@ -53,6 +53,15 @@ enum class CommandFlags {
    * This keystroke should be saved as part of the current insert
    */
   FLAG_SAVE_STROKE,
+
+  /**
+   * Don't include scrolljump when adjusting the scroll area to ensure the current cursor position is visible.
+   * Should be used for commands that adjust the scroll area (such as <C-D> or <C-E>).
+   * Technically, the current implementation doesn't need these flags, as these commands adjust the scroll area
+   * according to their own rules and then move the cursor to fit (e.g. move cursor down a line with <C-E>). Moving the
+   * cursor always tries to adjust the scroll area to ensure it's visible, which in this case is always a no-op.
+   * This is an implementation detail, so keep the flags for both documentation and in case of refactoring.
+   */
   FLAG_IGNORE_SCROLL_JUMP,
   FLAG_IGNORE_SIDE_SCROLL_JUMP,
 

--- a/src/com/maddyhome/idea/vim/ex/handler/SortHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/SortHandler.kt
@@ -28,6 +28,7 @@ import com.maddyhome.idea.vim.ex.ExCommand
 import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.ex.flags
 import com.maddyhome.idea.vim.ex.ranges.LineRange
+import com.maddyhome.idea.vim.helper.moveToInlayAwareOffset
 import com.maddyhome.idea.vim.helper.inBlockSubMode
 import java.util.*
 
@@ -51,7 +52,7 @@ class SortHandler : CommandHandler.SingleExecution() {
       val primaryCaret = editor.caretModel.primaryCaret
       val range = getLineRange(editor, primaryCaret, cmd)
       val worked = VimPlugin.getChange().sortRange(editor, range, lineComparator)
-      primaryCaret.moveToOffset(VimPlugin.getMotion().moveCaretToLineStartSkipLeading(editor, range.startLine))
+      primaryCaret.moveToInlayAwareOffset(VimPlugin.getMotion().moveCaretToLineStartSkipLeading(editor, range.startLine))
       return worked
     }
 
@@ -61,7 +62,7 @@ class SortHandler : CommandHandler.SingleExecution() {
       if (!VimPlugin.getChange().sortRange(editor, range, lineComparator)) {
         worked = false
       }
-      caret.moveToOffset(VimPlugin.getMotion().moveCaretToLineStartSkipLeading(editor, range.startLine))
+      caret.moveToInlayAwareOffset(VimPlugin.getMotion().moveCaretToLineStartSkipLeading(editor, range.startLine))
     }
 
     return worked

--- a/src/com/maddyhome/idea/vim/extension/argtextobj/VimArgTextObjExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/argtextobj/VimArgTextObjExtension.java
@@ -11,6 +11,7 @@ import com.maddyhome.idea.vim.ex.vimscript.VimScriptGlobalEnvironment;
 import com.maddyhome.idea.vim.extension.VimExtension;
 import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import com.maddyhome.idea.vim.handler.TextObjectActionHandler;
+import com.maddyhome.idea.vim.helper.InlayHelperKt;
 import com.maddyhome.idea.vim.listener.SelectionVimListenerSuppressor;
 import com.maddyhome.idea.vim.listener.VimListenerSuppressor;
 import org.jetbrains.annotations.NotNull;
@@ -234,7 +235,7 @@ public class VimArgTextObjExtension implements VimExtension {
               if (commandState.getMode() == CommandState.Mode.VISUAL) {
                 vimSetSelection(caret, range.getStartOffset(), range.getEndOffset() - 1, true);
               } else {
-                caret.moveToOffset(range.getStartOffset());
+                InlayHelperKt.moveToInlayAwareOffset(caret, range.getStartOffset());
               }
             }
           }

--- a/src/com/maddyhome/idea/vim/extension/exchange/VimExchangeExtension.kt
+++ b/src/com/maddyhome/idea/vim/extension/exchange/VimExchangeExtension.kt
@@ -43,11 +43,9 @@ import com.maddyhome.idea.vim.extension.VimExtensionFacade.setOperatorFunction
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.setRegister
 import com.maddyhome.idea.vim.extension.VimExtensionHandler
 import com.maddyhome.idea.vim.group.MarkGroup
-import com.maddyhome.idea.vim.helper.EditorHelper
+import com.maddyhome.idea.vim.helper.*
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.StringHelper.stringToKeys
-import com.maddyhome.idea.vim.helper.fileSize
-import com.maddyhome.idea.vim.helper.subMode
 import com.maddyhome.idea.vim.key.OperatorFunction
 
 /**
@@ -199,14 +197,14 @@ class VimExchangeExtension: VimExtension {
       fun fixCursor(ex1: Exchange, ex2: Exchange, reverse: Boolean) {
         val primaryCaret = editor.caretModel.primaryCaret
         if(reverse) {
-          primaryCaret.moveToOffset(editor.getMarkOffset(ex1.start))
+          primaryCaret.moveToInlayAwareOffset(editor.getMarkOffset(ex1.start))
         } else {
           if (ex1.start.logicalLine == ex2.start.logicalLine) {
             val horizontalOffset = ex1.end.col - ex2.end.col
-            primaryCaret.moveToLogicalPosition(LogicalPosition(ex1.start.logicalLine, ex1.start.col - horizontalOffset))
+            primaryCaret.moveToInlayAwareLogicalPosition(LogicalPosition(ex1.start.logicalLine, ex1.start.col - horizontalOffset))
           } else if(ex1.end.logicalLine - ex1.start.logicalLine != ex2.end.logicalLine - ex2.start.logicalLine) {
             val verticalOffset = ex1.end.logicalLine - ex2.end.logicalLine
-            primaryCaret.moveToLogicalPosition(LogicalPosition(ex1.start.logicalLine - verticalOffset, ex1.start.col))
+            primaryCaret.moveToInlayAwareLogicalPosition(LogicalPosition(ex1.start.logicalLine - verticalOffset, ex1.start.col))
           }
         }
       }

--- a/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
+++ b/src/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
@@ -175,10 +175,8 @@ class VimSurroundExtension : VimExtension {
         val change = VimPlugin.getChange()
         val leftSurround = pair.first
         val primaryCaret = editor.caretModel.primaryCaret
-        primaryCaret.moveToOffset(range.startOffset)
-        change.insertText(editor, primaryCaret, leftSurround)
-        primaryCaret.moveToOffset(range.endOffset + leftSurround.length)
-        change.insertText(editor, primaryCaret, pair.second)
+        change.insertText(editor, primaryCaret, range.startOffset, leftSurround)
+        change.insertText(editor, primaryCaret, range.endOffset + leftSurround.length, pair.second)
         // Jump back to start
         executeNormal(StringHelper.parseKeys("`["), editor)
       }

--- a/src/com/maddyhome/idea/vim/extension/textobjentire/VimTextObjEntireExtension.java
+++ b/src/com/maddyhome/idea/vim/extension/textobjentire/VimTextObjEntireExtension.java
@@ -26,6 +26,7 @@ import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.extension.VimExtension;
 import com.maddyhome.idea.vim.extension.VimExtensionHandler;
 import com.maddyhome.idea.vim.handler.TextObjectActionHandler;
+import com.maddyhome.idea.vim.helper.InlayHelperKt;
 import com.maddyhome.idea.vim.listener.SelectionVimListenerSuppressor;
 import com.maddyhome.idea.vim.listener.VimListenerSuppressor;
 import org.jetbrains.annotations.NotNull;
@@ -140,7 +141,7 @@ public class VimTextObjEntireExtension implements VimExtension {
               if (commandState.getMode() == CommandState.Mode.VISUAL) {
                 vimSetSelection(caret, range.getStartOffset(), range.getEndOffset() - 1, true);
               } else {
-                caret.moveToOffset(range.getStartOffset());
+                InlayHelperKt.moveToInlayAwareOffset(caret, range.getStartOffset());
               }
             }
           }

--- a/src/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -37,6 +37,7 @@ import com.intellij.openapi.editor.event.DocumentListener;
 import com.intellij.openapi.editor.event.EditorMouseEvent;
 import com.intellij.openapi.editor.event.EditorMouseListener;
 import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.editor.ex.util.EditorUtil;
 import com.intellij.openapi.editor.impl.TextRangeInterval;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
@@ -627,8 +628,7 @@ public class ChangeGroup {
             final String pad = EditorHelper.pad(editor, context, logicalLine + i, repeatColumn);
             if (pad.length() > 0) {
               final int offset = editor.getDocument().getLineEndOffset(logicalLine + i);
-              caret.moveToOffset(offset);
-              insertText(editor, caret, pad);
+              insertText(editor, caret, offset, pad);
             }
           }
           if (repeatColumn >= MotionGroup.LAST_COLUMN) {
@@ -714,7 +714,7 @@ public class ChangeGroup {
       final boolean res = deleteText(editor, new TextRange(caret.getOffset(), endOffset), SelectionType.CHARACTER_WISE);
       final int pos = caret.getOffset();
       final int norm = EditorHelper.normalizeOffset(editor, caret.getLogicalPosition().line, pos, isChange);
-      if (norm != pos) {
+      if (norm != pos || editor.offsetToVisualPosition(norm) != EditorUtil.inlayAwareOffsetToVisualPosition(editor, norm)) {
         MotionGroup.moveCaret(editor, caret, norm);
       }
 
@@ -1033,13 +1033,12 @@ public class ChangeGroup {
 
     // Indent new line if we replaced with a newline
     if (ch == '\n') {
-      caret.moveToOffset(offset + 1);
-      insertText(editor, caret, space);
+      insertText(editor, caret, offset + 1, space);
       int slen = space.length();
       if (slen == 0) {
         slen++;
       }
-      caret.moveToOffset(offset + slen);
+      InlayHelperKt.moveToInlayAwareOffset(caret, offset + slen);
     }
 
     return true;
@@ -1332,12 +1331,11 @@ public class ChangeGroup {
       if (column < MotionGroup.LAST_COLUMN && lineLength < column) {
         final String pad = EditorHelper.pad(editor, context, line, column);
         final int offset = editor.getDocument().getLineEndOffset(line);
-        caret.moveToOffset(offset);
-        insertText(editor, caret, pad);
+        insertText(editor, caret, offset, pad);
       }
 
       if (range.isMultiple() || !append) {
-        caret.moveToOffset(editor.logicalPositionToOffset(new LogicalPosition(line, column)));
+        InlayHelperKt.moveToInlayAwareLogicalPosition(caret, new LogicalPosition(line, column));
       }
       if (range.isMultiple()) {
         setInsertRepeat(lines, column, append);
@@ -1576,12 +1574,19 @@ public class ChangeGroup {
    * @param caret  The caret to start insertion in
    * @param str    The text to insert
    */
-  public void insertText(@NotNull Editor editor, @NotNull Caret caret, @NotNull String str) {
-    int start = caret.getOffset();
-    editor.getDocument().insertString(start, str);
-    caret.moveToOffset(start + str.length());
+  public void insertText(@NotNull Editor editor, @NotNull Caret caret, int offset, @NotNull String str) {
+    editor.getDocument().insertString(offset, str);
+    InlayHelperKt.moveToInlayAwareOffset(caret, offset + str.length());
 
-    VimPlugin.getMark().setMark(editor, MarkGroup.MARK_CHANGE_POS, start);
+    VimPlugin.getMark().setMark(editor, MarkGroup.MARK_CHANGE_POS, offset);
+  }
+
+  public void insertText(@NotNull Editor editor, @NotNull Caret caret, @NotNull String str) {
+    insertText(editor, caret, caret.getOffset(), str);
+  }
+
+  public void insertText(@NotNull Editor editor, @NotNull Caret caret, @NotNull LogicalPosition start, @NotNull String str) {
+    insertText(editor, caret, editor.logicalPositionToOffset(start), str);
   }
 
   public void indentMotion(@NotNull Editor editor,
@@ -1640,8 +1645,7 @@ public class ChangeGroup {
           int len = EditorHelper.getLineLength(editor, l);
           if (len > from) {
             LogicalPosition spos = new LogicalPosition(l, from);
-            caret.moveToOffset(editor.logicalPositionToOffset(spos));
-            insertText(editor, caret, indent);
+            insertText(editor, caret, spos, indent);
           }
         }
       }
@@ -1850,7 +1854,7 @@ public class ChangeGroup {
       replaceText(editor, rangeToReplace.getFirst().getStartOffset(), rangeToReplace.getFirst().getEndOffset(), newNumber);
     }
 
-    caret.moveToOffset(selectedRange.getStartOffset());
+    InlayHelperKt.moveToInlayAwareOffset(caret, selectedRange.getStartOffset());
     return true;
   }
 
@@ -1885,7 +1889,7 @@ public class ChangeGroup {
     }
     else {
       replaceText(editor, range.getFirst().getStartOffset(), range.getFirst().getEndOffset(), newNumber);
-      caret.moveToOffset(range.getFirst().getStartOffset() + newNumber.length() - 1);
+      InlayHelperKt.moveToInlayAwareOffset(caret, range.getFirst().getStartOffset() + newNumber.length() - 1);
       return true;
     }
   }

--- a/src/com/maddyhome/idea/vim/group/DigraphGroup.java
+++ b/src/com/maddyhome/idea/vim/group/DigraphGroup.java
@@ -81,7 +81,7 @@ public class DigraphGroup {
   }
 
   private void showDigraphs(@NotNull Editor editor) {
-    int width = EditorHelper.getScreenWidth(editor);
+    int width = EditorHelper.getApproximateScreenWidth(editor);
     if (width < 10) {
       width = 80;
     }

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -572,31 +572,26 @@ public class MotionGroup {
 
   public boolean scrollLineToFirstScreenLine(@NotNull Editor editor, int rawCount, boolean start) {
     scrollLineToScreenLocation(editor, ScreenLocation.TOP, rawCount, start);
-
     return true;
   }
 
   public boolean scrollLineToMiddleScreenLine(@NotNull Editor editor, int rawCount, boolean start) {
     scrollLineToScreenLocation(editor, ScreenLocation.MIDDLE, rawCount, start);
-
     return true;
   }
 
   public boolean scrollLineToLastScreenLine(@NotNull Editor editor, int rawCount, boolean start) {
     scrollLineToScreenLocation(editor, ScreenLocation.BOTTOM, rawCount, start);
-
     return true;
   }
 
   public boolean scrollColumnToFirstScreenColumn(@NotNull Editor editor) {
     scrollColumnToScreenColumn(editor, 0);
-
     return true;
   }
 
   public boolean scrollColumnToLastScreenColumn(@NotNull Editor editor) {
     scrollColumnToScreenColumn(editor, EditorHelper.getScreenWidth(editor));
-
     return true;
   }
 
@@ -1193,17 +1188,16 @@ public class MotionGroup {
   }
 
   // Scrolls current or [count] line to given screen location
-  // In Vim, [count] refers to a file line, so it's a logical line
+  // In Vim, [count] refers to a file line, so it's a one-based logical line
   private void scrollLineToScreenLocation(@NotNull Editor editor,
                                           @NotNull ScreenLocation screenLocation,
-                                          int line,
+                                          int rawCount,
                                           boolean start) {
     final int scrollOffset = getNormalizedScrollOffset(editor);
 
-    line = EditorHelper.normalizeLine(editor, line);
-    int visualLine = line == 0
-                     ? editor.getCaretModel().getVisualPosition().line
-                     : EditorHelper.logicalLineToVisualLine(editor, line - 1);
+    int visualLine = rawCount == 0
+      ? editor.getCaretModel().getVisualPosition().line
+      : EditorHelper.logicalLineToVisualLine(editor, EditorHelper.normalizeLine(editor, rawCount - 1));
 
     // This method moves the current (or [count]) line to the specified screen location
     // Scroll offset is applicable, but scroll jump isn't. Offset is applied to screen lines (visual lines)
@@ -1218,6 +1212,7 @@ public class MotionGroup {
         EditorHelper.scrollVisualLineToBottomOfScreen(editor, visualLine + scrollOffset);
         break;
     }
+
     if (visualLine != editor.getCaretModel().getVisualPosition().line || start) {
       int offset;
       if (start) {

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -812,14 +812,12 @@ public class MotionGroup {
     assert lines != 0 : "lines cannot be 0";
 
     if (lines > 0) {
-      int visualLine = EditorHelper.getVisualLineAtTopOfScreen(editor);
-      visualLine = EditorHelper.normalizeVisualLine(editor, visualLine + lines);
-      EditorHelper.scrollVisualLineToTopOfScreen(editor, visualLine);
+      final int visualLine = EditorHelper.getVisualLineAtTopOfScreen(editor);
+      EditorHelper.scrollVisualLineToTopOfScreen(editor, visualLine + lines);
     }
     else {
-      int visualLine = EditorHelper.getVisualLineAtBottomOfScreen(editor);
-      visualLine = EditorHelper.normalizeVisualLine(editor, visualLine + lines);
-      EditorHelper.scrollVisualLineToBottomOfScreen(editor, visualLine);
+      final int visualLine = EditorHelper.getVisualLineAtBottomOfScreen(editor);
+      EditorHelper.scrollVisualLineToBottomOfScreen(editor, visualLine + lines);
     }
 
     moveCaretToView(editor);

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -671,7 +671,7 @@ public class MotionGroup {
     int width = EditorHelper.getScreenWidth(editor);
     final EnumSet<CommandFlags> flags = CommandState.getInstance(editor).getExecutingCommandFlags();
     scrollJump = !flags.contains(CommandFlags.FLAG_IGNORE_SIDE_SCROLL_JUMP);
-    scrollOffset = OptionsManager.INSTANCE.getScrolloff().value();
+    scrollOffset = OptionsManager.INSTANCE.getSidescrolloff().value();
     scrollJumpSize = 0;
     if (scrollJump) {
       scrollJumpSize = Math.max(0, OptionsManager.INSTANCE.getSidescroll().value() - 1);

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -949,8 +949,8 @@ public class MotionGroup {
       EditorHelper.scrollColumnToLeftOfScreen(editor, caretVisualPosition.line, visualColumn);
     }
     else {
-      final int visualColumn = EditorHelper.normalizeVisualColumn(editor, caretVisualPosition.line,
-        EditorHelper.getVisualColumnAtRightOfScreen(editor, caretVisualPosition.line) + columns, false);
+      // Don't normalise the rightmost column, or we break virtual space
+      final int visualColumn = EditorHelper.getVisualColumnAtRightOfScreen(editor, caretVisualPosition.line) + columns;
       EditorHelper.scrollColumnToRightOfScreen(editor, caretVisualPosition.line, visualColumn);
     }
     moveCaretToView(editor);

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -603,7 +603,7 @@ public class MotionGroup {
 
   public static void scrollCaretIntoView(@NotNull Editor editor) {
     final EnumSet<CommandFlags> flags = CommandState.getInstance(editor).getExecutingCommandFlags();
-    final boolean scrollJump = flags.contains(CommandFlags.FLAG_IGNORE_SCROLL_JUMP);
+    final boolean scrollJump = !flags.contains(CommandFlags.FLAG_IGNORE_SCROLL_JUMP);
     scrollPositionIntoView(editor, editor.getCaretModel().getVisualPosition(), scrollJump);
   }
 

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -285,8 +285,11 @@ public class MotionGroup {
       return;
     }
 
-    if (caret.getOffset() != offset) {
-      caret.moveToOffset(offset);
+    // Always move the caret. It will be smart enough to not do anything if the offsets are the same, but it will also
+    // ensure that it's in the correct location relative to any inline inlays
+    final int oldOffset = caret.getOffset();
+    InlayHelperKt.moveToInlayAwareOffset(caret, offset);
+    if (oldOffset != offset) {
       UserDataManager.setVimLastColumn(caret, caret.getVisualPosition().column);
       if (caret == editor.getCaretModel().getPrimaryCaret()) {
         scrollCaretIntoView(editor);

--- a/src/com/maddyhome/idea/vim/group/copy/PutGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/copy/PutGroup.kt
@@ -46,6 +46,7 @@ import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.group.MarkGroup
 import com.maddyhome.idea.vim.group.MotionGroup
 import com.maddyhome.idea.vim.group.visual.VimSelection
+import com.maddyhome.idea.vim.helper.moveToInlayAwareOffset
 import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.fileSize
 import com.maddyhome.idea.vim.option.ClipboardOptionsData
@@ -127,7 +128,7 @@ class PutGroup {
       ApplicationManager.getApplication().runWriteAction {
         VimPlugin.getChange().deleteRange(editor, caret, range, selection.type, false)
       }
-      caret.moveToOffset(range.startOffset)
+      caret.moveToInlayAwareOffset(range.startOffset)
     }
   }
 
@@ -259,7 +260,7 @@ class PutGroup {
     EditorHelper.getOrderedCaretsList(editor).forEach { caret ->
       val startOffset = prepareDocumentAndGetStartOffsets(editor, caret, text.typeInRegister, data, additionalData).first()
       val pointMarker = editor.document.createRangeMarker(startOffset, startOffset)
-      caret.moveToOffset(startOffset)
+      caret.moveToInlayAwareOffset(startOffset)
       carets[caret] = pointMarker
     }
 

--- a/src/com/maddyhome/idea/vim/group/visual/VisualGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/visual/VisualGroup.kt
@@ -28,17 +28,7 @@ import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.command.CommandState
 import com.maddyhome.idea.vim.group.ChangeGroup
 import com.maddyhome.idea.vim.group.MotionGroup
-import com.maddyhome.idea.vim.helper.EditorHelper
-import com.maddyhome.idea.vim.helper.fileSize
-import com.maddyhome.idea.vim.helper.inBlockSubMode
-import com.maddyhome.idea.vim.helper.inSelectMode
-import com.maddyhome.idea.vim.helper.inVisualMode
-import com.maddyhome.idea.vim.helper.isEndAllowed
-import com.maddyhome.idea.vim.helper.mode
-import com.maddyhome.idea.vim.helper.sort
-import com.maddyhome.idea.vim.helper.subMode
-import com.maddyhome.idea.vim.helper.vimLastColumn
-import com.maddyhome.idea.vim.helper.vimSelectionStart
+import com.maddyhome.idea.vim.helper.*
 
 /**
  * @author Alex Plate
@@ -52,7 +42,7 @@ import com.maddyhome.idea.vim.helper.vimSelectionStart
 fun Caret.vimSetSelection(start: Int, end: Int = start, moveCaretToSelectionEnd: Boolean = false) {
   vimSelectionStart = start
   setVisualSelection(start, end, this)
-  if (moveCaretToSelectionEnd && !editor.inBlockSubMode) moveToOffset(end)
+  if (moveCaretToSelectionEnd && !editor.inBlockSubMode) moveToInlayAwareOffset(end)
 }
 
 /**
@@ -213,7 +203,7 @@ fun moveCaretOneCharLeftFromSelectionEnd(editor: Editor, predictedMode: CommandS
       editor.caretModel.allCarets.forEach { caret ->
         val lineEnd = EditorHelper.getLineEndForOffset(editor, caret.offset)
         val lineStart = EditorHelper.getLineStartForOffset(editor, caret.offset)
-        if (caret.offset == lineEnd && lineEnd != lineStart) caret.moveToOffset(caret.offset - 1)
+        if (caret.offset == lineEnd && lineEnd != lineStart) caret.moveToInlayAwareOffset(caret.offset - 1)
       }
     }
     return
@@ -223,9 +213,9 @@ fun moveCaretOneCharLeftFromSelectionEnd(editor: Editor, predictedMode: CommandS
       if (caret.selectionEnd <= 0) return@forEach
       if (EditorHelper.getLineStartForOffset(editor, caret.selectionEnd - 1) != caret.selectionEnd - 1
         && caret.selectionEnd > 1 && editor.document.text[caret.selectionEnd - 1] == '\n') {
-        caret.moveToOffset(caret.selectionEnd - 2)
+        caret.moveToInlayAwareOffset(caret.selectionEnd - 2)
       } else {
-        caret.moveToOffset(caret.selectionEnd - 1)
+        caret.moveToInlayAwareOffset(caret.selectionEnd - 1)
       }
     }
   }
@@ -263,7 +253,7 @@ private fun setVisualSelection(selectionStart: Int, selectionEnd: Int, caret: Ca
         if (lastColumn >= MotionGroup.LAST_COLUMN) {
           aCaret.vimSetSystemSelectionSilently(aCaret.selectionStart, lineEndOffset)
           val newOffset = (lineEndOffset - VimPlugin.getVisualMotion().selectionAdj).coerceAtLeast(lineStartOffset)
-          aCaret.moveToOffset(newOffset)
+          aCaret.moveToInlayAwareOffset(newOffset)
         }
         val visualPosition = editor.offsetToVisualPosition(aCaret.selectionEnd)
         if (aCaret.offset == aCaret.selectionEnd && visualPosition != aCaret.visualPosition) {
@@ -280,7 +270,7 @@ private fun setVisualSelection(selectionStart: Int, selectionEnd: Int, caret: Ca
         }
       }
 
-      editor.caretModel.primaryCaret.moveToOffset(selectionEnd)
+      editor.caretModel.primaryCaret.moveToInlayAwareOffset(selectionEnd)
     }
     else -> Unit
   }

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -679,7 +679,7 @@ public class EditorHelper {
     int y = editor.visualLineToY(visualLine);
     int height = inlayHeight + editor.getLineHeight() + exPanelHeight;
     Rectangle visibleArea = getVisibleArea(editor);
-    return scrollVertically(editor, y - visibleArea.height + height);
+    return scrollVertically(editor, max(0, y - visibleArea.height + height));
   }
 
   /**

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -231,7 +231,7 @@ public class EditorHelper {
    */
   public static int getVisualColumnAtRightOfScreen(final @NotNull Editor editor, int visualLine) {
     final Rectangle area = getVisibleArea(editor);
-    return getFullVisualColumn(editor, area.x + area.width, editor.visualLineToY(visualLine), area.x, area.x + area.width);
+    return getFullVisualColumn(editor, area.x + area.width - 1, editor.visualLineToY(visualLine), area.x, area.x + area.width);
   }
 
   /**
@@ -707,16 +707,18 @@ public class EditorHelper {
     // of columns. It also works with inline inlays and folds. It is slightly inaccurate for proportional fonts, but is
     // still a good solution. Besides, what kind of monster uses Vim with proportional fonts?
     final int standardColumnWidth = EditorUtil.getPlainSpaceWidth(editor);
-    final int something = ((point.x - (screenWidth / 2)) / standardColumnWidth) * standardColumnWidth;
-    EditorHelper.scrollHorizontally(editor, something);
+    final int x = point.x - (screenWidth / standardColumnWidth / 2 * standardColumnWidth);
+    EditorHelper.scrollHorizontally(editor, x);
   }
 
   public static void scrollColumnToRightOfScreen(@NotNull Editor editor, int visualLine, int visualColumn) {
     var inlay = editor.getInlayModel().getInlineElementAt(new VisualPosition(visualLine, visualColumn + 1));
     int inlayWidth = inlay != null && inlay.isRelatedToPrecedingText() ? inlay.getWidthInPixels() : 0;
-    final int columnRightX = editor.visualPositionToXY(new VisualPosition(visualLine, visualColumn + 1)).x;
+
+    // Scroll to the start of the next column, minus a screenwidth
+    final int nextColumnX = editor.visualPositionToXY(new VisualPosition(visualLine, visualColumn + 1)).x;
     final int screenWidth = EditorHelper.getVisibleArea(editor).width;
-    EditorHelper.scrollHorizontally(editor, columnRightX + inlayWidth - 1 - screenWidth);
+    EditorHelper.scrollHorizontally(editor, nextColumnX + inlayWidth - screenWidth);
   }
 
   /**

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -183,8 +183,18 @@ public class EditorHelper {
   }
 
   /**
-   * Gets the number of lines than can be displayed on the screen at one time. This is rounded down to the
-   * nearest whole line if there is a partial line visible at the bottom of the screen.
+   * Best efforts to ensure the side scroll offset doesn't overlap itself and remains a sensible value. Inline inlays
+   * can cause this to work incorrectly.
+   * @param editor The editor to use to normalize the side scroll offset
+   * @param sideScrollOffset The value of the 'sidescroll' option
+   * @return The side scroll offset value to use
+   */
+  public static int normalizeSideScrollOffset(final @NotNull Editor editor, int sideScrollOffset) {
+    return Math.min(sideScrollOffset, getApproximateScreenWidth(editor) / 2);
+  }
+
+  /**
+   * Gets the number of lines than can be displayed on the screen at one time.
    *
    * Note that this value is only approximate and should be avoided whenever possible!
    *
@@ -192,24 +202,20 @@ public class EditorHelper {
    * @return The number of screen lines
    */
   private static int getApproximateScreenHeight(final @NotNull Editor editor) {
-    int lh = editor.getLineHeight();
-    Rectangle area = getVisibleArea(editor);
-    int height = area.y + area.height - getVisualLineAtTopOfScreen(editor) * lh;
-    return height / lh;
+    return getVisibleArea(editor).height / editor.getLineHeight();
   }
 
   /**
-   * Gets the number of characters that are visible on a screen line
+   * Gets the number of characters that are visible on a screen line, based on screen width and assuming a fixed width
+   * font. It does not include inlays or folds.
+   *
+   * Note that this value is only approximate and should be avoided whenever possible!
    *
    * @param editor The editor
    * @return The number of screen columns
    */
-  public static int getScreenWidth(final @NotNull Editor editor) {
-    Rectangle rect = getVisibleArea(editor);
-    Point pt = new Point(rect.width, 0);
-    VisualPosition vp = editor.xyToVisualPosition(pt);
-
-    return vp.column;
+  public static int getApproximateScreenWidth(final @NotNull Editor editor) {
+    return getVisibleArea(editor).width / EditorUtil.getPlainSpaceWidth(editor);
   }
 
   /**

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -670,15 +670,14 @@ public class EditorHelper {
   public static boolean scrollVisualLineToBottomOfScreen(@NotNull Editor editor, int visualLine) {
     int inlayHeight = getHeightOfVisualLineInlays(editor, visualLine, false);
     int exPanelHeight = 0;
-    int exPanelWithoutShortcutsHeight = 0;
     if (ExEntryPanel.getInstance().isActive()) {
       exPanelHeight = ExEntryPanel.getInstance().getHeight();
     }
     if (ExEntryPanel.getInstanceWithoutShortcuts().isActive()) {
-      exPanelWithoutShortcutsHeight = ExEntryPanel.getInstanceWithoutShortcuts().getHeight();
+      exPanelHeight += ExEntryPanel.getInstanceWithoutShortcuts().getHeight();
     }
     int y = editor.visualLineToY(visualLine);
-    int height = inlayHeight + editor.getLineHeight() + exPanelHeight + exPanelWithoutShortcutsHeight;
+    int height = inlayHeight + editor.getLineHeight() + exPanelHeight;
     Rectangle visibleArea = getVisibleArea(editor);
     return scrollVertically(editor, y - visibleArea.height + height);
   }

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -90,15 +90,15 @@ public class EditorHelper {
    * characters if there are "real" tabs in the line.
    *
    * @param editor The editor
-   * @param line   The logical line within the file
+   * @param logicalLine   The logical line within the file
    * @return The number of characters in the specified line
    */
-  public static int getLineLength(final @NotNull Editor editor, final int line) {
+  public static int getLineLength(final @NotNull Editor editor, final int logicalLine) {
     if (getLineCount(editor) == 0) {
       return 0;
     }
     else {
-      return Math.max(0, editor.offsetToLogicalPosition(editor.getDocument().getLineEndOffset(line)).column);
+      return Math.max(0, editor.offsetToLogicalPosition(editor.getDocument().getLineEndOffset(logicalLine)).column);
     }
   }
 
@@ -462,6 +462,7 @@ public class EditorHelper {
    * @return The file offset of the visual position
    */
   public static int visualPositionToOffset(final @NotNull Editor editor, final @NotNull VisualPosition pos) {
+    // [202] return editor.visualPositionToOffset(pos);
     return editor.logicalPositionToOffset(editor.visualToLogicalPosition(pos));
   }
 

--- a/src/com/maddyhome/idea/vim/helper/InlayHelper.kt
+++ b/src/com/maddyhome/idea/vim/helper/InlayHelper.kt
@@ -1,0 +1,68 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.helper
+
+import com.intellij.injected.editor.EditorWindow
+import com.intellij.openapi.editor.*
+
+/**
+ * Move the caret to the given offset, handling inline inlays
+ *
+ * Inline inlays take up a single visual column. The caret can be positioned on the visual column of the inlay or the
+ * text. For Vim, we always want to position the caret before the text (when rendered as a block, this means over the
+ * text, and not over the inlay). Caret.moveToOffset will position itself correctly when an inlay relates to following
+ * text - it correctly adds one to the visual column. However, it does not add one if the inlay relates to preceding
+ * text.
+ *
+ * I believe this is an incorrect implementation of EditorUtil.inlayAwareOffsetToVisualPosition. When adding an
+ * inlay, it is added at an offset, and a new visual column is inserted there. When moving to an offset, that visual
+ * column is always there, regardless of whether the inlay relates to preceding or following text.
+ *
+ * It is safe to call this method if the caret hasn't actually moved. In fact, it is a good idea to do so, as it will
+ * make sure that if the document has changed to place an inlay at the caret position, the caret is re-positioned
+ * appropriately
+ */
+fun Caret.moveToInlayAwareOffset(offset: Int) {
+  val newVisualPosition = inlayAwareOffsetToVisualPosition(editor, offset)
+  if (newVisualPosition != visualPosition) {
+    this.moveToVisualPosition(inlayAwareOffsetToVisualPosition(editor, offset))
+  }
+}
+
+fun Caret.moveToInlayAwareLogicalPosition(pos: LogicalPosition) {
+  moveToInlayAwareOffset(editor.logicalPositionToOffset(pos))
+}
+
+// This is the same as EditorUtil.inlayAwareOffsetToVisualPosition, except it always skips the inlay, regardless of
+// its "relates to preceding text" state
+private fun inlayAwareOffsetToVisualPosition(editor: Editor, offset: Int): VisualPosition {
+  var logicalPosition = editor.offsetToLogicalPosition(offset)
+  val e = if (editor is EditorWindow) {
+    logicalPosition = editor.injectedToHost(logicalPosition)
+    editor.delegate
+  }
+  else {
+    editor
+  }
+  var pos = e.logicalToVisualPosition(logicalPosition)
+  while (editor.inlayModel.getInlineElementAt(pos) != null) {
+    pos = VisualPosition(pos.line, pos.column + 1)
+  }
+  return pos
+}

--- a/src/com/maddyhome/idea/vim/helper/InlayHelper.kt
+++ b/src/com/maddyhome/idea/vim/helper/InlayHelper.kt
@@ -39,9 +39,15 @@ import com.intellij.openapi.editor.*
  * appropriately
  */
 fun Caret.moveToInlayAwareOffset(offset: Int) {
-  val newVisualPosition = inlayAwareOffsetToVisualPosition(editor, offset)
-  if (newVisualPosition != visualPosition) {
-    this.moveToVisualPosition(inlayAwareOffsetToVisualPosition(editor, offset))
+  // If the target offset is collapsed inside a fold, move directly to the offset, expanding the fold
+  if (editor.foldingModel.isOffsetCollapsed(offset)) {
+    moveToOffset(offset)
+  }
+  else {
+    val newVisualPosition = inlayAwareOffsetToVisualPosition(editor, offset)
+    if (newVisualPosition != visualPosition) {
+      moveToVisualPosition(newVisualPosition)
+    }
   }
 }
 

--- a/src/com/maddyhome/idea/vim/helper/ModeExtensions.kt
+++ b/src/com/maddyhome/idea/vim/helper/ModeExtensions.kt
@@ -78,7 +78,7 @@ fun Editor.exitSelectMode(adjustCaretPosition: Boolean) {
         val lineEnd = EditorHelper.getLineEndForOffset(this, it.offset)
         val lineStart = EditorHelper.getLineStartForOffset(this, it.offset)
         if (it.offset == lineEnd && it.offset != lineStart) {
-          it.moveToOffset(it.offset - 1)
+          it.moveToInlayAwareOffset(it.offset - 1)
         }
       }
     }

--- a/src/com/maddyhome/idea/vim/listener/ListenerManager.kt
+++ b/src/com/maddyhome/idea/vim/listener/ListenerManager.kt
@@ -49,21 +49,8 @@ import com.maddyhome.idea.vim.group.EditorGroup
 import com.maddyhome.idea.vim.group.FileGroup
 import com.maddyhome.idea.vim.group.MotionGroup
 import com.maddyhome.idea.vim.group.SearchGroup
-import com.maddyhome.idea.vim.group.visual.IdeaSelectionControl
-import com.maddyhome.idea.vim.group.visual.VimVisualTimer
-import com.maddyhome.idea.vim.group.visual.moveCaretOneCharLeftFromSelectionEnd
-import com.maddyhome.idea.vim.group.visual.vimSetSystemSelectionSilently
-import com.maddyhome.idea.vim.helper.EditorHelper
-import com.maddyhome.idea.vim.helper.StatisticReporter
-import com.maddyhome.idea.vim.helper.disabledForThisEditor
-import com.maddyhome.idea.vim.helper.exitSelectMode
-import com.maddyhome.idea.vim.helper.exitVisualMode
-import com.maddyhome.idea.vim.helper.inSelectMode
-import com.maddyhome.idea.vim.helper.inVisualMode
-import com.maddyhome.idea.vim.helper.isEndAllowed
-import com.maddyhome.idea.vim.helper.isIdeaVimDisabledHere
-import com.maddyhome.idea.vim.helper.subMode
-import com.maddyhome.idea.vim.helper.vimLastColumn
+import com.maddyhome.idea.vim.group.visual.*
+import com.maddyhome.idea.vim.helper.*
 import com.maddyhome.idea.vim.listener.VimListenerManager.EditorListeners.add
 import com.maddyhome.idea.vim.listener.VimListenerManager.EditorListeners.remove
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -359,7 +346,7 @@ object VimListenerManager {
               val lineEnd = EditorHelper.getLineEndForOffset(editor, caret.offset)
               val lineStart = EditorHelper.getLineStartForOffset(editor, caret.offset)
               cutOffEnd = if (caret.offset == lineEnd && lineEnd != lineStart) {
-                caret.moveToOffset(caret.offset - 1)
+                caret.moveToInlayAwareOffset(caret.offset - 1)
                 true
               } else {
                 false

--- a/src/com/maddyhome/idea/vim/option/OptionsManager.kt
+++ b/src/com/maddyhome/idea/vim/option/OptionsManager.kt
@@ -552,6 +552,14 @@ object IdeaStatusIcon {
   val allValues = arrayOf(enabled, gray, disabled)
 }
 
+object ScrollOffData {
+  const val name = "scrolloff"
+}
+
+object ScrollJumpData {
+  const val name = "scrolljump"
+}
+
 object StrictMode {
   val on: Boolean
     get() = OptionsManager.ideastrictmode.isSet
@@ -566,12 +574,4 @@ object VirtualEditData {
 
   const val onemore = "onemore"
   val allValues = arrayOf("block", "insert", "all", onemore)
-}
-
-object ScrollOffData {
-  const val name = "scrolloff"
-}
-
-object ScrollJumpData {
-  const val name = "scrolljump"
 }

--- a/src/com/maddyhome/idea/vim/option/OptionsManager.kt
+++ b/src/com/maddyhome/idea/vim/option/OptionsManager.kt
@@ -66,8 +66,8 @@ object OptionsManager {
   val number = addOption(ToggleOption("number", "nu", false))
   val relativenumber = addOption(ToggleOption("relativenumber", "rnu", false))
   val scroll = addOption(NumberOption("scroll", "scr", 0))
-  val scrolljump = addOption(NumberOption("scrolljump", "sj", 1, -100, Integer.MAX_VALUE))
-  val scrolloff = addOption(NumberOption("scrolloff", "so", 0))
+  val scrolljump = addOption(NumberOption(ScrollJumpData.name, "sj", 1, -100, Integer.MAX_VALUE))
+  val scrolloff = addOption(NumberOption(ScrollOffData.name, "so", 0))
   val selection = addOption(BoundStringOption("selection", "sel", "inclusive", arrayOf("old", "inclusive", "exclusive")))
   val selectmode = addOption(SelectModeOptionData.option)
   val showcmd = addOption(ToggleOption("showcmd", "sc", true))  // Vim: Off by default on platforms with possibly slow tty. On by default elsewhere.
@@ -566,4 +566,12 @@ object VirtualEditData {
 
   const val onemore = "onemore"
   val allValues = arrayOf("block", "insert", "all", onemore)
+}
+
+object ScrollOffData {
+  const val name = "scrolloff"
+}
+
+object ScrollJumpData {
+  const val name = "scrolljump"
 }

--- a/src/com/maddyhome/idea/vim/option/OptionsManager.kt
+++ b/src/com/maddyhome/idea/vim/option/OptionsManager.kt
@@ -314,7 +314,7 @@ object OptionsManager {
     cols.sortBy { it.name }
     extra.sortBy { it.name }
 
-    var width = EditorHelper.getScreenWidth(editor)
+    var width = EditorHelper.getApproximateScreenWidth(editor)
     if (width < 20) {
       width = 80
     }

--- a/src/com/maddyhome/idea/vim/option/OptionsManager.kt
+++ b/src/com/maddyhome/idea/vim/option/OptionsManager.kt
@@ -66,7 +66,7 @@ object OptionsManager {
   val number = addOption(ToggleOption("number", "nu", false))
   val relativenumber = addOption(ToggleOption("relativenumber", "rnu", false))
   val scroll = addOption(NumberOption("scroll", "scr", 0))
-  val scrolljump = addOption(NumberOption("scrolljump", "sj", 1))
+  val scrolljump = addOption(NumberOption("scrolljump", "sj", 1, -100, Integer.MAX_VALUE))
   val scrolloff = addOption(NumberOption("scrolloff", "so", 0))
   val selection = addOption(BoundStringOption("selection", "sel", "inclusive", arrayOf("old", "inclusive", "exclusive")))
   val selectmode = addOption(SelectModeOptionData.option)

--- a/src/com/maddyhome/idea/vim/package-info.java
+++ b/src/com/maddyhome/idea/vim/package-info.java
@@ -460,7 +460,7 @@
  * |zF|                   TO BE IMPLEMENTED
  * |zG|                   TO BE IMPLEMENTED
  * |zH|                   {@link com.maddyhome.idea.vim.action.motion.scroll.MotionScrollHalfWidthLeftAction}
- * |zL|                   TO BE IMPLEMENTED
+ * |zL|                   {@link com.maddyhome.idea.vim.action.motion.scroll.MotionScrollHalfWidthRightAction}
  * |zM|                   {@link com.maddyhome.idea.vim.action.fold.VimCollapseAllRegions}
  * |zN|                   TO BE IMPLEMENTED
  * |zO|                   {@link com.maddyhome.idea.vim.action.fold.VimExpandRegionRecursively}

--- a/src/com/maddyhome/idea/vim/package-info.java
+++ b/src/com/maddyhome/idea/vim/package-info.java
@@ -459,7 +459,7 @@
  * |zE|                   TO BE IMPLEMENTED
  * |zF|                   TO BE IMPLEMENTED
  * |zG|                   TO BE IMPLEMENTED
- * |zH|                   TO BE IMPLEMENTED
+ * |zH|                   {@link com.maddyhome.idea.vim.action.motion.scroll.MotionScrollHalfWidthLeftAction}
  * |zL|                   TO BE IMPLEMENTED
  * |zM|                   {@link com.maddyhome.idea.vim.action.fold.VimCollapseAllRegions}
  * |zN|                   TO BE IMPLEMENTED

--- a/test/org/jetbrains/plugins/ideavim/NeovimTesting.kt
+++ b/test/org/jetbrains/plugins/ideavim/NeovimTesting.kt
@@ -104,6 +104,7 @@ annotation class TestWithoutNeovim(val reason: SkipNeovimReason, val description
 enum class SkipNeovimReason {
   PLUGIN,
   MULTICARET,
+  INLAYS,
   OPTION,
   UNCLEAR,
   NON_ASCII,

--- a/test/org/jetbrains/plugins/ideavim/VimOptionTestCase.kt
+++ b/test/org/jetbrains/plugins/ideavim/VimOptionTestCase.kt
@@ -20,6 +20,7 @@ package org.jetbrains.plugins.ideavim
 
 import com.maddyhome.idea.vim.option.BoundStringOption
 import com.maddyhome.idea.vim.option.ListOption
+import com.maddyhome.idea.vim.option.NumberOption
 import com.maddyhome.idea.vim.option.OptionsManager
 import com.maddyhome.idea.vim.option.ToggleOption
 
@@ -80,6 +81,11 @@ abstract class VimOptionTestCase(option: String, vararg otherOptions: String) : 
 
             option.set(it.values.first())
           }
+          VimTestOptionType.NUMBER -> {
+            if (option !is NumberOption) kotlin.test.fail("${it.option} is not a number option. Change it for method `${testMethod.name}`")
+
+            option.set(it.values.first().toInt())
+          }
         }
       }
     }
@@ -106,5 +112,6 @@ annotation class VimTestOption(
 enum class VimTestOptionType {
   LIST,
   TOGGLE,
-  VALUE
+  VALUE,
+  NUMBER
 }

--- a/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -23,11 +23,9 @@ import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.ide.highlighter.XmlFileType
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.editor.Caret
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.LogicalPosition
-import com.intellij.openapi.editor.VisualPosition
+import com.intellij.openapi.editor.*
 import com.intellij.openapi.editor.colors.EditorColors
+import com.intellij.openapi.editor.ex.util.EditorUtil
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.PlainTextFileType
@@ -387,6 +385,14 @@ abstract class VimTestCase : UsefulTestCase() {
 
   protected val fileManager: FileEditorManagerEx
     get() = FileEditorManagerEx.getInstanceEx(myFixture.project)
+
+  protected fun addInlay(offset: Int, relatesToPrecedingText: Boolean, widthInColumns: Int): Inlay<*> {
+    // Enforce deterministic tests for inlays. Default text char width is different per platform (e.g. Windows is 7 and
+    // Mac is 8) and using the same inlay width on all platforms can cause columns to be on or off screen unexpectedly.
+    // If inlay width is related to character width, we will scale correctly across different platforms
+    val columnWidth = EditorUtil.getPlainSpaceWidth(myFixture.editor)
+    return EditorTestUtil.addInlay(myFixture.editor, offset, relatesToPrecedingText, widthInColumns * columnWidth)!!
+  }
 
   companion object {
     const val c = EditorTestUtil.CARET_TAG

--- a/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -134,22 +134,23 @@ abstract class VimTestCase : UsefulTestCase() {
   protected val screenHeight: Int
     get() = 35
 
-  protected fun setEditorVisibleSize() {
-    EditorTestUtil.setEditorVisibleSize(myFixture.editor, screenWidth, screenHeight)
+  protected fun setEditorVisibleSize(width: Int, height: Int) {
+    EditorTestUtil.setEditorVisibleSize(myFixture.editor, width, height)
   }
+
   protected fun configureByText(content: String) = configureByText(PlainTextFileType.INSTANCE, content)
   protected fun configureByJavaText(content: String) = configureByText(JavaFileType.INSTANCE, content)
   protected fun configureByXmlText(content: String) = configureByText(XmlFileType.INSTANCE, content)
 
   private fun configureByText(fileType: FileType, content: String): Editor {
     myFixture.configureByText(fileType, content)
-    setEditorVisibleSize()
+    setEditorVisibleSize(screenWidth, screenHeight)
     return myFixture.editor
   }
 
   protected fun configureByFileName(fileName: String): Editor {
     myFixture.configureByText(fileName, "\n")
-    setEditorVisibleSize()
+    setEditorVisibleSize(screenWidth, screenHeight)
     return myFixture.editor
   }
 
@@ -168,6 +169,15 @@ abstract class VimTestCase : UsefulTestCase() {
       stringBuilder.appendln(line)
     }
     configureByText(stringBuilder.toString())
+  }
+
+  protected fun configureByColumns(columnCount: Int) {
+    val content = buildString {
+      repeat(columnCount) {
+        append('0' + (it % 10))
+      }
+    }
+    configureByText(content)
   }
 
   @JvmOverloads
@@ -253,6 +263,17 @@ abstract class VimTestCase : UsefulTestCase() {
 
     Assert.assertEquals("Top logical lines don't match", topLogicalLine, actualLogicalTop)
     Assert.assertEquals("Bottom logical lines don't match", bottomLogicalLine, actualLogicalBottom)
+  }
+
+  fun assertVisibleLineBounds(logicalLine: Int, leftLogicalColumn: Int, rightLogicalColumn: Int) {
+    val visualLine = EditorHelper.logicalLineToVisualLine(myFixture.editor, logicalLine)
+    val actualLeftVisualColumn = EditorHelper.getVisualColumnAtLeftOfScreen(myFixture.editor, visualLine)
+    val actualLeftLogicalColumn = myFixture.editor.visualToLogicalPosition(VisualPosition(visualLine, actualLeftVisualColumn)).column
+    val actualRightVisualColumn = EditorHelper.getVisualColumnAtRightOfScreen(myFixture.editor, visualLine)
+    val actualRightLogicalColumn =  myFixture.editor.visualToLogicalPosition(VisualPosition(visualLine, actualRightVisualColumn)).column
+
+    Assert.assertEquals(leftLogicalColumn, actualLeftLogicalColumn)
+    Assert.assertEquals(rightLogicalColumn, actualRightLogicalColumn)
   }
 
   fun assertMode(expectedMode: CommandState.Mode) {

--- a/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -272,8 +272,15 @@ abstract class VimTestCase : UsefulTestCase() {
     val actualRightVisualColumn = EditorHelper.getVisualColumnAtRightOfScreen(myFixture.editor, visualLine)
     val actualRightLogicalColumn =  myFixture.editor.visualToLogicalPosition(VisualPosition(visualLine, actualRightVisualColumn)).column
 
-    Assert.assertEquals(leftLogicalColumn, actualLeftLogicalColumn)
-    Assert.assertEquals(rightLogicalColumn, actualRightLogicalColumn)
+    val expected = ScreenBounds(leftLogicalColumn, rightLogicalColumn)
+    val actual = ScreenBounds(actualLeftLogicalColumn, actualRightLogicalColumn)
+    Assert.assertEquals(expected, actual)
+  }
+
+  private data class ScreenBounds(val leftLogicalColumn: Int, val rightLogicalColumn: Int) {
+    override fun toString(): String {
+      return "[$leftLogicalColumn-$rightLogicalColumn]"
+    }
   }
 
   fun assertMode(expectedMode: CommandState.Mode) {

--- a/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -26,6 +26,7 @@ import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.editor.VisualPosition
 import com.intellij.openapi.editor.colors.EditorColors
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.fileTypes.FileType
@@ -223,6 +224,13 @@ abstract class VimTestCase : UsefulTestCase() {
     Assert.assertEquals("Wrong amount of carets", 1, carets.size)
     val actualPosition = carets[0].logicalPosition
     Assert.assertEquals(LogicalPosition(line, column), actualPosition)
+  }
+
+  fun assertVisualPosition(visualLine: Int, visualColumn: Int) {
+    val carets = myFixture.editor.caretModel.allCarets
+    Assert.assertEquals("Wrong amount of carets", 1, carets.size)
+    val actualPosition = carets[0].visualPosition
+    Assert.assertEquals(VisualPosition(visualLine, visualColumn), actualPosition)
   }
 
   fun assertOffset(vararg expectedOffsets: Int) {

--- a/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterLeftActionTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.action.change.delete
 
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import org.jetbrains.plugins.ideavim.VimTestCase
 
@@ -78,7 +77,7 @@ class DeleteCharacterLeftActionTest : VimTestCase() {
     // Hitting 'X' on the character before the inlay should place the cursor after the inlay
     // Before: "I fo«:test»|u|nd it in a legendary land."
     // After: "I f«:test»|u|nd it in a legendary land."
-    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
+    addInlay(4, true, 5)
 
     typeText(keys)
     myFixture.checkResult(after)
@@ -103,7 +102,7 @@ class DeleteCharacterLeftActionTest : VimTestCase() {
     // Hitting 'X' on the character before the inlay should place the cursor after the inlay
     // Before: "I fo«test:»|u|nd it in a legendary land."
     // After: "I f«test:»|u|nd it in a legendary land."
-    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
+    addInlay(4, true, 5)
 
     typeText(keys)
     myFixture.checkResult(after)

--- a/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterLeftActionTest.kt
@@ -1,0 +1,117 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.change.delete
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |X|
+class DeleteCharacterLeftActionTest : VimTestCase() {
+  fun `test delete single character`() {
+    val keys = parseKeys("X")
+    val before = "I f${c}ound it in a legendary land"
+    val after = "I ${c}ound it in a legendary land"
+    configureByText(before)
+    typeText(keys)
+    myFixture.checkResult(after)
+  }
+
+  fun `test delete multiple characters`() {
+    val keys = parseKeys("5X")
+    val before = "I found$c it in a legendary land"
+    val after = "I $c it in a legendary land"
+    configureByText(before)
+    typeText(keys)
+    myFixture.checkResult(after)
+  }
+
+  fun `test deletes min of count and start of line`() {
+    val keys = parseKeys("25X")
+    val before = """
+            A Discovery
+
+            I found$c it in a legendary land
+            all rocks and lavender and tufted grass,
+            where it was settled on some sodden sand
+            hard by the torrent of a mountain pass.
+        """.trimIndent()
+    val after = """
+            A Discovery
+
+            $c it in a legendary land
+            all rocks and lavender and tufted grass,
+            where it was settled on some sodden sand
+            hard by the torrent of a mountain pass.
+        """.trimIndent()
+    configureByText(before)
+    typeText(keys)
+    myFixture.checkResult(after)
+  }
+
+  fun `test delete with inlay relating to preceding text`() {
+    val keys = parseKeys("X")
+    val before = "I fo${c}und it in a legendary land"
+    val after = "I f${c}und it in a legendary land"
+    configureByText(before)
+
+    // The inlay is inserted at offset 4 (0 based) - the 'u' in "found". It occupies visual column 4, and is associated
+    // with the text in visual column 3 ('o'). The 'u' is moved to the right one visual column, and now lives at offset
+    // 4, visual column 5.
+    // Kotlin type annotations are a real world example of inlays related to preceding text.
+    // Hitting 'X' on the character before the inlay should place the cursor after the inlay
+    // Before: "I fo«:test»|u|nd it in a legendary land."
+    // After: "I f«:test»|u|nd it in a legendary land."
+    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer(":test"))
+
+    typeText(keys)
+    myFixture.checkResult(after)
+
+    // It doesn't matter if the inlay is related to preceding or following text. Deleting visual column 3 moves the
+    // inlay one visual column to the left, from column 4 to 3. The cursor starts at offset 4, pushed to 5 by the inlay.
+    // 'X' moves the cursor one column to the left (along with the text), which puts it at offset 4. But offset 4 can
+    // now mean visual column 3 or 4 - the inlay or the text. Make sure the cursor is positioned on the text.
+    assertVisualPosition(0, 4)
+  }
+
+  fun `test delete with inlay relating to following text`() {
+    // This should have the same behaviour as related to preceding text
+    val keys = parseKeys("X")
+    val before = "I fo${c}und it in a legendary land"
+    val after = "I f${c}und it in a legendary land"
+    configureByText(before)
+
+    // The inlay is inserted at offset 4 (0 based) - the 'u' in "found". It occupies visual column 4, and is associated
+    // with the text in visual column 5 ('u' - because the inlay pushes it one visual column to the right).
+    // Kotlin parameter hints are a real world example of inlays related to following text.
+    // Hitting 'X' on the character before the inlay should place the cursor after the inlay
+    // Before: "I fo«test:»|u|nd it in a legendary land."
+    // After: "I f«test:»|u|nd it in a legendary land."
+    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer("test:"))
+
+    typeText(keys)
+    myFixture.checkResult(after)
+
+    // It doesn't matter if the inlay is related to preceding or following text. Deleting visual column 3 moves the
+    // inlay one visual column to the left, from column 4 to 3. The cursor starts at offset 4, pushed to 5 by the inlay.
+    // 'X' moves the cursor one column to the left (along with the text), which puts it at offset 4. But offset 4 can
+    // now mean visual column 3 or 4 - the inlay or the text. Make sure the cursor is positioned on the text.
+    assertVisualPosition(0, 4)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterLeftActionTest.kt
@@ -18,7 +18,7 @@
 
 package org.jetbrains.plugins.ideavim.action.change.delete
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import org.jetbrains.plugins.ideavim.VimTestCase
 
@@ -78,7 +78,7 @@ class DeleteCharacterLeftActionTest : VimTestCase() {
     // Hitting 'X' on the character before the inlay should place the cursor after the inlay
     // Before: "I fo«:test»|u|nd it in a legendary land."
     // After: "I f«:test»|u|nd it in a legendary land."
-    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
 
     typeText(keys)
     myFixture.checkResult(after)
@@ -103,7 +103,7 @@ class DeleteCharacterLeftActionTest : VimTestCase() {
     // Hitting 'X' on the character before the inlay should place the cursor after the inlay
     // Before: "I fo«test:»|u|nd it in a legendary land."
     // After: "I f«test:»|u|nd it in a legendary land."
-    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer("test:"))
+    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
 
     typeText(keys)
     myFixture.checkResult(after)

--- a/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterRightActionTest.kt
@@ -1,0 +1,121 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.change.delete
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |x|
+class DeleteCharacterRightActionTest : VimTestCase() {
+  fun `test delete single character`() {
+    val keys = parseKeys("x")
+    val before = "I ${c}found it in a legendary land"
+    val after = "I ${c}ound it in a legendary land"
+    configureByText(before)
+    typeText(keys)
+    myFixture.checkResult(after)
+  }
+
+  fun `test delete multiple characters`() {
+    val keys = parseKeys("5x")
+    val before = "I ${c}found it in a legendary land"
+    val after = "I $c it in a legendary land"
+    configureByText(before)
+    typeText(keys)
+    myFixture.checkResult(after)
+  }
+
+  fun `test deletes min of count and end of line`() {
+    val keys = parseKeys("20x")
+    val before = """
+            A Discovery
+
+            I found it in a legendary l${c}and
+            all rocks and lavender and tufted grass,
+            where it was settled on some sodden sand
+            hard by the torrent of a mountain pass.
+        """.trimIndent()
+    val after = """
+            A Discovery
+
+            I found it in a legendary ${c}l
+            all rocks and lavender and tufted grass,
+            where it was settled on some sodden sand
+            hard by the torrent of a mountain pass.
+        """.trimIndent()
+    configureByText(before)
+    typeText(keys)
+    myFixture.checkResult(after)
+  }
+
+  fun `test delete with inlay relating to preceding text`() {
+    val keys = parseKeys("x")
+    val before = "I f${c}ound it in a legendary land"
+    val after = "I f${c}und it in a legendary land"
+    configureByText(before)
+
+    // The inlay is inserted at offset 4 (0 based) - the 'u' in "found". It occupies visual column 4, and is associated
+    // with the text in visual column 3 ('o'). The 'u' is moved to the right one visual column, and now lives at offset
+    // 4, visual column 5.
+    // Kotlin type annotations are a real world example of inlays related to preceding text.
+    // Hitting 'x' on the character before the inlay should place the cursor after the inlay
+    // Before: "I f|o|«:test»und it in a legendary land."
+    // After: "I f«:test»|u|nd it in a legendary land."
+    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer(":test"))
+
+    typeText(keys)
+    myFixture.checkResult(after)
+
+    // It doesn't matter if the inlay is related to preceding or following text. Deleting visual column 3 moves the
+    // inlay one visual column to the left, from column 4 to 3. 'x' doesn't move the logical position/offset of the
+    // cursor, but offset 3 can now refer to the inlay as well as text - visual column 3 and 4. Make sure the cursor is
+    // positioned on the text, not the inlay.
+    // Note that the inlay isn't deleted - deleting a character from the end of a variable name shouldn't delete the
+    // type annotation
+    assertVisualPosition(0, 4)
+  }
+
+  fun `test delete with inlay relating to following text`() {
+    // This should have the same behaviour as related to preceding text
+    val keys = parseKeys("x")
+    val before = "I f${c}ound it in a legendary land"
+    val after = "I f${c}und it in a legendary land"
+    configureByText(before)
+
+    // The inlay is inserted at offset 4 (0 based) - the 'u' in "found". It occupies visual column 4, and is associated
+    // with the text in visual column 5 ('u' - because the inlay pushes it one visual column to the right).
+    // Kotlin parameter hints are a real world example of inlays related to following text.
+    // Hitting 'x' on the character before the inlay should place the cursor after the inlay
+    // Before: "I f|o|«test:»und it in a legendary land."
+    // After: "I f«test:»|u|nd it in a legendary land."
+    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer("test:"))
+
+    typeText(keys)
+    myFixture.checkResult(after)
+
+    // It doesn't matter if the inlay is related to preceding or following text. Deleting visual column 3 moves the
+    // inlay one visual column to the left, from column 4 to 3. 'x' doesn't move the logical position/offset of the
+    // cursor, but offset 3 can now refer to the inlay as well as text - visual column 3 and 4. Make sure the cursor is
+    // positioned on the text, not the inlay.
+    // Note that the inlay isn't deleted - deleting a character from the end of a variable name shouldn't delete the
+    // type annotation
+    assertVisualPosition(0, 4)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterRightActionTest.kt
@@ -18,7 +18,7 @@
 
 package org.jetbrains.plugins.ideavim.action.change.delete
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import org.jetbrains.plugins.ideavim.VimTestCase
 
@@ -78,7 +78,7 @@ class DeleteCharacterRightActionTest : VimTestCase() {
     // Hitting 'x' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«:test»und it in a legendary land."
     // After: "I f«:test»|u|nd it in a legendary land."
-    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
 
     typeText(keys)
     myFixture.checkResult(after)
@@ -105,7 +105,7 @@ class DeleteCharacterRightActionTest : VimTestCase() {
     // Hitting 'x' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I f«test:»|u|nd it in a legendary land."
-    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer("test:"))
+    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
 
     typeText(keys)
     myFixture.checkResult(after)

--- a/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/change/delete/DeleteCharacterRightActionTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.action.change.delete
 
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import org.jetbrains.plugins.ideavim.VimTestCase
 
@@ -78,7 +77,7 @@ class DeleteCharacterRightActionTest : VimTestCase() {
     // Hitting 'x' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«:test»und it in a legendary land."
     // After: "I f«:test»|u|nd it in a legendary land."
-    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
+    addInlay(4, true, 5)
 
     typeText(keys)
     myFixture.checkResult(after)
@@ -105,7 +104,7 @@ class DeleteCharacterRightActionTest : VimTestCase() {
     // Hitting 'x' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I f«test:»|u|nd it in a legendary land."
-    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
+    addInlay(4, true, 5)
 
     typeText(keys)
     myFixture.checkResult(after)

--- a/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowLeftActionTest.kt
@@ -20,7 +20,6 @@
 
 package org.jetbrains.plugins.ideavim.action.motion.leftright
 
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.command.CommandState
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.KeyModelOptionData
@@ -40,7 +39,7 @@ class MotionArrowLeftActionTest : VimOptionTestCase(KeyModelOptionData.name) {
     // Hitting 'l' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I f«test:»|u|nd it in a legendary land."
-    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
+    addInlay(4, true, 5)
 
     typeText(keys)
     myFixture.checkResult(after)
@@ -63,7 +62,7 @@ class MotionArrowLeftActionTest : VimOptionTestCase(KeyModelOptionData.name) {
     // Hitting 'l' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I fo«test:»|u|nd it in a legendary land."
-    EditorTestUtil.addInlay(myFixture.editor, 4, false, 40)
+    addInlay(4, false, 5)
 
     typeText(keys)
     myFixture.checkResult(after)

--- a/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowLeftActionTest.kt
@@ -20,7 +20,9 @@
 
 package org.jetbrains.plugins.ideavim.action.motion.leftright
 
+import com.intellij.codeInsight.daemon.impl.HintRenderer
 import com.maddyhome.idea.vim.command.CommandState
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.KeyModelOptionData
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
@@ -31,6 +33,52 @@ import org.jetbrains.plugins.ideavim.VimTestOption
 import org.jetbrains.plugins.ideavim.VimTestOptionType
 
 class MotionArrowLeftActionTest : VimOptionTestCase(KeyModelOptionData.name) {
+  @VimOptionDefaultAll
+  fun `test with inlay related to preceding text`() {
+    val keys = parseKeys("h")
+    val before = "I fou${c}nd it in a legendary land"
+    val after = "I fo${c}und it in a legendary land"
+    configureByText(before)
+
+    // The inlay is inserted at offset 4 (0 based) - the 'u' in "found". It occupies visual column 4, and is associated
+    // with the text in visual column 5 ('u' - because the inlay pushes it one visual column to the right).
+    // Kotlin parameter hints are a real world example of inlays related to following text.
+    // Hitting 'l' on the character before the inlay should place the cursor after the inlay
+    // Before: "I f|o|«test:»und it in a legendary land."
+    // After: "I f«test:»|u|nd it in a legendary land."
+    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer(":test"))
+
+    typeText(keys)
+    myFixture.checkResult(after)
+
+    // The cursor starts at offset 5 and moves to offset 4. Offset 4 contains both the inlay and the next character, at
+    // visual positions 4 and 5 respectively. We always want the cursor to move to the next character, not the inlay.
+    assertVisualPosition(0, 5)
+  }
+
+  @VimOptionDefaultAll
+  fun `test with inlay related to following text`() {
+    val keys = parseKeys("h")
+    val before = "I fou${c}nd it in a legendary land"
+    val after = "I fo${c}und it in a legendary land"
+    configureByText(before)
+
+    // The inlay is inserted at offset 4 (0 based) - the 'u' in "found". It occupies visual column 4, and is associated
+    // with the text in visual column 5 ('u' - because the inlay pushes it one visual column to the right).
+    // Kotlin parameter hints are a real world example of inlays related to following text.
+    // Hitting 'l' on the character before the inlay should place the cursor after the inlay
+    // Before: "I f|o|«test:»und it in a legendary land."
+    // After: "I fo«test:»|u|nd it in a legendary land."
+    myFixture.editor.inlayModel.addInlineElement(4, false, HintRenderer("test:"))
+
+    typeText(keys)
+    myFixture.checkResult(after)
+
+    // The cursor starts at offset 5 and moves to offset 4. Offset 4 contains both the inlay and the next character, at
+    // visual positions 4 and 5 respectively. We always want the cursor to move to the next character, not the inlay.
+    assertVisualPosition(0, 5)
+  }
+
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @VimOptionDefaultAll
   fun `test visual default options`() {

--- a/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowLeftActionTest.kt
@@ -20,17 +20,11 @@
 
 package org.jetbrains.plugins.ideavim.action.motion.leftright
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.command.CommandState
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.KeyModelOptionData
-import org.jetbrains.plugins.ideavim.SkipNeovimReason
-import org.jetbrains.plugins.ideavim.TestWithoutNeovim
-import org.jetbrains.plugins.ideavim.VimOptionDefaultAll
-import org.jetbrains.plugins.ideavim.VimOptionTestCase
-import org.jetbrains.plugins.ideavim.VimOptionTestConfiguration
-import org.jetbrains.plugins.ideavim.VimTestOption
-import org.jetbrains.plugins.ideavim.VimTestOptionType
+import org.jetbrains.plugins.ideavim.*
 
 class MotionArrowLeftActionTest : VimOptionTestCase(KeyModelOptionData.name) {
   @VimOptionDefaultAll
@@ -46,7 +40,7 @@ class MotionArrowLeftActionTest : VimOptionTestCase(KeyModelOptionData.name) {
     // Hitting 'l' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I f«test:»|u|nd it in a legendary land."
-    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
 
     typeText(keys)
     myFixture.checkResult(after)
@@ -69,7 +63,7 @@ class MotionArrowLeftActionTest : VimOptionTestCase(KeyModelOptionData.name) {
     // Hitting 'l' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I fo«test:»|u|nd it in a legendary land."
-    myFixture.editor.inlayModel.addInlineElement(4, false, HintRenderer("test:"))
+    EditorTestUtil.addInlay(myFixture.editor, 4, false, 40)
 
     typeText(keys)
     myFixture.checkResult(after)

--- a/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowRightActionTest.kt
@@ -20,7 +20,6 @@
 
 package org.jetbrains.plugins.ideavim.action.motion.leftright
 
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.command.CommandState
 import com.maddyhome.idea.vim.helper.StringHelper
 import com.maddyhome.idea.vim.option.KeyModelOptionData
@@ -40,7 +39,7 @@ class MotionArrowRightActionTest : VimOptionTestCase(KeyModelOptionData.name) {
     // Hitting 'l' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I f«test:»|u|nd it in a legendary land."
-    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
+    addInlay(4, true, 5)
 
     typeText(keys)
     myFixture.checkResult(after)
@@ -63,7 +62,7 @@ class MotionArrowRightActionTest : VimOptionTestCase(KeyModelOptionData.name) {
     // Hitting 'l' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I fo«test:»|u|nd it in a legendary land."
-    EditorTestUtil.addInlay(myFixture.editor, 4, false, 40)
+    addInlay(4, false, 5)
 
     typeText(keys)
     myFixture.checkResult(after)

--- a/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowRightActionTest.kt
@@ -20,17 +20,11 @@
 
 package org.jetbrains.plugins.ideavim.action.motion.leftright
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.command.CommandState
 import com.maddyhome.idea.vim.helper.StringHelper
 import com.maddyhome.idea.vim.option.KeyModelOptionData
-import org.jetbrains.plugins.ideavim.SkipNeovimReason
-import org.jetbrains.plugins.ideavim.TestWithoutNeovim
-import org.jetbrains.plugins.ideavim.VimOptionDefaultAll
-import org.jetbrains.plugins.ideavim.VimOptionTestCase
-import org.jetbrains.plugins.ideavim.VimOptionTestConfiguration
-import org.jetbrains.plugins.ideavim.VimTestOption
-import org.jetbrains.plugins.ideavim.VimTestOptionType
+import org.jetbrains.plugins.ideavim.*
 
 class MotionArrowRightActionTest : VimOptionTestCase(KeyModelOptionData.name) {
   @VimOptionDefaultAll
@@ -46,7 +40,7 @@ class MotionArrowRightActionTest : VimOptionTestCase(KeyModelOptionData.name) {
     // Hitting 'l' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I f«test:»|u|nd it in a legendary land."
-    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 4, true, 40)
 
     typeText(keys)
     myFixture.checkResult(after)
@@ -69,7 +63,7 @@ class MotionArrowRightActionTest : VimOptionTestCase(KeyModelOptionData.name) {
     // Hitting 'l' on the character before the inlay should place the cursor after the inlay
     // Before: "I f|o|«test:»und it in a legendary land."
     // After: "I fo«test:»|u|nd it in a legendary land."
-    myFixture.editor.inlayModel.addInlineElement(4, false, HintRenderer("test:"))
+    EditorTestUtil.addInlay(myFixture.editor, 4, false, 40)
 
     typeText(keys)
     myFixture.checkResult(after)

--- a/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionArrowRightActionTest.kt
@@ -20,7 +20,9 @@
 
 package org.jetbrains.plugins.ideavim.action.motion.leftright
 
+import com.intellij.codeInsight.daemon.impl.HintRenderer
 import com.maddyhome.idea.vim.command.CommandState
+import com.maddyhome.idea.vim.helper.StringHelper
 import com.maddyhome.idea.vim.option.KeyModelOptionData
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
@@ -31,6 +33,52 @@ import org.jetbrains.plugins.ideavim.VimTestOption
 import org.jetbrains.plugins.ideavim.VimTestOptionType
 
 class MotionArrowRightActionTest : VimOptionTestCase(KeyModelOptionData.name) {
+  @VimOptionDefaultAll
+  fun `test with inlay related to preceding text`() {
+    val keys = StringHelper.parseKeys("l")
+    val before = "I f${c}ound it in a legendary land"
+    val after = "I fo${c}und it in a legendary land"
+    configureByText(before)
+
+    // The inlay is inserted at offset 4 (0 based) - the 'u' in "found". It occupies visual column 4, and is associated
+    // with the text in visual column 5 ('u' - because the inlay pushes it one visual column to the right).
+    // Kotlin parameter hints are a real world example of inlays related to following text.
+    // Hitting 'l' on the character before the inlay should place the cursor after the inlay
+    // Before: "I f|o|«test:»und it in a legendary land."
+    // After: "I f«test:»|u|nd it in a legendary land."
+    myFixture.editor.inlayModel.addInlineElement(4, true, HintRenderer(":test"))
+
+    typeText(keys)
+    myFixture.checkResult(after)
+
+    // The cursor starts at offset 3 and moves to offset 4. Offset 4 contains both the inlay and the next character, at
+    // visual positions 4 and 5 respectively. We always want the cursor to move to the next character, not the inlay.
+    assertVisualPosition(0, 5)
+  }
+
+  @VimOptionDefaultAll
+  fun `test with inlay related to following text`() {
+    val keys = StringHelper.parseKeys("l")
+    val before = "I f${c}ound it in a legendary land"
+    val after = "I fo${c}und it in a legendary land"
+    configureByText(before)
+
+    // The inlay is inserted at offset 4 (0 based) - the 'u' in "found". It occupies visual column 4, and is associated
+    // with the text in visual column 5 ('u' - because the inlay pushes it one visual column to the right).
+    // Kotlin parameter hints are a real world example of inlays related to following text.
+    // Hitting 'l' on the character before the inlay should place the cursor after the inlay
+    // Before: "I f|o|«test:»und it in a legendary land."
+    // After: "I fo«test:»|u|nd it in a legendary land."
+    myFixture.editor.inlayModel.addInlineElement(4, false, HintRenderer("test:"))
+
+    typeText(keys)
+    myFixture.checkResult(after)
+
+    // The cursor starts at offset 3 and moves to offset 4. Offset 4 contains both the inlay and the next character, at
+    // visual positions 4 and 5 respectively. We always want the cursor to move to the next character, not the inlay.
+    assertVisualPosition(0, 5)
+  }
+
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @VimOptionDefaultAll
   fun `test visual default options`() {

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnLeftActionTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -114,7 +113,7 @@ class ScrollColumnLeftActionTest : VimTestCase() {
 
   fun `test scroll column to left correctly scrolls inline inlay associated with preceding text`() {
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 67, true, 40)
+    addInlay(67, true, 5)
     typeText(parseKeys("100|"))
     // Text at start of line is:            456:test7
     assertVisibleLineBounds(0, 64, 138)
@@ -126,7 +125,7 @@ class ScrollColumnLeftActionTest : VimTestCase() {
 
   fun `test scroll column to left correctly scrolls inline inlay associated with following text`() {
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 67, false, 40)
+    addInlay(67, false, 5)
     typeText(parseKeys("100|"))
     // Text at start of line is:            456test:78
     assertVisibleLineBounds(0, 64, 138)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnLeftActionTest.kt
@@ -18,7 +18,7 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -114,7 +114,7 @@ class ScrollColumnLeftActionTest : VimTestCase() {
 
   fun `test scroll column to left correctly scrolls inline inlay associated with preceding text`() {
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(67, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 67, true, 40)
     typeText(parseKeys("100|"))
     // Text at start of line is:            456:test7
     assertVisibleLineBounds(0, 64, 138)
@@ -126,7 +126,7 @@ class ScrollColumnLeftActionTest : VimTestCase() {
 
   fun `test scroll column to left correctly scrolls inline inlay associated with following text`() {
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(67, false, HintRenderer("test:"))
+    EditorTestUtil.addInlay(myFixture.editor, 67, false, 40)
     typeText(parseKeys("100|"))
     // Text at start of line is:            456test:78
     assertVisibleLineBounds(0, 64, 138)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnLeftActionTest.kt
@@ -1,0 +1,140 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+/*
+z<Right>    or                                         *zl* *z<Right>*
+zl                      Move the view on the text [count] characters to the
+                        right, thus scroll the text [count] characters to the
+                        left.  This only works when 'wrap' is off.
+ */
+class ScrollColumnLeftActionTest : VimTestCase() {
+  fun `test scrolls column to left`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "zl"))
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 60, 139)
+  }
+
+  fun `test scrolls column to left with zRight`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "z<Right>"))
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 60, 139)
+  }
+
+  fun `test scroll first column to left moves cursor`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "zs", "zl"))
+    assertPosition(0, 100)
+    assertVisibleLineBounds(0, 100, 179)
+  }
+
+  fun `test scrolls count columns to left`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "10zl"))
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 69, 148)
+  }
+
+  fun `test scrolls count columns to left with zRight`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "10z<Right>"))
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 69, 148)
+  }
+
+  fun `test scrolls column to left with sidescrolloff moves cursor`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("100|", "zs", "zl"))
+    assertPosition(0, 100)
+    assertVisibleLineBounds(0, 90, 169)
+  }
+
+  fun `test scroll column to left ignores sidescroll`() {
+    OptionsManager.sidescroll.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("100|"))
+    // Assert we got initial scroll correct
+    // sidescroll=10 means we don't get the sidescroll jump of half a screen and the cursor is positioned at the right edge
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 20, 99)
+
+    // Scrolls, but doesn't use sidescroll jump
+    typeText(parseKeys("zl"))
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 21, 100)
+  }
+
+  fun `test scroll column to left on last page enters virtual space`() {
+    configureByColumns(200)
+    typeText(parseKeys("200|", "ze", "zl"))
+    assertPosition(0, 199)
+    assertVisibleLineBounds(0, 121, 200)
+    typeText(parseKeys("zl"))
+    assertPosition(0, 199)
+    assertVisibleLineBounds(0, 122, 201)
+    typeText(parseKeys("zl"))
+    assertPosition(0, 199)
+    assertVisibleLineBounds(0, 123, 202)
+  }
+
+  @VimBehaviorDiffers(description = "Vim has virtual space at end of line")
+  fun `test scroll columns to left on last page does not have full virtual space`() {
+    configureByColumns(200)
+    typeText(parseKeys("200|", "ze", "50zl"))
+    assertPosition(0, 199)
+    // Vim is 179-258
+    // See also editor.settings.additionalColumnCount
+    assertVisibleLineBounds(0, 123, 202)
+  }
+
+  fun `test scroll column to left correctly scrolls inline inlay associated with preceding text`() {
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(67, true, HintRenderer(":test"))
+    typeText(parseKeys("100|"))
+    // Text at start of line is:            456:test7
+    assertVisibleLineBounds(0, 64, 138)
+    typeText(parseKeys("2zl"))  // 6:test7
+    assertVisibleLineBounds(0, 66, 140)
+    typeText(parseKeys("zl"))   // 7
+    assertVisibleLineBounds(0, 67, 146)
+  }
+
+  fun `test scroll column to left correctly scrolls inline inlay associated with following text`() {
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(67, false, HintRenderer("test:"))
+    typeText(parseKeys("100|"))
+    // Text at start of line is:            456test:78
+    assertVisibleLineBounds(0, 64, 138)
+    typeText(parseKeys("2zl"))  // 6test:78
+    assertVisibleLineBounds(0, 66, 140)
+    typeText(parseKeys("zl"))   // test:78
+    assertVisibleLineBounds(0, 67, 141)
+    typeText(parseKeys("zl"))   // 8
+    assertVisibleLineBounds(0, 68, 147)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnRightActionTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -121,7 +120,7 @@ class ScrollColumnRightActionTest : VimTestCase() {
 
   fun `test scroll column to right correctly scrolls inline inlay associated with preceding text`() {
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 130, true, 40)
+    addInlay(130, true, 5)
     typeText(parseKeys("100|"))
     // Text at end of line is:              89:inlay0123
     assertVisibleLineBounds(0, 59, 133) // 75 characters wide
@@ -135,7 +134,7 @@ class ScrollColumnRightActionTest : VimTestCase() {
 
   fun `test scroll column to right correctly scrolls inline inlay associated with following text`() {
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 130, false, 40)
+    addInlay(130, false, 5)
     typeText(parseKeys("100|"))
     // Text at end of line is:              89inlay:0123
     assertVisibleLineBounds(0, 59, 133) // 75 characters wide
@@ -149,7 +148,7 @@ class ScrollColumnRightActionTest : VimTestCase() {
 
   fun `test scroll column to right with preceding inline inlay moves cursor at end of screen`() {
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 90, false, 40)
+    addInlay(90, false, 5)
     typeText(parseKeys("100|", "ze", "zh"))
     assertPosition(0, 98)
     assertVisibleLineBounds(0, 24, 98)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnRightActionTest.kt
@@ -146,4 +146,21 @@ class ScrollColumnRightActionTest : VimTestCase() {
     typeText(parseKeys("zh"))   //           9
     assertVisibleLineBounds(0, 49, 128) // 80 characters
   }
+
+  fun `test scroll column to right with preceding inline inlay moves cursor at end of screen`() {
+    configureByColumns(200)
+    val inlay = myFixture.editor.inlayModel.addInlineElement(90, false, HintRenderer("test:"))!!
+    typeText(parseKeys("100|", "ze", "zh"))
+    assertPosition(0, 98)
+    assertVisibleLineBounds(0, 24, 98)
+    typeText(parseKeys("zh"))
+    assertPosition(0, 97)
+    assertVisibleLineBounds(0, 23, 97)
+    typeText(parseKeys("zh"))
+    assertPosition(0, 96)
+    assertVisibleLineBounds(0, 22, 96)
+    typeText(parseKeys("zh"))
+    assertPosition(0, 95)
+    assertVisibleLineBounds(0, 21, 95)
+  }
 }

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnRightActionTest.kt
@@ -18,7 +18,7 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -121,35 +121,35 @@ class ScrollColumnRightActionTest : VimTestCase() {
 
   fun `test scroll column to right correctly scrolls inline inlay associated with preceding text`() {
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(130, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 130, true, 40)
     typeText(parseKeys("100|"))
-    // Text at end of line is:              89:test0123
+    // Text at end of line is:              89:inlay0123
     assertVisibleLineBounds(0, 59, 133) // 75 characters wide
-    typeText(parseKeys("3zh"))  //    89:test0
+    typeText(parseKeys("3zh"))  //    89:inlay0
     assertVisibleLineBounds(0, 56, 130) // 75 characters
-    typeText(parseKeys("zh"))   //     89:test
+    typeText(parseKeys("zh"))   //     89:inlay
     assertVisibleLineBounds(0, 55, 129) // 75 characters
-    typeText(parseKeys("zh"))   //           8
+    typeText(parseKeys("zh"))   //            8
     assertVisibleLineBounds(0, 49, 128) // 80 characters
   }
 
   fun `test scroll column to right correctly scrolls inline inlay associated with following text`() {
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(130, false, HintRenderer("test:"))
+    EditorTestUtil.addInlay(myFixture.editor, 130, false, 40)
     typeText(parseKeys("100|"))
-    // Text at end of line is:              89test:0123
+    // Text at end of line is:              89inlay:0123
     assertVisibleLineBounds(0, 59, 133) // 75 characters wide
-    typeText(parseKeys("3zh"))  //    89test:0
+    typeText(parseKeys("3zh"))  //    89inlay:0
     assertVisibleLineBounds(0, 56, 130) // 75 characters
-    typeText(parseKeys("zh"))   //          89
+    typeText(parseKeys("zh"))   //           89
     assertVisibleLineBounds(0, 50, 129) // 80 characters
-    typeText(parseKeys("zh"))   //           9
+    typeText(parseKeys("zh"))   //            9
     assertVisibleLineBounds(0, 49, 128) // 80 characters
   }
 
   fun `test scroll column to right with preceding inline inlay moves cursor at end of screen`() {
     configureByColumns(200)
-    val inlay = myFixture.editor.inlayModel.addInlineElement(90, false, HintRenderer("test:"))!!
+    EditorTestUtil.addInlay(myFixture.editor, 90, false, 40)
     typeText(parseKeys("100|", "ze", "zh"))
     assertPosition(0, 98)
     assertVisibleLineBounds(0, 24, 98)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollColumnRightActionTest.kt
@@ -1,0 +1,149 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+/*
+z<Left>      or                                        *zh* *z<Left>*
+zh                      Move the view on the text [count] characters to the
+                        left, thus scroll the text [count] characters to the
+                        right.  This only works when 'wrap' is off.
+ */
+class ScrollColumnRightActionTest : VimTestCase() {
+  fun `test scrolls column to right`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "zh"))
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 58, 137)
+  }
+
+  fun `test scrolls column to right with zLeft`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "z<Left>"))
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 58, 137)
+  }
+
+  @VimBehaviorDiffers(description = "Vim has virtual space at the end of line. IdeaVim will scroll up to length of longest line")
+  fun `test scroll last column to right moves cursor 1`() {
+    configureByColumns(200)
+    typeText(parseKeys("$"))
+    // Assert we got initial scroll correct
+    // We'd need virtual space to scroll this. We're over 200 due to editor.settings.additionalColumnsCount
+    assertVisibleLineBounds(0, 123, 202)
+
+    typeText(parseKeys("zh"))
+    assertPosition(0, 199)
+    assertVisibleLineBounds(0, 122, 201)
+  }
+
+  @VimBehaviorDiffers(description = "Vim has virtual space at the end of line. IdeaVim will scroll up to length of longest line")
+  fun `test scroll last column to right moves cursor 2`() {
+    configureByText(buildString {
+      repeat(300) { append("0") }
+      appendln()
+      repeat(200) { append("0") }
+    })
+    typeText(parseKeys("j$"))
+    // Assert we got initial scroll correct
+    // Note, this matches Vim - we've scrolled to centre (but only because the line above allows us to scroll without
+    // virtual space)
+    assertVisibleLineBounds(1, 159, 238)
+
+    typeText(parseKeys("zh"))
+    assertPosition(1, 199)
+    assertVisibleLineBounds(1, 158, 237)
+  }
+
+  fun `test scrolls count columns to right`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "10zh"))
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 49, 128)
+  }
+
+  fun `test scrolls count columns to right with zLeft`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "10z<Left>"))
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 49, 128)
+  }
+
+  fun `test scrolls column to right with sidescrolloff moves cursor`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("100|", "ze", "zh"))
+    assertPosition(0, 98)
+    assertVisibleLineBounds(0, 29, 108)
+  }
+
+  fun `test scroll column to right ignores sidescroll`() {
+    OptionsManager.sidescroll.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("100|"))
+    // Assert we got initial scroll correct
+    // sidescroll=10 means we don't get the sidescroll jump of half a screen and the cursor is positioned at the right edge
+    assertPosition(0, 99)
+    assertVisibleLineBounds(0, 20, 99)
+
+    typeText(parseKeys("zh")) // Moves cursor, but not by sidescroll jump
+    assertPosition(0, 98)
+    assertVisibleLineBounds(0, 19, 98)
+  }
+
+  fun `test scroll column to right on first page does nothing`() {
+    configureByColumns(200)
+    typeText(parseKeys("10|", "zh"))
+    assertPosition(0, 9)
+    assertVisibleLineBounds(0, 0, 79)
+  }
+
+  fun `test scroll column to right correctly scrolls inline inlay associated with preceding text`() {
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(130, true, HintRenderer(":test"))
+    typeText(parseKeys("100|"))
+    // Text at end of line is:              89:test0123
+    assertVisibleLineBounds(0, 59, 133) // 75 characters wide
+    typeText(parseKeys("3zh"))  //    89:test0
+    assertVisibleLineBounds(0, 56, 130) // 75 characters
+    typeText(parseKeys("zh"))   //     89:test
+    assertVisibleLineBounds(0, 55, 129) // 75 characters
+    typeText(parseKeys("zh"))   //           8
+    assertVisibleLineBounds(0, 49, 128) // 80 characters
+  }
+
+  fun `test scroll column to right correctly scrolls inline inlay associated with following text`() {
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(130, false, HintRenderer("test:"))
+    typeText(parseKeys("100|"))
+    // Text at end of line is:              89test:0123
+    assertVisibleLineBounds(0, 59, 133) // 75 characters wide
+    typeText(parseKeys("3zh"))  //    89test:0
+    assertVisibleLineBounds(0, 56, 130) // 75 characters
+    typeText(parseKeys("zh"))   //          89
+    assertVisibleLineBounds(0, 50, 129) // 80 characters
+    typeText(parseKeys("zh"))   //           9
+    assertVisibleLineBounds(0, 49, 128) // 80 characters
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
@@ -27,9 +27,11 @@ import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.Assert
 
-/* zs   Scroll the text horizontally to position the cursor
-        at the start (left side) of the screen.  This only
-        works when 'wrap' is off.
+/*
+                                                       *zs*
+zs                      Scroll the text horizontally to position the cursor
+                        at the start (left side) of the screen.  This only
+                        works when 'wrap' is off.
  */
 class ScrollFirstScreenColumnActionTest : VimTestCase() {
   fun `test scroll caret column to first screen column`() {

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
@@ -20,7 +20,6 @@ package org.jetbrains.plugins.ideavim.action.scroll
 
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.ex.util.EditorUtil
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -71,7 +70,7 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
   fun `test first screen column includes previous inline inlay associated with following text`() {
     // The inlay is associated with the caret, on the left, so should appear before it when scrolling columns
     configureByColumns(200)
-    val inlay = EditorTestUtil.addInlay(myFixture.editor, 99, false, 40)
+    val inlay = addInlay(99, false, 5)
     typeText(parseKeys("100|", "zs"))
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
     val textWidth = visibleArea.width - inlay.widthInPixels
@@ -85,7 +84,7 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
   fun `test first screen column does not include previous inline inlay associated with preceding text`() {
     // The inlay is associated with the column before the caret, so should not affect scrolling
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 99, true, 40)
+    addInlay(99, true, 5)
     typeText(parseKeys("100|", "zs"))
     assertVisibleLineBounds(0, 99, 178)
   }
@@ -93,7 +92,7 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
   fun `test first screen column does not include subsequent inline inlay associated with following text`() {
     // The inlay is associated with the column after the caret, so should not affect scrolling
     configureByColumns(200)
-    val inlay = EditorTestUtil.addInlay(myFixture.editor, 100, false, 40)
+    val inlay = addInlay(100, false, 5)
     typeText(parseKeys("100|", "zs"))
     val availableColumns = getAvailableColumns(inlay)
     assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
@@ -102,7 +101,7 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
   fun `test first screen column does not include subsequent inline inlay associated with preceding text`() {
     // The inlay is associated with the caret column, but appears to the right of the column, so does not affect scrolling
     configureByColumns(200)
-    val inlay = EditorTestUtil.addInlay(myFixture.editor, 100, true, 40)
+    val inlay = addInlay(100, true, 5)
     typeText(parseKeys("100|", "zs"))
     val availableColumns = getAvailableColumns(inlay)
     assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
@@ -18,9 +18,9 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -71,7 +71,7 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
   fun `test first screen column includes previous inline inlay associated with following text`() {
     // The inlay is associated with the caret, on the left, so should appear before it when scrolling columns
     configureByColumns(200)
-    val inlay = myFixture.editor.inlayModel.addInlineElement(99, false, HintRenderer("test:"))!!
+    val inlay = EditorTestUtil.addInlay(myFixture.editor, 99, false, 40)
     typeText(parseKeys("100|", "zs"))
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
     val textWidth = visibleArea.width - inlay.widthInPixels
@@ -85,7 +85,7 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
   fun `test first screen column does not include previous inline inlay associated with preceding text`() {
     // The inlay is associated with the column before the caret, so should not affect scrolling
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(99, true, HintRenderer(":test"))!!
+    EditorTestUtil.addInlay(myFixture.editor, 99, true, 40)
     typeText(parseKeys("100|", "zs"))
     assertVisibleLineBounds(0, 99, 178)
   }
@@ -93,7 +93,7 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
   fun `test first screen column does not include subsequent inline inlay associated with following text`() {
     // The inlay is associated with the column after the caret, so should not affect scrolling
     configureByColumns(200)
-    val inlay = myFixture.editor.inlayModel.addInlineElement(100, false, HintRenderer("test:"))!!
+    val inlay = EditorTestUtil.addInlay(myFixture.editor, 100, false, 40)
     typeText(parseKeys("100|", "zs"))
     val availableColumns = getAvailableColumns(inlay)
     assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
@@ -102,13 +102,13 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
   fun `test first screen column does not include subsequent inline inlay associated with preceding text`() {
     // The inlay is associated with the caret column, but appears to the right of the column, so does not affect scrolling
     configureByColumns(200)
-    val inlay = myFixture.editor.inlayModel.addInlineElement(100, true, HintRenderer(":test"))!!
+    val inlay = EditorTestUtil.addInlay(myFixture.editor, 100, true, 40)
     typeText(parseKeys("100|", "zs"))
     val availableColumns = getAvailableColumns(inlay)
     assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
   }
 
-  private fun getAvailableColumns(inlay: Inlay<HintRenderer>): Int {
+  private fun getAvailableColumns(inlay: Inlay<*>): Int {
     val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
     return textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
   }

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
@@ -1,0 +1,113 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.openapi.editor.Inlay
+import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.Assert
+
+/* zs   Scroll the text horizontally to position the cursor
+        at the start (left side) of the screen.  This only
+        works when 'wrap' is off.
+ */
+class ScrollFirstScreenColumnActionTest : VimTestCase() {
+  fun `test scroll caret column to first screen column`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "zs"))
+    assertVisibleLineBounds(0, 99, 178)
+  }
+
+  fun `test scroll caret column to first screen column with sidescrolloff`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("100|", "zs"))
+    assertVisibleLineBounds(0, 89, 168)
+  }
+
+  fun `test scroll at or near start of line`() {
+    configureByColumns(200)
+    typeText(parseKeys("5|", "zs"))
+    assertVisibleLineBounds(0, 4, 83)
+  }
+
+  fun `test scroll at or near start of line with sidescrolloff does nothing`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("5|", "zs"))
+    assertVisibleLineBounds(0, 0, 79)
+  }
+
+  @VimBehaviorDiffers(description = "Vim scrolls caret to first screen column, filling with virtual space")
+  fun `test scroll end of line to first screen column`() {
+    configureByColumns(200)
+    typeText(parseKeys("$", "zs"))
+    // See also editor.settings.isVirtualSpace and editor.settings.additionalColumnsCount
+    assertVisibleLineBounds(0, 123, 202)
+  }
+
+  fun `test first screen column includes previous inline inlay associated with following text`() {
+    // The inlay is associated with the caret, on the left, so should appear before it when scrolling columns
+    configureByColumns(200)
+    val inlay = myFixture.editor.inlayModel.addInlineElement(99, false, HintRenderer("test:"))!!
+    typeText(parseKeys("100|", "zs"))
+    val visibleArea = myFixture.editor.scrollingModel.visibleArea
+    val textWidth = visibleArea.width - inlay.widthInPixels
+    val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+
+    // The first visible text column will be 99, with the inlay positioned to the left of it
+    assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
+    Assert.assertEquals(visibleArea.x, inlay.bounds!!.x)
+  }
+
+  fun `test first screen column does not include previous inline inlay associated with preceding text`() {
+    // The inlay is associated with the column before the caret, so should not affect scrolling
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(99, true, HintRenderer(":test"))!!
+    typeText(parseKeys("100|", "zs"))
+    assertVisibleLineBounds(0, 99, 178)
+  }
+
+  fun `test first screen column does not include subsequent inline inlay associated with following text`() {
+    // The inlay is associated with the column after the caret, so should not affect scrolling
+    configureByColumns(200)
+    val inlay = myFixture.editor.inlayModel.addInlineElement(100, false, HintRenderer("test:"))!!
+    typeText(parseKeys("100|", "zs"))
+    val availableColumns = getAvailableColumns(inlay)
+    assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
+  }
+
+  fun `test first screen column does not include subsequent inline inlay associated with preceding text`() {
+    // The inlay is associated with the caret column, but appears to the right of the column, so does not affect scrolling
+    configureByColumns(200)
+    val inlay = myFixture.editor.inlayModel.addInlineElement(100, true, HintRenderer(":test"))!!
+    typeText(parseKeys("100|", "zs"))
+    val availableColumns = getAvailableColumns(inlay)
+    assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
+  }
+
+  private fun getAvailableColumns(inlay: Inlay<HintRenderer>): Int {
+    val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
+    return textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLineActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLineActionTest.kt
@@ -23,8 +23,11 @@ import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |zt|
-/* Like "z<CR>", but leave the cursor in the same column. */
+/*
+                                                       *zt*
+zt                      Like "z<CR>", but leave the cursor in the same
+                        column.
+ */
 class ScrollFirstScreenLineActionTest : VimTestCase() {
   fun `test scroll current line to top of screen`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLineActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLineActionTest.kt
@@ -1,0 +1,88 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |zt|
+/* Like "z<CR>", but leave the cursor in the same column. */
+class ScrollFirstScreenLineActionTest : VimTestCase() {
+  fun `test scroll current line to top of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("zt"))
+    assertPosition(19, 0)
+    assertVisibleArea(19, 53)
+  }
+
+  fun `test scroll current line to top of screen and leave cursor in current column`() {
+    configureByLines(100, "    I found it in a legendary land")
+    setPositionAndScroll(0, 19, 14)
+    typeText(StringHelper.parseKeys("zt"))
+    assertPosition(19, 14)
+    assertVisibleArea(19, 53)
+  }
+
+  fun `test scroll current line to top of screen minus scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("zt"))
+    assertPosition(19, 0)
+    assertVisibleArea(9, 43)
+  }
+
+  fun `test scrolls count line to top of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("100zt"))
+    assertPosition(99, 0)
+    assertVisibleArea(99, 133)
+  }
+
+  fun `test scrolls count line to top of screen minus scrolloff`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("zt"))
+    assertPosition(19, 0)
+    assertVisibleArea(19, 53)
+  }
+
+  @VimBehaviorDiffers(description = "Virtual space at end of file")
+  fun `test invalid count scrolls last line to top of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("1000zt"))
+    assertPosition(175, 0)
+    assertVisibleArea(146, 175)
+  }
+
+  fun `test scroll current line to top of screen ignoring scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("zt"))
+    assertPosition(19, 0)
+    assertVisibleArea(19, 53)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLinePageStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLinePageStartActionTest.kt
@@ -23,7 +23,7 @@ import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |z+| (scrolls up)
+// |z+|
 /* Without [count]: Redraw with the line just below the
    window at the top of the window.  Put the cursor in
    that line, at the first non-blank in the line.

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLinePageStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLinePageStartActionTest.kt
@@ -1,0 +1,91 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |z+| (scrolls up)
+/* Without [count]: Redraw with the line just below the
+   window at the top of the window.  Put the cursor in
+   that line, at the first non-blank in the line.
+   With [count]: just like "z<CR>". */
+class ScrollFirstScreenLinePageStartActionTest : VimTestCase() {
+  fun `test scrolls first line on next page to top of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("z+"))
+    assertPosition(35, 0)
+    assertVisibleArea(35, 69)
+  }
+
+  fun `test scrolls to first non-blank in line`() {
+    configureByLines(100, "    I found it in a legendary land")
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("z+"))
+    assertPosition(35, 4)
+    assertVisibleArea(35, 69)
+  }
+
+  fun `test scrolls first line on next page to scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("z+"))
+    assertPosition(35, 0)
+    assertVisibleArea(25, 59)
+  }
+
+  fun `test scrolls first line on next page ignores scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("z+"))
+    assertPosition(35, 0)
+    assertVisibleArea(35, 69)
+  }
+
+  fun `test count z+ scrolls count line to top of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("100z+"))
+    assertPosition(99, 0)
+    assertVisibleArea(99, 133)
+  }
+
+  fun `test count z+ scrolls count line to top of screen plus scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("100z+"))
+    assertPosition(99, 0)
+    assertVisibleArea(89, 123)
+  }
+
+  @VimBehaviorDiffers(description = "Requires virtual space support")
+  fun `test scroll on penultimate page`() {
+    configureByPages(5)
+    setPositionAndScroll(130, 145)
+    typeText(parseKeys("z+"))
+    assertPosition(165, 0)
+    assertVisibleArea(146, 175)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLinePageStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLinePageStartActionTest.kt
@@ -23,11 +23,13 @@ import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |z+|
-/* Without [count]: Redraw with the line just below the
-   window at the top of the window.  Put the cursor in
-   that line, at the first non-blank in the line.
-   With [count]: just like "z<CR>". */
+/*
+                                                       *z+*
+z+                      Without [count]: Redraw with the line just below the
+                        window at the top of the window.  Put the cursor in
+                        that line, at the first non-blank in the line.
+                        With [count]: just like "z<CR>".
+ */
 class ScrollFirstScreenLinePageStartActionTest : VimTestCase() {
   fun `test scrolls first line on next page to top of screen`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLineStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLineStartActionTest.kt
@@ -23,10 +23,12 @@ import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |z<CR>|
-/* Redraw, line [count] at top of window (default
-   cursor line).  Put cursor at first non-blank in the
-   line. */
+/*
+                                                       *z<CR>*
+z<CR>                   Redraw, line [count] at top of window (default
+                        cursor line).  Put cursor at first non-blank in the
+                        line.
+ */
 class ScrollFirstScreenLineStartActionTest : VimTestCase() {
   fun `test scroll current line to top of screen`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLineStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenLineStartActionTest.kt
@@ -1,0 +1,90 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |z<CR>|
+/* Redraw, line [count] at top of window (default
+   cursor line).  Put cursor at first non-blank in the
+   line. */
+class ScrollFirstScreenLineStartActionTest : VimTestCase() {
+  fun `test scroll current line to top of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("z<CR>"))
+    assertPosition(19, 0)
+    assertVisibleArea(19, 53)
+  }
+
+  fun `test scroll current line to top of screen and move to first non-blank`() {
+    configureByLines(100, "    I found it in a legendary land")
+    setPositionAndScroll(0, 19, 0)
+    typeText(StringHelper.parseKeys("z<CR>"))
+    assertPosition(19, 4)
+    assertVisibleArea(19, 53)
+  }
+
+  fun `test scroll current line to top of screen minus scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("z<CR>"))
+    assertPosition(19, 0)
+    assertVisibleArea(9, 43)
+  }
+
+  fun `test scrolls count line to top of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("100z<CR>"))
+    assertPosition(99, 0)
+    assertVisibleArea(99, 133)
+  }
+
+  fun `test scrolls count line to top of screen minus scrolloff`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("z<CR>"))
+    assertPosition(19, 0)
+    assertVisibleArea(19, 53)
+  }
+
+  @VimBehaviorDiffers(description = "Virtual space at end of file")
+  fun `test invalid count scrolls last line to top of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("1000z<CR>"))
+    assertPosition(175, 0)
+    assertVisibleArea(146, 175)
+  }
+
+  fun `test scroll current line to top of screen ignoring scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 19)
+    typeText(StringHelper.parseKeys("z<CR>"))
+    assertPosition(19, 0)
+    assertVisibleArea(19, 53)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageDownActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageDownActionTest.kt
@@ -25,16 +25,18 @@ import com.maddyhome.idea.vim.option.OptionsManager
 import junit.framework.Assert
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |<C-D>|
-/* Scroll window Downwards in the buffer.  The number of
-   lines comes from the 'scroll' option (default: half a
-   screen).  If [count] given, first set 'scroll' option
-   to [count].  The cursor is moved the same number of
-   lines down in the file (if possible; when lines wrap
-   and when hitting the end of the file there may be a
-   difference).  When the cursor is on the last line of
-   the buffer nothing happens and a beep is produced.
-   See also 'startofline' option. */
+/*
+                                                       *CTRL-D*
+CTRL-D                  Scroll window Downwards in the buffer.  The number of
+                        lines comes from the 'scroll' option (default: half a
+                        screen).  If [count] given, first set 'scroll' option
+                        to [count].  The cursor is moved the same number of
+                        lines down in the file (if possible; when lines wrap
+                        and when hitting the end of the file there may be a
+                        difference).  When the cursor is on the last line of
+                        the buffer nothing happens and a beep is produced.
+                        See also 'startofline' option.
+ */
 class ScrollHalfPageDownActionTest : VimTestCase() {
   fun `test scroll half window downwards keeps cursor on same relative line`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageDownActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageDownActionTest.kt
@@ -1,0 +1,112 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import junit.framework.Assert
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |<C-D>|
+/* Scroll window Downwards in the buffer.  The number of
+   lines comes from the 'scroll' option (default: half a
+   screen).  If [count] given, first set 'scroll' option
+   to [count].  The cursor is moved the same number of
+   lines down in the file (if possible; when lines wrap
+   and when hitting the end of the file there may be a
+   difference).  When the cursor is on the last line of
+   the buffer nothing happens and a beep is produced.
+   See also 'startofline' option. */
+class ScrollHalfPageDownActionTest : VimTestCase() {
+  fun `test scroll half window downwards keeps cursor on same relative line`() {
+    configureByPages(5)
+    setPositionAndScroll(20, 25)
+    typeText(parseKeys("<C-D>"))
+    assertPosition(42, 0)
+    assertVisibleArea(37, 71)
+  }
+
+  fun `test scroll downwards on last line causes beep`() {
+    configureByPages(5)
+    setPositionAndScroll(146, 175)
+    typeText(parseKeys("<C-D>"))
+    assertPosition(175, 0)
+    assertVisibleArea(146, 175)
+    assertTrue(VimPlugin.isError())
+  }
+
+  fun `test scroll downwards in bottom half of last page moves to the last line`() {
+    configureByPages(5)
+    setPositionAndScroll(146, 165)
+    typeText(parseKeys("<C-D>"))
+    assertPosition(175, 0)
+    assertVisibleArea(146, 175)
+  }
+
+  fun `test scroll downwards in top half of last page moves cursor down half a page`() {
+    configureByPages(5)
+    setPositionAndScroll(146, 150)
+    typeText(parseKeys("<C-D>"))
+    assertPosition(167, 0)
+    assertVisibleArea(146, 175)
+  }
+
+  fun `test scroll count lines downwards`() {
+    configureByPages(5)
+    setPositionAndScroll(100, 130)
+    typeText(parseKeys("10<C-D>"))
+    assertPosition(140, 0)
+    assertVisibleArea(110, 144)
+  }
+
+  fun `test scroll count downwards modifies scroll option`() {
+    configureByPages(5)
+    setPositionAndScroll(100, 110)
+    typeText(parseKeys("10<C-D>"))
+    Assert.assertEquals(OptionsManager.scroll.value(), 10)
+  }
+
+  fun `test scroll downwards uses scroll option`() {
+    OptionsManager.scroll.set(10)
+    configureByPages(5)
+    setPositionAndScroll(100, 110)
+    typeText(parseKeys("<C-D>"))
+    assertPosition(120, 0)
+    assertVisibleArea(110, 144)
+  }
+
+  fun `test count scroll downwards is limited to single page`() {
+    configureByPages(5)
+    setPositionAndScroll(100, 110)
+    typeText(parseKeys("1000<C-D>"))
+    assertPosition(145, 0)
+    assertVisibleArea(135, 169)
+  }
+
+  @VimBehaviorDiffers(description = "IdeaVim does not support the 'startofline' options")
+  fun `test scroll downwards puts cursor on first non-blank column`() {
+    configureByLines(100, "    I found it in a legendary land")
+    setPositionAndScroll(20, 25, 14)
+    typeText(parseKeys("<C-D>"))
+    assertPosition(42, 4)
+    assertVisibleArea(37, 71)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageUpActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageUpActionTest.kt
@@ -1,0 +1,105 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import junit.framework.Assert
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |<C-U>|
+/* Scroll window Upwards in the buffer.  The number of
+   lines comes from the 'scroll' option (default: half a
+   screen).  If [count] given, first set the 'scroll'
+   option to [count].  The cursor is moved the same
+   number of lines up in the file (if possible; when
+   lines wrap and when hitting the end of the file there
+   may be a difference).  When the cursor is on the first
+   line of the buffer nothing happens and a beep is
+   produced.  See also 'startofline' option. */
+class ScrollHalfPageUpActionTest : VimTestCase() {
+  fun `test scroll half window upwards keeps cursor on same relative line`() {
+    configureByPages(5)
+    setPositionAndScroll(50, 60)
+    typeText(parseKeys("<C-U>"))
+    assertPosition(43, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll upwards on first line causes beep`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("<C-U>"))
+    assertPosition(0, 0)
+    assertVisibleArea(0, 34)
+    assertTrue(VimPlugin.isError())
+  }
+
+  fun `test scroll upwards in first half of first page moves to first line`() {
+    configureByPages(5)
+    setPositionAndScroll(5, 10)
+    typeText(parseKeys("<C-U>"))
+    assertPosition(0, 0)
+    assertVisibleArea(0, 34)
+  }
+
+  fun `test scroll count lines upwards`() {
+    configureByPages(5)
+    setPositionAndScroll(50, 53)
+    typeText(parseKeys("10<C-U>"))
+    assertPosition(43, 0)
+    assertVisibleArea(40, 74)
+  }
+
+  fun `test scroll count modifies scroll option`() {
+    configureByPages(5)
+    setPositionAndScroll(50, 53)
+    typeText(parseKeys("10<C-U>"))
+    Assert.assertEquals(OptionsManager.scroll.value(), 10)
+  }
+
+  fun `test scroll upwards uses scroll option`() {
+    OptionsManager.scroll.set(10)
+    configureByPages(5)
+    setPositionAndScroll(50, 53)
+    typeText(parseKeys("<C-U>"))
+    assertPosition(43, 0)
+    assertVisibleArea(40, 74)
+  }
+
+  fun `test count scroll upwards is limited to a single page`() {
+    configureByPages(5)
+    setPositionAndScroll(100, 134)
+    typeText(parseKeys("50<C-U>"))
+    assertPosition(99, 0)
+    assertVisibleArea(65, 99)
+  }
+
+  @VimBehaviorDiffers(description = "IdeaVim does not support the 'startofline' options")
+  fun `test scroll up puts cursor on first non-blank column`() {
+    configureByLines(100, "    I found it in a legendary land")
+    setPositionAndScroll(50, 60, 14)
+    typeText(parseKeys("<C-U>"))
+    assertPosition(43, 4)
+    assertVisibleArea(33, 67)
+  }
+}
+

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageUpActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageUpActionTest.kt
@@ -25,16 +25,18 @@ import com.maddyhome.idea.vim.option.OptionsManager
 import junit.framework.Assert
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |<C-U>|
-/* Scroll window Upwards in the buffer.  The number of
-   lines comes from the 'scroll' option (default: half a
-   screen).  If [count] given, first set the 'scroll'
-   option to [count].  The cursor is moved the same
-   number of lines up in the file (if possible; when
-   lines wrap and when hitting the end of the file there
-   may be a difference).  When the cursor is on the first
-   line of the buffer nothing happens and a beep is
-   produced.  See also 'startofline' option. */
+/*
+                                                       *CTRL-U*
+CTRL-U                  Scroll window Upwards in the buffer.  The number of
+                        lines comes from the 'scroll' option (default: half a
+                        screen).  If [count] given, first set the 'scroll'
+                        option to [count].  The cursor is moved the same
+                        number of lines up in the file (if possible; when
+                        lines wrap and when hitting the end of the file there
+                        may be a difference).  When the cursor is on the first
+                        line of the buffer nothing happens and a beep is
+                        produced.  See also 'startofline' option.
+ */
 class ScrollHalfPageUpActionTest : VimTestCase() {
   fun `test scroll half window upwards keeps cursor on same relative line`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthLeftActionTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -106,7 +105,7 @@ class ScrollHalfWidthLeftActionTest : VimTestCase() {
 
   fun `test scroll includes inlay visual column in half page width`() {
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 20, true, 40)
+    addInlay(20, true, 5)
     typeText(parseKeys("zL"))
     // The inlay is included in the count of scrolled visual columns
     assertPosition(0, 39)
@@ -115,7 +114,7 @@ class ScrollHalfWidthLeftActionTest : VimTestCase() {
 
   fun `test scroll with inlay in scrolled area and left of the cursor`() {
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 20, true, 40)
+    addInlay(20, true, 5)
     typeText(parseKeys("30|", "zL"))
     // The inlay is included in the count of scrolled visual columns
     assertPosition(0, 39)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthLeftActionTest.kt
@@ -1,0 +1,124 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+/*
+For the following four commands the cursor follows the screen.  If the
+character that the cursor is on is moved off the screen, the cursor is moved
+to the closest character that is on the screen.  The value of 'sidescroll' is
+not used.
+
+                                                       *zH*
+zH                      Move the view on the text half a screenwidth to the
+                        left, thus scroll the text half a screenwidth to the
+                        right.  This only works when 'wrap' is off.
+
+[count] is used but undocumented.
+ */
+class ScrollHalfWidthLeftActionTest : VimTestCase() {
+  fun `test scroll half page width`() {
+    configureByColumns(200)
+    typeText(parseKeys("zL"))
+    assertVisibleLineBounds(0, 40, 119)
+  }
+
+  fun `test scroll keeps cursor in place if already in scrolled area`() {
+    configureByColumns(200)
+    typeText(parseKeys("50|", "zL"))
+    assertPosition(0, 49)
+    assertVisibleLineBounds(0, 40, 119)
+  }
+
+  fun `test scroll moves cursor if moves off screen 1`() {
+    configureByColumns(200)
+    typeText(parseKeys("zL"))
+    assertPosition(0, 40)
+    assertVisibleLineBounds(0, 40, 119)
+  }
+
+  fun `test scroll moves cursor if moves off screen 2`() {
+    configureByColumns(200)
+    typeText(parseKeys("10|", "zL"))
+    assertPosition(0, 40)
+    assertVisibleLineBounds(0, 40, 119)
+  }
+
+  fun `test scroll count half page widths`() {
+    configureByColumns(300)
+    typeText(parseKeys("3zL"))
+    assertPosition(0, 120)
+    assertVisibleLineBounds(0, 120, 199)
+  }
+
+  fun `test scroll half page width with sidescrolloff`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("zL"))
+    assertPosition(0, 50)
+    assertVisibleLineBounds(0, 40, 119)
+  }
+
+  fun `test scroll half page width ignores sidescroll`() {
+    OptionsManager.sidescroll.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("zL"))
+    assertPosition(0, 40)
+    assertVisibleLineBounds(0, 40, 119)
+  }
+
+  @VimBehaviorDiffers(description = "Vim has virtual space at end of line")
+  fun `test scroll at end of line does not use full virtual space`() {
+    configureByColumns(200)
+    typeText(parseKeys("200|", "ze", "zL"))
+    assertPosition(0, 199)
+    assertVisibleLineBounds(0, 123, 202)
+  }
+
+  @VimBehaviorDiffers(description = "Vim has virtual space at end of line")
+  fun `test scroll near end of line does not use full virtual space`() {
+    configureByColumns(200)
+    typeText(parseKeys("190|", "ze", "zL"))
+    assertPosition(0, 189)
+    assertVisibleLineBounds(0, 123, 202)
+  }
+
+  fun `test scroll includes inlay visual column in half page width`() {
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(20, true, HintRenderer(":test"))
+    typeText(parseKeys("zL"))
+    // The inlay is included in the count of scrolled visual columns
+    assertPosition(0, 39)
+    assertVisibleLineBounds(0, 39, 118)
+  }
+
+  fun `test scroll with inlay in scrolled area and left of the cursor`() {
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(20, true, HintRenderer(":test"))
+    typeText(parseKeys("30|", "zL"))
+    // The inlay is included in the count of scrolled visual columns
+    assertPosition(0, 39)
+    assertVisibleLineBounds(0, 39, 118)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthLeftActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthLeftActionTest.kt
@@ -18,7 +18,7 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -106,7 +106,7 @@ class ScrollHalfWidthLeftActionTest : VimTestCase() {
 
   fun `test scroll includes inlay visual column in half page width`() {
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(20, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 20, true, 40)
     typeText(parseKeys("zL"))
     // The inlay is included in the count of scrolled visual columns
     assertPosition(0, 39)
@@ -115,7 +115,7 @@ class ScrollHalfWidthLeftActionTest : VimTestCase() {
 
   fun `test scroll with inlay in scrolled area and left of the cursor`() {
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(20, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 20, true, 40)
     typeText(parseKeys("30|", "zL"))
     // The inlay is included in the count of scrolled visual columns
     assertPosition(0, 39)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthRightActionTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -98,7 +97,7 @@ class ScrollHalfWidthRightActionTest : VimTestCase() {
 
   fun `test scroll includes inlay visual column in half page width`() {
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 180, true, 40)
+    addInlay(180, true, 5)
     typeText(parseKeys("190|", "ze", "zH"))
     // The inlay is included in the count of scrolled visual columns
     assertPosition(0, 150)
@@ -107,7 +106,7 @@ class ScrollHalfWidthRightActionTest : VimTestCase() {
 
   fun `test scroll with inlay and cursor in scrolled area`() {
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 180, true, 40)
+    addInlay(180, true, 5)
     typeText(parseKeys("170|", "ze", "zH"))
     // The inlay is after the cursor, and does not affect scrolling
     assertPosition(0, 129)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthRightActionTest.kt
@@ -18,7 +18,7 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -98,7 +98,7 @@ class ScrollHalfWidthRightActionTest : VimTestCase() {
 
   fun `test scroll includes inlay visual column in half page width`() {
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(180, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 180, true, 40)
     typeText(parseKeys("190|", "ze", "zH"))
     // The inlay is included in the count of scrolled visual columns
     assertPosition(0, 150)
@@ -107,7 +107,7 @@ class ScrollHalfWidthRightActionTest : VimTestCase() {
 
   fun `test scroll with inlay and cursor in scrolled area`() {
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(180, true, HintRenderer(":test"))
+    EditorTestUtil.addInlay(myFixture.editor, 180, true, 40)
     typeText(parseKeys("170|", "ze", "zH"))
     // The inlay is after the cursor, and does not affect scrolling
     assertPosition(0, 129)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthRightActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfWidthRightActionTest.kt
@@ -1,0 +1,116 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+/*
+For the following four commands the cursor follows the screen.  If the
+character that the cursor is on is moved off the screen, the cursor is moved
+to the closest character that is on the screen.  The value of 'sidescroll' is
+not used.
+
+                                                       *zH*
+zH                      Move the view on the text half a screenwidth to the
+                        left, thus scroll the text half a screenwidth to the
+                        right.  This only works when 'wrap' is off.
+
+[count] is used but undocumented.
+ */
+class ScrollHalfWidthRightActionTest : VimTestCase() {
+  fun `test scroll half page width`() {
+    configureByColumns(200)
+    typeText(parseKeys("200|", "ze", "zH"))
+    assertPosition(0, 159)
+    assertVisibleLineBounds(0, 80, 159)
+  }
+
+  fun `test scroll keeps cursor in place if already in scrolled area`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "zs", "zH"))
+    assertPosition(0, 99)
+    // Scroll right 40 characters 99 -> 59
+    assertVisibleLineBounds(0, 59, 138)
+  }
+
+  fun `test scroll moves cursor if moves off screen`() {
+    configureByColumns(200)
+    typeText(parseKeys("100|", "ze", "zH"))
+    assertPosition(0, 79)
+    assertVisibleLineBounds(0, 0, 79)
+  }
+
+  fun `test scroll count half page widths`() {
+    configureByColumns(400)
+    typeText(parseKeys("350|", "ze", "3zH"))
+    assertPosition(0, 229)
+    assertVisibleLineBounds(0, 150, 229)
+  }
+
+  fun `test scroll half page width with sidescrolloff`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("150|", "ze", "zH"))
+    assertPosition(0, 109)
+    assertVisibleLineBounds(0, 40, 119)
+  }
+
+  fun `test scroll half page width ignores sidescroll`() {
+    OptionsManager.sidescroll.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("200|", "ze", "zH"))
+    assertPosition(0, 159)
+    assertVisibleLineBounds(0, 80, 159)
+  }
+
+  fun `test scroll at start of line does nothing`() {
+    configureByColumns(200)
+    typeText(parseKeys("zH"))
+    assertPosition(0, 0)
+    assertVisibleLineBounds(0, 0, 79)
+  }
+
+  fun `test scroll near start of line does nothing`() {
+    configureByColumns(200)
+    typeText(parseKeys("10|", "zH"))
+    assertPosition(0, 9)
+    assertVisibleLineBounds(0, 0, 79)
+  }
+
+  fun `test scroll includes inlay visual column in half page width`() {
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(180, true, HintRenderer(":test"))
+    typeText(parseKeys("190|", "ze", "zH"))
+    // The inlay is included in the count of scrolled visual columns
+    assertPosition(0, 150)
+    assertVisibleLineBounds(0, 71, 150)
+  }
+
+  fun `test scroll with inlay and cursor in scrolled area`() {
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(180, true, HintRenderer(":test"))
+    typeText(parseKeys("170|", "ze", "zH"))
+    // The inlay is after the cursor, and does not affect scrolling
+    assertPosition(0, 129)
+    assertVisibleLineBounds(0, 50, 129)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
@@ -20,7 +20,6 @@ package org.jetbrains.plugins.ideavim.action.scroll
 
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.ex.util.EditorUtil
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -70,7 +69,7 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
     // The offset should include space for the inlay
     OptionsManager.sidescrolloff.set(10)
     configureByColumns(200)
-    val inlay = EditorTestUtil.addInlay(myFixture.editor, 101, true, 40)
+    val inlay = addInlay(101, true, 5)
     typeText(StringHelper.parseKeys("100|", "ze"))
     val availableColumns = getAvailableColumns(inlay)
     // Rightmost text column will still be the same, even if it's offset by an inlay
@@ -85,7 +84,7 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
     // The inlay is associated with the column before the caret, appears on the left of the caret, so does not affect
     // the last visible column
     configureByColumns(200)
-    val inlay = EditorTestUtil.addInlay(myFixture.editor, 99, true, 40)
+    val inlay = addInlay(99, true, 5)
     typeText(StringHelper.parseKeys("100|", "ze"))
     val availableColumns = getAvailableColumns(inlay)
     assertVisibleLineBounds(0, 99 - availableColumns + 1, 99)
@@ -94,7 +93,7 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
   fun `test last screen column does not include previous inline inlay associated with following text`() {
     // The inlay is associated with the caret, but appears on the left, so does not affect the last visible column
     configureByColumns(200)
-    val inlay = EditorTestUtil.addInlay(myFixture.editor, 99, false, 40)
+    val inlay = addInlay(99, false, 5)
     typeText(StringHelper.parseKeys("100|", "ze"))
     val availableColumns = getAvailableColumns(inlay)
     assertVisibleLineBounds(0, 99 - availableColumns + 1, 99)
@@ -103,7 +102,7 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
   fun `test last screen column includes subsequent inline inlay associated with preceding text`() {
     // The inlay is inserted after the caret and relates to the caret column. It should still be visible
     configureByColumns(200)
-    val inlay = EditorTestUtil.addInlay(myFixture.editor, 100, true, 40)
+    val inlay = addInlay(100, true, 5)
     typeText(StringHelper.parseKeys("100|", "ze"))
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
     val textWidth = visibleArea.width - inlay.widthInPixels
@@ -121,7 +120,7 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
     // The inlay is inserted after the caret, and relates to text after the caret. It should not affect the last visible
     // column
     configureByColumns(200)
-    EditorTestUtil.addInlay(myFixture.editor, 100, false, 40)
+    addInlay(100, false, 5)
     typeText(StringHelper.parseKeys("100|", "ze"))
     assertVisibleLineBounds(0, 20, 99)
   }

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
@@ -26,9 +26,11 @@ import com.maddyhome.idea.vim.option.OptionsManager
 import org.junit.Assert
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-/* ze   Scroll the text horizontally to position the cursor
-        at the end (right side) of the screen.  This only
-			  works when 'wrap' is off.
+/*
+                                                       *ze*
+ze                      Scroll the text horizontally to position the cursor
+                        at the end (right side) of the screen.  This only
+                        works when 'wrap' is off.
  */
 class ScrollLastScreenColumnActionTest : VimTestCase() {
   fun `test scroll caret column to last screen column`() {

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
@@ -111,10 +111,8 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
     assertVisibleLineBounds(0, 99 - availableColumns + 1, 99)
 
     // We have to assert the location of the inlay
-    Assert.assertTrue("Inlay bounds must be greater than last text location",
-      inlay.bounds!!.x > (visibleArea.x + textWidth))
-    Assert.assertTrue("Inlay bounds must be less than width of screen",
-      inlay.bounds!!.x + inlay.bounds!!.width <= (visibleArea.x + visibleArea.width + 1))
+    Assert.assertEquals(visibleArea.x + textWidth, inlay.bounds!!.x)
+    Assert.assertEquals(visibleArea.x + visibleArea.width, inlay.bounds!!.x + inlay.bounds!!.width)
   }
 
   fun `test last screen column does not include subsequent inline inlay associated with following text`() {

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
@@ -18,13 +18,13 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper
 import com.maddyhome.idea.vim.option.OptionsManager
-import org.junit.Assert
 import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.Assert
 
 /*
                                                        *ze*
@@ -70,7 +70,7 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
     // The offset should include space for the inlay
     OptionsManager.sidescrolloff.set(10)
     configureByColumns(200)
-    val inlay = myFixture.editor.inlayModel.addInlineElement(101, true, HintRenderer(":test"))!!
+    val inlay = EditorTestUtil.addInlay(myFixture.editor, 101, true, 40)
     typeText(StringHelper.parseKeys("100|", "ze"))
     val availableColumns = getAvailableColumns(inlay)
     // Rightmost text column will still be the same, even if it's offset by an inlay
@@ -85,7 +85,7 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
     // The inlay is associated with the column before the caret, appears on the left of the caret, so does not affect
     // the last visible column
     configureByColumns(200)
-    val inlay = myFixture.editor.inlayModel.addInlineElement(99, true, HintRenderer(":test"))!!
+    val inlay = EditorTestUtil.addInlay(myFixture.editor, 99, true, 40)
     typeText(StringHelper.parseKeys("100|", "ze"))
     val availableColumns = getAvailableColumns(inlay)
     assertVisibleLineBounds(0, 99 - availableColumns + 1, 99)
@@ -94,7 +94,7 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
   fun `test last screen column does not include previous inline inlay associated with following text`() {
     // The inlay is associated with the caret, but appears on the left, so does not affect the last visible column
     configureByColumns(200)
-    val inlay = myFixture.editor.inlayModel.addInlineElement(99, false, HintRenderer("test:"))!!
+    val inlay = EditorTestUtil.addInlay(myFixture.editor, 99, false, 40)
     typeText(StringHelper.parseKeys("100|", "ze"))
     val availableColumns = getAvailableColumns(inlay)
     assertVisibleLineBounds(0, 99 - availableColumns + 1, 99)
@@ -103,7 +103,7 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
   fun `test last screen column includes subsequent inline inlay associated with preceding text`() {
     // The inlay is inserted after the caret and relates to the caret column. It should still be visible
     configureByColumns(200)
-    val inlay = myFixture.editor.inlayModel.addInlineElement(100, true, HintRenderer(":test"))!!
+    val inlay = EditorTestUtil.addInlay(myFixture.editor, 100, true, 40)
     typeText(StringHelper.parseKeys("100|", "ze"))
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
     val textWidth = visibleArea.width - inlay.widthInPixels
@@ -121,12 +121,12 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
     // The inlay is inserted after the caret, and relates to text after the caret. It should not affect the last visible
     // column
     configureByColumns(200)
-    myFixture.editor.inlayModel.addInlineElement(100, false, HintRenderer("test:"))!!
+    EditorTestUtil.addInlay(myFixture.editor, 100, false, 40)
     typeText(StringHelper.parseKeys("100|", "ze"))
     assertVisibleLineBounds(0, 20, 99)
   }
 
-  private fun getAvailableColumns(inlay: Inlay<HintRenderer>): Int {
+  private fun getAvailableColumns(inlay: Inlay<*>): Int {
     val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
     return textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
   }

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
@@ -1,0 +1,133 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.openapi.editor.Inlay
+import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.maddyhome.idea.vim.helper.StringHelper
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.junit.Assert
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+/* ze   Scroll the text horizontally to position the cursor
+        at the end (right side) of the screen.  This only
+			  works when 'wrap' is off.
+ */
+class ScrollLastScreenColumnActionTest : VimTestCase() {
+  fun `test scroll caret column to last screen column`() {
+    configureByColumns(200)
+    typeText(StringHelper.parseKeys("100|", "ze"))
+    assertVisibleLineBounds(0, 20, 99)
+  }
+
+  fun `test scroll caret column to last screen column with sidescrolloff`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(StringHelper.parseKeys("100|", "ze"))
+    assertVisibleLineBounds(0, 30, 109)
+  }
+
+  fun `test scroll at or near start of line does nothing`() {
+    configureByColumns(200)
+    typeText(StringHelper.parseKeys("10|", "ze"))
+    assertVisibleLineBounds(0, 0, 79)
+  }
+
+  fun `test scroll end of line to last screen column`() {
+    configureByColumns(200)
+    typeText(StringHelper.parseKeys("$", "ze"))
+    assertVisibleLineBounds(0, 120, 199)
+  }
+
+  fun `test scroll end of line to last screen column with sidescrolloff`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(StringHelper.parseKeys("$", "ze"))
+    // See myFixture.editor.settings.additionalColumnsCount
+    assertVisibleLineBounds(0, 120, 199)
+  }
+
+  fun `test scroll caret column to last screen column with sidescrolloff containing an inline inlay`() {
+    // The offset should include space for the inlay
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    val inlay = myFixture.editor.inlayModel.addInlineElement(101, true, HintRenderer(":test"))!!
+    typeText(StringHelper.parseKeys("100|", "ze"))
+    val availableColumns = getAvailableColumns(inlay)
+    // Rightmost text column will still be the same, even if it's offset by an inlay
+    // TODO: Should the offset include the visual column taken up by the inlay?
+    // Note that the values for this test are -1 when compared to other tests. That's because the inlay takes up a
+    // visual column, and scrolling doesn't distinguish the type of visual column
+    // We need to decide if folds and/or inlays should be included in offsets, and figure out how to reasonably implement it
+    assertVisibleLineBounds(0, 108 - availableColumns + 1, 108)
+  }
+
+  fun `test last screen column does not include previous inline inlay associated with preceding text`() {
+    // The inlay is associated with the column before the caret, appears on the left of the caret, so does not affect
+    // the last visible column
+    configureByColumns(200)
+    val inlay = myFixture.editor.inlayModel.addInlineElement(99, true, HintRenderer(":test"))!!
+    typeText(StringHelper.parseKeys("100|", "ze"))
+    val availableColumns = getAvailableColumns(inlay)
+    assertVisibleLineBounds(0, 99 - availableColumns + 1, 99)
+  }
+
+  fun `test last screen column does not include previous inline inlay associated with following text`() {
+    // The inlay is associated with the caret, but appears on the left, so does not affect the last visible column
+    configureByColumns(200)
+    val inlay = myFixture.editor.inlayModel.addInlineElement(99, false, HintRenderer("test:"))!!
+    typeText(StringHelper.parseKeys("100|", "ze"))
+    val availableColumns = getAvailableColumns(inlay)
+    assertVisibleLineBounds(0, 99 - availableColumns + 1, 99)
+  }
+
+  fun `test last screen column includes subsequent inline inlay associated with preceding text`() {
+    // The inlay is inserted after the caret and relates to the caret column. It should still be visible
+    configureByColumns(200)
+    val inlay = myFixture.editor.inlayModel.addInlineElement(100, true, HintRenderer(":test"))!!
+    typeText(StringHelper.parseKeys("100|", "ze"))
+    val visibleArea = myFixture.editor.scrollingModel.visibleArea
+    val textWidth = visibleArea.width - inlay.widthInPixels
+    val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+
+    // The last visible text column will be 99, but it will be positioned before the inlay
+    assertVisibleLineBounds(0, 99 - availableColumns + 1, 99)
+
+    // We have to assert the location of the inlay
+    Assert.assertTrue("Inlay bounds must be greater than last text location",
+      inlay.bounds!!.x > (visibleArea.x + textWidth))
+    Assert.assertTrue("Inlay bounds must be less than width of screen",
+      inlay.bounds!!.x + inlay.bounds!!.width <= (visibleArea.x + visibleArea.width + 1))
+  }
+
+  fun `test last screen column does not include subsequent inline inlay associated with following text`() {
+    // The inlay is inserted after the caret, and relates to text after the caret. It should not affect the last visible
+    // column
+    configureByColumns(200)
+    myFixture.editor.inlayModel.addInlineElement(100, false, HintRenderer("test:"))!!
+    typeText(StringHelper.parseKeys("100|", "ze"))
+    assertVisibleLineBounds(0, 20, 99)
+  }
+
+  private fun getAvailableColumns(inlay: Inlay<HintRenderer>): Int {
+    val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
+    return textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLineActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLineActionTest.kt
@@ -1,0 +1,86 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |zb|
+/* Like "z-", but leave the cursor in the same column. */
+class ScrollLastScreenLineActionTest : VimTestCase() {
+  fun `test scroll current line to bottom of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("zb"))
+    assertPosition(60, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test scroll current line to bottom of screen and leave cursor in current column`() {
+    configureByLines(100, "    I found it in a legendary land")
+    setPositionAndScroll(40, 60, 14)
+    typeText(StringHelper.parseKeys("zb"))
+    assertPosition(60, 14)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test scroll current line to bottom of screen minus scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("zb"))
+    assertPosition(60, 0)
+    assertVisibleArea(36, 70)
+  }
+
+  fun `test scrolls count line to bottom of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("100zb"))
+    assertPosition(99, 0)
+    assertVisibleArea(65, 99)
+  }
+
+  fun `test scrolls count line to bottom of screen minus scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("100zb"))
+    assertPosition(99, 0)
+    assertVisibleArea(75, 109)
+  }
+
+  fun `test scrolls current line to bottom of screen ignoring scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("zb"))
+    assertPosition(60, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test scrolls correctly when less than a page to scroll`() {
+    configureByPages(5)
+    setPositionAndScroll(5, 15)
+    typeText(StringHelper.parseKeys("zb"))
+    assertPosition(15, 0)
+    assertVisibleArea(0, 34)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLineActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLineActionTest.kt
@@ -22,8 +22,10 @@ import com.maddyhome.idea.vim.helper.StringHelper
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |zb|
-/* Like "z-", but leave the cursor in the same column. */
+/*
+                                                       *zb*
+zb                      Like "z-", but leave the cursor in the same column.
+ */
 class ScrollLastScreenLineActionTest : VimTestCase() {
   fun `test scroll current line to bottom of screen`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLinePageStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLinePageStartActionTest.kt
@@ -22,15 +22,17 @@ import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |z^|
-/* Without [count]: Redraw with the line just above the
-   window at the bottom of the window.  Put the cursor in
-   that line, at the first non-blank in the line.
-   With [count]: First scroll the text to put the [count]
-   line at the bottom of the window, then redraw with the
-   line which is now at the top of the window at the
-   bottom of the window.  Put the cursor in that line, at
-   the first non-blank in the line. */
+/*
+                                                       *z^*
+z^                      Without [count]: Redraw with the line just above the
+                        window at the bottom of the window.  Put the cursor in
+                        that line, at the first non-blank in the line.
+                        With [count]: First scroll the text to put the [count]
+                        line at the bottom of the window, then redraw with the
+                        line which is now at the top of the window at the
+                        bottom of the window.  Put the cursor in that line, at
+                        the first non-blank in the line.
+ */
 class ScrollLastScreenLinePageStartActionTest : VimTestCase() {
   fun `test scrolls last line on previous page to bottom of screen`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLinePageStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLinePageStartActionTest.kt
@@ -1,0 +1,110 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |z^|
+/* Without [count]: Redraw with the line just above the
+   window at the bottom of the window.  Put the cursor in
+   that line, at the first non-blank in the line.
+   With [count]: First scroll the text to put the [count]
+   line at the bottom of the window, then redraw with the
+   line which is now at the top of the window at the
+   bottom of the window.  Put the cursor in that line, at
+   the first non-blank in the line. */
+class ScrollLastScreenLinePageStartActionTest : VimTestCase() {
+  fun `test scrolls last line on previous page to bottom of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(99, 119)
+    typeText(parseKeys("z^"))
+    assertPosition(98, 0)
+    assertVisibleArea(64, 98)
+  }
+
+  fun `test scrolls to first non-blank in line`() {
+    configureByLines(200, "    I found it in a legendary land")
+    setPositionAndScroll(99, 119)
+    typeText(parseKeys("z^"))
+    assertPosition(98, 4)
+    assertVisibleArea(64, 98)
+  }
+
+  fun `test scrolls last line on previous page to scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(99, 119)
+    typeText(parseKeys("z^"))
+    assertPosition(98, 0)
+    assertVisibleArea(74, 108)
+  }
+
+  fun `test scrolls last line on previous page ignores scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(99, 119)
+    typeText(parseKeys("z^"))
+    assertPosition(98, 0)
+    assertVisibleArea(64, 98)
+  }
+
+  fun `test count z^ puts count line at bottom of screen then scrolls back a page`() {
+    configureByPages(5)
+    setPositionAndScroll(140, 150)
+    typeText(parseKeys("100z^"))
+    // Put 100 at the bottom of the page. Top is 66. Scroll back a page so 66 is at bottom of page
+    assertPosition(65, 0)
+    assertVisibleArea(31, 65)
+  }
+
+  fun `test z^ on first page puts cursor on first line 1`() {
+    configureByLines(50, "    I found it in a legendary land")
+    setPositionAndScroll(0, 25)
+    typeText(parseKeys("z^"))
+    assertPosition(0, 4)
+    assertVisibleArea(0, 34)
+  }
+
+  fun `test z^ on first page puts cursor on first line 2`() {
+    configureByLines(50, "    I found it in a legendary land")
+    setPositionAndScroll(0, 6)
+    typeText(parseKeys("z^"))
+    assertPosition(0, 4)
+    assertVisibleArea(0, 34)
+  }
+
+  fun `test z^ on first page ignores scrolloff and puts cursor on last line of previous page`() {
+    OptionsManager.scrolloff.set(10)
+    configureByLines(50, "    I found it in a legendary land")
+    setPositionAndScroll(0, 6)
+    typeText(parseKeys("z^"))
+    assertPosition(0, 4)
+    assertVisibleArea(0, 34)
+  }
+
+  fun `test z^ on second page puts cursor on previous last line`() {
+    configureByLines(50, "    I found it in a legendary land")
+    setPositionAndScroll(19, 39)
+    typeText(parseKeys("z^"))
+    assertPosition(18, 4)
+    assertVisibleArea(0, 34)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLineStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLineStartActionTest.kt
@@ -1,0 +1,88 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |z-|
+/* Redraw, line [count] at bottom of window (default
+   cursor line).  Put cursor at first non-blank in the
+   line. */
+class ScrollLastScreenLineStartActionTest : VimTestCase() {
+  fun `test scroll current line to bottom of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("z-"))
+    assertPosition(60, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test scroll current line to bottom of screen and move cursor to first non-blank`() {
+    configureByLines(100, "    I found it in a legendary land")
+    setPositionAndScroll(40, 60, 14)
+    typeText(StringHelper.parseKeys("z-"))
+    assertPosition(60, 4)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test scroll current line to bottom of screen minus scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("z-"))
+    assertPosition(60, 0)
+    assertVisibleArea(36, 70)
+  }
+
+  fun `test scrolls count line to bottom of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("100z-"))
+    assertPosition(99, 0)
+    assertVisibleArea(65, 99)
+  }
+
+  fun `test scrolls count line to bottom of screen minus scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("100z-"))
+    assertPosition(99, 0)
+    assertVisibleArea(75, 109)
+  }
+
+  fun `test scrolls current line to bottom of screen ignoring scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(40, 60)
+    typeText(StringHelper.parseKeys("z-"))
+    assertPosition(60, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test scrolls correctly when less than a page to scroll`() {
+    configureByPages(5)
+    setPositionAndScroll(5, 15)
+    typeText(StringHelper.parseKeys("z-"))
+    assertPosition(15, 0)
+    assertVisibleArea(0, 34)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLineStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenLineStartActionTest.kt
@@ -22,10 +22,12 @@ import com.maddyhome.idea.vim.helper.StringHelper
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |z-|
-/* Redraw, line [count] at bottom of window (default
-   cursor line).  Put cursor at first non-blank in the
-   line. */
+/*
+                                                       *z-*
+z-                      Redraw, line [count] at bottom of window (default
+                        cursor line).  Put cursor at first non-blank in the
+                        line.
+ */
 class ScrollLastScreenLineStartActionTest : VimTestCase() {
   fun `test scroll current line to bottom of screen`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLineDownActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLineDownActionTest.kt
@@ -23,7 +23,12 @@ import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |<C-E>|
+/*
+                                                       *CTRL-E*
+CTRL-E                  Scroll window [count] lines downwards in the buffer.
+                        The text moves upwards on the screen.
+                        Mnemonic: Extra lines.
+ */
 class ScrollLineDownActionTest : VimTestCase() {
   fun `test scroll single line down`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLineDownActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLineDownActionTest.kt
@@ -1,0 +1,97 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |<C-E>|
+class ScrollLineDownActionTest : VimTestCase() {
+  fun `test scroll single line down`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 34)
+    typeText(parseKeys("<C-E>"))
+    assertPosition(34, 0)
+    assertVisibleArea(1, 35)
+  }
+
+  fun `test scroll line down will keep cursor on screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("<C-E>"))
+    assertPosition(1, 0)
+    assertVisibleArea(1, 35)
+  }
+
+  fun `test scroll count lines down`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 34)
+    typeText(parseKeys("10<C-E>"))
+    assertPosition(34, 0)
+    assertVisibleArea(10, 44)
+  }
+
+  fun `test scroll count lines down will keep cursor on screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("10<C-E>"))
+    assertPosition(10, 0)
+    assertVisibleArea(10, 44)
+  }
+
+  @VimBehaviorDiffers(description = "Vim has virtual space at the end of the file, IntelliJ (by default) does not")
+  fun `test too many lines down stops at last line`() {
+    configureByPages(5) // 5 * 35 = 175
+    setPositionAndScroll(100, 100)
+    typeText(parseKeys("100<C-E>"))
+
+    // TODO: Enforce virtual space
+    // Vim will put the caret on line 174, and put that line at the top of the screen
+    // See com.maddyhome.idea.vim.helper.EditorHelper.scrollVisualLineToTopOfScreen
+    assertPosition(146, 0)
+    assertVisibleArea(146, 175)
+  }
+
+  fun `test scroll down uses scrolloff and moves cursor`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(20, 30)
+    typeText(parseKeys("<C-E>"))
+    assertPosition(31, 0)
+    assertVisibleArea(21, 55)
+  }
+
+  fun `test scroll down is not affected by scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(20, 20)
+    typeText(parseKeys("<C-E>"))
+    assertPosition(21, 0)
+    assertVisibleArea(21, 55)
+  }
+
+  fun `test scroll down in visual mode`() {
+    configureByPages(5)
+    setPositionAndScroll(20, 30)
+    typeText(parseKeys("Vjjjj", "<C-E>"))
+    assertVisibleArea(21, 55)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLineUpActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLineUpActionTest.kt
@@ -1,0 +1,99 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |<C-Y>|
+class ScrollLineUpActionTest : VimTestCase() {
+  fun `test scroll single line up`() {
+    configureByPages(5)
+    setPositionAndScroll(29, 29)
+    typeText(parseKeys("<C-Y>"))
+    assertPosition(29, 0)
+    assertVisibleArea(28, 62)
+  }
+
+  fun `test scroll line up will keep cursor on screen`() {
+    configureByPages(5)
+    setPositionAndScroll(29, 63)
+    typeText(parseKeys("<C-Y>"))
+    assertPosition(62, 0)
+    assertVisibleArea(28, 62)
+  }
+
+  fun `test scroll count lines up`() {
+    configureByPages(5)
+    setPositionAndScroll(29, 29)
+    typeText(parseKeys("10<C-Y>"))
+    assertPosition(29, 0)
+    assertVisibleArea(19, 53)
+  }
+
+  fun `test scroll count lines up will keep cursor on screen`() {
+    configureByPages(5)
+    setPositionAndScroll(29, 63)
+    typeText(parseKeys("10<C-Y>"))
+    assertPosition(53, 0)
+    assertVisibleArea(19, 53)
+  }
+
+  fun `test too many lines up stops at zero`() {
+    configureByPages(5)
+    setPositionAndScroll(29, 29)
+    typeText(parseKeys("100<C-Y>"))
+    assertPosition(29, 0)
+    assertVisibleArea(0, 34)
+  }
+
+  fun `test too many lines up stops at zero and keeps cursor on screen`() {
+    configureByPages(5)
+    setPositionAndScroll(59, 59)
+    typeText(parseKeys("100<C-Y>"))
+    assertPosition(34, 0)
+    assertVisibleArea(0, 34)
+  }
+
+  fun `test scroll up uses scrolloff and moves cursor`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(20, 44)
+    typeText(parseKeys("<C-Y>"))
+    assertPosition(43, 0)
+    assertVisibleArea(19, 53)
+  }
+
+  fun `test scroll up is not affected by scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(29, 63)
+    typeText(parseKeys("<C-Y>"))
+    assertPosition(62, 0)
+    assertVisibleArea(28, 62)
+  }
+
+  fun `test scroll line up in visual mode`() {
+    configureByPages(5)
+    setPositionAndScroll(29, 29)
+    typeText(parseKeys("Vjjjj", "<C-Y>"))
+    assertVisibleArea(28, 62)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLineUpActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollLineUpActionTest.kt
@@ -22,7 +22,13 @@ import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |<C-Y>|
+/*
+                                                       *CTRL-Y*
+CTRL-Y                  Scroll window [count] lines upwards in the buffer.
+                        The text moves downwards on the screen.
+                        Note: When using the MS-Windows key bindings CTRL-Y is
+                        remapped to redo.
+ */
 class ScrollLineUpActionTest : VimTestCase() {
   fun `test scroll single line up`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollMiddleScreenLineActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollMiddleScreenLineActionTest.kt
@@ -23,8 +23,12 @@ import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |zz|
-/* Like "z.", but leave the cursor in the same column. */
+/*
+                                                       *zz*
+zz                      Like "z.", but leave the cursor in the same column.
+                        Careful: If caps-lock is on, this command becomes
+                        "ZZ": write buffer and exit!
+ */
 class ScrollMiddleScreenLineActionTest : VimTestCase() {
   fun `test scrolls current line to middle of screen`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollMiddleScreenLineActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollMiddleScreenLineActionTest.kt
@@ -1,0 +1,78 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |zz|
+/* Like "z.", but leave the cursor in the same column. */
+class ScrollMiddleScreenLineActionTest : VimTestCase() {
+  fun `test scrolls current line to middle of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 45)
+    typeText(parseKeys("zz"))
+    assertPosition(45, 0)
+    assertVisibleArea(28, 62)
+  }
+
+  fun `test scrolls current line to middle of screen and keeps cursor in the same column`() {
+    configureByLines(100, "    I found it in a legendary land")
+    setPositionAndScroll(40, 45, 14)
+    typeText(parseKeys("zz"))
+    assertPosition(45, 14)
+    assertVisibleArea(28, 62)
+  }
+
+  fun `test scrolls count line to the middle of the screen`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 45)
+    typeText(parseKeys("100zz"))
+    assertPosition(99, 0)
+    assertVisibleArea(82, 116)
+  }
+
+  fun `test scrolls count line ignoring scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(40, 45)
+    typeText(parseKeys("100zz"))
+    assertPosition(99, 0)
+    assertVisibleArea(82, 116)
+  }
+
+  fun `test scrolls correctly when count line is in first half of first page`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 45)
+    typeText(parseKeys("10zz"))
+    assertPosition(9, 0)
+    assertVisibleArea(0, 34)
+  }
+
+  @VimBehaviorDiffers(description = "Virtual space at end of file")
+  fun `test scrolls last line of file correctly`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("175zz"))
+    assertPosition(174, 0)
+    assertVisibleArea(146, 175)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollMiddleScreenLineStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollMiddleScreenLineStartActionTest.kt
@@ -23,10 +23,12 @@ import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |z.|
-/* Redraw, line [count] at center of window (default
-   cursor line).  Put cursor at first non-blank in the
-   line. */
+/*
+                                                       *z.*
+z.                      Redraw, line [count] at center of window (default
+                        cursor line).  Put cursor at first non-blank in the
+                        line.
+ */
 class ScrollMiddleScreenLineStartActionTest : VimTestCase() {
   fun `test scrolls current line to middle of screen`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollMiddleScreenLineStartActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollMiddleScreenLineStartActionTest.kt
@@ -1,0 +1,80 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |z.|
+/* Redraw, line [count] at center of window (default
+   cursor line).  Put cursor at first non-blank in the
+   line. */
+class ScrollMiddleScreenLineStartActionTest : VimTestCase() {
+  fun `test scrolls current line to middle of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 45)
+    typeText(parseKeys("z."))
+    assertPosition(45, 0)
+    assertVisibleArea(28, 62)
+  }
+
+  fun `test scrolls current line to middle of screen and moves cursor to first non-blank`() {
+    configureByLines(100, "    I found it in a legendary land")
+    setPositionAndScroll(40, 45, 14)
+    typeText(parseKeys("z."))
+    assertPosition(45, 4)
+    assertVisibleArea(28, 62)
+  }
+
+  fun `test scrolls count line to the middle of the screen`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 45)
+    typeText(parseKeys("100z."))
+    assertPosition(99, 0)
+    assertVisibleArea(82, 116)
+  }
+
+  fun `test scrolls count line ignoring scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(40, 45)
+    typeText(parseKeys("100z."))
+    assertPosition(99, 0)
+    assertVisibleArea(82, 116)
+  }
+
+  fun `test scrolls correctly when count line is in first half of first page`() {
+    configureByPages(5)
+    setPositionAndScroll(40, 45)
+    typeText(parseKeys("10z."))
+    assertPosition(9, 0)
+    assertVisibleArea(0, 34)
+  }
+
+  @VimBehaviorDiffers(description = "Virtual space at end of file")
+  fun `test scrolls last line of file correctly`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("175z."))
+    assertPosition(174, 0)
+    assertVisibleArea(146, 175)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageDownActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageDownActionTest.kt
@@ -24,8 +24,17 @@ import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |<S-Down>|, |<PageDown>|, |CTRL-F|
-// |i_<S-Down>|, |i_<PageDown>|
+/*
+<S-Down>        or                             *<S-Down>* *<kPageDown>*
+<PageDown>      or                             *<PageDown>* *CTRL-F*
+CTRL-F                  Scroll window [count] pages Forwards (downwards) in
+                        the buffer.  See also 'startofline' option.
+                        When there is only one window the 'window' option
+                        might be used.
+
+<S-Down>        move window one page down      *i_<S-Down>*
+<PageDown>      move window one page down      *i_<PageDown>*
+ */
 class ScrollPageDownActionTest : VimTestCase() {
   fun `test scroll single page down with S-Down`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageDownActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageDownActionTest.kt
@@ -1,0 +1,152 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |<S-Down>|, |<PageDown>|, |CTRL-F|
+// |i_<S-Down>|, |i_<PageDown>|
+class ScrollPageDownActionTest : VimTestCase() {
+  fun `test scroll single page down with S-Down`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("<S-Down>"))
+    assertPosition(33, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll single page down with PageDown`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("<PageDown>"))
+    assertPosition(33, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll single page down with CTRL-F`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("<C-F>"))
+    assertPosition(33, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll page down in insert mode with S-Down`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("i", "<S-Down>"))
+    assertPosition(33, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll page down in insert mode with PageDown`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("i", "<PageDown>"))
+    assertPosition(33, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll count pages down with S-Down`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("3<S-Down>"))
+    assertPosition(99, 0)
+    assertVisibleArea(99, 133)
+  }
+
+  fun `test scroll count pages down with PageDown`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("3<PageDown>"))
+    assertPosition(99, 0)
+    assertVisibleArea(99, 133)
+  }
+
+  fun `test scroll count pages down with CTRL-F`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("3<C-F>"))
+    assertPosition(99, 0)
+    assertVisibleArea(99, 133)
+  }
+
+  fun `test scroll page down moves cursor to top of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("<C-F>"))
+    assertPosition(33, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll page down in insert mode moves cursor`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("i", "<S-Down>"))
+    assertPosition(33, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll page down moves cursor with scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("<C-F>"))
+    assertPosition(43, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll page down in insert mode moves cursor with scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 20)
+    typeText(parseKeys("i", "<S-Down>"))
+    assertPosition(43, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  fun `test scroll page down ignores scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText(parseKeys("<C-F>"))
+    assertPosition(33, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  @VimBehaviorDiffers(description = "IntelliJ does not have virtual space enabled by default")
+  fun `test scroll page down on final page moves cursor to end of file`() {
+    configureByPages(5)
+    setPositionAndScroll(145, 150)
+    typeText(parseKeys("<C-F>"))
+    assertPosition(175, 0)
+    assertVisibleArea(146, 175)
+  }
+
+  fun `test scroll page down on penultimate page`() {
+    configureByPages(5)
+    setPositionAndScroll(110, 130)
+    typeText(parseKeys("<C-F>"))
+    assertPosition(143, 0)
+    assertVisibleArea(143, 175)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageDownActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageDownActionTest.kt
@@ -18,6 +18,7 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
+import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.OptionsManager
@@ -134,7 +135,7 @@ class ScrollPageDownActionTest : VimTestCase() {
   }
 
   @VimBehaviorDiffers(description = "IntelliJ does not have virtual space enabled by default")
-  fun `test scroll page down on final page moves cursor to end of file`() {
+  fun `test scroll page down on last page moves cursor to end of file`() {
     configureByPages(5)
     setPositionAndScroll(145, 150)
     typeText(parseKeys("<C-F>"))
@@ -148,5 +149,12 @@ class ScrollPageDownActionTest : VimTestCase() {
     typeText(parseKeys("<C-F>"))
     assertPosition(143, 0)
     assertVisibleArea(143, 175)
+  }
+
+  fun `test scroll page down on last line causes beep`() {
+    configureByPages(5)
+    setPositionAndScroll(146, 175)
+    typeText(parseKeys("<C-F>"))
+    assertTrue(VimPlugin.isError())
   }
 }

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageUpActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageUpActionTest.kt
@@ -24,8 +24,17 @@ import com.maddyhome.idea.vim.option.OptionsManager
 import junit.framework.Assert
 import org.jetbrains.plugins.ideavim.VimTestCase
 
-// |<S-Up>|, |<PageUp>|, |CTRL-B|
-// |i_<S-Up>|, |i_<PageUp>|
+/*
+<S-Up>          or                                     *<S-Up>* *<kPageUp>*
+<PageUp>        or                                     *<PageUp>* *CTRL-B*
+CTRL-B                  Scroll window [count] pages Backwards (upwards) in the
+                        buffer.  See also 'startofline' option.
+                        When there is only one window the 'window' option
+                        might be used.
+
+<S-Up>          move window one page up        *i_<S-Up>*
+<PageUp>        move window one page up        *i_<PageUp>*
+ */
 class ScrollPageUpActionTest : VimTestCase() {
   fun `test scroll single page up with S-Up`() {
     configureByPages(5)

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageUpActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageUpActionTest.kt
@@ -18,8 +18,10 @@
 
 package org.jetbrains.plugins.ideavim.action.scroll
 
+import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.OptionsManager
+import junit.framework.Assert
 import org.jetbrains.plugins.ideavim.VimTestCase
 
 // |<S-Up>|, |<PageUp>|, |CTRL-B|
@@ -138,6 +140,13 @@ class ScrollPageUpActionTest : VimTestCase() {
     typeText(parseKeys("<C-B>"))
     assertPosition(25, 0)
     assertVisibleArea(0, 34)
+  }
+
+  fun `test scroll page up on first page causes beep`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 25)
+    typeText(parseKeys("<C-B>"))
+    Assert.assertTrue(VimPlugin.isError())
   }
 
   fun `test scroll page up on second page moves cursor to previous top`() {

--- a/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageUpActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageUpActionTest.kt
@@ -1,0 +1,150 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.action.scroll
+
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// |<S-Up>|, |<PageUp>|, |CTRL-B|
+// |i_<S-Up>|, |i_<PageUp>|
+class ScrollPageUpActionTest : VimTestCase() {
+  fun `test scroll single page up with S-Up`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("<S-Up>"))
+    assertPosition(130, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll single page up with PageUp`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("<PageUp>"))
+    assertPosition(130, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll single page up with CTRL-B`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("<C-B>"))
+    assertPosition(130, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll page up in insert mode with S-Up`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("i", "<S-Up>"))
+    assertPosition(130, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll page up in insert mode with PageUp`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("i", "<PageUp>"))
+    assertPosition(130, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll count pages up with S-Up`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("3<S-Up>"))
+    assertPosition(64, 0)
+    assertVisibleArea(30, 64)
+  }
+
+  fun `test scroll count pages up with PageUp`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("3<PageUp>"))
+    assertPosition(64, 0)
+    assertVisibleArea(30, 64)
+  }
+
+  fun `test scroll count pages up with CTRL-B`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("3<C-B>"))
+    assertPosition(64, 0)
+    assertVisibleArea(30, 64)
+  }
+
+  fun `test scroll page up moves cursor to bottom of screen`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("<C-B>"))
+    assertPosition(130, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll page up in insert mode moves cursor`() {
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("i", "<S-Up>"))
+    assertPosition(130, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll page up moves cursor with scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("<C-B>"))
+    assertPosition(120, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll page up in insert mode cursor with scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("i", "<S-Up>"))
+    assertPosition(120, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll page up ignores scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(129, 149)
+    typeText(parseKeys("<C-B>"))
+    assertPosition(130, 0)
+    assertVisibleArea(96, 130)
+  }
+
+  fun `test scroll page up on first page does not move`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 25)
+    typeText(parseKeys("<C-B>"))
+    assertPosition(25, 0)
+    assertVisibleArea(0, 34)
+  }
+
+  fun `test scroll page up on second page moves cursor to previous top`() {
+    configureByPages(5)
+    setPositionAndScroll(10, 35)
+    typeText(parseKeys("<C-B>"))
+    assertPosition(11, 0)
+    assertVisibleArea(0, 34)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewHorizontally_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewHorizontally_Test.kt
@@ -18,8 +18,8 @@
 
 package org.jetbrains.plugins.ideavim.group.motion
 
-import com.intellij.codeInsight.daemon.impl.HintRenderer
 import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -91,12 +91,11 @@ class MotionGroup_ScrollCaretIntoViewHorizontally_Test : VimTestCase() {
   fun `test moving right with inline inlay`() {
     OptionsManager.sidescroll.set(1)
     configureByColumns(200)
-    val inlayRenderer = HintRenderer(":test")
-    val inlay = myFixture.editor.inlayModel.addInlineElement(110, true, inlayRenderer)!!
+    val inlay = EditorTestUtil.addInlay(myFixture.editor, 110, true, 40)
     typeText(parseKeys("100|", "20l"))
     // These columns are hard to calculate, because the visible offset depends on the rendered width of the inlay
     // Also, because we're scrolling right (adding columns to the right) we make the right most column line up
-    val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlayRenderer.calcWidthInPixels(inlay)
+    val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
     val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
     assertVisibleLineBounds(0, 119 - availableColumns + 1, 119)
   }
@@ -159,11 +158,10 @@ class MotionGroup_ScrollCaretIntoViewHorizontally_Test : VimTestCase() {
   fun `test moving left with inline inlay`() {
     OptionsManager.sidescroll.set(1)
     configureByColumns(200)
-    val inlayRenderer = HintRenderer(":test")
-    val inlay = myFixture.editor.inlayModel.addInlineElement(110, true, inlayRenderer)!!
+    val inlay = EditorTestUtil.addInlay(myFixture.editor, 110, true, 40)
     typeText(parseKeys("120|zs", "20h"))
     // These columns are hard to calculate, because the visible offset depends on the rendered width of the inlay
-    val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlayRenderer.calcWidthInPixels(inlay)
+    val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
     val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
     assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
   }

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewHorizontally_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewHorizontally_Test.kt
@@ -1,0 +1,177 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.group.motion
+
+import com.intellij.codeInsight.daemon.impl.HintRenderer
+import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+@Suppress("ClassName")
+class MotionGroup_ScrollCaretIntoViewHorizontally_Test : VimTestCase() {
+  fun `test moving right scrolls half screen to right by default`() {
+    configureByColumns(200)
+    typeText(parseKeys("80|", "l")) // 1 based
+    assertPosition(0, 80) // 0 based
+    assertVisibleLineBounds(0, 40, 119) // 0 based
+  }
+
+  fun `test moving right scrolls half screen to right by default 2`() {
+    configureByColumns(200)
+    setEditorVisibleSize(100, screenHeight)
+    typeText(parseKeys("100|", "l"))
+    assertVisibleLineBounds(0, 50, 149)
+  }
+
+  fun `test moving right scrolls half screen if moving too far 1`() {
+    configureByColumns(400)
+    typeText(parseKeys("70|", "41l")) // Move more than half screen width, but scroll less
+    assertVisibleLineBounds(0, 70, 149)
+  }
+
+  fun `test moving right scrolls half screen if moving too far 2`() {
+    configureByColumns(400)
+    typeText(parseKeys("50|", "200l")) // Move and scroll more than half screen width
+    assertVisibleLineBounds(0, 209, 288)
+  }
+
+  fun `test moving right with sidescroll 1`() {
+    OptionsManager.sidescroll.set(1)
+    configureByColumns(200)
+    typeText(parseKeys("80|", "l"))
+    assertVisibleLineBounds(0, 1, 80)
+  }
+
+  fun `test moving right with sidescroll 2`() {
+    OptionsManager.sidescroll.set(2)
+    configureByColumns(200)
+    typeText(parseKeys("80|", "l"))
+    assertVisibleLineBounds(0, 2, 81)
+  }
+
+  fun `test moving right with sidescrolloff`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("70|", "l"))
+    assertVisibleLineBounds(0, 30, 109)
+  }
+
+  fun `test moving right with sidescroll and sidescrolloff`() {
+    OptionsManager.sidescroll.set(1)
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("70|", "l"))
+    assertVisibleLineBounds(0, 1, 80)
+  }
+
+  fun `test moving right with large sidescrolloff keeps cursor centred`() {
+    OptionsManager.sidescrolloff.set(999)
+    configureByColumns(200)
+    typeText(parseKeys("50|", "l"))
+    assertVisibleLineBounds(0, 10, 89)
+  }
+
+  fun `test moving right with inline inlay`() {
+    OptionsManager.sidescroll.set(1)
+    configureByColumns(200)
+    val inlayRenderer = HintRenderer(":test")
+    val inlay = myFixture.editor.inlayModel.addInlineElement(110, true, inlayRenderer)!!
+    typeText(parseKeys("100|", "20l"))
+    // These columns are hard to calculate, because the visible offset depends on the rendered width of the inlay
+    // Also, because we're scrolling right (adding columns to the right) we make the right most column line up
+    val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlayRenderer.calcWidthInPixels(inlay)
+    val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+    assertVisibleLineBounds(0, 119 - availableColumns + 1, 119)
+  }
+
+  fun `test moving left scrolls half screen to left by default`() {
+    configureByColumns(200)
+    typeText(parseKeys("80|zs", "h"))
+    assertPosition(0, 78)
+    assertVisibleLineBounds(0, 38, 117)
+  }
+
+  fun `test moving left scrolls half screen to left by default 2`() {
+    configureByColumns(200)
+    setEditorVisibleSize(100, screenHeight)
+    typeText(parseKeys("100|zs", "h"))
+    assertVisibleLineBounds(0, 48, 147)
+  }
+
+  fun `test moving left scrolls half screen if moving too far 1`() {
+    configureByColumns(400)
+    typeText(parseKeys("170|zs", "41h")) // Move more than half screen width, but scroll less
+    assertVisibleLineBounds(0, 88, 167)
+  }
+
+  fun `test moving left scrolls half screen if moving too far 2`() {
+    configureByColumns(400)
+    typeText(parseKeys("290|zs", "200h")) // Move more than half screen width, but scroll less
+    assertVisibleLineBounds(0, 49, 128)
+  }
+
+  fun `test moving left with sidescroll 1`() {
+    OptionsManager.sidescroll.set(1)
+    configureByColumns(200)
+    typeText(parseKeys("100|zs", "h"))
+    assertVisibleLineBounds(0, 98, 177)
+  }
+
+  fun `test moving left with sidescroll 2`() {
+    OptionsManager.sidescroll.set(2)
+    configureByColumns(200)
+    typeText(parseKeys("100|zs", "h"))
+    assertVisibleLineBounds(0, 97, 176)
+  }
+
+  fun `test moving left with sidescrolloff`() {
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("120|zs", "h"))
+    assertVisibleLineBounds(0, 78, 157)
+  }
+
+  fun `test moving left with sidescroll and sidescrolloff`() {
+    OptionsManager.sidescroll.set(1)
+    OptionsManager.sidescrolloff.set(10)
+    configureByColumns(200)
+    typeText(parseKeys("120|zs", "h"))
+    assertVisibleLineBounds(0, 108, 187)
+  }
+
+  fun `test moving left with inline inlay`() {
+    OptionsManager.sidescroll.set(1)
+    configureByColumns(200)
+    val inlayRenderer = HintRenderer(":test")
+    val inlay = myFixture.editor.inlayModel.addInlineElement(110, true, inlayRenderer)!!
+    typeText(parseKeys("120|zs", "20h"))
+    // These columns are hard to calculate, because the visible offset depends on the rendered width of the inlay
+    val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlayRenderer.calcWidthInPixels(inlay)
+    val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+    assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
+  }
+
+  fun `test moving left with large sidescrolloff keeps cursor centred`() {
+    OptionsManager.sidescrolloff.set(999)
+    configureByColumns(200)
+    typeText(parseKeys("50|", "h"))
+    assertVisibleLineBounds(0, 8, 87)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewHorizontally_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewHorizontally_Test.kt
@@ -19,7 +19,6 @@
 package org.jetbrains.plugins.ideavim.group.motion
 
 import com.intellij.openapi.editor.ex.util.EditorUtil
-import com.intellij.testFramework.EditorTestUtil
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -91,7 +90,7 @@ class MotionGroup_ScrollCaretIntoViewHorizontally_Test : VimTestCase() {
   fun `test moving right with inline inlay`() {
     OptionsManager.sidescroll.set(1)
     configureByColumns(200)
-    val inlay = EditorTestUtil.addInlay(myFixture.editor, 110, true, 40)
+    val inlay = addInlay(110, true, 5)
     typeText(parseKeys("100|", "20l"))
     // These columns are hard to calculate, because the visible offset depends on the rendered width of the inlay
     // Also, because we're scrolling right (adding columns to the right) we make the right most column line up
@@ -158,7 +157,7 @@ class MotionGroup_ScrollCaretIntoViewHorizontally_Test : VimTestCase() {
   fun `test moving left with inline inlay`() {
     OptionsManager.sidescroll.set(1)
     configureByColumns(200)
-    val inlay = EditorTestUtil.addInlay(myFixture.editor, 110, true, 40)
+    val inlay = addInlay(110, true, 5)
     typeText(parseKeys("120|zs", "20h"))
     // These columns are hard to calculate, because the visible offset depends on the rendered width of the inlay
     val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewVertically_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewVertically_Test.kt
@@ -24,7 +24,7 @@ import com.maddyhome.idea.vim.option.OptionsManager
 import org.jetbrains.plugins.ideavim.VimTestCase
 
 @Suppress("ClassName")
-class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
+class MotionGroup_ScrollCaretIntoViewVertically_Test : VimTestCase() {
   fun `test moving up causes scrolling up`() {
     configureByPages(5)
     setPositionAndScroll(19, 24)

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoView_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoView_Test.kt
@@ -1,0 +1,246 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.group.motion
+
+import com.maddyhome.idea.vim.helper.EditorHelper
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+@Suppress("ClassName")
+class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
+  fun `test moving up causes scrolling up`() {
+    configureLargeText(200)
+    setPositionAndScroll(19, 24)
+
+    typeText(parseKeys("12k"))
+    assertPosition(12, 0)
+    assertVisibleArea(12, 46)
+  }
+
+  fun `test scroll up with scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureLargeText(200)
+    setPositionAndScroll(19, 24)
+
+    typeText(parseKeys("12k"))
+    assertPosition(12, 0)
+    assertVisibleArea(3, 37)
+  }
+
+  fun `test scroll up with scrolloff`() {
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+    setPositionAndScroll(19, 29)
+
+    typeText(parseKeys("12k"))
+    assertPosition(17, 0)
+    assertVisibleArea(12, 46)
+  }
+
+  fun `test scroll up with scrolljump and scrolloff 1`() {
+    OptionsManager.scrolljump.set(10)
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+
+    setPositionAndScroll(19, 29)
+    typeText(parseKeys("12k"))
+    assertPosition(17, 0)
+    assertVisibleArea(8, 42)
+  }
+
+  fun `test scroll up with scrolljump and scrolloff 2`() {
+    OptionsManager.scrolljump.set(10)
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+    setPositionAndScroll(29, 39)
+
+    typeText(parseKeys("20k"))
+    assertPosition(19, 0)
+    assertVisibleArea(10, 44)
+  }
+
+  fun `test scroll up with collapsed folds`() {
+    configureLargeText(200)
+    // TODO: Implement zf
+    typeText(parseKeys("40G", "Vjjjj", ":'<,'>action CollapseSelection<CR>", "V"))
+    setPositionAndScroll(29, 49)
+
+    typeText(parseKeys("30k"))
+    assertPosition(15, 0)
+    assertVisibleArea(15, 53)
+  }
+
+  // TODO: Handle soft wraps
+//  fun `test scroll up with soft wraps`() {
+//  }
+
+  fun `test scroll up more than half height moves caret to middle 1`() {
+    configureLargeText(200)
+    setPositionAndScroll(114, 149)
+
+    typeText(parseKeys("50k"))
+    assertPosition(99, 0)
+    assertVisualLineAtMiddleOfScreen(99)
+  }
+
+  fun `test scroll up more than half height moves caret to middle with scrolloff`() {
+    configureLargeText(200)
+    OptionsManager.scrolljump.set(10)
+    OptionsManager.scrolloff.set(5)
+    setPositionAndScroll(99, 109)
+    assertPosition(109, 0)
+
+    typeText(parseKeys("21k"))
+    assertPosition(88, 0)
+    assertVisualLineAtMiddleOfScreen(88)
+  }
+
+  fun `test scroll up with less than half height moves caret to top of screen`() {
+    configureLargeText(200)
+    OptionsManager.scrolljump.set(10)
+    OptionsManager.scrolloff.set(5)
+    setPositionAndScroll(99, 109)
+
+    typeText(parseKeys("20k"))
+    assertPosition(89, 0)
+    assertVisibleArea(80, 114)
+  }
+
+  fun `test moving down causes scrolling down`() {
+    configureLargeText(200)
+    setPositionAndScroll(0, 29)
+
+    typeText(parseKeys("12j"))
+    assertPosition(41, 0)
+    assertVisibleArea(7, 41)
+  }
+
+  fun `test scroll down with scrolljump`() {
+    OptionsManager.scrolljump.set(10)
+    configureLargeText(200)
+    setPositionAndScroll(0, 29)
+
+    typeText(parseKeys("12j"))
+    assertPosition(41, 0)
+    assertVisibleArea(11, 45)
+  }
+
+  fun `test scroll down with scrolloff`() {
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+    setPositionAndScroll(0, 24)
+
+    typeText(parseKeys("12j"))
+    assertPosition(36, 0)
+    assertVisibleArea(7, 41)
+  }
+
+  fun `test scroll down with scrolljump and scrolloff 1`() {
+    OptionsManager.scrolljump.set(10)
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+    setPositionAndScroll(0, 24)
+
+    typeText(parseKeys("12j"))
+    assertPosition(36, 0)
+    assertVisibleArea(10, 44)
+  }
+
+  fun `test scroll down with scrolljump and scrolloff 2`() {
+    OptionsManager.scrolljump.set(15)
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+    setPositionAndScroll(0, 24)
+
+    typeText(parseKeys("20j"))
+    assertPosition(44, 0)
+    assertVisibleArea(17, 51)
+  }
+
+  fun `test scroll down with scrolljump and scrolloff 3`() {
+    OptionsManager.scrolljump.set(20)
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+    setPositionAndScroll(0, 24)
+
+    typeText(parseKeys("25j"))
+    assertPosition(49, 0)
+    assertVisibleArea(24, 58)
+  }
+
+  fun `test scroll down with scrolljump and scrolloff 4`() {
+    OptionsManager.scrolljump.set(11)
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+    setPositionAndScroll(0, 24)
+
+    typeText(parseKeys("12j"))
+    assertPosition(36, 0)
+    assertVisibleArea(11, 45)
+  }
+
+  fun `test scroll down with scrolljump and scrolloff 5`() {
+    OptionsManager.scrolljump.set(10)
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+    setPositionAndScroll(0, 29)
+
+    typeText(parseKeys("12j"))
+    assertPosition(41, 0)
+    assertVisibleArea(12, 46)
+  }
+
+  fun `test scroll down with scrolljump and scrolloff 6`() {
+    OptionsManager.scrolljump.set(10)
+    OptionsManager.scrolloff.set(5)
+    configureLargeText(200)
+    setPositionAndScroll(0, 24)
+
+    typeText(parseKeys("20j"))
+    assertPosition(44, 0)
+    assertVisibleArea(15, 49)
+  }
+
+  fun `test scroll down too large cursor is centred`() {
+    OptionsManager.scrolljump.set(10)
+    OptionsManager.scrolloff.set(10)
+    configureLargeText(200)
+    setPositionAndScroll(0, 19)
+
+    typeText(parseKeys("35j"))
+    assertPosition(54, 0)
+    assertVisualLineAtMiddleOfScreen(54)
+  }
+
+  // 0-based
+  private fun setPositionAndScroll(scrollToLogicalLine: Int, caretLogicalLine: Int) {
+    val scrolloff = OptionsManager.scrolloff.value
+    val scrolljump = OptionsManager.scrolljump.value
+    OptionsManager.scrolloff.set(0)
+    OptionsManager.scrolljump.set(1)
+    typeText(parseKeys("${scrollToLogicalLine+1}z<CR>", "${caretLogicalLine+1}G"))
+    OptionsManager.scrolloff.set(scrolloff)
+    OptionsManager.scrolljump.set(scrolljump)
+  }
+
+  private fun assertVisualLineAtMiddleOfScreen(expected: Int) {
+    assertEquals(expected, EditorHelper.getVisualLineAtMiddleOfScreen(myFixture.editor))
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoView_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoView_Test.kt
@@ -26,7 +26,7 @@ import org.jetbrains.plugins.ideavim.VimTestCase
 @Suppress("ClassName")
 class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test moving up causes scrolling up`() {
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(19, 24)
 
     typeText(parseKeys("12k"))
@@ -36,7 +36,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
 
   fun `test scroll up with scrolljump`() {
     OptionsManager.scrolljump.set(10)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(19, 24)
 
     typeText(parseKeys("12k"))
@@ -46,7 +46,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
 
   fun `test scroll up with scrolloff`() {
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(19, 29)
 
     typeText(parseKeys("12k"))
@@ -57,7 +57,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test scroll up with scrolljump and scrolloff 1`() {
     OptionsManager.scrolljump.set(10)
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
 
     setPositionAndScroll(19, 29)
     typeText(parseKeys("12k"))
@@ -68,7 +68,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test scroll up with scrolljump and scrolloff 2`() {
     OptionsManager.scrolljump.set(10)
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(29, 39)
 
     typeText(parseKeys("20k"))
@@ -77,7 +77,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   }
 
   fun `test scroll up with collapsed folds`() {
-    configureLargeText(200)
+    configureByPages(5)
     // TODO: Implement zf
     typeText(parseKeys("40G", "Vjjjj", ":'<,'>action CollapseSelection<CR>", "V"))
     setPositionAndScroll(29, 49)
@@ -92,8 +92,8 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
 //  }
 
   fun `test scroll up more than half height moves caret to middle 1`() {
-    configureLargeText(200)
-    setPositionAndScroll(114, 149)
+    configureByPages(5)
+    setPositionAndScroll(115, 149)
 
     typeText(parseKeys("50k"))
     assertPosition(99, 0)
@@ -101,7 +101,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   }
 
   fun `test scroll up more than half height moves caret to middle with scrolloff`() {
-    configureLargeText(200)
+    configureByPages(5)
     OptionsManager.scrolljump.set(10)
     OptionsManager.scrolloff.set(5)
     setPositionAndScroll(99, 109)
@@ -113,7 +113,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   }
 
   fun `test scroll up with less than half height moves caret to top of screen`() {
-    configureLargeText(200)
+    configureByPages(5)
     OptionsManager.scrolljump.set(10)
     OptionsManager.scrolloff.set(5)
     setPositionAndScroll(99, 109)
@@ -124,7 +124,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   }
 
   fun `test moving down causes scrolling down`() {
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 29)
 
     typeText(parseKeys("12j"))
@@ -134,7 +134,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
 
   fun `test scroll down with scrolljump`() {
     OptionsManager.scrolljump.set(10)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 29)
 
     typeText(parseKeys("12j"))
@@ -144,7 +144,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
 
   fun `test scroll down with scrolloff`() {
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 24)
 
     typeText(parseKeys("12j"))
@@ -155,7 +155,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test scroll down with scrolljump and scrolloff 1`() {
     OptionsManager.scrolljump.set(10)
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 24)
 
     typeText(parseKeys("12j"))
@@ -166,7 +166,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test scroll down with scrolljump and scrolloff 2`() {
     OptionsManager.scrolljump.set(15)
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 24)
 
     typeText(parseKeys("20j"))
@@ -177,7 +177,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test scroll down with scrolljump and scrolloff 3`() {
     OptionsManager.scrolljump.set(20)
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 24)
 
     typeText(parseKeys("25j"))
@@ -188,7 +188,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test scroll down with scrolljump and scrolloff 4`() {
     OptionsManager.scrolljump.set(11)
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 24)
 
     typeText(parseKeys("12j"))
@@ -199,7 +199,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test scroll down with scrolljump and scrolloff 5`() {
     OptionsManager.scrolljump.set(10)
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 29)
 
     typeText(parseKeys("12j"))
@@ -210,7 +210,7 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test scroll down with scrolljump and scrolloff 6`() {
     OptionsManager.scrolljump.set(10)
     OptionsManager.scrolloff.set(5)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 24)
 
     typeText(parseKeys("20j"))
@@ -221,23 +221,12 @@ class MotionGroup_ScrollCaretIntoView_Test : VimTestCase() {
   fun `test scroll down too large cursor is centred`() {
     OptionsManager.scrolljump.set(10)
     OptionsManager.scrolloff.set(10)
-    configureLargeText(200)
+    configureByPages(5)
     setPositionAndScroll(0, 19)
 
     typeText(parseKeys("35j"))
     assertPosition(54, 0)
     assertVisualLineAtMiddleOfScreen(54)
-  }
-
-  // 0-based
-  private fun setPositionAndScroll(scrollToLogicalLine: Int, caretLogicalLine: Int) {
-    val scrolloff = OptionsManager.scrolloff.value
-    val scrolljump = OptionsManager.scrolljump.value
-    OptionsManager.scrolloff.set(0)
-    OptionsManager.scrolljump.set(1)
-    typeText(parseKeys("${scrollToLogicalLine+1}z<CR>", "${caretLogicalLine+1}G"))
-    OptionsManager.scrolloff.set(scrolloff)
-    OptionsManager.scrolljump.set(scrolljump)
   }
 
   private fun assertVisualLineAtMiddleOfScreen(expected: Int) {

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_scrolloff_scrolljump_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_scrolloff_scrolljump_Test.kt
@@ -21,14 +21,21 @@
 package org.jetbrains.plugins.ideavim.group.motion
 
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
-import com.maddyhome.idea.vim.option.OptionsManager
-import org.jetbrains.plugins.ideavim.VimTestCase
+import com.maddyhome.idea.vim.option.ScrollJumpData
+import com.maddyhome.idea.vim.option.ScrollOffData
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimOptionTestCase
+import org.jetbrains.plugins.ideavim.VimOptionTestConfiguration
+import org.jetbrains.plugins.ideavim.VimTestOption
+import org.jetbrains.plugins.ideavim.VimTestOptionType
 
 // These tests are sanity tests for scrolloff and scrolljump, with actions that move the cursor. Other actions that are
 // affected by scrolloff or scrolljump should include that in the action specific tests
-class MotionGroup_scrolloff_Test : VimTestCase() {
+class MotionGroup_scrolloff_Test : VimOptionTestCase(ScrollOffData.name) {
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["0"]))
   fun `test move up shows no context with scrolloff=0`() {
-    OptionsManager.scrolloff.set(0)
     configureByPages(5)
     setPositionAndScroll(25, 25)
     typeText(parseKeys("k"))
@@ -36,8 +43,9 @@ class MotionGroup_scrolloff_Test : VimTestCase() {
     assertVisibleArea(24, 58)
   }
 
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["1"]))
   fun `test move up shows context line with scrolloff=1`() {
-    OptionsManager.scrolloff.set(1)
     configureByPages(5)
     setPositionAndScroll(25, 26)
     typeText(parseKeys("k"))
@@ -45,8 +53,9 @@ class MotionGroup_scrolloff_Test : VimTestCase() {
     assertVisibleArea(24, 58)
   }
 
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["10"]))
   fun `test move up shows context lines with scrolloff=10`() {
-    OptionsManager.scrolloff.set(10)
     configureByPages(5)
     setPositionAndScroll(25, 35)
     typeText(parseKeys("k"))
@@ -54,8 +63,9 @@ class MotionGroup_scrolloff_Test : VimTestCase() {
     assertVisibleArea(24, 58)
   }
 
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["0"]))
   fun `test move down shows no context with scrolloff=0`() {
-    OptionsManager.scrolloff.set(0)
     configureByPages(5)
     setPositionAndScroll(25, 59)
     typeText(parseKeys("j"))
@@ -63,8 +73,9 @@ class MotionGroup_scrolloff_Test : VimTestCase() {
     assertVisibleArea(26, 60)
   }
 
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["1"]))
   fun `test move down shows context line with scrolloff=1`() {
-    OptionsManager.scrolloff.set(1)
     configureByPages(5)
     setPositionAndScroll(25, 58)
     typeText(parseKeys("j"))
@@ -72,8 +83,9 @@ class MotionGroup_scrolloff_Test : VimTestCase() {
     assertVisibleArea(26, 60)
   }
 
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["10"]))
   fun `test move down shows context lines with scrolloff=10`() {
-    OptionsManager.scrolloff.set(10)
     configureByPages(5)
     setPositionAndScroll(25, 49)
     typeText(parseKeys("j"))
@@ -81,17 +93,81 @@ class MotionGroup_scrolloff_Test : VimTestCase() {
     assertVisibleArea(26, 60)
   }
 
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["999"]))
   fun `test scrolloff=999 keeps cursor in centre of screen`() {
-    OptionsManager.scrolloff.set(999)
     configureByPages(5)
     setPositionAndScroll(25, 42)
     typeText(parseKeys("j"))
     assertPosition(43, 0)
     assertVisibleArea(26, 60)
   }
+}
 
+class MotionGroup_scrolljump_Test : VimOptionTestCase(ScrollJumpData.name) {
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["0"]))
+  fun `test move up scrolls single line with scrolljump=0`() {
+    configureByPages(5)
+    setPositionAndScroll(25, 25)
+    typeText(parseKeys("k"))
+    assertPosition(24, 0)
+    assertVisibleArea(24, 58)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["1"]))
+  fun `test move up scrolls single line with scrolljump=1`() {
+    configureByPages(5)
+    setPositionAndScroll(25, 25)
+    typeText(parseKeys("k"))
+    assertPosition(24, 0)
+    assertVisibleArea(24, 58)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["10"]))
+  fun `test move up scrolls multiple lines with scrolljump=10`() {
+    configureByPages(5)
+    setPositionAndScroll(25, 25)
+    typeText(parseKeys("k"))
+    assertPosition(24, 0)
+    assertVisibleArea(15, 49)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["0"]))
+  fun `test move down scrolls single line with scrolljump=0`() {
+    configureByPages(5)
+    setPositionAndScroll(25, 59)
+    typeText(parseKeys("j"))
+    assertPosition(60, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["1"]))
+  fun `test move down scrolls single line with scrolljump=1`() {
+    configureByPages(5)
+    setPositionAndScroll(25, 59)
+    typeText(parseKeys("j"))
+    assertPosition(60, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["10"]))
+  fun `test move down scrolls multiple lines with scrolljump=10`() {
+    configureByPages(5)
+    setPositionAndScroll(25, 59)
+    typeText(parseKeys("j"))
+    assertPosition(60, 0)
+    assertVisibleArea(35, 69)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["-50"]))
   fun `test negative scrolljump treated as percentage 1`() {
-    OptionsManager.scrolljump.set(-50)
     configureByPages(5)
     setPositionAndScroll(39, 39)
     typeText(parseKeys("k"))
@@ -99,8 +175,9 @@ class MotionGroup_scrolloff_Test : VimTestCase() {
     assertVisibleArea(22, 56)
   }
 
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["-10"]))
   fun `test negative scrolljump treated as percentage 2`() {
-    OptionsManager.scrolljump.set(-10)
     configureByPages(5)
     setPositionAndScroll(39, 39)
     typeText(parseKeys("k"))
@@ -109,66 +186,13 @@ class MotionGroup_scrolloff_Test : VimTestCase() {
   }
 }
 
-class MotionGroup_scrolljump_Test : VimTestCase() {
-  fun `test move up scrolls single line with scrolljump=0`() {
-    OptionsManager.scrolljump.set(0)
-    configureByPages(5)
-    setPositionAndScroll(25, 25)
-    typeText(parseKeys("k"))
-    assertPosition(24, 0)
-    assertVisibleArea(24, 58)
-  }
-
-  fun `test move up scrolls single line with scrolljump=1`() {
-    OptionsManager.scrolljump.set(1)
-    configureByPages(5)
-    setPositionAndScroll(25, 25)
-    typeText(parseKeys("k"))
-    assertPosition(24, 0)
-    assertVisibleArea(24, 58)
-  }
-
-  fun `test move up scrolls multiple lines with scrolljump=10`() {
-    OptionsManager.scrolljump.set(10)
-    configureByPages(5)
-    setPositionAndScroll(25, 25)
-    typeText(parseKeys("k"))
-    assertPosition(24, 0)
-    assertVisibleArea(15, 49)
-  }
-
-  fun `test move down scrolls single line with scrolljump=0`() {
-    OptionsManager.scrolljump.set(0)
-    configureByPages(5)
-    setPositionAndScroll(25, 59)
-    typeText(parseKeys("j"))
-    assertPosition(60, 0)
-    assertVisibleArea(26, 60)
-  }
-
-  fun `test move down scrolls single line with scrolljump=1`() {
-    OptionsManager.scrolljump.set(1)
-    configureByPages(5)
-    setPositionAndScroll(25, 59)
-    typeText(parseKeys("j"))
-    assertPosition(60, 0)
-    assertVisibleArea(26, 60)
-  }
-
-  fun `test move down scrolls multiple lines with scrolljump=10`() {
-    OptionsManager.scrolljump.set(10)
-    configureByPages(5)
-    setPositionAndScroll(25, 59)
-    typeText(parseKeys("j"))
-    assertPosition(60, 0)
-    assertVisibleArea(35, 69)
-  }
-}
-
-class MotionGroup_scrolloff_scrolljump_Test : VimTestCase() {
+class MotionGroup_scrolloff_scrolljump_Test : VimOptionTestCase(ScrollJumpData.name, ScrollOffData.name) {
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(
+    VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["10"]),
+    VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["5"])
+  )
   fun `test scroll up with scrolloff and scrolljump set`() {
-    OptionsManager.scrolloff.set(5)
-    OptionsManager.scrolljump.set(10)
     configureByPages(5)
     setPositionAndScroll(50, 55)
     typeText(parseKeys("k"))
@@ -176,9 +200,12 @@ class MotionGroup_scrolloff_scrolljump_Test : VimTestCase() {
     assertVisibleArea(40, 74)
   }
 
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(
+    VimTestOption(ScrollJumpData.name, VimTestOptionType.NUMBER, ["10"]),
+    VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["5"])
+  )
   fun `test scroll down with scrolloff and scrolljump set`() {
-    OptionsManager.scrolloff.set(5)
-    OptionsManager.scrolljump.set(10)
     configureByPages(5)
     setPositionAndScroll(50, 79)
     typeText(parseKeys("j"))

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_scrolloff_scrolljump_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_scrolloff_scrolljump_Test.kt
@@ -1,0 +1,188 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("ClassName")
+
+package org.jetbrains.plugins.ideavim.group.motion
+
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.option.OptionsManager
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+// These tests are sanity tests for scrolloff and scrolljump, with actions that move the cursor. Other actions that are
+// affected by scrolloff or scrolljump should include that in the action specific tests
+class MotionGroup_scrolloff_Test : VimTestCase() {
+  fun `test move up shows no context with scrolloff=0`() {
+    OptionsManager.scrolloff.set(0)
+    configureByPages(5)
+    setPositionAndScroll(25, 25)
+    typeText(parseKeys("k"))
+    assertPosition(24, 0)
+    assertVisibleArea(24, 58)
+  }
+
+  fun `test move up shows context line with scrolloff=1`() {
+    OptionsManager.scrolloff.set(1)
+    configureByPages(5)
+    setPositionAndScroll(25, 26)
+    typeText(parseKeys("k"))
+    assertPosition(25, 0)
+    assertVisibleArea(24, 58)
+  }
+
+  fun `test move up shows context lines with scrolloff=10`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(25, 35)
+    typeText(parseKeys("k"))
+    assertPosition(34, 0)
+    assertVisibleArea(24, 58)
+  }
+
+  fun `test move down shows no context with scrolloff=0`() {
+    OptionsManager.scrolloff.set(0)
+    configureByPages(5)
+    setPositionAndScroll(25, 59)
+    typeText(parseKeys("j"))
+    assertPosition(60, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test move down shows context line with scrolloff=1`() {
+    OptionsManager.scrolloff.set(1)
+    configureByPages(5)
+    setPositionAndScroll(25, 58)
+    typeText(parseKeys("j"))
+    assertPosition(59, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test move down shows context lines with scrolloff=10`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(25, 49)
+    typeText(parseKeys("j"))
+    assertPosition(50, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test scrolloff=999 keeps cursor in centre of screen`() {
+    OptionsManager.scrolloff.set(999)
+    configureByPages(5)
+    setPositionAndScroll(25, 42)
+    typeText(parseKeys("j"))
+    assertPosition(43, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test negative scrolljump treated as percentage 1`() {
+    OptionsManager.scrolljump.set(-50)
+    configureByPages(5)
+    setPositionAndScroll(39, 39)
+    typeText(parseKeys("k"))
+    assertPosition(38, 0)
+    assertVisibleArea(22, 56)
+  }
+
+  fun `test negative scrolljump treated as percentage 2`() {
+    OptionsManager.scrolljump.set(-10)
+    configureByPages(5)
+    setPositionAndScroll(39, 39)
+    typeText(parseKeys("k"))
+    assertPosition(38, 0)
+    assertVisibleArea(36, 70)
+  }
+}
+
+class MotionGroup_scrolljump_Test : VimTestCase() {
+  fun `test move up scrolls single line with scrolljump=0`() {
+    OptionsManager.scrolljump.set(0)
+    configureByPages(5)
+    setPositionAndScroll(25, 25)
+    typeText(parseKeys("k"))
+    assertPosition(24, 0)
+    assertVisibleArea(24, 58)
+  }
+
+  fun `test move up scrolls single line with scrolljump=1`() {
+    OptionsManager.scrolljump.set(1)
+    configureByPages(5)
+    setPositionAndScroll(25, 25)
+    typeText(parseKeys("k"))
+    assertPosition(24, 0)
+    assertVisibleArea(24, 58)
+  }
+
+  fun `test move up scrolls multiple lines with scrolljump=10`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(25, 25)
+    typeText(parseKeys("k"))
+    assertPosition(24, 0)
+    assertVisibleArea(15, 49)
+  }
+
+  fun `test move down scrolls single line with scrolljump=0`() {
+    OptionsManager.scrolljump.set(0)
+    configureByPages(5)
+    setPositionAndScroll(25, 59)
+    typeText(parseKeys("j"))
+    assertPosition(60, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test move down scrolls single line with scrolljump=1`() {
+    OptionsManager.scrolljump.set(1)
+    configureByPages(5)
+    setPositionAndScroll(25, 59)
+    typeText(parseKeys("j"))
+    assertPosition(60, 0)
+    assertVisibleArea(26, 60)
+  }
+
+  fun `test move down scrolls multiple lines with scrolljump=10`() {
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(25, 59)
+    typeText(parseKeys("j"))
+    assertPosition(60, 0)
+    assertVisibleArea(35, 69)
+  }
+}
+
+class MotionGroup_scrolloff_scrolljump_Test : VimTestCase() {
+  fun `test scroll up with scrolloff and scrolljump set`() {
+    OptionsManager.scrolloff.set(5)
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(50, 55)
+    typeText(parseKeys("k"))
+    assertPosition(54, 0)
+    assertVisibleArea(40, 74)
+  }
+
+  fun `test scroll down with scrolloff and scrolljump set`() {
+    OptionsManager.scrolloff.set(5)
+    OptionsManager.scrolljump.set(10)
+    configureByPages(5)
+    setPositionAndScroll(50, 79)
+    typeText(parseKeys("j"))
+    assertPosition(80, 0)
+    assertVisibleArea(60, 94)
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/helper/EditorHelperTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/helper/EditorHelperTest.kt
@@ -1,0 +1,65 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.helper
+
+import com.maddyhome.idea.vim.helper.EditorHelper
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.Assert
+
+class EditorHelperTest : VimTestCase() {
+  fun `test scroll column to left of screen`() {
+    configureByColumns(100)
+    EditorHelper.scrollColumnToLeftOfScreen(myFixture.editor, 0, 2)
+    val visibleArea = myFixture.editor.scrollingModel.visibleArea
+    val columnWidth = visibleArea.width / screenWidth
+    Assert.assertEquals(2 * columnWidth, visibleArea.x)
+  }
+
+  fun `test scroll column to right of screen`() {
+    configureByColumns(100)
+    val column = screenWidth + 2
+    EditorHelper.scrollColumnToRightOfScreen(myFixture.editor, 0, column)
+    val visibleArea = myFixture.editor.scrollingModel.visibleArea
+    val columnWidth = visibleArea.width / screenWidth
+    Assert.assertEquals((column - screenWidth + 1) * columnWidth, visibleArea.x)
+  }
+
+  fun `test scroll column to middle of screen with even number of columns`() {
+    configureByColumns(200)
+    // For an 80 column screen, moving a column to the centre should position it in column 41 (1 based) - 40 columns on
+    // the left, mid point, 39 columns on the right
+    // Put column 100 into position 41 -> offset is 59 columns
+    EditorHelper.scrollColumnToMiddleOfScreen(myFixture.editor, 0, 99)
+    val visibleArea = myFixture.editor.scrollingModel.visibleArea
+    val columnWidth = visibleArea.width / screenWidth
+    Assert.assertEquals(59 * columnWidth, visibleArea.x)
+  }
+
+  fun `test scroll column to middle of screen with odd number of columns`() {
+    configureByColumns(200)
+    setEditorVisibleSize(81, 25)
+    // For an 81 column screen, moving a column to the centre should position it in column 41 (1 based) - 40 columns on
+    // the left, mid point, 40 columns on the right
+    // Put column 100 into position 41 -> offset is 59 columns
+    EditorHelper.scrollColumnToMiddleOfScreen(myFixture.editor, 0, 99)
+    val visibleArea = myFixture.editor.scrollingModel.visibleArea
+    val columnWidth = visibleArea.width / screenWidth
+    Assert.assertEquals(59 * columnWidth, visibleArea.x)
+  }
+}


### PR DESCRIPTION
This PR introduces a number of fixes for scrolling, primarily for support of inline inlays, such as a parameter hints.

- [x] Fixes [VIM-2104](https://youtrack.jetbrains.com/issue/VIM-2104) - `scrolloff` instead of `sidescrolloff` is used for horizontal offset
- [x] Fix `scrolljump` not working
- [x] Improve handling of `scrolljump` to match Vim's fairly unintuitive rules
- [x] Fix [VIM-1080](https://youtrack.jetbrains.com/issue/VIM-1080) - handling of scrolling with virtual space
- [x] Add internal action to add test inline inlays, using the parameter hint renderer
- [x] Improve handling of inline inlays, especially around positioning after deletion, and also handling inlays associated with preceding text (e.g. Kotlin type annotations, as opposed to inlays associated with following text, such as Kotlin parameter hints)
- [x] Fix issues with side scrolling and inline inlays, including `sidescrolloff` and `sidescroll`(jump). Leading and trailing inlays are correctly positioned when scrolling offscreen.
  * Fixes [VIM-1556](https://youtrack.jetbrains.com/issue/VIM-1556) - Editor window is not correctly scrolled horizontally
  * Fixes [VIM-1770](https://youtrack.jetbrains.com/issue/VIM-1770) - Go to end of line conflicts with parameter name hints
- [x] Fix [VIM-2110](https://youtrack.jetbrains.com/issue/VIM-2110) - support for line scrolling with proportional fonts
- [x] Implement scroll screen half width actions (`zL`/`zH`)

Added tests:

- [x] Add tests for vertical scrolling with `scrolloff` and `scrolljump`
- [x] Add tests for scrolling up/down by line (`<C-Y>`/`<C-E>`)
- [x] Add tests for scrolling up/down by page (`<C-B>`/`<C-F>`)
- [x] Add tests and fixes for scrolling page (`z+`/`z^`)
- [x] Add tests for scrolling caret line to top/bottom/middle of page (`zt`/`zb`/`zz` + `z<CR>`/`z-`/`z.`)
- [x] Add tests for scrolling half page up/down (`<C-U>`/`<C-D>`)
- [x] Add tests for scrolling caret column to first/last column of page (`zs`/`ze`)
- [x] Add tests for scrolling screen one column to left/right (`zl`/`zh`)
- [x] Add tests for delete character left/right (+inlays) (`X`/`x`)

Known issues:

* Virtual space handling doesn't exactly match Vim (e.g. `<C-F>` at the end of file doesn't scroll up), but it at least behaves sensibly
* Side scroll offset is calculated on visual column to correctly handle closed inline folds, but both inline inlays and folds are implemented as visual columns, which means the offset isn't technically correct - it is not an offset of characters. The alternative is to iterate over visual columns and skip columns that are folds or inlays. I think this minor inaccuracy in a feature designed to show additional context is acceptable.

Questions:

* Now that virtual space is working, shall we enable it for all Vim-enabled editors? This would match Vim behaviour, but might be a little intrusive, so we could also add an option to disable it (it would be on by default to match Vim)