### PR TITLE
VIM-1756: Fix escape key when moving from insert mode to select mode

### DIFF
--- a/src/com/maddyhome/idea/vim/action/motion/select/SelectEscapeAction.kt
+++ b/src/com/maddyhome/idea/vim/action/motion/select/SelectEscapeAction.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.helper.exitInsertMode
 import com.maddyhome.idea.vim.helper.exitSelectMode
 import com.maddyhome.idea.vim.helper.inBlockSubMode
 
@@ -32,6 +33,7 @@ class SelectEscapeAction : VimActionHandler.SingleExecution() {
   override fun execute(editor: Editor, context: DataContext, cmd: Command): Boolean {
     val blockMode = editor.inBlockSubMode
     editor.exitSelectMode(true)
+    editor.exitInsertMode(context);
     if (blockMode) editor.caretModel.removeSecondaryCarets()
     return true
   }


### PR DESCRIPTION
Bug fix for VIM-1756. Original PR: #251 

When moving from Insert mode to Select mode, the escape key would only exit select mode.

Steps to reproduce:

With ideavimrc settings

set selectmode+=key
set keymodel^=startsel

From anywhere in an editor, enter insert mode, select+arrow left, escape. Your cursor will still be in insert mode. This fix escapes Insert mode as well.

Not sure if this is the BEST fix. Open to suggestions.