### PR TITLE
Emulate matchit.vim

### DIFF
--- a/resources/META-INF/includes/VimExtensions.xml
+++ b/resources/META-INF/includes/VimExtensions.xml
@@ -109,6 +109,13 @@
         <alias name="vim-indent-object"/>
       </aliases>
     </vimExtension>
+
+    <vimExtension implementation="com.maddyhome.idea.vim.extension.matchit.Matchit" name="matchit">
+      <aliases>
+        <alias name="vim-matchit"/>
+        <alias name="chrisbra/matchit"/>
+      </aliases>
+    </vimExtension>
   </extensions>
 
   <!--  IdeaVim extensions-->

--- a/src/com/maddyhome/idea/vim/command/CommandBuilder.kt
+++ b/src/com/maddyhome/idea/vim/command/CommandBuilder.kt
@@ -187,6 +187,10 @@ class CommandBuilder(private var currentCommandPartNode: CommandPartNode<ActionB
     prevExpectedArgumentType = null
   }
 
+  fun resetCount() {
+    count = 0
+  }
+
   fun resetInProgressCommandPart(commandPartNode: CommandPartNode<ActionBeanClass>) {
     count = 0
     setCurrentCommandPartNode(commandPartNode)

--- a/src/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -1,0 +1,579 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2021 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.maddyhome.idea.vim.extension.matchit
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.command.Argument
+import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
+import com.maddyhome.idea.vim.command.CommandState.Companion.getInstance
+import com.maddyhome.idea.vim.command.MappingMode
+import com.maddyhome.idea.vim.command.MotionType
+import com.maddyhome.idea.vim.extension.VimExtension
+import com.maddyhome.idea.vim.extension.VimExtensionFacade
+import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMappingIfMissing
+import com.maddyhome.idea.vim.extension.VimExtensionHandler
+import com.maddyhome.idea.vim.group.MotionGroup
+import com.maddyhome.idea.vim.handler.Motion
+import com.maddyhome.idea.vim.handler.MotionActionHandler
+import com.maddyhome.idea.vim.handler.toMotionOrError
+import com.maddyhome.idea.vim.helper.EditorHelper
+import com.maddyhome.idea.vim.helper.PsiHelper
+import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
+import com.maddyhome.idea.vim.helper.commandState
+import com.maddyhome.idea.vim.helper.enumSetOf
+import com.maddyhome.idea.vim.helper.getTopLevelEditor
+import com.maddyhome.idea.vim.helper.vimForEachCaret
+import java.util.*
+import java.util.regex.Pattern
+
+/**
+ * Port of matchit.vim (https://github.com/chrisbra/matchit)
+ * Languages currently supported:
+ *   Ruby, Embedded Ruby, XML, and HTML (including HTML in JavaScript/TypeScript, JSX/TSX, and JSPs)
+ *
+ * @author Martin Yzeiri (@myzeiri)
+ */
+class Matchit : VimExtension {
+
+  override fun getName(): String = "matchit"
+
+  override fun init() {
+    VimExtensionFacade.putExtensionHandlerMapping(MappingMode.NXO, parseKeys("<Plug>(MatchitMotion)"), owner, MatchitHandler(false), false)
+    VimExtensionFacade.putExtensionHandlerMapping(MappingMode.NXO, parseKeys("<Plug>(MatchitMotion)"), owner, MatchitHandler(false), false)
+    putKeyMappingIfMissing(MappingMode.NXO, parseKeys("%"), owner, parseKeys("<Plug>(MatchitMotion)"), true)
+
+    VimExtensionFacade.putExtensionHandlerMapping(MappingMode.NXO, parseKeys("<Plug>(ReverseMatchitMotion)"), owner, MatchitHandler(true), false)
+    VimExtensionFacade.putExtensionHandlerMapping(MappingMode.NXO, parseKeys("<Plug>(ReverseMatchitMotion)"), owner, MatchitHandler(true), false)
+    putKeyMappingIfMissing(MappingMode.NXO, parseKeys("g%"), owner, parseKeys("<Plug>(ReverseMatchitMotion)"), true)
+  }
+
+  private class MatchitAction : MotionActionHandler.ForEachCaret() {
+    var reverse = false
+    var isInOpPending = false
+
+    override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_SAVE_JUMP)
+
+    override fun getOffset(
+      editor: Editor,
+      caret: Caret,
+      context: DataContext,
+      count: Int,
+      rawCount: Int,
+      argument: Argument?,
+    ): Motion {
+      return getMatchitOffset(editor, caret, rawCount, isInOpPending, reverse).toMotionOrError()
+    }
+
+    override fun process(cmd: Command) {
+      motionType = if (cmd.rawCount != 0) MotionType.LINE_WISE else MotionType.INCLUSIVE
+    }
+
+    override var motionType: MotionType = MotionType.INCLUSIVE
+  }
+
+  private class MatchitHandler(private val reverse: Boolean) : VimExtensionHandler {
+
+    override fun execute(editor: Editor, context: DataContext) {
+      val commandState = getInstance(editor)
+      val count = commandState.commandBuilder.count
+
+      // Reset the command count so it doesn't transfer onto subsequent commands.
+      editor.getTopLevelEditor().commandState.commandBuilder.resetCount()
+
+      // Normally we want to jump to the start of the matching pair. But when moving forward in operator
+      // pending mode, we want to include the entire match. isInOpPending makes that distinction.
+      val isInOpPending = commandState.isOperatorPending
+
+      if (isInOpPending) {
+        val matchitAction = MatchitAction()
+        matchitAction.reverse = reverse
+        matchitAction.isInOpPending = true
+
+        commandState.commandBuilder.completeCommandPart(Argument(Command(count,
+          matchitAction, Command.Type.MOTION, EnumSet.noneOf(CommandFlags::class.java))))
+      } else {
+        editor.vimForEachCaret { caret ->
+          VimPlugin.getMark().saveJumpLocation(editor)
+          MotionGroup.moveCaret(editor, caret, getMatchitOffset(editor, caret, count, isInOpPending, reverse))
+        }
+      }
+    }
+  }
+
+}
+
+/**
+ * To find a matching pair, we need patterns that describe what the opening and closing pairs look like.
+ *
+ * We pass around strings instead of compiled Java Patterns since a pattern may require back references to be added
+ * before the search can proceed. E.g. for HTML, we use a general pattern to check if the cursor is inside a tag. The
+ * pattern captures the tag's name as a back reference so we can later search for something more specific like "</div>"
+ */
+private typealias MatchitSearchPair = Pair<String, String>
+
+/**
+ * A language can have many patterns that describe its matching pairs. We divide the patterns into two maps, one for
+ * the opening pairs (e.g. "if" or "def" in Ruby) and one for the closing pairs.
+ * For each pair, we take the pattern that describes the text the cursor can be on and map it to the MatchitSearchPair
+ * we need to find the match.
+ *
+ * Simple example: if we wanted the cursor to jump from an opening angle bracket to a closing angle bracket even if the
+ * cursor was on whitespace, then we would add "\\s*<" -> MatchitSearchPair("<", ">") to the openingPatterns map.
+ */
+private data class MatchitPatternsTable(
+  val openingPatterns: Map<String, MatchitSearchPair>,
+  val closingPatterns: Map<String, MatchitSearchPair>
+)
+
+/**
+ * All the information we need to find a match.
+ */
+private data class MatchitSearchParams(
+  val caretOffset: Int,
+  val endOfCurrentPattern: Int,
+  val targetOpeningPattern: String,
+  val targetClosingPattern: String,
+
+  // If the cursor is not in a comment, then we want to ignore any matches found in comments.
+  // But if we are in comment, then we only want to match on things in comments. The same goes for quotes.
+  val skipComments: Boolean,
+  val skipStrings: Boolean
+)
+
+/**
+ * Patterns for the supported file types are stored in this object.
+ */
+private object MatchitPatterns {
+
+  fun getPatternsForFile(virtualFile: VirtualFile?, reverse: Boolean): MatchitPatternsTable? {
+    val fileExtension = virtualFile?.extension
+    val fileTypeName = virtualFile?.fileType?.name
+
+    // Ruby file types are only detected if the user is running RubyMine or the Ruby plugin.
+    // Checking the extension is a simple fallback that also lets us unit test the Ruby patterns.
+    return if (fileTypeName == "Ruby" || fileExtension == "rb") {
+      if (reverse) this.reverseRubyPatternsTable else this.rubyPatternsTable
+    } else if (fileTypeName == "RHTML" || fileExtension == "erb") {
+      if (reverse) this.reverseRubyAndHtmlPatternsTable else this.rubyAndHtmlPatternsTable
+    } else if (fileTypeName in htmlLikeFileTypes) {
+      this.htmlPatternsTable
+    } else {
+      return null
+    }
+  }
+
+  // Files that can contain HTML or HTML-like content.
+  // These are just the file types that have HTML Matchit support enabled by default in their Vim ftplugin files.
+  private val htmlLikeFileTypes = arrayOf("HTML", "XML", "XHTML", "JSP", "JavaScript", "JSX Harmony", "TypeScript", "TypeScript JSX")
+
+  private val htmlPatternsTable = createHtmlPatternsTable()
+  private val rubyPatternsTable = createRubyPatternsTable()
+  private val reverseRubyPatternsTable = createRubyPatternsTable(true)
+  private val rubyAndHtmlPatternsTable = MatchitPatternsTable(
+    rubyPatternsTable.openingPatterns + htmlPatternsTable.openingPatterns,
+    rubyPatternsTable.closingPatterns + htmlPatternsTable.closingPatterns
+  )
+  private val reverseRubyAndHtmlPatternsTable = MatchitPatternsTable(
+    reverseRubyPatternsTable.openingPatterns + htmlPatternsTable.openingPatterns,
+    reverseRubyPatternsTable.closingPatterns + htmlPatternsTable.closingPatterns
+  )
+
+  private fun createHtmlPatternsTable(): MatchitPatternsTable {
+    // A tag name may contain any characters except slashes, whitespace, and angle brackets.
+    // We surround the tag name in a capture group so that we can use it when searching for a match later.
+    val tagNamePattern = "([^/\\s><]+)"
+
+    // An opening tag consists of "<" followed by a tag name and optionally some additional text after whitespace.
+    // Note the assertion on "<" to not match on that character. If the cursor is on an angle bracket, then we want to
+    // match angle brackets, not HTML tags.
+    val openingTagPattern = String.format("(?<=<)%s(?:\\s[^<>]*(\".*\")?)?", tagNamePattern)
+
+    // A closing tag consists of a "<" followed by a slash, the tag name, and a ">".
+    val closingTagPattern = String.format("(?<=<)/%s(?=>)", tagNamePattern)
+
+    // The tag name is left as %s so we can substitute the back reference we captured.
+    val htmlSearchPair = Pair("(?<=<)%s(?:\\s[^<>]*(\".*\")?)?", "(?<=<)/%s>")
+
+    // Along with being on a "<", we also want to jump to a matching ">" if the cursor is anywhere before a "<" on the
+    // same line. We exclude the other bracket types since the closest bracket to the cursor should take precedence.
+    val openingAngleBracketPattern = "[^<>(){}\\[\\]]*<"
+    val closingAngleBracketPattern = ">"
+    val angleBracketSearchPair = Pair("<", ">")
+
+    return MatchitPatternsTable(
+      mapOf(
+        openingTagPattern to htmlSearchPair,
+        openingAngleBracketPattern to angleBracketSearchPair
+      ),
+      mapOf(
+        closingTagPattern to htmlSearchPair,
+        closingAngleBracketPattern to angleBracketSearchPair
+      )
+    )
+  }
+
+  private fun createRubyPatternsTable(reverse: Boolean = false): MatchitPatternsTable {
+    // Original patterns are defined here: https://github.com/vim/vim/blob/master/runtime/ftplugin/ruby.vim
+    // We use non-capturing groups (?:) since we don't need any back refs. The \\b marker takes care of word boundaries.
+    // On the class keyword we exclude an equal sign from appearing afterwards since it clashes with the HTML attribute.
+    val openingKeywords = "(?:\\b(?:do|if|unless|case|def|for|while|until|module|begin)\\b)|(?:\\bclass\\b[^=])"
+
+    val endKeyword = "\\bend\\b"
+
+    // A "middle" keyword is one that can act as both an opening or a closing pair. E.g. "elsif" can appear any number
+    // of times between the opening "if" and the closing "end".
+    val middleKeywords = "(?:\\b(?:else|elsif|break|when|rescue|ensure|redo|next|retry)\\b)"
+    val openingAndMiddleKeywords = "$openingKeywords|$middleKeywords"
+    val middleAndClosingKeywords = "$middleKeywords|(?:$endKeyword)"
+
+    // We want the cursor to jump to an opening even if it's on whitespace before an "end".
+    val prefixedEndKeyword = "\\s*$endKeyword"
+
+    // For the openings, we want to jump if the cursor is on any non-bracket character before the keyword.
+    val prefix = "[^(){}<>\\[\\]]*?"
+    val prefixedOpeningKeywords = "$prefix(?:$openingKeywords)"
+    val prefixedMiddleKeywords = "$prefix(?:$middleKeywords)"
+    val prefixedOpeningAndMiddleKeywords = "$prefix(?:$openingAndMiddleKeywords)"
+    val prefixedMiddleAndClosingKeywords = "(?:$prefix(?:$middleKeywords))|$prefixedEndKeyword"
+
+    val blockCommentStart = "=begin\\b"
+    val blockCommentEnd = "=end\\b"
+    // The cursor shouldn't jump to the equal sign on a block comment, so we exclude it with a look-behind assertion.
+    val blockCommentSearchPair = Pair("(?<==)begin\\b", "(?<==)end\\b")
+
+    if (reverse) {
+      // Supporting the g% motion is just a matter of rearranging the patterns table.
+      // This particular arrangement relies on our checking if the cursor is on a closing pattern first.
+      return MatchitPatternsTable(
+        mapOf(
+          blockCommentStart to blockCommentSearchPair,
+          prefixedOpeningKeywords to Pair(openingKeywords, endKeyword),
+          prefixedMiddleKeywords to Pair(openingAndMiddleKeywords, middleKeywords)
+        ),
+        mapOf(
+          blockCommentEnd to blockCommentSearchPair,
+          prefixedMiddleAndClosingKeywords to Pair(openingAndMiddleKeywords, middleAndClosingKeywords)
+        ))
+    } else {
+      // Patterns for the regular % motion.
+      return MatchitPatternsTable(
+        mapOf(
+          blockCommentStart to blockCommentSearchPair,
+          prefixedOpeningAndMiddleKeywords to Pair(openingAndMiddleKeywords, middleAndClosingKeywords)
+        ),
+        mapOf(
+          blockCommentEnd to blockCommentSearchPair,
+          prefixedEndKeyword to Pair(openingKeywords, endKeyword)
+        ))
+    }
+  }
+
+}
+
+/*
+ * Helper search functions.
+ */
+
+private fun getMatchitOffset(editor: Editor, caret: Caret, count: Int, isInOpPending: Boolean, reverse: Boolean): Int {
+  val defaultPairs = arrayOf('(', ')', '[', ']', '{', '}')
+  val virtualFile = EditorHelper.getVirtualFile(editor)
+  var caretOffset = caret.offset
+
+  // Handle the case where visual mode has brought the cursor past the end of the line.
+  val lineEndOffset = EditorHelper.getLineEndOffset(editor, caret.logicalPosition.line, true)
+  if (caretOffset > 0 && caretOffset == lineEndOffset) {
+    caretOffset--
+  }
+
+  val currentChar = editor.document.charsSequence[caretOffset]
+  var motion = -1
+
+  if (count > 0) {
+    // Matchit doesn't affect the percent motion, so we fall back to the default behavior.
+    motion = VimPlugin.getMotion().moveCaretToLinePercent(editor, caret, count)
+  } else {
+    // Check the simplest case first.
+    if (defaultPairs.contains(currentChar)) {
+      motion = VimPlugin.getMotion().moveCaretToMatchingPair(editor, caret)
+    } else {
+      val patternsTable = MatchitPatterns.getPatternsForFile(virtualFile, reverse)
+      if (patternsTable != null) {
+        motion = findMatchingPair(editor, caretOffset, isInOpPending, patternsTable)
+      }
+
+      if (motion < 0) {
+        // Use default motion if the file type isn't supported or we didn't find any extended pairs.
+        motion = VimPlugin.getMotion().moveCaretToMatchingPair(editor, caret)
+      }
+    }
+  }
+
+  if (motion >= 0) {
+    motion = EditorHelper.normalizeOffset(editor, motion, false)
+  }
+
+  return motion
+}
+
+private fun findMatchingPair(editor: Editor, caretOffset: Int, isInOpPending:Boolean, patternsTable: MatchitPatternsTable): Int {
+  val openingPatternsTable = patternsTable.openingPatterns
+  val closingPatternsTable = patternsTable.closingPatterns
+
+  // Check if the cursor is on a closing pair.
+  val offset: Int
+  var searchParams = getMatchitSearchParams(editor, caretOffset, closingPatternsTable)
+  if (searchParams != null) {
+    offset = findOpeningPair(editor, isInOpPending, searchParams)
+    // If the user is on a valid pattern, but we didn't find a matching pair, then the cursor shouldn't move.
+    // We return the current caret offset to reflect that case, as opposed to -1 which means the cursor isn't on a
+    // valid pattern at all.
+    return if (offset < 0) caretOffset else offset
+  }
+
+  // Check if the cursor is on an opening pair.
+  searchParams = getMatchitSearchParams(editor, caretOffset, openingPatternsTable)
+  if (searchParams != null) {
+    offset = findClosingPair(editor, isInOpPending, searchParams)
+    return if (offset < 0) caretOffset else offset
+  }
+
+  return -1
+}
+
+/**
+ * Checks if the cursor is on valid a pattern and returns the necessary search params if it is.
+ * Returns null if the cursor is not on a pattern.
+ */
+private fun getMatchitSearchParams(editor: Editor, caretOffset: Int, patternsTable: Map<String, Pair<String, String>>): MatchitSearchParams? {
+  // For better performance, we limit our search to the current line. This way we don't have to scan the entire file
+  // to determine if we're on a pattern or not. The original plugin behaves the same way.
+  val currentLineStart = EditorHelper.getLineStartForOffset(editor, caretOffset)
+  val currentLineEnd = EditorHelper.getLineEndForOffset(editor, caretOffset)
+  val currentLineChars = editor.document.charsSequence.subSequence(currentLineStart, currentLineEnd)
+  val currentPsiElement = PsiHelper.getFile(editor)!!.findElementAt(caretOffset)
+
+  val targetOpeningPattern: String
+  val targetClosingPattern: String
+
+  for ((pattern, searchPair) in patternsTable) {
+    val (searchOffset, backRef) = parsePatternAtOffset(currentLineChars, caretOffset - currentLineStart, pattern)
+    if (searchOffset >= 0) {
+      // HTML attributes are a special case where the cursor is inside of quotes, but we want to jump as if we were
+      // anywhere else inside the opening tag.
+      val skipComments = !isComment(currentPsiElement)
+      val skipQuotes = !isQuoted(currentPsiElement) || isHtmlAttribute(currentPsiElement)
+
+      // Substitute any captured back references to the search patterns, if necessary.
+      if (backRef != "") {
+        targetOpeningPattern = String.format(searchPair.first, backRef)
+        targetClosingPattern = String.format(searchPair.second, backRef)
+      } else {
+        targetOpeningPattern = searchPair.first
+        targetClosingPattern = searchPair.second
+      }
+
+      val endOfCurrentPattern = currentLineStart + searchOffset
+      return MatchitSearchParams(caretOffset, endOfCurrentPattern, targetOpeningPattern, targetClosingPattern, skipComments, skipQuotes)
+    }
+  }
+
+  return null
+}
+
+private fun findClosingPair(editor: Editor, isInOpPending: Boolean, searchParams: MatchitSearchParams): Int {
+  val (caretOffset, searchStartOffset, openingPattern, closingPattern, skipComments, skipStrings) = searchParams
+  val chars = editor.document.charsSequence
+  val searchSpace = chars.subSequence(searchStartOffset, chars.length)
+
+  val compiledClosingPattern = Pattern.compile(closingPattern)
+  val compiledSearchPattern = Pattern.compile(String.format("(?<opening>%s)|(?<closing>%s)", openingPattern, closingPattern))
+  val matcher = compiledSearchPattern.matcher(searchSpace)
+
+  // We're looking for the first closing pair that isn't already matched by an opening.
+  // As we find opening patterns, we push their offsets to this stack and pop whenever we find a closing pattern,
+  // effectively crossing off that item from our search. We have to track both the start and end of the pattern since
+  // the motion depends on whether we're in op pending mode or not.
+  var closingPairRange: Pair<Int, Int>? = null
+  val unmatchedOpeningPairs: Deque<Pair<Int, Int>> = ArrayDeque()
+  while (matcher.find()) {
+    val matchStartOffset = searchStartOffset + matcher.start()
+    val matchEndOffset = searchStartOffset + matcher.end()
+
+    if (matchShouldBeSkipped(editor, matchStartOffset, skipComments, skipStrings)) {
+      continue
+    }
+
+    val foundOpeningPattern = matcher.group("opening") != null
+    // Middle patterns e.g. "elsif" can appear any number of times between a strict opening and a strict closing.
+    val foundMiddlePattern = foundOpeningPattern && compiledClosingPattern.matcher(matcher.group("opening")).matches()
+
+    if (foundMiddlePattern) {
+      if (!unmatchedOpeningPairs.isEmpty()) {
+        unmatchedOpeningPairs.pop()
+        unmatchedOpeningPairs.push(Pair(matchStartOffset, matchEndOffset))
+      } else {
+        closingPairRange = Pair(matchStartOffset, matchEndOffset)
+        break
+      }
+    } else if (foundOpeningPattern) {
+      unmatchedOpeningPairs.push(Pair(matchStartOffset, matchEndOffset))
+    } else {
+      // Found a closing pattern
+      if (!unmatchedOpeningPairs.isEmpty()) {
+        unmatchedOpeningPairs.pop()
+      } else {
+        closingPairRange = Pair(matchStartOffset, matchEndOffset)
+        break
+      }
+    }
+  }
+
+  if (closingPairRange != null) {
+    return if (isInOpPending && caretOffset < closingPairRange.first) {
+      closingPairRange.second - 1 // Jump to the last char of the match
+    } else {
+      closingPairRange.first
+    }
+  }
+
+  return -1
+}
+
+private fun findOpeningPair(editor: Editor, isInOpPending: Boolean, searchParams: MatchitSearchParams): Int {
+  val (caretOffset, _, openingPattern, closingPattern, skipComments, skipStrings) = searchParams
+  val chars = editor.document.charsSequence
+  val searchSpace = chars.subSequence(0, caretOffset)
+
+  val compiledClosingPattern = Pattern.compile(closingPattern)
+  val compiledSearchPattern = Pattern.compile(String.format("(?<opening>%s)|(?<closing>%s)", openingPattern, closingPattern))
+  val matcher = compiledSearchPattern.matcher(searchSpace)
+
+  val unmatchedOpeningPairs: Deque<Pair<Int, Int>> = ArrayDeque()
+  while (matcher.find()) {
+    val matchStartOffset = matcher.start()
+    val matchEndOffset = matcher.end()
+
+    if (matchShouldBeSkipped(editor, matchStartOffset, skipComments, skipStrings)) {
+      continue
+    }
+
+    val foundOpeningPattern = matcher.group("opening") != null
+    val foundMiddlePattern = foundOpeningPattern && compiledClosingPattern.matcher(matcher.group("opening")).matches()
+
+    if (foundMiddlePattern) {
+      if (!unmatchedOpeningPairs.isEmpty()) {
+        unmatchedOpeningPairs.pop()
+        unmatchedOpeningPairs.push(Pair(matchStartOffset, matchEndOffset))
+      } else {
+        unmatchedOpeningPairs.push(Pair(matchStartOffset, matchEndOffset))
+      }
+    } else if (foundOpeningPattern) {
+      unmatchedOpeningPairs.push(Pair(matchStartOffset, matchEndOffset))
+    } else if (!unmatchedOpeningPairs.isEmpty()) {
+      // Found a closing pattern. We check the stack isn't empty to handle malformed code.
+      unmatchedOpeningPairs.pop()
+    }
+  }
+
+  if (!unmatchedOpeningPairs.isEmpty()) {
+    val openingPairRange = unmatchedOpeningPairs.pop()
+
+    return if (isInOpPending && caretOffset < openingPairRange.first) {
+      openingPairRange.second - 1
+    } else {
+      openingPairRange.first
+    }
+  }
+
+  return -1
+}
+
+/**
+ * If the char sequence at the given offset matches the pattern, this will return the final offset of the match
+ * as well as any back references that were captured.
+ */
+private fun parsePatternAtOffset(chars: CharSequence, offset: Int, pattern: String): Pair<Int, String> {
+  val matcher = Pattern.compile(pattern).matcher(chars)
+
+  while (matcher.find()) {
+    val matchStart = matcher.start()
+    val matchEnd = matcher.end()
+
+    if (offset in matchStart until matchEnd) {
+      if (matcher.groupCount() > 0) {
+        return Pair(matchEnd, matcher.group(1))
+      }
+      return Pair(matchEnd, "")
+    } else if (offset < matchStart) {
+      return Pair(-1, "")
+    }
+  }
+  return Pair(-1, "")
+}
+
+private fun matchShouldBeSkipped(editor: Editor, offset: Int, skipComments: Boolean, skipStrings: Boolean): Boolean {
+  val psiFile = PsiHelper.getFile(editor)
+  val psiElement = psiFile!!.findElementAt(offset)
+
+  // TODO: as we add support for more languages, we should store the ignored keywords for each language in its own
+  //  data structure. The original plugin stores that information in strings called match_skip.
+  if (isSkippedRubyKeyword(psiElement)) {
+    return true
+  }
+
+  val insideComment = isComment(psiElement)
+  val insideQuotes = isQuoted(psiElement)
+  return (skipComments && insideComment) || (!skipComments && !insideComment)
+    || (skipStrings && insideQuotes) || (!skipStrings && !insideQuotes)
+}
+
+private fun isSkippedRubyKeyword(psiElement: PsiElement?): Boolean {
+  // In Ruby code, we want to ignore anything inside of a regular expression like "/ class /" and identifiers like
+  // "Foo.class". Matchit also ignores any "do" keywords that follow a loop or an if condition, as well as any inline
+  // "if" and "unless" expressions (a.k.a conditional modifiers).
+  val elementType = psiElement?.node?.elementType?.debugName
+
+  return elementType == "do_cond" || elementType == "if modifier" || elementType == "unless modifier"
+    || elementType == "regexp content" || elementType == "identifier"
+}
+
+private fun isComment(psiElement: PsiElement?): Boolean {
+  // This works for languages other than Java.
+  return PsiTreeUtil.getParentOfType(psiElement, PsiComment::class.java, false) != null
+}
+
+private fun isQuoted(psiElement: PsiElement?): Boolean {
+  val elementType = psiElement?.elementType?.debugName
+  return elementType == "STRING_LITERAL" || elementType == "XML_ATTRIBUTE_VALUE_TOKEN"
+    || elementType == "string content" // Ruby specific.
+}
+
+private fun isHtmlAttribute(psiElement: PsiElement?): Boolean {
+  val elementType = psiElement?.elementType?.debugName
+  return elementType == "XML_ATTRIBUTE_VALUE_TOKEN"
+}

--- a/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/test/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -174,6 +174,13 @@ abstract class VimTestCase : UsefulTestCase() {
     return myFixture.editor
   }
 
+  private fun configureByText(fileName: String, content: String): Editor {
+    @Suppress("IdeaVimAssertState")
+    myFixture.configureByText(fileName, content)
+    setEditorVisibleSize(screenWidth, screenHeight)
+    return myFixture.editor
+  }
+
   protected fun configureByFileName(fileName: String): Editor {
     @Suppress("IdeaVimAssertState")
     myFixture.configureByText(fileName, "\n")
@@ -455,6 +462,42 @@ abstract class VimTestCase : UsefulTestCase() {
     subModeAfter: SubMode,
   ) {
     configureByText(before)
+
+    performTest(keys, after, modeAfter, subModeAfter)
+
+    NeovimTesting.assertState(myFixture.editor, this)
+  }
+
+  fun doTest(
+    keys: String,
+    before: String,
+    after: String,
+    modeAfter: CommandState.Mode,
+    subModeAfter: SubMode,
+    fileType: FileType
+  ) {
+    configureByText(fileType, before)
+
+    NeovimTesting.setupEditor(myFixture.editor, this)
+    NeovimTesting.typeCommand(keys, this)
+
+    performTest(keys, after, modeAfter, subModeAfter)
+
+    NeovimTesting.assertState(myFixture.editor, this)
+  }
+
+  fun doTest(
+    keys: String,
+    before: String,
+    after: String,
+    modeAfter: CommandState.Mode,
+    subModeAfter: SubMode,
+    fileName: String
+  ) {
+    configureByText(fileName, before)
+
+    NeovimTesting.setupEditor(myFixture.editor, this)
+    NeovimTesting.typeCommand(keys, this)
 
     performTest(keys, after, modeAfter, subModeAfter)
 

--- a/test/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGeneralTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGeneralTest.kt
@@ -1,0 +1,267 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.matchit
+
+import com.intellij.ide.highlighter.HtmlFileType
+import com.intellij.ide.highlighter.JavaFileType
+import com.maddyhome.idea.vim.command.CommandState
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+class MatchitGeneralTest : VimTestCase() {
+  @Throws(Exception::class)
+  override fun setUp() {
+    super.setUp()
+    enableExtensions("matchit")
+  }
+
+  /*
+   * Tests to make sure we didn't break the default % motion
+   */
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from Java comment start to end`() {
+    doTest("%",
+      """
+        /${c}**
+         *
+         */
+      """.trimIndent(),
+      """
+        /**
+         *
+         *${c}/
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, JavaFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from Java comment end to start`() {
+    doTest("%",
+      """
+        /**
+         *
+         *${c}/
+      """.trimIndent(),
+      """
+        ${c}/**
+         *
+         */
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, JavaFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test 25 percent jump`() {
+    doTest("25%",
+      """
+        int a;
+        int b;
+        in${c}t c;
+        int d;
+      """.trimIndent(),
+      """
+        ${c}int a;
+        int b;
+        int c;
+        int d;
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  fun `test jump from visual end of line to opening parenthesis`() {
+    doTest("v$%",
+      """foo(${c}bar)""",
+      """foo${s}${c}(b${se}ar)""",
+      CommandState.Mode.VISUAL, CommandState.SubMode.VISUAL_CHARACTER, HtmlFileType.INSTANCE
+    )
+  }
+
+  fun `test jump from visual end of line to opening parenthesis then back to closing`() {
+    doTest("v$%%",
+      """foo(${c}bar)""",
+      """foo(${s}bar${c})${se}""",
+      CommandState.Mode.VISUAL, CommandState.SubMode.VISUAL_CHARACTER, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete everything from opening parenthesis to closing parenthesis`() {
+    doTest("d%",
+      "${c}(x == 123)", "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete everything from closing parenthesis to opening parenthesis`() {
+    doTest("d%",
+      "(x == 123${c})", "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete everything from opening curly brace to closing curly brace`() {
+    doTest("d%",
+      "${c}{ foo: 123 }", "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete everything from closing curly brace to opening curly brace`() {
+    doTest("d%",
+      "{ foo: 123 ${c}}", "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete everything from opening square bracket to closing square bracket`() {
+    doTest("d%",
+      "${c}[1, 2, 3]", "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete everything from closing square bracket to opening square bracket`() {
+    doTest("d%",
+      "[1, 2, 3${c}]", "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  /*
+   * Tests for visual mode and deleting on the new Matchit patterns.
+   */
+
+  fun `test jump from visual end of line to opening angle bracket`() {
+    doTest("v$%",
+      """</h${c}tml>""",
+      """${s}${c}</ht${se}ml>""",
+      CommandState.Mode.VISUAL, CommandState.SubMode.VISUAL_CHARACTER, HtmlFileType.INSTANCE
+    )
+  }
+
+  fun `test jump from visual end of line to start of for loop`() {
+    doTest("v$%",
+      """
+        for n in [1, 2, 3]
+          puts n
+        e${c}nd
+      """.trimIndent(),
+      """
+        ${s}${c}for n in [1, 2, 3]
+          puts n
+        en${se}d
+      """.trimIndent(),
+      CommandState.Mode.VISUAL, CommandState.SubMode.VISUAL_CHARACTER, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete from elseif to else`() {
+    doTest("d%",
+      """
+        if x == 0
+          puts "Zero"
+        ${c}elsif x < -1
+          puts "Negative"
+        else
+          puts "Positive"
+        end
+      """.trimIndent(),
+      """
+        if x == 0
+          puts "Zero"
+        $c
+          puts "Positive"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete from opening to closing div`() {
+    doTest("d%",
+      """
+        <${c}div>
+          <img src="fff">
+        </div>
+      """.trimIndent(),
+      "${c}<", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete from opening angle bracket to closing angle bracket`() {
+    doTest("d%",
+      """
+        ${c}<div></div>
+      """.trimIndent(),
+      "${c}</div>", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete whole function from def`() {
+    doTest("d%",
+      """
+        ${c}def function
+          puts "hello"
+        end
+      """.trimIndent(),
+      "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete whole function from def with reverse motion`() {
+    doTest("dg%",
+      """
+        ${c}def function
+          puts "hello"
+        end
+      """.trimIndent(),
+      "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete whole function from end`() {
+    doTest("d%",
+      """
+        def function
+          puts "hello"
+        en${c}d
+      """.trimIndent(),
+      "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete whole function from end with reverse motion`() {
+    doTest("dg%",
+      """
+        def function
+          puts "hello"
+        en${c}d
+      """.trimIndent(),
+      "", CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+}

--- a/test/org/jetbrains/plugins/ideavim/extension/matchit/MatchitHtmlTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/matchit/MatchitHtmlTest.kt
@@ -1,0 +1,921 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.matchit
+
+import com.intellij.ide.highlighter.HtmlFileType
+import com.maddyhome.idea.vim.command.CommandState
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+class MatchitHtmlTest : VimTestCase() {
+  @Throws(Exception::class)
+  override fun setUp() {
+    super.setUp()
+    enableExtensions("matchit")
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump to closing tag`() {
+    doTest("%",
+      """
+        <${c}h1>Heading</h1>
+      """.trimIndent(),
+      """
+        <h1>Heading<${c}/h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump to opening tag`() {
+    doTest("%",
+      """
+        <h1>Heading</${c}h1>
+      """.trimIndent(),
+      """
+        <${c}h1>Heading</h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test multiline jump to closing tag`() {
+    doTest("%",
+      """
+        <${c}div>
+          <p>paragraph body</p>
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+          <p>paragraph body</p>
+        <${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test multiline jump to opening tag`() {
+    doTest("%",
+      """
+        <div>
+          <p>paragraph body</p>
+        </${c}div>
+      """.trimIndent(),
+      """
+        <${c}div>
+          <p>paragraph body</p>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to closing tag while ignoring nested tags`() {
+    doTest("%",
+      """
+        <${c}div>
+          <div>
+            <div>contents</div>
+          </div>
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+          <div>
+            <div>contents</div>
+          </div>
+        <${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to closing tag while ignoring outer tags`() {
+    doTest("%",
+      """
+        <div>
+          <${c}div>contents</div>
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+          <div>contents<${c}/div>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to opening tag while ignoring nested tags`() {
+    doTest("%",
+      """
+        <div>
+          <div>
+            <div>contents</div>
+          </div>
+        </d${c}iv>
+      """.trimIndent(),
+      """
+        <${c}div>
+          <div>
+            <div>contents</div>
+          </div>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to opening tag while ignoring outer tags`() {
+    doTest("%",
+      """
+        <div>
+          <div>contents</d${c}iv>
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+          <${c}div>contents</div>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to closing tag while in tag attributes`() {
+    doTest("%",
+      """
+        <h1 class="he${c}adline">Post HeadLine</h1>
+      """.trimIndent(),
+      """
+        <h1 class="headline">Post HeadLine<${c}/h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test don't jump on standalone tags`() {
+    doTest("%",
+      """
+        <div>
+          <img src=${c}"my-image.png" alt="my-image">
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+          <img src=${c}"my-image.png" alt="my-image">
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test don't jump on empty lines`() {
+    doTest("%",
+      """
+        <div>
+        $c 
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+        $c 
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump forwards to matching angle bracket on opening tag`() {
+    doTest("%",
+      """
+        ${c}<h1>Heading</h1>
+      """.trimIndent(),
+      """
+        <h1${c}>Heading</h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump forwards to matching angle bracket when on whitespace`() {
+    doTest("%",
+      "$c    <h1>Heading</h1>",
+      "    <h1${c}>Heading</h1>",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to last angle bracket when in tag body`() {
+    doTest("%",
+      """
+        <h1 class="headline">Post${c} HeadLine</h1>
+      """.trimIndent(),
+      """
+        <h1 class="headline">Post HeadLine</h1${c}>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump forwards to matching angle bracket on closing tag`() {
+    doTest("%",
+      """
+        <h1>Heading${c}</h1>
+      """.trimIndent(),
+      """
+        <h1>Heading</h1${c}>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump backwards to matching angle bracket on opening tag`() {
+    doTest("%",
+      """
+        <h1${c}>Heading</h1>
+      """.trimIndent(),
+      """
+        ${c}<h1>Heading</h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump backwards to matching angle bracket on closing tag`() {
+    doTest("%",
+      """
+        <h1>Heading</h1${c}>
+      """.trimIndent(),
+      """
+        <h1>Heading${c}</h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to matching square bracket inside tag`() {
+    doTest("%",
+      """
+        <div ${c}[ngIf]="someCondition()">{{displayValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf${c}]="someCondition()">{{displayValue}}</div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to matching parenthesis inside tag`() {
+    doTest("%",
+      """
+        <div [ngIf]="someCondition${c}()">{{displayValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf]="someCondition(${c})">{{displayValue}}</div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to matching curly brace in tag body`() {
+    doTest("%",
+      """
+        <div [ngIf]="someCondition()">${c}{{displayValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf]="someCondition()">{{displayValue}${c}}</div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to closing tag when inside brackets in opening tag`() {
+    doTest("%",
+      """
+        <div [ng${c}If]="someCondition()">{{displayValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf]="someCondition()">{{displayValue}}<${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump to opening curly brace when in tag body`() {
+    doTest("%",
+      """
+        <div [ngIf]="someCondition()">{{dis${c}playValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf]="someCondition()">{${c}{displayValue}}</div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test don't jump on standalone tag with brackets on the same line`() {
+    doTest("%",
+      """
+        <img ${c}src={{imagePath}} alt={{imageDescription}}>
+      """.trimIndent(),
+      """
+        <img ${c}src={{imagePath}} alt={{imageDescription}}>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from opening to closing tag while ignoring comments`() {
+    doTest("%",
+      """
+        <!-- <div> -->
+        <!-- This div is completely commented out -->
+        <!-- </div> -->
+        
+        <${c}div>
+          <p>paragraph 1</p>
+          <!-- </div> -->
+          <p>paragraph 2</p>
+        </div>
+      """.trimIndent(),
+      """
+        <!-- <div> -->
+        <!-- This div is completely commented out -->
+        <!-- </div> -->
+        
+        <div>
+          <p>paragraph 1</p>
+          <!-- </div> -->
+          <p>paragraph 2</p>
+        <${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from closing to opening tag while ignoring comments`() {
+    doTest("%",
+      """
+        <!-- <div> -->
+        <!-- This div is completely commented out -->
+        <!-- </div> -->
+        
+        <${c}div>
+          <!-- This <div> holds paragraphs -->
+          <p>paragraph 1</p>
+          <p>paragraph 2</p>
+        </div>
+      """.trimIndent(),
+      """
+        <!-- <div> -->
+        <!-- This div is completely commented out -->
+        <!-- </div> -->
+        
+        <div>
+          <!-- This <div> holds paragraphs -->
+          <p>paragraph 1</p>
+          <p>paragraph 2</p>
+        <${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from opening to closing tag inside a comment block`() {
+    doTest("%",
+      """
+        <!-- <${c}div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(),
+      """
+        <!-- <div> -->
+        <!--   This div is commented out -->
+        <!-- <${c}/div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from closing to opening tag inside a comment block`() {
+    doTest("%",
+      """
+        <!-- <div> -->
+        <!--   This div is commented out -->
+        <!-- <${c}/div> -->
+      """.trimIndent(),
+      """
+        <!-- <${c}div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from opening to closing angle bracket inside a comment block`() {
+    doTest("%",
+      """
+        <!-- ${c}<div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(),
+      """
+        <!-- <div${c}> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from closing to opening angle bracket inside a comment block`() {
+    doTest("%",
+      """
+        <!-- <div${c}> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(),
+      """
+        <!-- ${c}<div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from opening to closing angle bracket on a comment marker`() {
+    doTest("%",
+      """
+        ${c}<!-- <div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(),
+      """
+        <!-- <div> --${c}>
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from opening to closing angle bracket ignoring bracket in string`() {
+    doTest("%",
+      """
+        ${c}<p *ngIf="count > 0">Count is greater than zero</p>
+      """.trimIndent(),
+      """
+        <p *ngIf="count > 0"${c}>Count is greater than zero</p>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  /*
+   *  g% motion tests. For HTML, g% should behave the same as %.
+   */
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to closing tag`() {
+    doTest("g%",
+      """
+        <${c}h1>Heading</h1>
+      """.trimIndent(),
+      """
+        <h1>Heading<${c}/h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to opening tag`() {
+    doTest("g%",
+      """
+        <h1>Heading</${c}h1>
+      """.trimIndent(),
+      """
+        <${c}h1>Heading</h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to closing tag while ignoring nested tags`() {
+    doTest("g%",
+      """
+        <${c}div>
+          <div>
+            <div>contents</div>
+          </div>
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+          <div>
+            <div>contents</div>
+          </div>
+        <${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to closing tag while ignoring outer tags`() {
+    doTest("g%",
+      """
+        <div>
+          <${c}div>contents</div>
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+          <div>contents<${c}/div>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to opening tag while ignoring nested tags`() {
+    doTest("g%",
+      """
+        <div>
+          <div>
+            <div>contents</div>
+          </div>
+        </d${c}iv>
+      """.trimIndent(),
+      """
+        <${c}div>
+          <div>
+            <div>contents</div>
+          </div>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to opening tag while ignoring outer tags`() {
+    doTest("g%",
+      """
+        <div>
+          <div>contents</d${c}iv>
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+          <${c}div>contents</div>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to closing tag while in tag attributes`() {
+    doTest("g%",
+      """
+        <h1 class="he${c}adline">Post HeadLine</h1>
+      """.trimIndent(),
+      """
+        <h1 class="headline">Post HeadLine<${c}/h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test don't reverse jump on standalone tags`() {
+    doTest("g%",
+      """
+        <div>
+          <img src=${c}"my-image.png" alt="my-image">
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+          <img src=${c}"my-image.png" alt="my-image">
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test don't reverse jump on empty lines`() {
+    doTest("g%",
+      """
+        <div>
+        $c 
+        </div>
+      """.trimIndent(),
+      """
+        <div>
+        $c 
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to closing angle bracket`() {
+    doTest("g%",
+      """
+        ${c}<h1>Heading</h1>
+      """.trimIndent(),
+      """
+        <h1${c}>Heading</h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to closing angle bracket when on whitespace`() {
+    doTest("g%",
+      "$c    <h1>Heading</h1>",
+      "    <h1${c}>Heading</h1>",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to last angle bracket when in tag body`() {
+    doTest("g%",
+      """
+        <h1 class="headline">Post${c} HeadLine</h1>
+      """.trimIndent(),
+      """
+        <h1 class="headline">Post HeadLine</h1${c}>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to opening angle bracket`() {
+    doTest("g%",
+      """
+        <h1${c}>Heading</h1>
+      """.trimIndent(),
+      """
+        ${c}<h1>Heading</h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to matching square bracket inside tag`() {
+    doTest("g%",
+      """
+        <div ${c}[ngIf]="someCondition()">{{displayValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf${c}]="someCondition()">{{displayValue}}</div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to matching parenthesis inside tag`() {
+    doTest("g%",
+      """
+        <div [ngIf]="someCondition${c}()">{{displayValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf]="someCondition(${c})">{{displayValue}}</div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to matching curly brace in tag body`() {
+    doTest("g%",
+      """
+        <div [ngIf]="someCondition()">${c}{{displayValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf]="someCondition()">{{displayValue}${c}}</div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to closing tag when inside brackets in opening tag`() {
+    doTest("g%",
+      """
+        <div [ng${c}If]="someCondition()">{{displayValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf]="someCondition()">{{displayValue}}<${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump to opening curly brace when in tag body`() {
+    doTest("g%",
+      """
+        <div [ngIf]="someCondition()">{{dis${c}playValue}}</div>
+      """.trimIndent(),
+      """
+        <div [ngIf]="someCondition()">{${c}{displayValue}}</div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test don't reverse jump on standalone tag with brackets on the same line`() {
+    doTest("g%",
+      """
+        <img ${c}src={{imagePath}} alt={{imageDescription}}>
+      """.trimIndent(),
+      """
+        <img ${c}src={{imagePath}} alt={{imageDescription}}>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from opening to closing tag while ignoring comments`() {
+    doTest("g%",
+      """
+        <!-- <div> -->
+        <!-- This div is completely commented out -->
+        <!-- </div> -->
+        
+        <${c}div>
+          <p>paragraph 1</p>
+          <!-- </div> -->
+          <p>paragraph 2</p>
+        </div>
+      """.trimIndent(),
+      """
+        <!-- <div> -->
+        <!-- This div is completely commented out -->
+        <!-- </div> -->
+        
+        <div>
+          <p>paragraph 1</p>
+          <!-- </div> -->
+          <p>paragraph 2</p>
+        <${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from closing to opening tag while ignoring comments`() {
+    doTest("g%",
+      """
+        <!-- <div> -->
+        <!-- This div is completely commented out -->
+        <!-- </div> -->
+        
+        <${c}div>
+          <!-- This <div> holds paragraphs -->
+          <p>paragraph 1</p>
+          <p>paragraph 2</p>
+        </div>
+      """.trimIndent(),
+      """
+        <!-- <div> -->
+        <!-- This div is completely commented out -->
+        <!-- </div> -->
+        
+        <div>
+          <!-- This <div> holds paragraphs -->
+          <p>paragraph 1</p>
+          <p>paragraph 2</p>
+        <${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from opening to closing tag inside a comment block`() {
+    doTest("g%",
+      """
+        <!-- <${c}div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(),
+      """
+        <!-- <div> -->
+        <!--   This div is commented out -->
+        <!-- <${c}/div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from closing to opening tag inside a comment block`() {
+    doTest("g%",
+      """
+        <!-- <div> -->
+        <!--   This div is commented out -->
+        <!-- <${c}/div> -->
+      """.trimIndent(),
+      """
+        <!-- <${c}div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from opening to closing angle bracket inside a comment block`() {
+    doTest("g%",
+      """
+        <!-- ${c}<div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(),
+      """
+        <!-- <div${c}> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from closing to opening angle bracket inside a comment block`() {
+    doTest("g%",
+      """
+        <!-- <div${c}> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(),
+      """
+        <!-- ${c}<div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from opening to closing angle bracket on a comment marker`() {
+    doTest("g%",
+      """
+        ${c}<!-- <div> -->
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(),
+      """
+        <!-- <div> --${c}>
+        <!--   This div is commented out -->
+        <!-- </div> -->
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from opening to closing angle bracket ignoring bracket in string`() {
+    doTest("g%",
+      """
+        ${c}<p *ngIf="count > 0">Count is greater than zero</p>
+      """.trimIndent(),
+      """
+        <p *ngIf="count > 0"${c}>Count is greater than zero</p>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from multiline opening tag to closing`() {
+    doTest("%",
+      """
+        <h1 ${c}id="title"
+           class="red right-aligned">
+           Header Content
+        </h1>
+      """.trimIndent(),
+      """
+        <h1 id="title"
+           class="red right-aligned">
+           Header Content
+        <${c}/h1>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, HtmlFileType.INSTANCE
+    )
+  }
+}

--- a/test/org/jetbrains/plugins/ideavim/extension/matchit/MatchitRubyTest.kt
+++ b/test/org/jetbrains/plugins/ideavim/extension/matchit/MatchitRubyTest.kt
@@ -1,0 +1,2568 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2020 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.matchit
+
+import com.maddyhome.idea.vim.command.CommandState
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+class MatchitRubyTest : VimTestCase() {
+  @Throws(Exception::class)
+  override fun setUp() {
+    super.setUp()
+    enableExtensions("matchit")
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump from if to end`() {
+    doTest("%",
+      """
+        ${c}if some_boolean
+          puts "result is true"
+        end
+      """.trimIndent(),
+      """
+        if some_boolean
+          puts "result is true"
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from whitespace before if to end`() {
+    doTest("%",
+      """ $c  if some_boolean puts "result is true" end""",
+      """   if some_boolean puts "result is true" ${c}end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from whitespace before class to end`() {
+    doTest("%",
+      """ $c class Foo end""",
+      """  class Foo ${c}end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump from end to if`() {
+    doTest("%",
+      """
+        if some_boolean
+          puts "result is true"
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}if some_boolean
+          puts "result is true"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump from if to else`() {
+    doTest("%",
+      """
+        ${c}if some_boolean
+          puts "result is true"
+        else
+          puts "result is false"
+        end
+      """.trimIndent(),
+      """
+        if some_boolean
+          puts "result is true"
+        ${c}else
+          puts "result is false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump from else to end`() {
+    doTest("%",
+      """
+        if some_boolean
+          puts "result is true"
+        ${c}else
+          puts "result is false"
+        end
+      """.trimIndent(),
+      """
+        if some_boolean
+          puts "result is true"
+        else
+          puts "result is false"
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to if in if-else structure`() {
+    doTest("%",
+      """
+        if some_boolean
+          puts "result is true"
+        else
+          puts "result is false"
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}if some_boolean
+          puts "result is true"
+        else
+          puts "result is false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from if to elsif`() {
+    doTest("%",
+      """
+        ${c}if first_value
+          puts "first value is true"
+        elsif second_value
+          puts "second value is true"
+        else
+          puts "both values are false"
+        end
+      """.trimIndent(),
+      """
+        if first_value
+          puts "first value is true"
+        ${c}elsif second_value
+          puts "second value is true"
+        else
+          puts "both values are false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from elsif to else`() {
+    doTest("%",
+      """
+        if first_value
+          puts "first value is true"
+        ${c}elsif second_value
+          puts "second value is true"
+        else
+          puts "both values are false"
+        end
+      """.trimIndent(),
+      """
+        if first_value
+          puts "first value is true"
+        elsif second_value
+          puts "second value is true"
+        ${c}else
+          puts "both values are false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from elsif to end`() {
+    doTest("%",
+      """
+        if first_value
+          puts "first value is true"
+        ${c}elsif second_value
+          puts "second value is true"
+        end
+      """.trimIndent(),
+      """
+        if first_value
+          puts "first value is true"
+        elsif second_value
+          puts "second value is true"
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from elsif to elsif`() {
+    doTest("%",
+      """
+        if first_value
+          puts "first value is true"
+        ${c}elsif second_value
+          puts "second value is true"
+        elsif third_value
+          puts "third value is true"
+        else
+          puts "all values are false"
+        end
+      """.trimIndent(),
+      """
+        if first_value
+          puts "first value is true"
+        elsif second_value
+          puts "second value is true"
+        ${c}elsif third_value
+          puts "third value is true"
+        else
+          puts "all values are false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from for to end`() {
+    doTest("%",
+      """
+        target = "baz"
+        ${c}for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          end
+        end
+      """.trimIndent(),
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          end
+        ${c}end
+     """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from for to end and ignore inner if blocks`() {
+    doTest("%",
+      """
+        ${c}for i in 0..5
+          if i > 1
+            puts "Greater than 1"
+          elsif i > 2
+            puts "Greater than 2"
+          elsif i > 3 
+            puts "Greater than 3"
+          elsif i > 4 
+            puts "Greater than 4"
+          end
+        end
+      """.trimIndent(),
+      """
+        for i in 0..5
+          if i > 1
+            puts "Greater than 1"
+          elsif i > 2
+            puts "Greater than 2"
+          elsif i > 3 
+            puts "Greater than 3"
+          elsif i > 4 
+            puts "Greater than 4"
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from if to break`() {
+    doTest("%",
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          ${c}if s == target
+            puts "Found target"
+            break
+          end
+        end
+      """.trimIndent(),
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            ${c}break
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from break to end`() {
+    doTest("%",
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            ${c}break
+          end
+        end
+      """.trimIndent(),
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          ${c}end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to if`() {
+    doTest("%",
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          ${c}end
+        end
+      """.trimIndent(),
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          ${c}if s == target
+            puts "Found target"
+            break
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to for`() {
+    doTest("%",
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          end
+        ${c}end
+      """.trimIndent(),
+      """
+        target = "baz"
+        ${c}for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump from class to end`() {
+    doTest("%",
+      """
+        ${c}class SomeRubyClass
+          def some_method
+            puts "hello!"
+          end
+        end
+      """.trimIndent(),
+      """
+        class SomeRubyClass
+          def some_method
+            puts "hello!"
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump from end to class`() {
+    doTest("%",
+      """
+        class SomeRubyClass
+          def some_method
+            puts "hello!"
+          end
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}class SomeRubyClass
+          def some_method
+            puts "hello!"
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump from def to end`() {
+    doTest("%",
+      """
+        class SomeRubyClass
+          ${c}def some_method
+            puts "hello!"
+          end
+        end
+      """.trimIndent(),
+      """
+        class SomeRubyClass
+          def some_method
+            puts "hello!"
+          ${c}end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic jump from end to def`() {
+    doTest("%",
+      """
+        class SomeRubyClass
+          def some_method
+            puts "hello!"
+          ${c}end
+        end
+      """.trimIndent(),
+      """
+        class SomeRubyClass
+          ${c}def some_method
+            puts "hello!"
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from class to end ignoring nested class`() {
+    doTest("%",
+      """
+        ${c}class OuterClass
+
+          class InnerClass
+            def inner_method(arg1, arg2)
+              puts "I am the inner method"
+            end
+          end
+
+          def outer_method
+            puts "I am the outer method"
+          end
+
+        end
+      """.trimIndent(),
+      """
+        class OuterClass
+
+          class InnerClass
+            def inner_method(arg1, arg2)
+              puts "I am the inner method"
+            end
+          end
+
+          def outer_method
+            puts "I am the outer method"
+          end
+
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from if to end over inner loop`() {
+    doTest("%",
+      """
+        ${c}if some_boolean
+          for i in 0..5
+            if i > 2
+              puts "Greater than 2"
+            elsif i > 3
+              puts "Greater than 3"
+            end
+          end
+        end
+      """.trimIndent(),
+      """
+        if some_boolean
+          for i in 0..5
+            if i > 2
+              puts "Greater than 2"
+            elsif i > 3
+              puts "Greater than 3"
+            end
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to if ignoring malformed code`() {
+    doTest("%",
+      """
+        end # Syntax error
+ 
+        if some_boolean
+          puts some_boolean
+        ${c}end
+      """.trimIndent(),
+      """
+        end # Syntax error
+ 
+        ${c}if some_boolean
+          puts some_boolean
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from if to end after a semicolon`() {
+    doTest("%",
+      """puts "This line has two statements"; ${c}if true then puts "true" end""",
+      """puts "This line has two statements"; if true then puts "true" ${c}end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to if after a semicolon`() {
+    doTest("%",
+      """puts "This line has two statements"; if true then puts "true" ${c}end""",
+      """puts "This line has two statements"; ${c}if true then puts "true" end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from before if and semicolon to end`() {
+    doTest("%",
+      """puts "This line has ${c}two statements"; if true then puts "true" end""",
+      """puts "This line has two statements"; if true then puts "true" ${c}end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from unless to end after a semicolon`() {
+    doTest("%",
+      """puts "This line has two statements"; ${c}unless nil then puts "not nil" end""",
+      """puts "This line has two statements"; unless nil then puts "not nil" ${c}end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to unless after a semicolon`() {
+    doTest("%",
+      """puts "This line has two statements"; unless nil then puts "not nill" ${c}end""",
+      """puts "This line has two statements"; ${c}unless nil then puts "not nill" end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to do when no other opening keyword is present`() {
+    doTest("%",
+      """
+        for x in [1, 2, 3] do
+          puts x
+        end
+       
+        [1, 2, 3].each do |x| puts x ${c}end
+      """.trimIndent(),
+      """
+        for x in [1, 2, 3] do
+          puts x
+        end
+       
+        [1, 2, 3].each ${c}do |x| puts x end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from do to end`() {
+    doTest("%",
+      """
+        for number in [1, 2, 3, 4, 5] ${c}do
+          if number.even?
+            puts "Even"
+          else
+            puts "Odd"
+          end
+        end
+      """.trimIndent(),
+      """
+        for number in [1, 2, 3, 4, 5] do
+          if number.even?
+            puts "Even"
+          else
+            puts "Odd"
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from module to end`() {
+    doTest("%",
+      """
+        ${c}module MyModule
+          def my_function
+            return true
+          end
+        end
+      """.trimIndent(),
+      """
+        module MyModule
+          def my_function
+            return true
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to module`() {
+    doTest("%",
+      """
+        module MyModule
+          def my_function
+            return true
+          end
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}module MyModule
+          def my_function
+            return true
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from while to end`() {
+    doTest("%",
+      """
+        def count_down(x)
+          ${c}while x >= 0 
+            puts x
+            x = x - 1
+          end        
+        end
+      """.trimIndent(),
+      """
+        def count_down(x)
+          while x >= 0 
+            puts x
+            x = x - 1
+          ${c}end        
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from begin to rescue`() {
+    doTest("%",
+      """
+        def open_file(file_name)
+          ${c}begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          end
+        end
+      """.trimIndent(),
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          ${c}rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from rescue to ensure`() {
+    doTest("%",
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          ${c}rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          end
+        end
+      """.trimIndent(),
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ${c}ensure
+            file.close
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ensure to end`() {
+    doTest("%",
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ${c}ensure
+            file.close
+          end
+        end
+      """.trimIndent(),
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          ${c}end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to begin`() {
+    doTest("%",
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          ${c}end
+        end
+      """.trimIndent(),
+      """
+        def open_file(file_name)
+          ${c}begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from rescue to retry`() {
+    doTest("%",
+      """
+        begin
+          puts "Loop forever"
+          raise
+        ${c}rescue
+          retry
+        end
+      """.trimIndent(),
+      """
+        begin
+          puts "Loop forever"
+          raise
+        rescue
+          ${c}retry
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from retry to end`() {
+    doTest("%",
+      """
+        begin
+          puts "Loop forever"
+          raise
+        rescue
+          ${c}retry
+        end
+      """.trimIndent(),
+      """
+        begin
+          puts "Loop forever"
+          raise
+        rescue
+          retry
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to while`() {
+    doTest("%",
+      """
+        def count_down(x)
+          while x >= 0 
+            puts x
+            x = x - 1
+          ${c}end        
+        end
+      """.trimIndent(),
+      """
+        def count_down(x)
+          ${c}while x >= 0 
+            puts x
+            x = x - 1
+          end        
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from case to when`() {
+    doTest("%",
+      """
+        ${c}case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(),
+      """
+        case age
+          ${c}when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from when to when`() {
+    doTest("%",
+      """
+        case age
+          ${c}when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(),
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          ${c}when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from else to end in case block`() {
+    doTest("%",
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          ${c}else
+            puts "Adult"
+        end
+      """.trimIndent(),
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to case`() {
+    doTest("%",
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from until to end`() {
+    doTest("%",
+      """
+        ${c}until var == 11
+          var = var + 1
+        end
+      """.trimIndent(),
+      """
+        until var == 11
+          var = var + 1
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from if to redo`() {
+    doTest("%",
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          ${c}if i > 2
+            redo
+          elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(),
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            ${c}redo
+          elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from redo to elsif`() {
+    doTest("%",
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            ${c}redo
+          elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(),
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          ${c}elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from elsif to next`() {
+    doTest("%",
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          ${c}elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(),
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          elsif i == 3
+            ${c}next
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from next to end`() {
+    doTest("%",
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          elsif i == 3
+            ${c}next
+          end
+        end
+      """.trimIndent(),
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          elsif i == 3
+            next
+          ${c}end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from =begin to =end`() {
+    doTest("%",
+      """
+        ${c}=begin
+          Multiline comment
+        =end
+      """.trimIndent(),
+      """
+        =begin
+          Multiline comment
+        =${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from =end to =begin`() {
+    doTest("%",
+      """
+        =begin
+          Multiline comment
+        ${c}=end
+      """.trimIndent(),
+      """
+        =${c}begin
+          Multiline comment
+        =end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from middle of cucumber test to end`() {
+    doTest("%",
+      """
+        Given /^ Some ${c}Cucumber test $/ do
+          users.each do |group|
+            begin
+              test_fun()
+            rescue
+              clean_up()
+            end
+          end
+        end
+      """.trimIndent(),
+      """
+        Given /^ Some Cucumber test $/ do
+          users.each do |group|
+            begin
+              test_fun()
+            rescue
+              clean_up()
+            end
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end of cucumber test to do`() {
+    doTest("%",
+      """
+        Given /^ Some Cucumber test $/ do
+          users.each do |group|
+            begin
+              test_fun()
+            rescue
+              clean_up()
+            end
+          end
+        ${c}end
+      """.trimIndent(),
+      """
+        Given /^ Some Cucumber test ${'$'}/ ${c}do
+          users.each do |group|
+            begin
+              test_fun()
+            rescue
+              clean_up()
+            end
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  /*
+   * Tests for reverse g% motion
+   */
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic reverse jump from end to if `() {
+    doTest("g%",
+      """
+        if some_boolean
+          puts "result is true"
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}if some_boolean
+          puts "result is true"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic reverse jump from end to if`() {
+    doTest("g%",
+      """
+        if some_boolean
+          puts "result is true"
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}if some_boolean
+          puts "result is true"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic reverse jump from else to if`() {
+    doTest("g%",
+      """
+        if some_boolean
+          puts "result is true"
+        ${c}else
+          puts "result is false"
+        end
+      """.trimIndent(),
+      """
+        ${c}if some_boolean
+          puts "result is true"
+        else
+          puts "result is false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic reverse jump from end to else`() {
+    doTest("g%",
+      """
+        if some_boolean
+          puts "result is true"
+        else
+          puts "result is false"
+        ${c}end
+      """.trimIndent(),
+      """
+        if some_boolean
+          puts "result is true"
+        ${c}else
+          puts "result is false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from if to end in if-else structure`() {
+    doTest("g%",
+      """
+        ${c}if some_boolean
+          puts "result is true"
+        else
+          puts "result is false"
+        end
+      """.trimIndent(),
+      """
+        if some_boolean
+          puts "result is true"
+        else
+          puts "result is false"
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from elsif to if`() {
+    doTest("g%",
+      """
+        if first_value
+          puts "first value is true"
+        ${c}elsif second_value
+          puts "second value is true"
+        else
+          puts "both values are false"
+        end
+      """.trimIndent(),
+      """
+        ${c}if first_value
+          puts "first value is true"
+        elsif second_value
+          puts "second value is true"
+        else
+          puts "both values are false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from else to elsif`() {
+    doTest("g%",
+      """
+        if first_value
+          puts "first value is true"
+        elsif second_value
+          puts "second value is true"
+        ${c}else
+          puts "both values are false"
+        end
+      """.trimIndent(),
+      """
+        if first_value
+          puts "first value is true"
+        ${c}elsif second_value
+          puts "second value is true"
+        else
+          puts "both values are false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to elsif`() {
+    doTest("g%",
+      """
+        if first_value
+          puts "first value is true"
+        elsif second_value
+          puts "second value is true"
+        ${c}end
+      """.trimIndent(),
+      """
+        if first_value
+          puts "first value is true"
+        ${c}elsif second_value
+          puts "second value is true"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from elsif to elsif`() {
+    doTest("g%",
+      """
+        if first_value
+          puts "first value is true"
+        elsif second_value
+          puts "second value is true"
+        ${c}elsif third_value
+          puts "third value is true"
+        else
+          puts "all values are false"
+        end
+      """.trimIndent(),
+      """
+        if first_value
+          puts "first value is true"
+        ${c}elsif second_value
+          puts "second value is true"
+        elsif third_value
+          puts "third value is true"
+        else
+          puts "all values are false"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to for and ignore inner if blocks`() {
+    doTest("g%",
+      """
+        for i in 0..5
+          if i > 1
+            puts "Greater than 1"
+          elsif i > 2
+            puts "Greater than 2"
+          elsif i > 3 
+            puts "Greater than 3"
+          elsif i > 4 
+            puts "Greater than 4"
+          end
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}for i in 0..5
+          if i > 1
+            puts "Greater than 1"
+          elsif i > 2
+            puts "Greater than 2"
+          elsif i > 3 
+            puts "Greater than 3"
+          elsif i > 4 
+            puts "Greater than 4"
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from break to if`() {
+    doTest("g%",
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            ${c}break
+          end
+        end
+      """.trimIndent(),
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          ${c}if s == target
+            puts "Found target"
+            break
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to break`() {
+    doTest("g%",
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          ${c}end
+        end
+      """.trimIndent(),
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            ${c}break
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from if to end ignoring break`() {
+    doTest("g%",
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          ${c}if s == target
+            puts "Found target"
+            break
+          end
+        end
+      """.trimIndent(),
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          ${c}end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from for to end ignoring nested if`() {
+    doTest("g%",
+      """
+        target = "baz"
+        ${c}for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          end
+        end
+      """.trimIndent(),
+      """
+        target = "baz"
+        for s in ["foo", "bar", "baz"]
+          if s == target
+            puts "Found target"
+            break
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic reverse jump from end to class`() {
+    doTest("g%",
+      """
+        class SomeRubyClass
+          def some_method
+            puts "hello!"
+          end
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}class SomeRubyClass
+          def some_method
+            puts "hello!"
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test basic reverse jump from class to end`() {
+    doTest("g%",
+      """
+        ${c}class SomeRubyClass
+          def some_method
+            puts "hello!"
+          end
+        end
+      """.trimIndent(),
+      """
+        class SomeRubyClass
+          def some_method
+            puts "hello!"
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from def to end`() {
+    doTest("g%",
+      """
+        class SomeRubyClass
+          ${c}def some_method
+            puts "hello!"
+          end
+        end
+      """.trimIndent(),
+      """
+        class SomeRubyClass
+          def some_method
+            puts "hello!"
+          ${c}end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to def across multiple functions`() {
+    doTest("g%",
+      """
+        def func_one
+          puts "I am func_one"
+        end
+       
+        def func_two
+          puts "I am func_two"
+        end
+        
+        def func_three
+          puts "I am func_three"
+        ${c}end
+      """.trimIndent(),
+      """
+        def func_one
+          puts "I am func_one"
+        end
+       
+        def func_two
+          puts "I am func_two"
+        end
+        
+        ${c}def func_three
+          puts "I am func_three"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to def`() {
+    doTest("g%",
+      """
+        class SomeRubyClass
+          def some_method
+            puts "hello!"
+          ${c}end
+        end
+      """.trimIndent(),
+      """
+        class SomeRubyClass
+          ${c}def some_method
+            puts "hello!"
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to class ignoring nested class`() {
+    doTest("g%",
+      """
+        class OuterClass
+
+          class InnerClass
+            def inner_method(arg1, arg2)
+              puts "I am the inner method"
+            end
+          end
+
+          def outer_method
+            puts "I am the outer method"
+          end
+
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}class OuterClass
+
+          class InnerClass
+            def inner_method(arg1, arg2)
+              puts "I am the inner method"
+            end
+          end
+
+          def outer_method
+            puts "I am the outer method"
+          end
+
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to if over inner loop`() {
+    doTest("g%",
+      """
+        if some_boolean
+          for i in 0..5
+            if i > 2
+              puts "Greater than 2"
+            elsif i > 3
+              puts "Greater than 3"
+            end
+          end
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}if some_boolean
+          for i in 0..5
+            if i > 2
+              puts "Greater than 2"
+            elsif i > 3
+              puts "Greater than 3"
+            end
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to if ignoring malformed code`() {
+    doTest("g%",
+      """
+        end # Syntax error
+ 
+        if some_boolean
+          puts some_boolean
+        ${c}end
+      """.trimIndent(),
+      """
+        end # Syntax error
+ 
+        ${c}if some_boolean
+          puts some_boolean
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from do to end`() {
+    doTest("g%",
+      """
+        for number in [1, 2, 3, 4, 5] ${c}do
+          if number.even?
+            puts "Even"
+          else
+            puts "Odd"
+          end
+        end
+      """.trimIndent(),
+      """
+        for number in [1, 2, 3, 4, 5] do
+          if number.even?
+            puts "Even"
+          else
+            puts "Odd"
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from module to end`() {
+    doTest("g%",
+      """
+        ${c}module MyModule
+          def my_function
+            return true
+          end
+        end
+      """.trimIndent(),
+      """
+        module MyModule
+          def my_function
+            return true
+          end
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to module`() {
+    doTest("g%",
+      """
+        module MyModule
+          def my_function
+            return true
+          end
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}module MyModule
+          def my_function
+            return true
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to ensure`() {
+    doTest("g%",
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          ${c}end
+        end
+      """.trimIndent(),
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ${c}ensure
+            file.close
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ensure to rescue`() {
+    doTest("g%",
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ${c}ensure
+            file.close
+          end
+        end
+      """.trimIndent(),
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          ${c}rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from rescue to begin`() {
+    doTest("g%",
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          ${c}rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          end
+        end
+      """.trimIndent(),
+      """
+        def open_file(file_name)
+          ${c}begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from begin to end`() {
+    doTest("g%",
+      """
+        def open_file(file_name)
+          ${c}begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          end
+        end
+      """.trimIndent(),
+      """
+        def open_file(file_name)
+          begin
+            file = open(file_name)
+          rescue
+            puts "File could not be opened"
+          ensure
+            file.close
+          ${c}end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to retry`() {
+    doTest("g%",
+      """
+        begin
+          puts "Loop forever"
+          raise
+        rescue
+          retry
+        ${c}end
+      """.trimIndent(),
+      """
+        begin
+          puts "Loop forever"
+          raise
+        rescue
+          ${c}retry
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from retry to rescue`() {
+    doTest("g%",
+      """
+        begin
+          puts "Loop forever"
+          raise
+        rescue
+          ${c}retry
+        end
+      """.trimIndent(),
+      """
+        begin
+          puts "Loop forever"
+          raise
+        ${c}rescue
+          retry
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from while to end`() {
+    doTest("g%",
+      """
+        def count_down(x)
+          ${c}while x >= 0 
+            puts x
+            x = x - 1
+          end        
+        end
+      """.trimIndent(),
+      """
+        def count_down(x)
+          while x >= 0 
+            puts x
+            x = x - 1
+          ${c}end        
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to while`() {
+    doTest("g%",
+      """
+        def count_down(x)
+          while x >= 0 
+            puts x
+            x = x - 1
+          ${c}end        
+        end
+      """.trimIndent(),
+      """
+        def count_down(x)
+          ${c}while x >= 0 
+            puts x
+            x = x - 1
+          end        
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from case to end`() {
+    doTest("g%",
+      """
+        ${c}case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(),
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to else in case block`() {
+    doTest("g%",
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        ${c}end
+      """.trimIndent(),
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          ${c}else
+            puts "Adult"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from else to when`() {
+    doTest("g%",
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          ${c}else
+            puts "Adult"
+        end
+      """.trimIndent(),
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          ${c}when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from when to when`() {
+    doTest("g%",
+      """
+        case age
+          when 0 .. 12
+            puts "Child"
+          ${c}when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(),
+      """
+        case age
+          ${c}when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from when to case`() {
+    doTest("g%",
+      """
+        case age
+          ${c}when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(),
+      """
+        ${c}case age
+          when 0 .. 12
+            puts "Child"
+          when 13 .. 18
+            puts "Youth"
+          else
+            puts "Adult"
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to until`() {
+    doTest("g%",
+      """
+        until var == 11
+          var = var + 1
+        ${c}end
+      """.trimIndent(),
+      """
+        ${c}until var == 11
+          var = var + 1
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from until to end`() {
+    doTest("g%",
+      """
+        ${c}until var == 11
+          var = var + 1
+        end
+      """.trimIndent(),
+      """
+        until var == 11
+          var = var + 1
+        ${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to next`() {
+    doTest("g%",
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          elsif i == 3
+            next
+          ${c}end
+        end
+      """.trimIndent(),
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          elsif i == 3
+            ${c}next
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from next to elsif`() {
+    doTest("g%",
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          elsif i == 3
+            ${c}next
+          end
+        end
+      """.trimIndent(),
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          ${c}elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from elsif to redo`() {
+    doTest("g%",
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            redo
+          ${c}elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(),
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            ${c}redo
+          elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from redo to if`() {
+    doTest("g%",
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          if i > 2
+            ${c}redo
+          elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(),
+      """
+        10.times do |i|
+          puts "Iteration #{i}"
+          ${c}if i > 2
+            redo
+          elsif i == 3
+            next
+          end
+        end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from =begin to =end`() {
+    doTest("g%",
+      """
+        ${c}=begin
+          Multiline comment
+        =end
+      """.trimIndent(),
+      """
+        =begin
+          Multiline comment
+        =${c}end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from =end to =begin`() {
+    doTest("g%",
+      """
+        =begin
+          Multiline comment
+        ${c}=end
+      """.trimIndent(),
+      """
+        =${c}begin
+          Multiline comment
+        =end
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from before if and semicolon to end`() {
+    doTest("g%",
+      """puts "This line has ${c}two statements"; if true then puts "true" end""",
+      """puts "This line has two statements"; if true then puts "true" ${c}end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from whitespace before class to end`() {
+    doTest("g%",
+      """ $c  class Foo end""",
+      """   class Foo ${c}end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  /*
+   * Tests for embedded Ruby
+   */
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from opening to closing HTML tag`() {
+    // This is just to test that HTML jumps are working in Ruby files.
+    // MatchitHtmlTest is what tests the correctness of the HTML jumps.
+    doTest("%",
+      """
+        <div><${c}div>contents</div></div>
+      """.trimIndent(),
+      """
+        <div><div>contents<${c}/div></div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from opening to closing div while on class attribute`() {
+    doTest("%",
+      """
+        <div ${c}class="container">
+          <% flash.each do |message_type, message| %>
+            <div class="alert alert-<%= message_type %>"><%= message %></div>
+          <% end %>
+          <%= yield %>
+          <%= render 'layouts/footer' %>
+        </div>
+      """.trimIndent(),
+      """
+        <div class="container">
+          <% flash.each do |message_type, message| %>
+            <div class="alert alert-<%= message_type %>"><%= message %></div>
+          <% end %>
+          <%= yield %>
+          <%= render 'layouts/footer' %>
+        <${c}/div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from do to end in template block`() {
+    doTest("%",
+      """
+        <div class="container">
+          <% flash.each ${c}do |message_type, message| %>
+            <div class="alert alert-<%= message_type %>"><%= message %></div>
+          <% end %>
+          <%= yield %>
+          <%= render 'layouts/footer' %>
+        </div>
+      """.trimIndent(),
+      """
+        <div class="container">
+          <% flash.each do |message_type, message| %>
+            <div class="alert alert-<%= message_type %>"><%= message %></div>
+          <% ${c}end %>
+          <%= yield %>
+          <%= render 'layouts/footer' %>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from end to do in template block`() {
+    doTest("%",
+      """
+        <div class="container">
+          <% flash.each do |message_type, message| %>
+            <div class="alert alert-<%= message_type %>"><%= message %></div>
+          <% ${c}end %>
+          <%= yield %>
+          <%= render 'layouts/footer' %>
+        </div>
+      """.trimIndent(),
+      """
+        <div class="container">
+          <% flash.each ${c}do |message_type, message| %>
+            <div class="alert alert-<%= message_type %>"><%= message %></div>
+          <% end %>
+          <%= yield %>
+          <%= render 'layouts/footer' %>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from closing to opening div`() {
+    doTest("%",
+      """
+        <div class="container">
+          <% flash.each do |message_type, message| %>
+            <div class="alert alert-<%= message_type %>"><%= message %></div>
+          <% end %>
+          <%= yield %>
+          <%= render 'layouts/footer' %>
+        </d${c}iv>
+      """.trimIndent(),
+      """
+        <${c}div class="container">
+          <% flash.each do |message_type, message| %>
+            <div class="alert alert-<%= message_type %>"><%= message %></div>
+          <% end %>
+          <%= yield %>
+          <%= render 'layouts/footer' %>
+        </div>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from opening to closing angle bracket in template`() {
+    doTest("%",
+      """<div class="alert alert-${c}<%= message_type %>"><%= message %></div>""",
+      """<div class="alert alert-<%= message_type %${c}>"><%= message %></div>""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from opening to closing angle bracket in template`() {
+    doTest("g%",
+      """<div class="alert alert-${c}<%= message_type %>"><%= message %></div>""",
+      """<div class="alert alert-<%= message_type %${c}>"><%= message %></div>""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from do to end in table template`() {
+    doTest("%",
+      """
+        <tbody>
+          <% @books.each ${c}do |book| %>
+            <tr>
+              <td><%= book.title %></td>
+              <% if book.content %>
+                <td><%= book.content %></td>
+              <% else %>
+                <td> N/A </td>
+              <% end %>
+              <td><%= link_to "Show", book %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      """.trimIndent(),
+      """
+        <tbody>
+          <% @books.each do |book| %>
+            <tr>
+              <td><%= book.title %></td>
+              <% if book.content %>
+                <td><%= book.content %></td>
+              <% else %>
+                <td> N/A </td>
+              <% end %>
+              <td><%= link_to "Show", book %></td>
+            </tr>
+          <% ${c}end %>
+        </tbody>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from if to else in table template`() {
+    doTest("%",
+      """
+        <tbody>
+          <% @books.each do |book| %>
+            <tr>
+              <td><%= book.title %></td>
+              <% ${c}if book.content %>
+                <td><%= book.content %></td>
+              <% else %>
+                <td> N/A </td>
+              <% end %>
+              <td><%= link_to "Show", book %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      """.trimIndent(),
+      """
+        <tbody>
+          <% @books.each do |book| %>
+            <tr>
+              <td><%= book.title %></td>
+              <% if book.content %>
+                <td><%= book.content %></td>
+              <% ${c}else %>
+                <td> N/A </td>
+              <% end %>
+              <td><%= link_to "Show", book %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from else to end in table template`() {
+    doTest("%",
+      """
+        <tbody>
+          <% @books.each do |book| %>
+            <tr>
+              <td><%= book.title %></td>
+              <% if book.content %>
+                <td><%= book.content %></td>
+              <% ${c}else %>
+                <td> N/A </td>
+              <% end %>
+              <td><%= link_to "Show", book %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      """.trimIndent(),
+      """
+        <tbody>
+          <% @books.each do |book| %>
+            <tr>
+              <td><%= book.title %></td>
+              <% if book.content %>
+                <td><%= book.content %></td>
+              <% else %>
+                <td> N/A </td>
+              <% ${c}end %>
+              <td><%= link_to "Show", book %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from end to else in table template`() {
+    doTest("g%",
+      """
+        <tbody>
+          <% @books.each do |book| %>
+            <tr>
+              <td><%= book.title %></td>
+              <% if book.content %>
+                <td><%= book.content %></td>
+              <% else %>
+                <td> N/A </td>
+              <% ${c}end %>
+              <td><%= link_to "Show", book %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      """.trimIndent(),
+      """
+        <tbody>
+          <% @books.each do |book| %>
+            <tr>
+              <td><%= book.title %></td>
+              <% if book.content %>
+                <td><%= book.content %></td>
+              <% ${c}else %>
+                <td> N/A </td>
+              <% end %>
+              <td><%= link_to "Show", book %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      """.trimIndent(), CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby-template.html.erb"
+    )
+  }
+
+}


### PR DESCRIPTION
[Addresses VIM-539](https://youtrack.jetbrains.com/issue/VIM-539)

Hello! This is my attempt at emulating [matchit.vim](https://github.com/chrisbra/matchit), a plugin which extends the `%` motion to match whole words and patterns.

My version currently supports jumping with `%` and `g%` on matching HTML/XML tags (including HTML found in JavaScript/TypeScript and React files), and Ruby keywords, including Embedded Ruby `erb` files. It handles comments and strings like the original plugin.

I plan on adding support for more languages in the future. But I think that the HTML jumps alone make this plugin worth adding to IdeaVim. 🙂  

I took care to make sure this doesn't break the default `%` motion, and I've included a lot of unit tests.

**There are a couple of things I'm uncertain about:**

The original plugin uses Vim syntax groups to check for comments, strings, and other language features it wants to ignore. I've done the same but with PSI elements. However, I'm not sure how to check the types of Ruby elements since they appear to be defined outside of IntelliJ. I've resorted to checking the debugNames.

Similarly, I wasn't sure how write unit tests just for Ruby files. I added a new `doTest()` method which takes a filetype parameter -- that makes it easy to deal with `HTMLFileType` or `JavaFileType`. But there's no `RubyFileType`, so I needed another `doTest` that takes a filename parameter. If a better solution for these Ruby features exists then I'd love to hear it.

Thank you for your time, Alex! I look forward to your feedback.