### PR TITLE
Fix scrolling at end of file with folds

### DIFF
--- a/src/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -656,7 +656,7 @@ public class MotionGroup {
 
     final int topLine = getVisualLineAtTopOfScreen(editor);
     final int bottomLine = getVisualLineAtBottomOfScreen(editor);
-    final int lastLine = EditorHelper.getLineCount(editor) - 1;
+    final int lastLine = EditorHelper.getVisualLineCount(editor) - 1;
 
     // We need the non-normalised value here, so we can handle cases such as so=999 to keep the current line centred
     final int scrollOffset = OptionsManager.INSTANCE.getScrolloff().value();

--- a/test/org/jetbrains/plugins/ideavim/action/motion/updown/MotionGotoLineLastActionTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/action/motion/updown/MotionGotoLineLastActionTest.kt
@@ -255,4 +255,15 @@ class MotionGotoLineLastActionTest : VimTestCase() {
     assertPosition(99, 4)
     assertVisibleArea(67, 99)
   }
+
+  fun `test go to line does not scroll when last line is less than scrolloff above bottom of file with folds`() {
+    OptionsManager.scrolloff.set(10)
+    configureByLines(100, "    I found it in a legendary land")
+    setEditorVirtualSpace()
+    typeText(parseKeys("20G", "V10j", ":'<,'>action CollapseSelection<CR>", "V"))
+    setPositionAndScroll(67, 97)
+    typeText(parseKeys("G"))
+    assertPosition(99, 4)
+    assertVisibleArea(67, 99)
+  }
 }


### PR DESCRIPTION
Fixes [VIM-2291](https://youtrack.jetbrains.com/issue/VIM-2291). If a file has any folds (most Java or Kotlin files) and `scrolloff` > 0 and the caret is within `scrolloff` lines of the bottom of the file, the screen is incorrectly scrolled to put the last line at the bottom of the screen. This is due to mixing up logical lines and visual lines.