### PR TITLE
Add Matchit support for Vue.js files

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -194,7 +194,7 @@ private object MatchitPatterns {
 
   // Files that can contain HTML or HTML-like content.
   // These are just the file types that have HTML Matchit support enabled by default in their Vim ftplugin files.
-  private val htmlLikeFileTypes = arrayOf("HTML", "XML", "XHTML", "JSP", "JavaScript", "JSX Harmony", "TypeScript", "TypeScript JSX")
+  private val htmlLikeFileTypes = arrayOf("HTML", "XML", "XHTML", "JSP", "JavaScript", "JSX Harmony", "TypeScript", "TypeScript JSX", "Vue.js")
 
   private val htmlPatternsTable = createHtmlPatternsTable()
   private val rubyPatternsTable = createRubyPatternsTable()


### PR DESCRIPTION
Rebased the changes from #421 to master.

This feature adds support for single file Vue components which have its own .vue-extension and are a "mixture" of a HTML-Template, JavaScript- and CSS-code. (A bit similar to JSX-files...)
With this added "Vue.js" fileType they work now as expected.