### PR TITLE
Support custom element names in vim-surround

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
@@ -204,7 +204,7 @@ class VimSurroundExtension : VimExtension {
   companion object {
     private const val REGISTER = '"'
 
-    private val tagNameAndAttributesCapturePattern = "(\\w+)([^>]*)>".toPattern()
+    private val tagNameAndAttributesCapturePattern = "(\\S+)([^>]*)>".toPattern()
 
     private val SURROUND_PAIRS = mapOf(
       'b' to ("(" to ")"),

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
@@ -111,6 +111,13 @@ class VimSurroundExtensionTest : VimTestCase() {
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN)
+  fun testSurroundCustomElement() {
+    configureByText("${c}Click me!")
+    typeText(parseKeys("VS<custom-button>"))
+    assertState("<custom-button>Click me!</custom-button>")
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.PLUGIN)
   fun testSurroundFunctionName() {
     configureByText("foo = b${c}ar")
     typeText(parseKeys("ysiwfbaz"))


### PR DESCRIPTION
Hi there!

This PR adds support for custom elements (e.g. `<custom-element></custom-element>`) to the vim-surround extension. Let me know if I should change something.

Thanks a lot for creating this plugin. I like it a lot!