### PR TITLE
VIM-1357+VIM-1566: Use OS shell to run filter command

### DIFF
--- a/resources/dictionaries/ideavim.dic
+++ b/resources/dictionaries/ideavim.dic
@@ -16,6 +16,9 @@ relativenumber
 scrolljump
 scrolloff
 selectmode
+shellcmdflag
+shellxescape
+shellxquote
 showcmd
 showmode
 sidescroll

--- a/resources/messages/IdeaVimBundle.properties
+++ b/resources/messages/IdeaVimBundle.properties
@@ -72,6 +72,9 @@ e_patnotf2=Pattern not found: {0}
 unkopt=Unknown option: {0}
 e_invarg=Invalid argument: {0}
 E475=E475: Invalid argument: {0}
+# Vim's message includes alternate files and the :p:h file name modifier, which we don't support
+# E499: Empty file name for '%' or '#', only works with ":p:h"
+E499=E499: Empty file name for '%'
 E774=E774: 'operatorfunc' is empty
 
 action.VimPluginToggle.text=Vim Emulator

--- a/src/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/com/maddyhome/idea/vim/VimPlugin.java
@@ -370,6 +370,10 @@ public class VimPlugin implements PersistentStateComponent<Element>, Disposable 
     // Initialize extensions
     VimExtensionRegistrar.enableDelayedExtensions();
 
+    // Some options' default values are based on values set in .ideavimrc, e.g. 'shellxquote' on Windows when 'shell'
+    // is cmd.exe has a different default to when 'shell' contains "sh"
+    OptionsManager.INSTANCE.completeInitialisation();
+
     // Turing on should be performed after all commands registration
     getSearch().turnOn();
     VimListenerManager.INSTANCE.turnOn();

--- a/src/com/maddyhome/idea/vim/ex/handler/CmdFilterHandler.kt
+++ b/src/com/maddyhome/idea/vim/ex/handler/CmdFilterHandler.kt
@@ -19,20 +19,23 @@
 package com.maddyhome.idea.vim.ex.handler
 
 import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.ex.CommandHandler
 import com.maddyhome.idea.vim.ex.ExCommand
 import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.ex.ExOutputModel
 import com.maddyhome.idea.vim.ex.flags
+import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.MessageHelper
 import com.maddyhome.idea.vim.helper.Msg
-import java.io.IOException
 
 class CmdFilterHandler : CommandHandler.SingleExecution() {
-  override val argFlags = flags(RangeFlag.RANGE_OPTIONAL, ArgumentFlag.ARGUMENT_OPTIONAL, Access.WRITABLE)
+  override val argFlags = flags(RangeFlag.RANGE_OPTIONAL, ArgumentFlag.ARGUMENT_OPTIONAL, Access.SELF_SYNCHRONIZED)
+
   override fun execute(editor: Editor, context: DataContext, cmd: ExCommand): Boolean {
     logger.debug("execute")
 
@@ -53,15 +56,30 @@ class CmdFilterHandler : CommandHandler.SingleExecution() {
     return try {
       if (cmd.ranges.size() == 0) {
         // Show command output in a window
-        val commandOutput = VimPlugin.getProcess().executeCommand(command, null)
-        ExOutputModel.getInstance(editor).output(commandOutput)
+        VimPlugin.getProcess().executeCommand(editor, command, null)?.let {
+          ExOutputModel.getInstance(editor).output(it)
+        }
         true
       } else {
         // Filter
         val range = cmd.getTextRange(editor, false)
-        VimPlugin.getProcess().executeFilter(editor, range, command)
+        val input = editor.document.charsSequence.subSequence(range.startOffset, range.endOffset)
+        VimPlugin.getProcess().executeCommand(editor, command, input)?.let {
+          ApplicationManager.getApplication().runWriteAction {
+            val start = editor.offsetToLogicalPosition(range.startOffset)
+            val end = editor.offsetToLogicalPosition(range.endOffset)
+            editor.document.replaceString(range.startOffset, range.endOffset, it)
+            val linesFiltered = end.line - start.line
+            if (linesFiltered > 2) {
+              VimPlugin.showMessage("$linesFiltered lines filtered")
+            }
+          }
+        }
+        true
       }
-    } catch (e: IOException) {
+    } catch (e: ProcessCanceledException) {
+      throw ExException("Command terminated")
+    } catch (e: Exception) {
       throw ExException(e.message)
     }
   }

--- a/src/com/maddyhome/idea/vim/group/ProcessGroup.java
+++ b/src/com/maddyhome/idea/vim/group/ProcessGroup.java
@@ -18,15 +18,25 @@
 
 package com.maddyhome.idea.vim.group;
 
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.CapturingProcessHandler;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressIndicatorProvider;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.util.execution.ParametersListUtil;
 import com.intellij.util.text.CharSequenceReader;
 import com.maddyhome.idea.vim.KeyHandler;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.command.Command;
 import com.maddyhome.idea.vim.command.CommandState;
-import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.ex.CommandParser;
 import com.maddyhome.idea.vim.ex.ExException;
 import com.maddyhome.idea.vim.ex.InvalidCommandException;
@@ -37,6 +47,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.io.*;
+import java.util.List;
 
 
 public class ProcessGroup {
@@ -159,36 +170,55 @@ public class ProcessGroup {
     return initText;
   }
 
-  public boolean executeFilter(@NotNull Editor editor, @NotNull TextRange range,
-                               @NotNull String command) throws IOException {
-    final CharSequence charsSequence = editor.getDocument().getCharsSequence();
-    final int startOffset = range.getStartOffset();
-    final int endOffset = range.getEndOffset();
-    final String output = executeCommand(command, charsSequence.subSequence(startOffset, endOffset));
-    editor.getDocument().replaceString(startOffset, endOffset, output);
-    return true;
-  }
+  public @Nullable String executeCommand(@NotNull Editor editor, @NotNull String command, @Nullable CharSequence input)
+    throws ExecutionException, ProcessCanceledException {
 
-  public @NotNull String executeCommand(@NotNull String command, @Nullable CharSequence input) throws IOException {
-    if (logger.isDebugEnabled()) {
-      logger.debug("command=" + command);
-    }
+    // TODO: This is much simpler than what Vim does. We should pass execution through the OS shell
+    return ProgressManager.getInstance().runProcessWithProgressSynchronously(() -> {
+      if (logger.isDebugEnabled()) {
+        logger.debug("command=" + command);
+      }
 
-    final Process process = Runtime.getRuntime().exec(command);
+      final List<String> commands = ParametersListUtil.parse(command, false, true);
+      final GeneralCommandLine commandLine = new GeneralCommandLine(commands);
+      final CapturingProcessHandler handler = new CapturingProcessHandler(commandLine);
+      if (input != null) {
+        handler.addProcessListener(new ProcessAdapter() {
+          @Override
+          public void startNotified(@NotNull ProcessEvent event) {
+            try {
+              final CharSequenceReader charSequenceReader = new CharSequenceReader(input);
+              final BufferedWriter outputStreamWriter = new BufferedWriter(new OutputStreamWriter(handler.getProcessInput()));
+              copy(charSequenceReader, outputStreamWriter);
+              outputStreamWriter.close();
+            }
+            catch (IOException e) {
+              logger.error(e);
+            }
+          }
+        });
+      }
 
-    if (input != null) {
-      final BufferedWriter outputWriter = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()));
-      copy(new CharSequenceReader(input), outputWriter);
-      outputWriter.close();
-    }
+      final ProgressIndicator progressIndicator = ProgressIndicatorProvider.getInstance().getProgressIndicator();
+      final ProcessOutput output = handler.runProcessWithProgressIndicator(progressIndicator);
 
-    final BufferedReader inputReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-    final StringWriter writer = new StringWriter();
-    copy(inputReader, writer);
-    writer.close();
+      lastCommand = command;
 
-    lastCommand = command;
-    return writer.toString();
+      if (output.isCancelled()) {
+        // TODO: Vim will use whatever text has already been written to stdout
+        // For whatever reason, we're not getting any here, so just throw an exception
+        throw new ProcessCanceledException();
+      }
+
+      final Integer exitCode = handler.getExitCode();
+      if (exitCode != null && exitCode != 0) {
+        VimPlugin.showMessage("shell returned " + exitCode);
+        VimPlugin.indicateError();
+        return output.getStderr() + output.getStdout();
+      }
+
+      return output.getStdout();
+    }, "IdeaVim filter command", true, editor.getProject());
   }
 
   private void copy(@NotNull Reader from, @NotNull Writer to) throws IOException {

--- a/src/com/maddyhome/idea/vim/option/OptionsManager.kt
+++ b/src/com/maddyhome/idea/vim/option/OptionsManager.kt
@@ -601,7 +601,7 @@ object ShellCmdFlagOptionData {
     return if (SystemInfo.isWindows && !shell.contains("sh")) "/c" else "-c"
   }
 
-  val option = object: StringOption(name, "shcf", defaultValue) {
+  val option = object : StringOption(name, "shcf", defaultValue) {
     override fun getDefaultValue() = ShellCmdFlagOptionData.defaultValue
   }
 }
@@ -635,7 +635,7 @@ object ShellXQuoteOptionData {
     }
   }
 
-  val option = object: StringOption(name, "sxq", defaultValue) {
+  val option = object : StringOption(name, "sxq", defaultValue) {
     override fun getDefaultValue() = ShellXQuoteOptionData.defaultValue
   }
 }

--- a/src/com/maddyhome/idea/vim/option/StringOption.java
+++ b/src/com/maddyhome/idea/vim/option/StringOption.java
@@ -24,7 +24,8 @@ import org.jetbrains.annotations.NotNull;
  * An option that has an arbitrary string value
  */
 public class StringOption extends TextOption {
-  protected final String dflt;
+  private final String dflt;
+
   protected String value;
 
   /**
@@ -122,7 +123,7 @@ public class StringOption extends TextOption {
    */
   @Override
   public boolean isDefault() {
-    return dflt.equals(value);
+    return getDefaultValue().equals(value);
   }
 
   /**
@@ -130,9 +131,9 @@ public class StringOption extends TextOption {
    */
   @Override
   public void resetDefault() {
-    if (!dflt.equals(value)) {
+    if (!getDefaultValue().equals(value)) {
       String oldValue = getValue();
-      value = dflt;
+      value = getDefaultValue();
       fireOptionChangeEvent(oldValue, getValue());
     }
   }
@@ -143,7 +144,10 @@ public class StringOption extends TextOption {
    * @return The option as a string for display
    */
   public @NotNull String toString() {
-
     return "  " + getName() + "=" + value;
+  }
+
+  protected @NotNull String getDefaultValue() {
+    return dflt;
   }
 }


### PR DESCRIPTION
This PR fixes a few issues with the filter (`:!`) command:

- [x] Use OS shell to execute the given command. On Unix, this is `$SHELL` or `sh`, on Windows, this is `cmd.exe`. Fixes [VIM-1566](https://youtrack.jetbrains.com/issue/VIM-1566) and [VIM-1357](https://youtrack.jetbrains.com/issue/VIM-1357)
- [x] Add `'shellcmdflag'`, `'shellxescape'` and `'shellxquote'` options, required to properly run, quote and escape parameters
- [x] Errors are displayed or substituted into text, like Vim
- [x] Long running tasks can be cancelled
- [x] Adds support for `%` inside a filter command, mapping to the current file name