### PR TITLE
Fix compile errors in unit tests on Windows

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,6 @@ publishToken=token
 publishChannels=eap
 
 slackUrl=
+
+# Gradle settings
+org.gradle.jvmargs='-Dfile.encoding=UTF-8'


### PR DESCRIPTION
JVM on Windows doesn't use UTF-8, so compilation of unit test sources with special characters fails on Windows:
```
assertIsKeyword('Ā');
// unclosed character literal
// unclosed character literal
// not a statement
```

Discussion: https://github.com/JetBrains/ideavim/discussions/389

Unfortunately I don't know how to fix the `doc` folder containing files with quotes, which are illegal on Windows. In case anyone finds this, all I can recommend is this command to remove the `doc` folder altogether, so that `git status` doesn't constantly complain about missing files:
```
git submodule deinit -f doc
```