### PR TITLE
Refactor SearchGroup

### DIFF
--- a/src/com/maddyhome/idea/vim/group/SearchGroup.java
+++ b/src/com/maddyhome/idea/vim/group/SearchGroup.java
@@ -109,7 +109,7 @@ public class SearchGroup implements PersistentStateComponent<Element> {
   public void resetState() {
     lastSearch = lastPattern = lastSubstitute = lastReplace = lastOffset = null;
     lastIgnoreSmartCase = false;
-    lastDir = Direction.UNSET;
+    lastDir = Direction.FORWARDS;
     resetShowSearchHighlight();
   }
 

--- a/src/com/maddyhome/idea/vim/group/SearchGroup.java
+++ b/src/com/maddyhome/idea/vim/group/SearchGroup.java
@@ -17,7 +17,6 @@
  */
 package com.maddyhome.idea.vim.group;
 
-import com.google.common.collect.Lists;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.RoamingType;
@@ -120,54 +119,25 @@ public class SearchGroup implements PersistentStateComponent<Element> {
     VimPlugin.getHistory().addEntry(HistoryGroup.SEARCH, lastPattern);
   }
 
-  // This method should not be private because it's used in external plugins
-  @SuppressWarnings("WeakerAccess")
+  /**
+   * Find all occurrences of the pattern
+   *
+   * @deprecated Use SearchHelper#findAll instead. Kept for compatibility with existing plugins
+   *
+   * @param editor      The editor to search in
+   * @param pattern     The pattern to search for
+   * @param startLine   The start line of the range to search for, or -1 for the whole document
+   * @param endLine     The end line of the range to search for, or -1 for the whole document
+   * @param ignoreCase  Case sensitive or insensitive searching
+   * @return            A list of TextRange objects representing the results
+   */
+  @Deprecated()
   public static @NotNull List<TextRange> findAll(@NotNull Editor editor,
-                                         @NotNull String pattern,
-                                         int startLine,
-                                         int endLine,
-                                         boolean ignoreCase) {
-    final List<TextRange> results = Lists.newArrayList();
-    final int lineCount = EditorHelper.getLineCount(editor);
-    final int actualEndLine = endLine == -1 ? lineCount : endLine;
-
-    final RegExp.regmmatch_T regMatch = new RegExp.regmmatch_T();
-    final RegExp regExp = new RegExp();
-    regMatch.regprog = regExp.vim_regcomp(pattern, 1);
-    if (regMatch.regprog == null) {
-      return results;
-    }
-
-    regMatch.rmm_ic = ignoreCase;
-
-    int col = 0;
-    for (int line = startLine; line <= actualEndLine; ) {
-      int matchedLines = regExp.vim_regexec_multi(regMatch, editor, lineCount, line, col);
-      if (matchedLines > 0) {
-        final CharacterPosition startPos = new CharacterPosition(line + regMatch.startpos[0].lnum,
-                                                                 regMatch.startpos[0].col);
-        final CharacterPosition endPos = new CharacterPosition(line + regMatch.endpos[0].lnum,
-                                                               regMatch.endpos[0].col);
-        int start = startPos.toOffset(editor);
-        int end = endPos.toOffset(editor);
-        results.add(new TextRange(start, end));
-
-        if (start != end) {
-          line += matchedLines - 1;
-          col = endPos.column;
-        }
-        else {
-          line += matchedLines;
-          col = 0;
-        }
-      }
-      else {
-        line++;
-        col = 0;
-      }
-    }
-
-    return results;
+                                                 @NotNull String pattern,
+                                                 int startLine,
+                                                 int endLine,
+                                                 boolean ignoreCase) {
+    return SearchHelper.findAll(editor, pattern, startLine, endLine, ignoreCase);
   }
 
   private static @NotNull ReplaceConfirmationChoice confirmChoice(@NotNull Editor editor, @NotNull String match, @NotNull Caret caret, int startoff) {
@@ -400,7 +370,7 @@ public class SearchGroup implements PersistentStateComponent<Element> {
   private @Nullable TextRange findNextSearchForGn(@NotNull Editor editor, int count, boolean forwards) {
     if (forwards) {
       final EnumSet<SearchOptions> searchOptions = EnumSet.of(SearchOptions.WRAP, SearchOptions.WHOLE_FILE);
-      return findIt(editor, lastSearch, editor.getCaretModel().getOffset(), count, searchOptions);
+      return SearchHelper.findPattern(editor, lastSearch, editor.getCaretModel().getOffset(), count, searchOptions);
     } else {
       return searchBackward(editor, editor.getCaretModel().getOffset(), count);
     }
@@ -415,283 +385,12 @@ public class SearchGroup implements PersistentStateComponent<Element> {
   private @Nullable TextRange searchBackward(@NotNull Editor editor, int offset, int count) {
     // Backward search returns wrongs end offset for some cases. That's why we should perform additional forward search
     final EnumSet<SearchOptions> searchOptions = EnumSet.of(SearchOptions.WRAP, SearchOptions.WHOLE_FILE, SearchOptions.BACKWARDS);
-    final TextRange foundBackward = findIt(editor, lastSearch, offset, count, searchOptions);
+    final TextRange foundBackward = SearchHelper.findPattern(editor, lastSearch, offset, count, searchOptions);
     if (foundBackward == null) return null;
     int startOffset = foundBackward.getStartOffset() - 1;
     if (startOffset < 0) startOffset = EditorHelperRt.getFileSize(editor);
     searchOptions.remove(SearchOptions.BACKWARDS);
-    return findIt(editor, lastSearch, startOffset, 1, searchOptions);
-  }
-
-  public static TextRange findIt(@NotNull Editor editor, @Nullable String pattern, int startOffset, int count, EnumSet<SearchOptions> searchOptions) {
-    if (pattern == null || pattern.length() == 0) {
-      logger.warn("Pattern is null or empty. Cannot perform search");
-      return null;
-    }
-
-    Direction dir = searchOptions.contains(SearchOptions.BACKWARDS) ? Direction.BACKWARDS : Direction.FORWARDS;
-
-    //RE sp;
-    RegExp sp;
-    RegExp.regmmatch_T regmatch = new RegExp.regmmatch_T();
-    regmatch.rmm_ic = shouldIgnoreCase(pattern, searchOptions.contains(SearchOptions.IGNORE_SMARTCASE));
-    sp = new RegExp();
-    regmatch.regprog = sp.vim_regcomp(pattern, 1);
-    if (regmatch.regprog == null) {
-      if (logger.isDebugEnabled()) logger.debug("bad pattern: " + pattern);
-      return null;
-    }
-
-    /*
-    int extra_col = 1;
-    int startcol = -1;
-    boolean found = false;
-    boolean match_ok = true;
-    LogicalPosition pos = editor.offsetToLogicalPosition(startOffset);
-    LogicalPosition endpos = null;
-    //REMatch match = null;
-    */
-
-    CharacterPosition lpos = CharacterPosition.Companion.fromOffset(editor, startOffset);
-    RegExp.lpos_T pos = new RegExp.lpos_T();
-    pos.lnum = lpos.line;
-    pos.col = lpos.column;
-
-    int found;
-    int lnum;           /* no init to shut up Apollo cc */
-    //RegExp.regmmatch_T regmatch;
-    CharPointer ptr;
-    int matchcol;
-    RegExp.lpos_T matchpos;
-    RegExp.lpos_T endpos = new RegExp.lpos_T();
-    int loop;
-    RegExp.lpos_T start_pos;
-    boolean at_first_line;
-    int extra_col = dir == Direction.FORWARDS ? 1 : 0;
-    boolean match_ok;
-    long nmatched;
-    //int         submatch = 0;
-    boolean first_match = true;
-
-    int lineCount = EditorHelper.getLineCount(editor);
-    int startLine = 0;
-    int endLine = lineCount;
-
-    do  /* loop for count */ {
-      start_pos = new RegExp.lpos_T(pos);       /* remember start pos for detecting no match */
-      found = 0;              /* default: not found */
-      at_first_line = true;   /* default: start in first line */
-      if (pos.lnum == -1)     /* correct lnum for when starting in line 0 */ {
-        pos.lnum = 0;
-        pos.col = 0;
-        at_first_line = false;  /* not in first line now */
-      }
-
-      /*
-      * Start searching in current line, unless searching backwards and
-      * we're in column 0.
-      */
-      if (dir == Direction.BACKWARDS && start_pos.col == 0) {
-        lnum = pos.lnum - 1;
-        at_first_line = false;
-      }
-      else {
-        lnum = pos.lnum;
-      }
-
-      int lcount = EditorHelper.getLineCount(editor);
-      for (loop = 0; loop <= 1; ++loop)   /* loop twice if 'wrapscan' set */ {
-        if (!searchOptions.contains(SearchOptions.WHOLE_FILE)) {
-          startLine = lnum;
-          endLine = lnum + 1;
-        }
-        for (; lnum >= startLine && lnum < endLine; lnum += dir.toInt(), at_first_line = false) {
-          /*
-          * Look for a match somewhere in the line.
-          */
-          nmatched = sp.vim_regexec_multi(regmatch, editor, lcount, lnum, 0);
-          if (nmatched > 0) {
-            /* match may actually be in another line when using \zs */
-            matchpos = new RegExp.lpos_T(regmatch.startpos[0]);
-            endpos = new RegExp.lpos_T(regmatch.endpos[0]);
-
-            ptr = new CharPointer(EditorHelper.getLineBuffer(editor, lnum + matchpos.lnum));
-
-            /*
-            * Forward search in the first line: match should be after
-            * the start position. If not, continue at the end of the
-            * match (this is vi compatible) or on the next char.
-            */
-            if (dir == Direction.FORWARDS && at_first_line) {
-              match_ok = true;
-              /*
-              * When match lands on a NUL the cursor will be put
-              * one back afterwards, compare with that position,
-              * otherwise "/$" will get stuck on end of line.
-              */
-              while (matchpos.lnum == 0
-                && (searchOptions.contains(SearchOptions.WANT_ENDPOS) && first_match
-                  ? (nmatched == 1 && endpos.col - 1 < start_pos.col + extra_col)
-                  : (matchpos.col - (ptr.charAt(matchpos.col) == '\u0000' ? 1 : 0) < start_pos.col + extra_col))) {
-                if (nmatched > 1) {
-                  /* end is in next line, thus no match in
-                   * this line */
-                  match_ok = false;
-                  break;
-                }
-                matchcol = endpos.col;
-                /* for empty match: advance one char */
-                if (matchcol == matchpos.col && ptr.charAt(matchcol) != '\u0000') {
-                  ++matchcol;
-                }
-                if (ptr.charAt(matchcol) == '\u0000' ||
-                    (nmatched = sp.vim_regexec_multi(regmatch, editor, lcount, lnum, matchcol)) == 0) {
-                  match_ok = false;
-                  break;
-                }
-                matchpos = new RegExp.lpos_T(regmatch.startpos[0]);
-                endpos = new RegExp.lpos_T(regmatch.endpos[0]);
-
-                /* Need to get the line pointer again, a
-                 * multi-line search may have made it invalid. */
-                ptr = new CharPointer(EditorHelper.getLineBuffer(editor, lnum));
-              }
-              if (!match_ok) {
-                continue;
-              }
-            }
-            if (dir == Direction.BACKWARDS) {
-              /*
-              * Now, if there are multiple matches on this line,
-              * we have to get the last one. Or the last one before
-              * the cursor, if we're on that line.
-              * When putting the new cursor at the end, compare
-              * relative to the end of the match.
-              */
-              match_ok = false;
-              for (;;) {
-                if (loop != 0 ||
-                  (searchOptions.contains(SearchOptions.WANT_ENDPOS)
-                    ? (lnum + regmatch.endpos[0].lnum < start_pos.lnum || (lnum + regmatch.endpos[0].lnum == start_pos.lnum && regmatch.endpos[0].col - 1 < start_pos.col + extra_col))
-                    : (lnum + regmatch.startpos[0].lnum < start_pos.lnum || (lnum + regmatch.startpos[0].lnum == start_pos.lnum && regmatch.startpos[0].col < start_pos.col + extra_col)))) {
-                  /* Remember this position, we use it if it's
-                   * the last match in the line. */
-                  match_ok = true;
-                  matchpos = new RegExp.lpos_T(regmatch.startpos[0]);
-                  endpos = new RegExp.lpos_T(regmatch.endpos[0]);
-                }
-                else {
-                  break;
-                }
-
-                /*
-                * We found a valid match, now check if there is
-                * another one after it.
-                * If vi-compatible searching, continue at the end
-                * of the match, otherwise continue one position
-                * forward.
-                */
-                if (nmatched > 1) {
-                  break;
-                }
-                matchcol = endpos.col;
-                /* for empty match: advance one char */
-                if (matchcol == matchpos.col && ptr.charAt(matchcol) != '\u0000') {
-                  ++matchcol;
-                }
-                if (ptr.charAt(matchcol) == '\u0000' ||
-                    (nmatched = sp.vim_regexec_multi(regmatch, editor, lcount, lnum + matchpos.lnum, matchcol)) == 0) {
-                  break;
-                }
-
-                /* Need to get the line pointer again, a
-                 * multi-line search may have made it invalid. */
-                ptr = new CharPointer(EditorHelper.getLineBuffer(editor, lnum + matchpos.lnum));
-              }
-
-              /*
-              * If there is only a match after the cursor, skip
-              * this match.
-              */
-              if (!match_ok) {
-                continue;
-              }
-            }
-
-            pos.lnum = lnum + matchpos.lnum;
-            pos.col = matchpos.col;
-            endpos.lnum = lnum + endpos.lnum;
-            found = 1;
-            first_match = false;
-
-            /* Set variables used for 'incsearch' highlighting. */
-            //search_match_lines = endpos.lnum - (lnum - first_lnum);
-            //search_match_endcol = endpos.col;
-            break;
-          }
-          //line_breakcheck();      /* stop if ctrl-C typed */
-          //if (got_int)
-          //    break;
-
-          if (loop != 0 && lnum == start_pos.lnum) {
-            break;          /* if second loop, stop where started */
-          }
-        }
-        at_first_line = false;
-
-        /*
-        * stop the search if wrapscan isn't set, after an interrupt and
-        * after a match
-        */
-        if (!searchOptions.contains(SearchOptions.WRAP) || found != 0) {
-          break;
-        }
-
-        /*
-        * If 'wrapscan' is set we continue at the other end of the file.
-        * If 'shortmess' does not contain 's', we give a message.
-        * This message is also remembered in keep_msg for when the screen
-        * is redrawn. The keep_msg is cleared whenever another message is
-        * written.
-        */
-        if (dir == Direction.BACKWARDS)    /* start second loop at the other end */ {
-          lnum = lineCount - 1;
-          //if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG))
-          //    give_warning((char_u *)_(top_bot_msg), TRUE);
-        }
-        else {
-          lnum = 0;
-          //if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG))
-          //    give_warning((char_u *)_(bot_top_msg), TRUE);
-        }
-      }
-      //if (got_int || called_emsg || break_loop)
-      //    break;
-    }
-    while (--count > 0 && found != 0);   /* stop after count matches or no match */
-
-    if (found == 0)             /* did not find it */ {
-      //if ((options & SEARCH_MSG) == SEARCH_MSG)
-      if (searchOptions.contains(SearchOptions.SHOW_MESSAGES)) {
-        if (searchOptions.contains(SearchOptions.WRAP)) {
-          VimPlugin.showMessage(MessageHelper.message(Msg.e_patnotf2, pattern));
-        }
-        else if (lnum <= 0) {
-          VimPlugin.showMessage(MessageHelper.message(Msg.E384, pattern));
-        }
-        else {
-          VimPlugin.showMessage(MessageHelper.message(Msg.E385, pattern));
-        }
-      }
-      return null;
-    }
-
-    //return new TextRange(editor.logicalPositionToOffset(new LogicalPosition(pos.lnum, pos.col)),
-    //    editor.logicalPositionToOffset(new LogicalPosition(endpos.lnum, endpos.col)));
-    //return new TextRange(editor.logicalPositionToOffset(new LogicalPosition(pos.lnum, 0)) + pos.col,
-    //    editor.logicalPositionToOffset(new LogicalPosition(endpos.lnum, 0)) + endpos.col);
-    return new TextRange(new CharacterPosition(pos.lnum, pos.col).toOffset(editor),
-                         new CharacterPosition(endpos.lnum, endpos.col).toOffset(editor));
+    return SearchHelper.findPattern(editor, lastSearch, startOffset, 1, searchOptions);
   }
 
   private int findItOffset(@NotNull Editor editor, int startOffset, int count, Direction dir) {
@@ -761,7 +460,7 @@ public class SearchGroup implements PersistentStateComponent<Element> {
     if (lastIgnoreSmartCase) searchOptions.add(SearchOptions.IGNORE_SMARTCASE);
     if (wrap) searchOptions.add(SearchOptions.WRAP);
     if (hasEndOffset) searchOptions.add(SearchOptions.WANT_ENDPOS);
-    TextRange range = findIt(editor, lastSearch, startOffset, count, searchOptions);
+    TextRange range = SearchHelper.findPattern(editor, lastSearch, startOffset, count, searchOptions);
     if (range == null) {
       logger.warn("No range is found");
       return -1;
@@ -1283,15 +982,6 @@ public class SearchGroup implements PersistentStateComponent<Element> {
     SKIP,
     QUIT,
     SUBSTITUTE_ALL,
-  }
-
-  public enum SearchOptions {
-    BACKWARDS,
-    WANT_ENDPOS,
-    WRAP,
-    SHOW_MESSAGES,
-    WHOLE_FILE,
-    IGNORE_SMARTCASE,
   }
 
   private @Nullable String lastSearch;

--- a/src/com/maddyhome/idea/vim/helper/SearchHelper.java
+++ b/src/com/maddyhome/idea/vim/helper/SearchHelper.java
@@ -18,6 +18,7 @@
 
 package com.maddyhome.idea.vim.helper;
 
+import com.google.common.collect.Lists;
 import com.intellij.lang.CodeDocumentationAwareCommenter;
 import com.intellij.lang.Commenter;
 import com.intellij.lang.Language;
@@ -29,10 +30,14 @@ import com.intellij.psi.PsiComment;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.CommandState;
+import com.maddyhome.idea.vim.common.CharacterPosition;
 import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.option.ListOption;
 import com.maddyhome.idea.vim.option.OptionsManager;
+import com.maddyhome.idea.vim.regexp.CharPointer;
+import com.maddyhome.idea.vim.regexp.RegExp;
 import kotlin.Pair;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -44,11 +49,357 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.maddyhome.idea.vim.helper.SearchHelperKtKt.checkInString;
+import static com.maddyhome.idea.vim.helper.SearchHelperKtKt.shouldIgnoreCase;
 
 /**
  * Helper methods for searching text
  */
 public class SearchHelper {
+
+  /**
+   * Find text matching the given pattern.
+   *
+   * @param editor          The editor to search in
+   * @param pattern         The pattern to search for
+   * @param startOffset     The offset to start searching from
+   * @param count           Find the nth next occurrence of the pattern. Must be 1 or greater.
+   * @param searchOptions   A set of options, such as direction and wrap
+   * @return                A TextRange representing the result, or null
+   */
+  @Nullable
+  public static TextRange findPattern(@NotNull Editor editor,
+                                      @Nullable String pattern,
+                                      int startOffset,
+                                      int count,
+                                      EnumSet<SearchOptions> searchOptions) {
+    if (pattern == null || pattern.length() == 0) {
+      logger.warn("Pattern is null or empty. Cannot perform search");
+      return null;
+    }
+
+    Direction dir = searchOptions.contains(SearchOptions.BACKWARDS) ? Direction.BACKWARDS : Direction.FORWARDS;
+
+    //RE sp;
+    RegExp sp;
+    RegExp.regmmatch_T regmatch = new RegExp.regmmatch_T();
+    regmatch.rmm_ic = shouldIgnoreCase(pattern, searchOptions.contains(SearchOptions.IGNORE_SMARTCASE));
+    sp = new RegExp();
+    regmatch.regprog = sp.vim_regcomp(pattern, 1);
+    if (regmatch.regprog == null) {
+      if (logger.isDebugEnabled()) logger.debug("bad pattern: " + pattern);
+      return null;
+    }
+
+    /*
+    int extra_col = 1;
+    int startcol = -1;
+    boolean found = false;
+    boolean match_ok = true;
+    LogicalPosition pos = editor.offsetToLogicalPosition(startOffset);
+    LogicalPosition endpos = null;
+    //REMatch match = null;
+    */
+
+    CharacterPosition lpos = CharacterPosition.Companion.fromOffset(editor, startOffset);
+    RegExp.lpos_T pos = new RegExp.lpos_T();
+    pos.lnum = lpos.line;
+    pos.col = lpos.column;
+
+    int found;
+    int lnum;           /* no init to shut up Apollo cc */
+    //RegExp.regmmatch_T regmatch;
+    CharPointer ptr;
+    int matchcol;
+    RegExp.lpos_T matchpos;
+    RegExp.lpos_T endpos = new RegExp.lpos_T();
+    int loop;
+    RegExp.lpos_T start_pos;
+    boolean at_first_line;
+    int extra_col = dir == Direction.FORWARDS ? 1 : 0;
+    boolean match_ok;
+    long nmatched;
+    //int         submatch = 0;
+    boolean first_match = true;
+
+    int lineCount = EditorHelper.getLineCount(editor);
+    int startLine = 0;
+    int endLine = lineCount;
+
+    do  /* loop for count */ {
+      start_pos = new RegExp.lpos_T(pos);       /* remember start pos for detecting no match */
+      found = 0;              /* default: not found */
+      at_first_line = true;   /* default: start in first line */
+      if (pos.lnum == -1)     /* correct lnum for when starting in line 0 */ {
+        pos.lnum = 0;
+        pos.col = 0;
+        at_first_line = false;  /* not in first line now */
+      }
+
+      /*
+       * Start searching in current line, unless searching backwards and
+       * we're in column 0.
+       */
+      if (dir == Direction.BACKWARDS && start_pos.col == 0) {
+        lnum = pos.lnum - 1;
+        at_first_line = false;
+      }
+      else {
+        lnum = pos.lnum;
+      }
+
+      int lcount = EditorHelper.getLineCount(editor);
+      for (loop = 0; loop <= 1; ++loop)   /* loop twice if 'wrapscan' set */ {
+        if (!searchOptions.contains(SearchOptions.WHOLE_FILE)) {
+          startLine = lnum;
+          endLine = lnum + 1;
+        }
+        for (; lnum >= startLine && lnum < endLine; lnum += dir.toInt(), at_first_line = false) {
+          /*
+           * Look for a match somewhere in the line.
+           */
+          nmatched = sp.vim_regexec_multi(regmatch, editor, lcount, lnum, 0);
+          if (nmatched > 0) {
+            /* match may actually be in another line when using \zs */
+            matchpos = new RegExp.lpos_T(regmatch.startpos[0]);
+            endpos = new RegExp.lpos_T(regmatch.endpos[0]);
+
+            ptr = new CharPointer(EditorHelper.getLineBuffer(editor, lnum + matchpos.lnum));
+
+            /*
+             * Forward search in the first line: match should be after
+             * the start position. If not, continue at the end of the
+             * match (this is vi compatible) or on the next char.
+             */
+            if (dir == Direction.FORWARDS && at_first_line) {
+              match_ok = true;
+              /*
+               * When match lands on a NUL the cursor will be put
+               * one back afterwards, compare with that position,
+               * otherwise "/$" will get stuck on end of line.
+               */
+              while (matchpos.lnum == 0
+                && (searchOptions.contains(SearchOptions.WANT_ENDPOS) && first_match
+                ? (nmatched == 1 && endpos.col - 1 < start_pos.col + extra_col)
+                : (matchpos.col - (ptr.charAt(matchpos.col) == '\u0000' ? 1 : 0) < start_pos.col + extra_col))) {
+                if (nmatched > 1) {
+                  /* end is in next line, thus no match in
+                   * this line */
+                  match_ok = false;
+                  break;
+                }
+                matchcol = endpos.col;
+                /* for empty match: advance one char */
+                if (matchcol == matchpos.col && ptr.charAt(matchcol) != '\u0000') {
+                  ++matchcol;
+                }
+                if (ptr.charAt(matchcol) == '\u0000' ||
+                  (nmatched = sp.vim_regexec_multi(regmatch, editor, lcount, lnum, matchcol)) == 0) {
+                  match_ok = false;
+                  break;
+                }
+                matchpos = new RegExp.lpos_T(regmatch.startpos[0]);
+                endpos = new RegExp.lpos_T(regmatch.endpos[0]);
+
+                /* Need to get the line pointer again, a
+                 * multi-line search may have made it invalid. */
+                ptr = new CharPointer(EditorHelper.getLineBuffer(editor, lnum));
+              }
+              if (!match_ok) {
+                continue;
+              }
+            }
+            if (dir == Direction.BACKWARDS) {
+              /*
+               * Now, if there are multiple matches on this line,
+               * we have to get the last one. Or the last one before
+               * the cursor, if we're on that line.
+               * When putting the new cursor at the end, compare
+               * relative to the end of the match.
+               */
+              match_ok = false;
+              for (;;) {
+                if (loop != 0 ||
+                  (searchOptions.contains(SearchOptions.WANT_ENDPOS)
+                    ? (lnum + regmatch.endpos[0].lnum < start_pos.lnum || (lnum + regmatch.endpos[0].lnum == start_pos.lnum && regmatch.endpos[0].col - 1 < start_pos.col + extra_col))
+                    : (lnum + regmatch.startpos[0].lnum < start_pos.lnum || (lnum + regmatch.startpos[0].lnum == start_pos.lnum && regmatch.startpos[0].col < start_pos.col + extra_col)))) {
+                  /* Remember this position, we use it if it's
+                   * the last match in the line. */
+                  match_ok = true;
+                  matchpos = new RegExp.lpos_T(regmatch.startpos[0]);
+                  endpos = new RegExp.lpos_T(regmatch.endpos[0]);
+                }
+                else {
+                  break;
+                }
+
+                /*
+                 * We found a valid match, now check if there is
+                 * another one after it.
+                 * If vi-compatible searching, continue at the end
+                 * of the match, otherwise continue one position
+                 * forward.
+                 */
+                if (nmatched > 1) {
+                  break;
+                }
+                matchcol = endpos.col;
+                /* for empty match: advance one char */
+                if (matchcol == matchpos.col && ptr.charAt(matchcol) != '\u0000') {
+                  ++matchcol;
+                }
+                if (ptr.charAt(matchcol) == '\u0000' ||
+                  (nmatched = sp.vim_regexec_multi(regmatch, editor, lcount, lnum + matchpos.lnum, matchcol)) == 0) {
+                  break;
+                }
+
+                /* Need to get the line pointer again, a
+                 * multi-line search may have made it invalid. */
+                ptr = new CharPointer(EditorHelper.getLineBuffer(editor, lnum + matchpos.lnum));
+              }
+
+              /*
+               * If there is only a match after the cursor, skip
+               * this match.
+               */
+              if (!match_ok) {
+                continue;
+              }
+            }
+
+            pos.lnum = lnum + matchpos.lnum;
+            pos.col = matchpos.col;
+            endpos.lnum = lnum + endpos.lnum;
+            found = 1;
+            first_match = false;
+
+            /* Set variables used for 'incsearch' highlighting. */
+            //search_match_lines = endpos.lnum - (lnum - first_lnum);
+            //search_match_endcol = endpos.col;
+            break;
+          }
+          //line_breakcheck();      /* stop if ctrl-C typed */
+          //if (got_int)
+          //    break;
+
+          if (loop != 0 && lnum == start_pos.lnum) {
+            break;          /* if second loop, stop where started */
+          }
+        }
+        at_first_line = false;
+
+        /*
+         * stop the search if wrapscan isn't set, after an interrupt and
+         * after a match
+         */
+        if (!searchOptions.contains(SearchOptions.WRAP) || found != 0) {
+          break;
+        }
+
+        /*
+         * If 'wrapscan' is set we continue at the other end of the file.
+         * If 'shortmess' does not contain 's', we give a message.
+         * This message is also remembered in keep_msg for when the screen
+         * is redrawn. The keep_msg is cleared whenever another message is
+         * written.
+         */
+        if (dir == Direction.BACKWARDS)    /* start second loop at the other end */ {
+          lnum = lineCount - 1;
+          //if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG))
+          //    give_warning((char_u *)_(top_bot_msg), TRUE);
+        }
+        else {
+          lnum = 0;
+          //if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG))
+          //    give_warning((char_u *)_(bot_top_msg), TRUE);
+        }
+      }
+      //if (got_int || called_emsg || break_loop)
+      //    break;
+    }
+    while (--count > 0 && found != 0);   /* stop after count matches or no match */
+
+    if (found == 0)             /* did not find it */ {
+      //if ((options & SEARCH_MSG) == SEARCH_MSG)
+      if (searchOptions.contains(SearchOptions.SHOW_MESSAGES)) {
+        if (searchOptions.contains(SearchOptions.WRAP)) {
+          VimPlugin.showMessage(MessageHelper.message(Msg.e_patnotf2, pattern));
+        }
+        else if (lnum <= 0) {
+          VimPlugin.showMessage(MessageHelper.message(Msg.E384, pattern));
+        }
+        else {
+          VimPlugin.showMessage(MessageHelper.message(Msg.E385, pattern));
+        }
+      }
+      return null;
+    }
+
+    //return new TextRange(editor.logicalPositionToOffset(new LogicalPosition(pos.lnum, pos.col)),
+    //    editor.logicalPositionToOffset(new LogicalPosition(endpos.lnum, endpos.col)));
+    //return new TextRange(editor.logicalPositionToOffset(new LogicalPosition(pos.lnum, 0)) + pos.col,
+    //    editor.logicalPositionToOffset(new LogicalPosition(endpos.lnum, 0)) + endpos.col);
+    return new TextRange(new CharacterPosition(pos.lnum, pos.col).toOffset(editor),
+      new CharacterPosition(endpos.lnum, endpos.col).toOffset(editor));
+  }
+
+  /**
+   * Find all occurrences of the pattern.
+   *
+   * @param editor      The editor to search in
+   * @param pattern     The pattern to search for
+   * @param startLine   The start line of the range to search for, or -1 for the whole document
+   * @param endLine     The end line of the range to search for, or -1 for the whole document
+   * @param ignoreCase  Case sensitive or insensitive searching
+   * @return            A list of TextRange objects representing the results
+   */
+  public static @NotNull List<TextRange> findAll(@NotNull Editor editor,
+                                                 @NotNull String pattern,
+                                                 int startLine,
+                                                 int endLine,
+                                                 boolean ignoreCase) {
+    final List<TextRange> results = Lists.newArrayList();
+    final int lineCount = EditorHelper.getLineCount(editor);
+    final int actualEndLine = endLine == -1 ? lineCount : endLine;
+
+    final RegExp.regmmatch_T regMatch = new RegExp.regmmatch_T();
+    final RegExp regExp = new RegExp();
+    regMatch.regprog = regExp.vim_regcomp(pattern, 1);
+    if (regMatch.regprog == null) {
+      return results;
+    }
+
+    regMatch.rmm_ic = ignoreCase;
+
+    int col = 0;
+    for (int line = startLine; line <= actualEndLine; ) {
+      int matchedLines = regExp.vim_regexec_multi(regMatch, editor, lineCount, line, col);
+      if (matchedLines > 0) {
+        final CharacterPosition startPos = new CharacterPosition(line + regMatch.startpos[0].lnum,
+          regMatch.startpos[0].col);
+        final CharacterPosition endPos = new CharacterPosition(line + regMatch.endpos[0].lnum,
+          regMatch.endpos[0].col);
+        int start = startPos.toOffset(editor);
+        int end = endPos.toOffset(editor);
+        results.add(new TextRange(start, end));
+
+        if (start != end) {
+          line += matchedLines - 1;
+          col = endPos.column;
+        }
+        else {
+          line += matchedLines;
+          col = 0;
+        }
+      }
+      else {
+        line++;
+        col = 0;
+      }
+    }
+
+    return results;
+  }
+
   public static boolean anyNonWhitespace(@NotNull Editor editor, int offset, int dir) {
     int start;
     int end;

--- a/src/com/maddyhome/idea/vim/helper/SearchHelperKt.kt
+++ b/src/com/maddyhome/idea/vim/helper/SearchHelperKt.kt
@@ -41,6 +41,10 @@ enum class Direction(private val value: Int) {
   }
 }
 
+enum class SearchOptions {
+  BACKWARDS, WANT_ENDPOS, WRAP, SHOW_MESSAGES, WHOLE_FILE, IGNORE_SMARTCASE
+}
+
 private data class State(val position: Int, val trigger: Char, val inQuote: Boolean?, val lastOpenSingleQuotePos: Int)
 
 // bounds are considered inside corresponding quotes

--- a/src/com/maddyhome/idea/vim/helper/SearchHelperKt.kt
+++ b/src/com/maddyhome/idea/vim/helper/SearchHelperKt.kt
@@ -23,20 +23,19 @@ import com.maddyhome.idea.vim.option.OptionsManager.ignorecase
 import com.maddyhome.idea.vim.option.OptionsManager.smartcase
 
 enum class Direction(private val value: Int) {
-  BACKWARDS(-1), FORWARDS(1), UNSET(0);
+  BACKWARDS(-1), FORWARDS(1);
 
   fun toInt(): Int = value
   fun reverse(): Direction = when (this) {
     BACKWARDS -> FORWARDS
     FORWARDS -> BACKWARDS
-    UNSET -> UNSET
   }
 
   companion object {
     fun fromInt(value: Int) = when (value) {
       BACKWARDS.value -> BACKWARDS
       FORWARDS.value -> FORWARDS
-      else -> UNSET
+      else -> FORWARDS
     }
   }
 }

--- a/src/com/maddyhome/idea/vim/helper/SearchHelperKt.kt
+++ b/src/com/maddyhome/idea/vim/helper/SearchHelperKt.kt
@@ -185,7 +185,19 @@ private fun quoteChanges(chars: CharSequence, begin: Int) = sequence {
   }
 }
 
-fun shouldIgnoreCase(pattern: String, ignoreSmartCase: Boolean): Boolean {
-  val sc = smartcase.isSet && !ignoreSmartCase
+/**
+ * Check ignorecase and smartcase options to see if a case insensitive search should be performed with the given pattern.
+ *
+ * When ignorecase is not set, this will always return false - perform a case sensitive search.
+ *
+ * Otherwise, check smartcase. When set, the search will be case insensitive if the pattern contains only lowercase
+ * characters, and case sensitive (returns false) if the pattern contains any lowercase characters.
+ *
+ * The smartcase option can be ignored, e.g. when searching for the whole word under the cursor. This always performs a
+ * case insensitive search, so `\<Work\>` will match `Work` and `work`. But when choosing the same pattern from search
+ * history, the smartcase option is applied, and `\<Work\>` will only match `Work`.
+ */
+fun shouldIgnoreCase(pattern: String, ignoreSmartCaseOption: Boolean): Boolean {
+  val sc = smartcase.isSet && !ignoreSmartCaseOption
   return ignorecase.isSet && !(sc && StringHelper.containsUpperCase(pattern))
 }

--- a/src/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
+++ b/src/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
@@ -34,8 +34,6 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.ColorUtil
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.ex.ranges.LineRange
-import com.maddyhome.idea.vim.group.SearchGroup
-import com.maddyhome.idea.vim.group.SearchGroup.SearchOptions
 import com.maddyhome.idea.vim.option.OptionsManager.hlsearch
 import com.maddyhome.idea.vim.option.OptionsManager.wrapscan
 import org.jetbrains.annotations.Contract
@@ -107,7 +105,7 @@ private fun updateSearchHighlights(
         val startLine = searchRange?.startLine ?: 0
         val endLine = searchRange?.endLine ?: -1
         val results =
-          SearchGroup.findAll(editor, pattern, startLine, endLine, shouldIgnoreCase(pattern, shouldIgnoreSmartCase))
+          SearchHelper.findAll(editor, pattern, startLine, endLine, shouldIgnoreCase(pattern, shouldIgnoreSmartCase))
         if (results.isNotEmpty()) {
           currentMatchOffset = findClosestMatch(editor, results, initialOffset, forwards)
           highlightSearchResults(editor, pattern, results, currentMatchOffset)
@@ -119,7 +117,7 @@ private fun updateSearchHighlights(
         if (wrapscan.isSet) searchOptions.add(SearchOptions.WRAP)
         if (shouldIgnoreSmartCase) searchOptions.add(SearchOptions.IGNORE_SMARTCASE)
         if (!forwards) searchOptions.add(SearchOptions.BACKWARDS)
-        val result = SearchGroup.findIt(editor, pattern, initialOffset, 1, searchOptions)
+        val result = SearchHelper.findPattern(editor, pattern, initialOffset, 1, searchOptions)
         if (result != null) {
           currentMatchOffset = result.startOffset
           val results = listOf(result)


### PR DESCRIPTION
Continuing the groundwork for [VIM-2173](https://youtrack.jetbrains.com/issue/VIM-2173) that began in #257, this PR refactors `SearchGroup`. There are no code changes, only moving methods around. This is a separate PR to make the next PR easier to review - it will be making code changes without moving things around :smile: 

* Static "find" methods are moved to `SearchHelper`. The methods in `SearchGroup` are now the "high level" APIs to implement Vim's search and replace functionality. They maintain state, parse commands and call into `SearchHelper` to do the actual searching.
* Rearrange and document the APIs in `SearchGroup` to better understand what the methods are doing (there are quite a few overloads simply called `search` that do different things with state and carets, etc.)
* Remove the unnecessary `Direction.UNSET` introduced in #257 