### PR TITLE
Add shortcut to ideajoin example

### DIFF
--- a/doc/ideajoin-examples.md
+++ b/doc/ideajoin-examples.md
@@ -1,6 +1,8 @@
 Some examples of join command with `ideajoin` option enabled.  
 Put `set ideajoin` to your `~/.ideavimrc` to enable this functionality.
 
+Now, you can press `shift+j` on a selected block of text to join the lines together.
+
 * Automatic join concatenated lines:
 
 ```

--- a/doc/ideajoin-examples.md
+++ b/doc/ideajoin-examples.md
@@ -1,7 +1,7 @@
 Some examples of join command with `ideajoin` option enabled.  
 Put `set ideajoin` to your `~/.ideavimrc` to enable this functionality.
 
-Now, you can press `shift+j` on a selected block of text to join the lines together.
+Now, you can press `J` (`shift+j`) on a line or a selected block of text to join the lines together.
 
 * Automatic join concatenated lines:
 


### PR DESCRIPTION
I didn't find which shortcut to use in order to activate `ideajoin`.

I checked the [source code](https://github.com/JetBrains/ideavim/blob/master/src/test/java/org/jetbrains/plugins/ideavim/action/change/delete/DeleteJoinLinesSpacesActionTest.kt) to find that is `shift+j`

This PR update the documentation with that information.

And thanks for this fantastic plugin, I use it for years and I cannot use any other IDEs given how good this plugin is ❤️ 