### PR TITLE
VIM-1475: Add an option to use block caret in insert mode

### DIFF
--- a/src/com/maddyhome/idea/vim/KeyHandler.java
+++ b/src/com/maddyhome/idea/vim/KeyHandler.java
@@ -325,7 +325,7 @@ public class KeyHandler {
       }
     }
     reset(editor);
-    ChangeGroup.resetCaret(editor, false);
+    ChangeGroup.resetCaret(editor, VimPlugin.getEditor().isBarCursor());
   }
 
   private boolean handleKeyMapping(final @NotNull Editor editor,

--- a/src/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -203,6 +203,10 @@ public class EditorGroup implements PersistentStateComponent<Element> {
     }
   }
 
+  public boolean isBarCursor() {
+    return !isBlockCursor;
+  }
+
   public void editorCreated(@NotNull Editor editor) {
     isBlockCursor = editor.getSettings().isBlockCursor();
     isRefrainFromScrolling = editor.getSettings().isRefrainFromScrolling();
@@ -217,7 +221,7 @@ public class EditorGroup implements PersistentStateComponent<Element> {
       VimPlugin.getChange().insertBeforeCursor(editor, new EditorDataContext(editor, null));
       KeyHandler.getInstance().reset(editor);
     }
-    editor.getSettings().setBlockCursor(!CommandStateHelper.inInsertMode(editor));
+    editor.getSettings().setBlockCursor(!CommandStateHelper.inInsertMode(editor) || isBlockCursor);
     editor.getSettings().setRefrainFromScrolling(REFRAIN_FROM_SCROLLING_VIM_VALUE);
   }
 

--- a/src/com/maddyhome/idea/vim/group/visual/VisualGroup.kt
+++ b/src/com/maddyhome/idea/vim/group/visual/VisualGroup.kt
@@ -163,7 +163,7 @@ fun updateCaretState(editor: Editor) {
 
 fun CommandState.Mode.resetShape(editor: Editor) = when (this) {
   CommandState.Mode.COMMAND, CommandState.Mode.VISUAL, CommandState.Mode.REPLACE -> ChangeGroup.resetCaret(editor, false)
-  CommandState.Mode.SELECT, CommandState.Mode.INSERT -> ChangeGroup.resetCaret(editor, true)
+  CommandState.Mode.SELECT, CommandState.Mode.INSERT -> ChangeGroup.resetCaret(editor, VimPlugin.getEditor().isBarCursor)
   CommandState.Mode.CMD_LINE, CommandState.Mode.OP_PENDING -> Unit
 }
 

--- a/src/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -253,11 +253,11 @@ object VimListenerManager {
         if (onLineEnd(caret)) {
           // UX protection for case when user performs a small dragging while putting caret on line end
           caret.removeSelection()
-          ChangeGroup.resetCaret(e.editor, true)
+          ChangeGroup.resetCaret(e.editor, VimPlugin.getEditor().isBarCursor)
         }
       }
       if (mouseDragging && e.editor.caretModel.primaryCaret.hasSelection()) {
-        ChangeGroup.resetCaret(e.editor, true)
+        ChangeGroup.resetCaret(e.editor, VimPlugin.getEditor().isBarCursor)
 
         if (!cutOffFixed && ComponentMouseListener.cutOffEnd) {
           cutOffFixed = true


### PR DESCRIPTION
Hi,

This is my first pull request here, and for an Idea plugin in general, and I admit I don't know the API very well. So, please tell me what do you think first, and if something's not right, feel free to point it out or close the PR.

Currently IdeaVim always uses block caret for normal mode, and bar caret for insert mode. This commit introduces a new `.ideavimrc` option named "ideacursor", which can hold an array of "bar" and "block" properties. User can choose which caret style can be used for normal and insert mode by specifying 'bar' or 'caret' in this option:

    set ideacursor=<insert caret style>,<normal caret style>

For example:

    set ideacursor=block,bar

This option will instruct IdeaVim to display block caret in insert mode, and bar caret in normal node. The second argument is optional and will be defaulted to 'block' in case it's missing. If the first argument is missing as well, it will be defaulted to 'bar'. So, not specifying the 'ideacursor' option is equivalent to setting it as:

    set ideacursor=bar,block

(use bar in insert mode, and block in normal mode, this is the standard behavior)

This commit should fix VIM-1475.

Example video: https://www.youtube.com/watch?v=QtcAQvX-a-8

YouTrack link to the issue: https://youtrack.jetbrains.com/issue/VIM-1475