### PR TITLE
Implement UserDataHolder for EditorDataContext

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorDataContext.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorDataContext.kt
@@ -20,11 +20,13 @@ package com.maddyhome.idea.vim.helper
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.UserDataHolder
 
 class EditorDataContext @Deprecated("Please use `init` method") constructor(
   private val editor: Editor,
   private val contextDelegate: DataContext? = null,
-) : DataContext {
+) : DataContext, UserDataHolder {
   /**
    * Returns the object corresponding to the specified data identifier. Some of the supported data identifiers are
    * defined in the [PlatformDataKeys] class.
@@ -37,6 +39,20 @@ class EditorDataContext @Deprecated("Please use `init` method") constructor(
     PlatformDataKeys.PROJECT.name == dataId -> editor.project
     PlatformDataKeys.VIRTUAL_FILE.name == dataId -> EditorHelper.getVirtualFile(editor)
     else -> contextDelegate?.getData(dataId)
+  }
+
+  override fun <T : Any?> getUserData(key: Key<T>): T? {
+    return if (contextDelegate is UserDataHolder) {
+      contextDelegate.getUserData(key)
+    } else {
+      null
+    }
+  }
+
+  override fun <T : Any?> putUserData(key: Key<T>, value: T?) {
+    if (contextDelegate is UserDataHolder) {
+      contextDelegate.putUserData(key, value)
+    }
   }
 
   companion object {


### PR DESCRIPTION
This PR fixes Hannah-Sten/TeXiFy-IDEA#2230

### How to reproduce the issue
* In `build.gradle.kts`, add a dependency on plugin [TeXiFy-IDEA](https://github.com/Hannah-Sten/TeXiFy-IDEA): `nl.rubensten.texifyidea:0.7.14`
* `runIde`
* Go to Settings > Editor > Code Style, set `Hard wrap at` to 120 characters and enable `Wrap on typing`.
* Create a LaTeX file (`.tex`) and paste the following content:
```tex
\begin{itemize}
    \item This is the first item: pressing enter at the end of this line will insert an \verb|\item| on the next line.
    \item This line should hard-wrap to a next line without inserting an \verb|\item| in front of it, when typing here:
\end{itemize}
```
* Continue typing after `... when typing here:`
* Expected behaviour, and this is what happens when IdeaVim is not installed: the text is wrapped to the next line, no `\item` is inserted.
* Actual behaviour with IdeaVim installed: `\item` is inserted at the beginning of the next line.

### Issue description

* The [AutoHardWrapHandler:188](https://upsource.jetbrains.com/idea-ce/file/idea-ce-65a154986bab4efd090c38ce682166210d378878/platform/lang-impl/src/com/intellij/codeInsight/editorActions/AutoHardWrapHandler.java) saves data for a custom key to the data context. Without IdeaVim, the data context is an EdtDataContext, with IdeaVim the EditorDataContext which has as contextDelegate the EdtDataContext.
* TeXiFy implements a typed handler, which checks for this data key in order to determine whether an auto hard wrap is in progress.
* Without IdeaVim, TeXiFy can retrieve the data from the context. With IdeaVim, the data cannot be retrieved from the context (DataManager#loadFromDataContext) because the context is not a `UserDataHolder`.

### Issue fix

This PR fixes that last point, so that the IdeaVim data context now correctly delegates the user data.
I verified that it fixes the problem, but please check if this doesn't break something else.
