### PR TITLE
Print stderr when running a command just like vim does

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/ProcessGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/ProcessGroup.java
@@ -249,7 +249,8 @@ public class ProcessGroup {
         VimPlugin.indicateError();
       }
 
-      return output.getStderr() + output.getStdout();
+      // Get stderr; stdout and strip colors, which are not handles properly.
+      return (output.getStderr() + output.getStdout()).replaceAll("\u001B\\[[;\\d]*m", "");
     }, "IdeaVim - !" + command, true, editor.getProject());
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/group/ProcessGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/ProcessGroup.java
@@ -247,10 +247,9 @@ public class ProcessGroup {
       if (exitCode != null && exitCode != 0) {
         VimPlugin.showMessage("shell returned " + exitCode);
         VimPlugin.indicateError();
-        return output.getStderr() + output.getStdout();
       }
 
-      return output.getStdout();
+      return output.getStderr() + output.getStdout();
     }, "IdeaVim - !" + command, true, editor.getProject());
   }
 


### PR DESCRIPTION
I noticed that whenever try to run a local command: ":! something" only stdout gets printed.

In `vim/nvim` both `stderr` and `stdout` get printed. We can fix this with this PR.

TODO:
- [x] Test that the stderr is printed
- [x] Test that colors are properly stripped from the output.