### PR TITLE
[VIM-2255] Missing reload icon in .ideavimrc on Windows

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/ui/ReloadVimRc.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ReloadVimRc.kt
@@ -116,7 +116,7 @@ class ReloadVimRc : DumbAwareAction() {
       return
     }
 
-    if (virtualFile.path != VimRcFileState.filePath) {
+    if (FileUtil.toSystemDependentName(virtualFile.path) != VimRcFileState.filePath) {
       e.presentation.isEnabledAndVisible = false
       return
     }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/VIM-2255

Due to:
```kt
  fun saveFileState(filePath: String, text: String) {
    this.filePath = FileUtil.toSystemDependentName(filePath)
    // ....
  }
```
the path never matches, since on Windows, `virtualFile.path` has forward slashes and `VimRcFileState.filePath` has backslashes.