### PR TITLE
fix(VIM-2432): handle scrolloff with <C-D> and <C-U>

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -256,6 +256,8 @@ public class MotionGroup {
     return SearchHelper.findParagraphRange(editor, caret, count, isOuter);
   }
 
+  // Get the visual line that will be in the same screen relative location as the current caret line, after the screen
+  // has been scrolled
   private static int getScrollScreenTargetCaretVisualLine(final @NotNull Editor editor, int rawCount, boolean down) {
     final Rectangle visibleArea = getVisibleArea(editor);
     final int caretVisualLine = editor.getCaretModel().getVisualPosition().line;
@@ -271,7 +273,7 @@ public class MotionGroup {
       targetCaretVisualLine = down ? caretVisualLine + scrollOption : caretVisualLine - scrollOption;
     }
 
-    return targetCaretVisualLine;
+    return EditorHelper.normalizeVisualLine(editor, targetCaretVisualLine);
   }
 
   public @Range(from = 0, to = Integer.MAX_VALUE) int moveCaretToNthCharacter(@NotNull Editor editor, int count) {
@@ -1167,6 +1169,8 @@ public class MotionGroup {
 
     final Rectangle visibleArea = getVisibleArea(editor);
 
+    // We want to scroll the screen and keep the caret in the same screen-relative position. Calculate which line will
+    // be at the current caret line and work the offsets out from that
     int targetCaretVisualLine = getScrollScreenTargetCaretVisualLine(editor, rawCount, down);
 
     // Scroll at most one screen height
@@ -1190,12 +1194,11 @@ public class MotionGroup {
       }
     }
     else {
-
       scrollVisualLineToCaretLocation(editor, targetCaretVisualLine);
 
       final int scrollOffset = getNormalizedScrollOffset(editor);
-      final int visualTop = getVisualLineAtTopOfScreen(editor) + scrollOffset;
-      final int visualBottom = getVisualLineAtBottomOfScreen(editor) - scrollOffset;
+      final int visualTop = getVisualLineAtTopOfScreen(editor) + (down ? scrollOffset : 0);
+      final int visualBottom = getVisualLineAtBottomOfScreen(editor) - (down ? 0 : scrollOffset);
 
       targetCaretVisualLine = max(visualTop, min(visualBottom, targetCaretVisualLine));
     }

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -635,7 +635,8 @@ public class EditorHelper {
   }
 
   /**
-   * Scrolls the editor to put the given visual line at the current caret location, relative to the screen.
+   * Scrolls the editor to put the given visual line at the current caret location, relative to the screen, as long as
+   * this doesn't add virtual space to the bottom of the file.
    * <p>
    * Due to block inlays, the caret location is maintained as a scroll offset, rather than the number of lines from the
    * top of the screen. This means the line offset can change if the number of inlays above the caret changes during
@@ -668,7 +669,11 @@ public class EditorHelper {
       inlayOffset = -bottomInlayHeight;
     }
 
-    scrollVertically(editor, yVisualLine - caretScreenOffset - inlayOffset);
+    // Scroll the given visual line to the caret location, but do not scroll down passed the end of file, or the current
+    // virtual space at the bottom of the screen
+    final int lastVisualLine = EditorHelper.getVisualLineCount(editor) - 1;
+    final int yBottomLineOffset = max(getOffsetToScrollVisualLineToBottomOfScreen(editor, lastVisualLine), visibleArea.y);
+    scrollVertically(editor, min(yVisualLine - caretScreenOffset - inlayOffset, yBottomLineOffset));
   }
 
   /**

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageDownActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageDownActionTest.kt
@@ -58,9 +58,28 @@ class ScrollHalfPageDownActionTest : VimTestCase() {
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SCROLL)
-  fun`test scroll downwards in bottom half of last page moves to the last line`() {
+  fun`test scroll downwards in bottom half of last page moves caret to the last line without scrolling`() {
     configureByPages(5)
-    setPositionAndScroll(146, 165)
+    setPositionAndScroll(140, 165)
+    typeText(parseKeys("<C-D>"))
+    assertPosition(175, 0)
+    assertVisibleArea(141, 175)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.SCROLL)
+  fun`test scroll downwards in bottom half of last page moves caret to the last line with scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(140, 164)
+    typeText(parseKeys("<C-D>"))
+    assertPosition(175, 0)
+    assertVisibleArea(141, 175)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.SCROLL)
+  fun`test scroll downwards at end of file with existing virtual space moves caret without scrolling window`() {
+    configureByPages(5)
+    setPositionAndScroll(146, 165) // 146 at top line means bottom line is 181 (out of 175)
     typeText(parseKeys("<C-D>"))
     assertPosition(175, 0)
     assertVisibleArea(146, 175)

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageUpActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollHalfPageUpActionTest.kt
@@ -67,6 +67,16 @@ class ScrollHalfPageUpActionTest : VimTestCase() {
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SCROLL)
+  fun`test scroll upwards in first half of first page moves to first line with scrolloff`() {
+    OptionsManager.scrolloff.set(10)
+    configureByPages(5)
+    setPositionAndScroll(5, 15)
+    typeText(parseKeys("<C-U>"))
+    assertPosition(0, 0)
+    assertVisibleArea(0, 34)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.SCROLL)
   fun`test scroll count lines upwards`() {
     configureByPages(5)
     setPositionAndScroll(50, 53)


### PR DESCRIPTION
Fixes [VIM-2432](https://youtrack.jetbrains.com/issue/VIM-2432). `<C-U>` and `<C-D>` would not place the caret on the very first or very last line of the file when `'scrolloff'` was set. Also, `<C-D>` would introduce virtual space rather than keep the last line of the file at the bottom of the screen (unless virtual space was already there, in which case it wouldn't scroll at all).