### PR TITLE
Show the correct handler class in :map

### DIFF
--- a/src/com/maddyhome/idea/vim/key/MappingInfo.kt
+++ b/src/com/maddyhome/idea/vim/key/MappingInfo.kt
@@ -107,7 +107,7 @@ class ToHandlerMappingInfo(
   isRecursive: Boolean,
   owner: MappingOwner
 ) : MappingInfo(fromKeys, isRecursive, owner) {
-  override fun getPresentableString(): String = "call ${this.javaClass.canonicalName}"
+  override fun getPresentableString(): String = "call ${extensionHandler.javaClass.canonicalName}"
 
   override fun execute(editor: Editor, context: DataContext) {
     val processor = CommandProcessor.getInstance()


### PR DESCRIPTION
Small fix to show the correct handler class name in the output of `:map`, instead of all handlers showing `call com.maddyhome.idea.vim.key.ToHandlerMappingInfo`