### PR TITLE
Fix various scrolling issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@ usual beta standards.
 * Add option to disable IdeaVim in dialogs / single line editors. [VIM-765](https://youtrack.jetbrains.com/issue/VIM-765)  
 Use `set ideaenabledbufs=` to disable IdeaVim in dialog editors.  
 _Note for EAP users: the option name can be changed for the stable release_
+* Reposition cursor when `scrolloff` changes
 
 ### Fixes:
 * [VIM-2150](https://youtrack.jetbrains.com/issue/VIM-2150) `Shift-D` should not delete an empty line

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@ _Note for EAP users: the option name can be changed for the stable release_
 * [VIM-2157](https://youtrack.jetbrains.com/issue/VIM-2157) Fix tab with an active template
 * [VIM-2156](https://youtrack.jetbrains.com/issue/VIM-2156) Correct up/down motions with inlays
 * [VIM-2144](https://youtrack.jetbrains.com/issue/VIM-2144) Correct text position after block insert with inlays
+* [VIM-2158](https://youtrack.jetbrains.com/issue/VIM-2158) Fix scrolling when `scrolloff` is over half screen height, but less than full height
 
 ## 0.60, 2020-10-09
 

--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -42,10 +42,12 @@ import com.maddyhome.idea.vim.handler.MotionActionHandler;
 import com.maddyhome.idea.vim.handler.TextObjectActionHandler;
 import com.maddyhome.idea.vim.helper.*;
 import com.maddyhome.idea.vim.option.NumberOption;
+import com.maddyhome.idea.vim.option.OptionChangeListener;
 import com.maddyhome.idea.vim.option.OptionsManager;
 import com.maddyhome.idea.vim.ui.ExEntryPanel;
 import kotlin.Pair;
 import kotlin.ranges.IntProgression;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -1380,6 +1382,23 @@ public class MotionGroup {
     }
     else {
       return moveCaretToLineEnd(editor, visualLineToLogicalLine(editor, line), allowPastEnd);
+    }
+  }
+
+  public static class ScrollOptionsChangeListener implements OptionChangeListener<String> {
+    public static ScrollOptionsChangeListener INSTANCE = new ScrollOptionsChangeListener();
+
+    @Contract(pure = true)
+    private ScrollOptionsChangeListener() {
+    }
+
+    @Override
+    public void valueChange(String oldValue, String newValue) {
+      for (Editor editor : EditorFactory.getInstance().getAllEditors()) {
+        if (UserDataManager.getVimEditorGroup(editor)) {
+          MotionGroup.scrollCaretIntoView(editor);
+        }
+      }
     }
   }
 }

--- a/src/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -201,7 +201,7 @@ public class EditorHelper {
    * @param editor The editor
    * @return The number of screen lines
    */
-  private static int getApproximateScreenHeight(final @NotNull Editor editor) {
+  public static int getApproximateScreenHeight(final @NotNull Editor editor) {
     return getVisibleArea(editor).height / editor.getLineHeight();
   }
 
@@ -653,7 +653,7 @@ public class EditorHelper {
       // Get the max line number that can sit at the top of the screen
       final int editorHeight = getVisibleArea(editor).height;
       final int virtualSpaceHeight = editor.getSettings().getAdditionalLinesCount() * editor.getLineHeight();
-      final int yLastLine = editor.visualLineToY(EditorHelper.getLineCount(editor));  // last line + 1
+      final int yLastLine = editor.visualLineToY(getLineCount(editor));  // last line + 1
       y = Math.min(y, yLastLine + virtualSpaceHeight - editorHeight);
     }
     return scrollVertically(editor, y);
@@ -662,21 +662,25 @@ public class EditorHelper {
   /**
    * Scrolls the editor to place the given visual line in the middle of the current window.
    *
+   * <p>Snaps the line to the nearest standard line height grid, which gives a good position for both an odd and even
+   * number of lines and mimics what Vim does.</p>
+   *
    * @param editor The editor to scroll
    * @param visualLine The visual line to place in the middle of the current window
    */
   public static void scrollVisualLineToMiddleOfScreen(@NotNull Editor editor, int visualLine) {
-    int y = editor.visualLineToY(normalizeVisualLine(editor, visualLine));
-    int lineHeight = editor.getLineHeight();
-    int height = getVisibleArea(editor).height;
-    scrollVertically(editor, y - ((height - lineHeight) / 2));
+    final int y = editor.visualLineToY(normalizeVisualLine(editor, visualLine));
+    final int screenHeight = getVisibleArea(editor).height;
+    final int lineHeight = editor.getLineHeight();
+    scrollVertically(editor, y - ((screenHeight - lineHeight) / lineHeight / 2 * lineHeight));
   }
 
   /**
    * Scrolls the editor to place the given visual line at the bottom of the screen.
    *
-   * When we're moving the caret down a few lines and want to scroll to keep this visible, we need to be able to place a
-   * line at the bottom of the screen. Due to block inlays, we can't do this by specifying a top line to scroll to.
+   * <p>When we're moving the caret down a few lines and want to scroll to keep this visible, we need to be able to
+   * place a line at the bottom of the screen. Due to block inlays, we can't do this by specifying a top line to scroll
+   * to.</p>
    *
    * @param editor The editor to scroll
    * @param visualLine The visual line to place at the bottom of the current window
@@ -714,19 +718,19 @@ public class EditorHelper {
     }
 
     final int columnLeftX = editor.visualPositionToXY(new VisualPosition(visualLine, targetVisualColumn)).x;
-    EditorHelper.scrollHorizontally(editor, columnLeftX);
+    scrollHorizontally(editor, columnLeftX);
   }
 
   public static void scrollColumnToMiddleOfScreen(@NotNull Editor editor, int visualLine, int visualColumn) {
     final Point point = editor.visualPositionToXY(new VisualPosition(visualLine, visualColumn));
-    final int screenWidth = EditorHelper.getVisibleArea(editor).width;
+    final int screenWidth = getVisibleArea(editor).width;
 
     // Snap the column to the nearest standard column grid. This positions us nicely if there are an odd or even number
     // of columns. It also works with inline inlays and folds. It is slightly inaccurate for proportional fonts, but is
     // still a good solution. Besides, what kind of monster uses Vim with proportional fonts?
     final int standardColumnWidth = EditorUtil.getPlainSpaceWidth(editor);
     final int x = point.x - (screenWidth / standardColumnWidth / 2 * standardColumnWidth);
-    EditorHelper.scrollHorizontally(editor, x);
+    scrollHorizontally(editor, x);
   }
 
   public static void scrollColumnToRightOfScreen(@NotNull Editor editor, int visualLine, int visualColumn) {
@@ -751,8 +755,8 @@ public class EditorHelper {
 
     // Scroll to the left edge of the target column, minus a screenwidth, and adjusted for inlays
     final int targetColumnRightX = editor.visualPositionToXY(new VisualPosition(visualLine, targetVisualColumn + 1)).x;
-    final int screenWidth = EditorHelper.getVisibleArea(editor).width;
-    EditorHelper.scrollHorizontally(editor, targetColumnRightX - screenWidth);
+    final int screenWidth = getVisibleArea(editor).width;
+    scrollHorizontally(editor, targetColumnRightX - screenWidth);
   }
 
   /**

--- a/src/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -106,6 +106,7 @@ object VimListenerManager {
 
       OptionsManager.number.addOptionChangeListener(EditorGroup.NumberChangeListener.INSTANCE)
       OptionsManager.relativenumber.addOptionChangeListener(EditorGroup.NumberChangeListener.INSTANCE)
+      OptionsManager.scrolloff.addOptionChangeListener(MotionGroup.ScrollOptionsChangeListener.INSTANCE)
       OptionsManager.showcmd.addOptionChangeListener(ShowCmdOptionChangeListener)
 
       EventFacade.getInstance().addEditorFactoryListener(VimEditorFactoryListener, VimPlugin.getInstance())
@@ -116,6 +117,7 @@ object VimListenerManager {
 
       OptionsManager.number.removeOptionChangeListener(EditorGroup.NumberChangeListener.INSTANCE)
       OptionsManager.relativenumber.removeOptionChangeListener(EditorGroup.NumberChangeListener.INSTANCE)
+      OptionsManager.scrolloff.removeOptionChangeListener(MotionGroup.ScrollOptionsChangeListener.INSTANCE)
       OptionsManager.showcmd.removeOptionChangeListener(ShowCmdOptionChangeListener)
 
       EventFacade.getInstance().removeEditorFactoryListener(VimEditorFactoryListener)

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_scrolloff_scrolljump_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_scrolloff_scrolljump_Test.kt
@@ -22,6 +22,7 @@ package org.jetbrains.plugins.ideavim.group.motion
 
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
+import com.maddyhome.idea.vim.option.OptionsManager
 import com.maddyhome.idea.vim.option.ScrollJumpData
 import com.maddyhome.idea.vim.option.ScrollOffData
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
@@ -348,6 +349,18 @@ class MotionGroup_scrolloff_Test : VimOptionTestCase(ScrollOffData.name) {
     typeText(parseKeys("k"))
     assertPosition(42, 0)
     assertVisibleArea(26, 59)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["0"]))
+  fun `test reposition cursor when scrolloff is set`() {
+    configureByPages(5)
+    setPositionAndScroll(50, 50)
+
+    OptionsManager.scrolloff.set(999)
+
+    assertPosition(50, 0)
+    assertVisibleArea(33, 67)
   }
 }
 

--- a/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_scrolloff_scrolljump_Test.kt
+++ b/test/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_scrolloff_scrolljump_Test.kt
@@ -21,6 +21,7 @@
 package org.jetbrains.plugins.ideavim.group.motion
 
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.option.ScrollJumpData
 import com.maddyhome.idea.vim.option.ScrollOffData
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
@@ -64,6 +65,119 @@ class MotionGroup_scrolloff_Test : VimOptionTestCase(ScrollOffData.name) {
   }
 
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["15"]))
+  fun `test move up when scrolloff is slightly less than half screen height`() {
+    // Screen height = 35. scrolloff=15. This gives 5 possible caret lines without scrolling (48, 49, 50, 51 + 52)
+    configureByPages(5)
+    setPositionAndScroll(33, 52)
+
+    typeText(parseKeys("k"))
+    assertPosition(51, 0)
+    assertVisibleArea(33, 67)
+
+    typeText(parseKeys("k"))
+    assertPosition(50, 0)
+    assertVisibleArea(33, 67)
+
+    typeText(parseKeys("k"))
+    assertPosition(49, 0)
+    assertVisibleArea(33, 67)
+
+    typeText(parseKeys("k"))
+    assertPosition(48, 0)
+    assertVisibleArea(33, 67)
+
+    // Scroll
+    typeText(parseKeys("k"))
+    assertPosition(47, 0)
+    assertVisibleArea(32, 66)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["16"]))
+  fun `test move up when scrolloff is slightly less than half screen height 2`() {
+    // Screen height = 35. scrolloff=16. This gives 3 possible caret lines without scrolling (49, 50 + 51)
+    configureByPages(5)
+    setPositionAndScroll(33, 51)
+
+    typeText(parseKeys("k"))
+    assertPosition(50, 0)
+    assertVisibleArea(33, 67)
+
+    typeText(parseKeys("k"))
+    assertPosition(49, 0)
+    assertVisibleArea(33, 67)
+
+    // Scroll
+    typeText(parseKeys("k"))
+    assertPosition(48, 0)
+    assertVisibleArea(32, 66)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["16"]))
+  fun `test move up when scrolloff is slightly less than half screen height 3`() {
+    // Screen height = 34. scrolloff=16
+    // Even numbers. 2 possible caret lines without scrolling (49 + 50)
+    configureByPages(5)
+    setEditorVisibleSize(screenWidth, 34)
+    setPositionAndScroll(33, 50)
+
+    typeText(parseKeys("k"))
+    assertPosition(49, 0)
+    assertVisibleArea(33, 66)
+
+    // Scroll
+    typeText(parseKeys("k"))
+    assertPosition(48, 0)
+    assertVisibleArea(32, 65)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["17"]))
+  @VimBehaviorDiffers(description = "Moving up in Vim will always have 16 lines above the caret line. IdeaVim keeps 17")
+  fun `test move up when scrolloff is exactly screen height`() {
+    // Page height = 34. scrolloff=17
+    // 2 possible caret lines without scrolling (49 + 50)
+    configureByPages(5)
+    setEditorVisibleSize(screenWidth, 34)
+    setPositionAndScroll(33, 50)
+
+    typeText(parseKeys("k"))
+    assertPosition(49, 0)
+    assertVisibleArea(33, 66)
+
+    // Scroll
+    typeText(parseKeys("k"))
+    assertPosition(48, 0)
+    assertVisibleArea(32, 65)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["17"]))
+  fun `test move up when scrolloff is slightly greater than screen height keeps cursor in centre of screen`() {
+    // Page height = 35. scrolloff=17
+    configureByPages(5)
+    setPositionAndScroll(33, 50)
+
+    typeText(parseKeys("k"))
+    assertPosition(49, 0)
+    assertVisibleArea(32, 66)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["22"]))
+  fun `test move up when scrolloff is slightly greater than screen height keeps cursor in centre of screen 2`() {
+    // Page height = 35. scrolloff=17
+    configureByPages(5)
+    setPositionAndScroll(33, 50)
+
+    typeText(parseKeys("k"))
+    assertPosition(49, 0)
+    assertVisibleArea(32, 66)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["0"]))
   fun `test move down shows no context with scrolloff=0`() {
     configureByPages(5)
@@ -94,13 +208,146 @@ class MotionGroup_scrolloff_Test : VimOptionTestCase(ScrollOffData.name) {
   }
 
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["15"]))
+  fun `test move down when scrolloff is slightly less than half screen height`() {
+    // Screen height = 35. scrolloff=15. This gives 5 possible caret lines without scrolling (48, 49, 50, 51 + 52)
+    configureByPages(5)
+    setPositionAndScroll(33, 48)
+
+    typeText(parseKeys("j"))
+    assertPosition(49, 0)
+    assertVisibleArea(33, 67)
+
+    typeText(parseKeys("j"))
+    assertPosition(50, 0)
+    assertVisibleArea(33, 67)
+
+    typeText(parseKeys("j"))
+    assertPosition(51, 0)
+    assertVisibleArea(33, 67)
+
+    typeText(parseKeys("j"))
+    assertPosition(52, 0)
+    assertVisibleArea(33, 67)
+
+    // Scroll
+    typeText(parseKeys("j"))
+    assertPosition(53, 0)
+    assertVisibleArea(34, 68)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["16"]))
+  fun `test move down when scrolloff is slightly less than half screen height 2`() {
+    // Screen height = 35. scrolloff=16. This gives 3 possible caret lines without scrolling (49, 50 + 51)
+    configureByPages(5)
+    setPositionAndScroll(33, 49)
+
+    typeText(parseKeys("j"))
+    assertPosition(50, 0)
+    assertVisibleArea(33, 67)
+
+    typeText(parseKeys("j"))
+    assertPosition(51, 0)
+    assertVisibleArea(33, 67)
+
+    // Scroll
+    typeText(parseKeys("j"))
+    assertPosition(52, 0)
+    assertVisibleArea(34, 68)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["16"]))
+  fun `test move down when scrolloff is slightly less than half screen height 3`() {
+    // Screen height = 34. scrolloff=16
+    // Even numbers. 2 possible caret lines without scrolling (49 + 50)
+    configureByPages(5)
+    setEditorVisibleSize(screenWidth, 34)
+    setPositionAndScroll(33, 49)
+
+    typeText(parseKeys("j"))
+    assertPosition(50, 0)
+    assertVisibleArea(33, 66)
+
+    // Scroll
+    typeText(parseKeys("j"))
+    assertPosition(51, 0)
+    assertVisibleArea(34, 67)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["17"]))
+  fun `test move down when scrolloff is exactly screen height`() {
+    // Page height = 34. scrolloff=17
+    // 2 possible caret lines without scrolling (49 + 50), but moving to line 51 will scroll 2 lines!
+    configureByPages(5)
+    setEditorVisibleSize(screenWidth, 34)
+    setPositionAndScroll(33, 49)
+
+    typeText(parseKeys("j"))
+    assertPosition(50, 0)
+    assertVisibleArea(33, 66)
+
+    // Scroll. By 2 lines!
+    typeText(parseKeys("j"))
+    assertPosition(51, 0)
+    assertVisibleArea(35, 68)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["17"]))
+  fun `test move down when scrolloff is slightly greater than half screen height keeps cursor in centre of screen`() {
+    // Page height = 35. scrolloff=17
+    configureByPages(5)
+    setPositionAndScroll(33, 50)
+
+    typeText(parseKeys("j"))
+    assertPosition(51, 0)
+    assertVisibleArea(34, 68)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["22"]))
+  fun `test move down when scrolloff is slightly greater than half screen height keeps cursor in centre of screen 2`() {
+    // Page height = 35. scrolloff=17
+    configureByPages(5)
+    setPositionAndScroll(33, 50)
+
+    typeText(parseKeys("j"))
+    assertPosition(51, 0)
+    assertVisibleArea(34, 68)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["999"]))
   fun `test scrolloff=999 keeps cursor in centre of screen`() {
     configureByPages(5)
     setPositionAndScroll(25, 42)
+
     typeText(parseKeys("j"))
     assertPosition(43, 0)
     assertVisibleArea(26, 60)
+
+    typeText(parseKeys("k"))
+    assertPosition(42, 0)
+    assertVisibleArea(25, 59)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @VimOptionTestConfiguration(VimTestOption(ScrollOffData.name, VimTestOptionType.NUMBER, ["999"]))
+  fun `test scrolloff=999 keeps cursor in centre of screen with even screen height`() {
+    configureByPages(5)
+    setEditorVisibleSize(screenWidth, 34)
+    setPositionAndScroll(26, 42)
+
+    typeText(parseKeys("j"))
+    assertPosition(43, 0)
+    assertVisibleArea(27, 60)
+
+    typeText(parseKeys("k"))
+    assertPosition(42, 0)
+    assertVisibleArea(26, 59)
   }
 }
 


### PR DESCRIPTION
- [x] Fix [VIM-2158](https://youtrack.jetbrains.com/issue/VIM-2158): scrolling jumps around when `scrolloff` is greater than half the screen height, but less than the total screen height
- [x] Reposition the cursor when `scrolloff` changes. E.g. `:set so=999` will reposition the cursor in the middle of the screen immediately, rather than waiting for the next motion
- [x] Limit the height of inlays shown above/below a line when scrolling up/down. Normally, IdeaVim will try to show the associated block inlay (e.g. Rider's Code Vision links for usages, source control, etc.) above a line, when moving that line to the top of the screen, and vice versa - inlays attached below a line when moving that line to the bottom. However, [multiline rendered doc comments](https://blog.jetbrains.com/idea/2020/03/intellij-idea-2020-1-eap8/#in_editor_javadocs_rendering) are treated as block inlays rather than lines, and can take up a lot of space. Trying to show all of the inlay can cause the visible area to bounce around and can even force the cursor off screen. IdeaVim will now limit the block inlay height to 3 standard line heights. If the inlay is taller than this, it will be cut off.
- [x] Workaround an issue with lots of block inlays/doc comments causing the actual number of text lines to be very small. This forces the scrolling algorithm to treat a small movement as a large scroll and so position the cursor in the middle of the screen. This can cause scrolling to "stick", with the cursor unable to scroll to the proper location. A fudge factor has been added to try to catch when there are significantly less text lines than expected, and avoid the scroll to centre loop.
- [x] Tests

Top tip: if you're looking for a good example file to test rendered doc comments, then `String.java` is a good place to go.