### PR TITLE
Add CJK characterType for delimiting caret movement

### DIFF
--- a/src/com/maddyhome/idea/vim/helper/CharacterHelper.kt
+++ b/src/com/maddyhome/idea/vim/helper/CharacterHelper.kt
@@ -50,6 +50,8 @@ object CharacterHelper {
       CharacterType.KATAKANA
     } else if (isHalfWidthKatakanaLetter(ch)) {
       CharacterType.HALF_WIDTH_KATAKANA
+    } else if (block == UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS) {
+      CharacterType.CJK_UNIFIED_IDEOGRAPHS
     } else if (punctuationAsLetters || iskeyword.isKeyword(ch)) {
       CharacterType.KEYWORD
     } else {
@@ -89,6 +91,6 @@ object CharacterHelper {
   }
 
   enum class CharacterType {
-    KEYWORD, HIRAGANA, KATAKANA, HALF_WIDTH_KATAKANA, PUNCTUATION, WHITESPACE
+    KEYWORD, HIRAGANA, KATAKANA, HALF_WIDTH_KATAKANA, CJK_UNIFIED_IDEOGRAPHS, PUNCTUATION, WHITESPACE
   }
 }

--- a/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
+++ b/test/org/jetbrains/plugins/ideavim/action/MotionActionTest.java
@@ -559,6 +559,41 @@ public class MotionActionTest extends VimTestCase {
   }
 
   // |w|
+  public void testCjkToPunctuation() {
+    typeTextInFile(parseKeys("w"),
+      "测试<caret>测试!!!");
+    assertOffset(4);
+  }
+
+  // |w|
+  public void testCjkToFullWidthPunctuation() {
+    typeTextInFile(parseKeys("w"),
+      "测试<caret>测试！！！");
+    assertOffset(4);
+  }
+
+  // |w|
+  public void testCjkToDigits() {
+    typeTextInFile(parseKeys("w"),
+      "测试<caret>测试123");
+    assertOffset(4);
+  }
+
+  // |w|
+  public void testCjkToFullWidthLatin() {
+    typeTextInFile(parseKeys("w"),
+      "测试<caret>测试ＡＡＡ");
+    assertOffset(4);
+  }
+
+  // |w|
+  public void testCjkToFullWidthDigits() {
+    typeTextInFile(parseKeys("w"),
+      "测试<caret>测试３３３");
+    assertOffset(4);
+  }
+
+  // |w|
   public void testEmptyLineIsWord() {
     typeTextInFile(parseKeys("w"),
                    "<caret>one\n" +


### PR DESCRIPTION
- Add unicode CJK Unified Ideographs type
- Stop caret movement for CJK chars (as VIM does). Similar to [VIM-58](https://youtrack.jetbrains.com/issue/VIM-58)