### PR TITLE
Add Matchit support for the C family of languages

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -228,6 +228,9 @@ private object FileTypePatterns {
       this.rubyPatterns
     } else if (fileTypeName == "RHTML" || fileExtension == "erb") {
       this.rubyAndHtmlPatterns
+    } else if (fileTypeName == "C++" || fileTypeName == "C#" || fileTypeName == "ObjectiveC" || fileExtension == "c") {
+      // "C++" also covers plain C.
+      this.cPatterns
     } else {
       return null
     }
@@ -240,6 +243,7 @@ private object FileTypePatterns {
   private val htmlPatterns = createHtmlPatterns()
   private val rubyPatterns = createRubyPatterns()
   private val rubyAndHtmlPatterns = rubyPatterns + htmlPatterns
+  private val cPatterns = createCPatterns()
 
   private fun createHtmlPatterns(): LanguagePatterns {
     // A tag name may contain any characters except slashes, whitespace, and angle brackets.
@@ -282,6 +286,11 @@ private object FileTypePatterns {
       LanguagePatterns(blockCommentStart, blockCommentEnd) +
       LanguagePatterns(openingKeywords, middleKeywords, endKeyword)
     )
+  }
+
+  private fun createCPatterns(): LanguagePatterns {
+    // Original patterns: https://github.com/vim/vim/blob/master/runtime/ftplugin/c.vim
+    return LanguagePatterns("#\\s*if(?:def|ndef)?\\b", "#\\s*(?:elif|else)\\b", "#\\s*endif\\b")
   }
 
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -220,6 +220,7 @@ private object FileTypePatterns {
     // fileType is only populated for files supported by the user's IDE + language plugins.
     // Checking the file's name or extension is a simple fallback which also makes unit testing easier.
     val fileTypeName = virtualFile?.fileType?.name
+    val fileName = virtualFile?.nameWithoutExtension
     val fileExtension = virtualFile?.extension
 
     return if (fileTypeName in htmlLikeFileTypes) {
@@ -231,6 +232,8 @@ private object FileTypePatterns {
     } else if (fileTypeName == "C++" || fileTypeName == "C#" || fileTypeName == "ObjectiveC" || fileExtension == "c") {
       // "C++" also covers plain C.
       this.cPatterns
+    } else if (fileTypeName == "Makefile" || fileName == "Makefile") {
+      this.gnuMakePatterns
     } else {
       return null
     }
@@ -244,6 +247,7 @@ private object FileTypePatterns {
   private val rubyPatterns = createRubyPatterns()
   private val rubyAndHtmlPatterns = rubyPatterns + htmlPatterns
   private val cPatterns = createCPatterns()
+  private val gnuMakePatterns = createGnuMakePatterns()
 
   private fun createHtmlPatterns(): LanguagePatterns {
     // A tag name may contain any characters except slashes, whitespace, and angle brackets.
@@ -291,6 +295,14 @@ private object FileTypePatterns {
   private fun createCPatterns(): LanguagePatterns {
     // Original patterns: https://github.com/vim/vim/blob/master/runtime/ftplugin/c.vim
     return LanguagePatterns("#\\s*if(?:def|ndef)?\\b", "#\\s*(?:elif|else)\\b", "#\\s*endif\\b")
+  }
+
+  private fun createGnuMakePatterns(): LanguagePatterns {
+    // Original patterns: https://github.com/vim/vim/blob/master/runtime/ftplugin/make.vim
+    return (
+      LanguagePatterns("\\bdefine\\b", "\\bendef\\b") +
+      LanguagePatterns("(?<!else )ifn?(?:eq|def)\\b", "\\belse(?:\\s+ifn?(?:eq|def))?\\b", "\\bendif\\b")
+    )
   }
 
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -234,6 +234,8 @@ private object FileTypePatterns {
       this.cPatterns
     } else if (fileTypeName == "Makefile" || fileName == "Makefile") {
       this.gnuMakePatterns
+    } else if (fileTypeName == "CMakeLists.txt" || fileName == "CMakeLists") {
+      this.cMakePatterns
     } else {
       return null
     }
@@ -248,6 +250,7 @@ private object FileTypePatterns {
   private val rubyAndHtmlPatterns = rubyPatterns + htmlPatterns
   private val cPatterns = createCPatterns()
   private val gnuMakePatterns = createGnuMakePatterns()
+  private val cMakePatterns = createCMakePatterns()
 
   private fun createHtmlPatterns(): LanguagePatterns {
     // A tag name may contain any characters except slashes, whitespace, and angle brackets.
@@ -302,6 +305,16 @@ private object FileTypePatterns {
     return (
       LanguagePatterns("\\bdefine\\b", "\\bendef\\b") +
       LanguagePatterns("(?<!else )ifn?(?:eq|def)\\b", "\\belse(?:\\s+ifn?(?:eq|def))?\\b", "\\bendif\\b")
+    )
+  }
+
+  private fun createCMakePatterns(): LanguagePatterns {
+    // Original patterns: https://github.com/vim/vim/blob/master/runtime/ftplugin/cmake.vim
+    return (
+      LanguagePatterns("\\bif\\b", "\\belse(?:if)?\\b", "\\bendif\\b") +
+      LanguagePatterns("\\b(?:foreach)|(?:while)\\b", "\\bbreak\\b", "\\b(?:endforeach)|(?:endwhile)\\b") +
+      LanguagePatterns("\\bmacro\\b", "\\bendmacro\\b") +
+      LanguagePatterns("\\bfunction\\b", "\\bendfunction\\b")
     )
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -198,7 +198,9 @@ private object MatchitPatterns {
 
   // Files that can contain HTML or HTML-like content.
   // These are just the file types that have HTML Matchit support enabled by default in their Vim ftplugin files.
-  private val htmlLikeFileTypes = arrayOf("Handlebars/Mustache", "HTML", "XML", "XHTML", "JSP", "JavaScript", "JSX Harmony", "TypeScript", "TypeScript JSX", "Vue.js")
+  private val htmlLikeFileTypes = setOf(
+    "HTML", "XML", "XHTML", "JSP", "JavaScript", "JSX Harmony", "TypeScript", "TypeScript JSX", "Vue.js", "Handlebars/Mustache"
+  )
 
   private val htmlPatternsTable = createHtmlPatternsTable()
   private val rubyPatternsTable = createRubyPatternsTable()
@@ -310,7 +312,7 @@ private object MatchitPatterns {
  */
 
 private fun getMatchitOffset(editor: Editor, caret: Caret, count: Int, isInOpPending: Boolean, reverse: Boolean): Int {
-  val defaultPairs = arrayOf('(', ')', '[', ']', '{', '}')
+  val defaultPairs = setOf('(', ')', '[', ']', '{', '}')
   val virtualFile = EditorHelper.getVirtualFile(editor)
   var caretOffset = caret.offset
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitCMakeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitCMakeTest.kt
@@ -1,0 +1,995 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2021 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.matchit
+
+import com.maddyhome.idea.vim.command.CommandState
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+class MatchitCMakeTest : VimTestCase() {
+  @Throws(Exception::class)
+  override fun setUp() {
+    super.setUp()
+    enableExtensions("matchit")
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from if to else`() {
+    doTest(
+      "%",
+      """
+        ${c}if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        else()
+          message("Non-linux system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        ${c}else()
+          message("Non-linux system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from else to endif`() {
+    doTest(
+      "%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        ${c}else()
+          message("Non-linux system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        else()
+          message("Non-linux system")
+        ${c}endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endif to if`() {
+    doTest(
+      "%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        else()
+          message("Non-linux system")
+        ${c}endif()
+      """.trimIndent(),
+      """
+        ${c}if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        else()
+          message("Non-linux system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from if to elseif in if-else structure`() {
+    doTest(
+      "%",
+      """
+        ${c}if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        ${c}elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from elseif to elseif`() {
+    doTest(
+      "%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        ${c}elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        ${c}elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from elseif to else`() {
+    doTest(
+      "%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        ${c}elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        ${c}else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from else to endif in if-else structure`() {
+    doTest(
+      "%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        ${c}else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        ${c}endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endif to if in if-else structure`() {
+    doTest(
+      "%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        ${c}endif()
+      """.trimIndent(),
+      """
+        ${c}if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from foreach to endforeach`() {
+    doTest(
+      "%",
+      """
+        ${c}foreach(X IN LISTS A B C)
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      """
+        foreach(X IN LISTS A B C)
+          message(STATUS "X=${"\${X}"}")
+        ${c}endforeach()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endforeach to foreach`() {
+    doTest(
+      "%",
+      """
+        foreach(X IN LISTS A B C)
+          message(STATUS "X=${"\${X}"}")
+        ${c}endforeach()
+      """.trimIndent(),
+      """
+        ${c}foreach(X IN LISTS A B C)
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from foreach to break`() {
+    doTest(
+      "%",
+      """
+        ${c}foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      """
+        foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            ${c}break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from break to endforeach`() {
+    doTest(
+      "%",
+      """
+        foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            ${c}break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      """
+        foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        ${c}endforeach()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from while to endwhile`() {
+    doTest(
+      "%",
+      """
+        ${c}while(${"\${index}"} LESS 10)
+          MATH(EXPR VAR "${"\${index}"}+1")
+        endwhile()
+      """.trimIndent(),
+      """
+        while(${"\${index}"} LESS 10)
+          MATH(EXPR VAR "${"\${index}"}+1")
+        ${c}endwhile()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endwhile to while`() {
+    doTest(
+      "%",
+      """
+        while(${"\${index}"} LESS 10)
+          MATH(EXPR VAR "${"\${index}"}+1")
+        ${c}endwhile()
+      """.trimIndent(),
+      """
+        ${c}while(${"\${index}"} LESS 10)
+          MATH(EXPR VAR "${"\${index}"}+1")
+        endwhile()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from while to break`() {
+    doTest(
+      "%",
+      """
+        ${c}while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            break
+          endif()
+        endwhile()
+      """.trimIndent(),
+      """
+        while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            ${c}break
+          endif()
+        endwhile()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from break to endwhile`() {
+    doTest(
+      "%",
+      """
+        while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            ${c}break
+          endif()
+        endwhile()
+      """.trimIndent(),
+      """
+        while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            break
+          endif()
+        ${c}endwhile()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from function to endfunction`() {
+    doTest(
+      "%",
+      """
+        ${c}function(foo)
+          bar(x y z)
+        endfunction()
+      """.trimIndent(),
+      """
+        function(foo)
+          bar(x y z)
+        ${c}endfunction()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endfunction to function`() {
+    doTest(
+      "%",
+      """
+        function(foo)
+          bar(x y z)
+        ${c}endfunction()
+      """.trimIndent(),
+      """
+        ${c}function(foo)
+          bar(x y z)
+        endfunction()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from macro to endmacro`() {
+    doTest(
+      "%",
+      """
+        ${c}macro(Foo arg)
+          message("arg = ${"\${arg}\""}")
+        endmacro()
+      """.trimIndent(),
+      """
+        macro(Foo arg)
+          message("arg = ${"\${arg}\""}")
+        ${c}endmacro()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endmacro to macro`() {
+    doTest(
+      "%",
+      """
+        macro(Foo arg)
+          message("arg = ${"\${arg}\""}")
+        ${c}endmacro()
+      """.trimIndent(),
+      """
+        ${c}macro(Foo arg)
+          message("arg = ${"\${arg}\""}")
+        endmacro()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  // Tests for reverse motion
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from if to endif`() {
+    doTest(
+      "g%",
+      """
+        ${c}if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        else()
+          message("Non-linux system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        else()
+          message("Non-linux system")
+        ${c}endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from else to if`() {
+    doTest(
+      "g%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        ${c}else()
+          message("Non-linux system")
+        endif()
+      """.trimIndent(),
+      """
+        ${c}if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        else()
+          message("Non-linux system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endif to else`() {
+    doTest(
+      "g%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        else()
+          message("Non-linux system")
+        ${c}endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        ${c}else()
+          message("Non-linux system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from if to endif in if-else block`() {
+    doTest(
+      "g%",
+      """
+        ${c}if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        ${c}endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from elseif to if`() {
+    doTest(
+      "g%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        ${c}elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      """
+        ${c}if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from elseif in else block to elseif`() {
+    doTest(
+      "g%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        ${c}elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        ${c}elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from else to elseif`() {
+    doTest(
+      "g%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        ${c}else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        ${c}elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endif to else in if-else block`() {
+    doTest(
+      "g%",
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        else()
+          message("Unknown system")
+        ${c}endif()
+      """.trimIndent(),
+      """
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+          message("Linux")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+          message("MacOS")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+          message("Windows")
+        ${c}else()
+          message("Unknown system")
+        endif()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from foreach to endforeach`() {
+    doTest(
+      "g%",
+      """
+        ${c}foreach(X IN LISTS A B C)
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      """
+        foreach(X IN LISTS A B C)
+          message(STATUS "X=${"\${X}"}")
+        ${c}endforeach()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endforeach to foreach`() {
+    doTest(
+      "g%",
+      """
+        foreach(X IN LISTS A B C)
+          message(STATUS "X=${"\${X}"}")
+        ${c}endforeach()
+      """.trimIndent(),
+      """
+        ${c}foreach(X IN LISTS A B C)
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from foreach to endforeach over a break`() {
+    doTest(
+      "g%",
+      """
+        ${c}foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      """
+        foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        ${c}endforeach()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endforeach to break`() {
+    doTest(
+      "g%",
+      """
+        foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        ${c}endforeach()
+      """.trimIndent(),
+      """
+        foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            ${c}break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from break to foreach`() {
+    doTest(
+      "g%",
+      """
+        foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            ${c}break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      """
+        ${c}foreach(X IN LISTS A B C)
+          if (X MATCHES "FOO")
+            break
+          endif()
+          message(STATUS "X=${"\${X}"}")
+        endforeach()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from while to endwhile`() {
+    doTest(
+      "g%",
+      """
+        ${c}while(${"\${index}"} LESS 10)
+          MATH(EXPR VAR "${"\${index}"}+1")
+        endwhile()
+      """.trimIndent(),
+      """
+        while(${"\${index}"} LESS 10)
+          MATH(EXPR VAR "${"\${index}"}+1")
+        ${c}endwhile()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endwhile to while`() {
+    doTest(
+      "g%",
+      """
+        while(${"\${index}"} LESS 10)
+          MATH(EXPR VAR "${"\${index}"}+1")
+        ${c}endwhile()
+      """.trimIndent(),
+      """
+        ${c}while(${"\${index}"} LESS 10)
+          MATH(EXPR VAR "${"\${index}"}+1")
+        endwhile()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from while to endwhile over a break`() {
+    doTest(
+      "g%",
+      """
+        ${c}while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            break
+          endif()
+        endwhile()
+      """.trimIndent(),
+      """
+        while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            break
+          endif()
+        ${c}endwhile()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endwhile to break`() {
+    doTest(
+      "g%",
+      """
+        while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            break
+          endif()
+        ${c}endwhile()
+      """.trimIndent(),
+      """
+        while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            ${c}break
+          endif()
+        endwhile()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from break to while`() {
+    doTest(
+      "g%",
+      """
+        while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            ${c}break
+          endif()
+        endwhile()
+      """.trimIndent(),
+      """
+        ${c}while (TRUE)
+          MATH(EXPR VAR "${"\${index}+1\""}")
+          if (${"\${index}"} EQUAL 5)
+            break
+          endif()
+        endwhile()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from function to endfunction`() {
+    doTest(
+      "g%",
+      """
+        ${c}function(foo)
+          bar(x y z)
+        endfunction()
+      """.trimIndent(),
+      """
+        function(foo)
+          bar(x y z)
+        ${c}endfunction()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endfunction to function`() {
+    doTest(
+      "g%",
+      """
+        function(foo)
+          bar(x y z)
+        ${c}endfunction()
+      """.trimIndent(),
+      """
+        ${c}function(foo)
+          bar(x y z)
+        endfunction()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from macro to endmacro`() {
+    doTest(
+      "g%",
+      """
+        ${c}macro(Foo arg)
+          message("arg = ${"\${arg}\""}")
+        endmacro()
+      """.trimIndent(),
+      """
+        macro(Foo arg)
+          message("arg = ${"\${arg}\""}")
+        ${c}endmacro()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endmacro to macro`() {
+    doTest(
+      "g%",
+      """
+        macro(Foo arg)
+          message("arg = ${"\${arg}\""}")
+        ${c}endmacro()
+      """.trimIndent(),
+      """
+        ${c}macro(Foo arg)
+          message("arg = ${"\${arg}\""}")
+        endmacro()
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "CMakeLists.txt"
+    )
+  }
+
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitCTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitCTest.kt
@@ -1,0 +1,637 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2021 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.matchit
+
+import com.maddyhome.idea.vim.command.CommandState
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+class MatchitCTest : VimTestCase() {
+  @Throws(Exception::class)
+  override fun setUp() {
+    super.setUp()
+    enableExtensions("matchit")
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #if to #endif`() {
+    doTest(
+      "%",
+      """
+        ${c}#if !defined (VAL_1)
+        #endif
+      """.trimIndent(),
+      """
+        #if !defined (VAL_1)
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from whitespace before #if to #endif`() {
+    doTest(
+      "%",
+      """
+        $c   #if !defined (VAL_1)
+        #endif
+      """.trimIndent(),
+      """
+           #if !defined (VAL_1)
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #if to #elif`() {
+    doTest(
+      "%",
+      """
+        ${c}#if !defined (VAL_1)
+          #define VAL_1 1
+        #elif !defined (VAL_2)
+          #define VAL_2 2
+      """.trimIndent(),
+      """
+        #if !defined (VAL_1)
+          #define VAL_1 1
+        ${c}#elif !defined (VAL_2)
+          #define VAL_2 2
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #if to #else`() {
+    doTest(
+      "%",
+      """
+        ${c}#if !defined (VAL_1)
+          #define VAL_1 1
+        #else
+          #define VAL_2 2
+      """.trimIndent(),
+      """
+        #if !defined (VAL_1)
+          #define VAL_1 1
+        ${c}#else
+          #define VAL_2 2
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #elif to #else`() {
+    doTest(
+      "%",
+      """
+        ${c}#elif !defined (VAL_2)
+        #else
+      """.trimIndent(),
+      """
+        #elif !defined (VAL_2)
+        ${c}#else
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from whitespace before #elif to #else`() {
+    doTest(
+      "%",
+      """
+        $c   #elif !defined (VAL_2)
+        #else
+      """.trimIndent(),
+      """
+           #elif !defined (VAL_2)
+        ${c}#else
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #else to #endif`() {
+    doTest(
+      "%",
+      """
+        ${c}#else
+        #endif
+      """.trimIndent(),
+      """
+        #else
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from whitespace before #else to #endif`() {
+    doTest(
+      "%",
+      """
+        $c   #else !defined (VAL_2)
+        #endif
+      """.trimIndent(),
+      """
+           #else !defined (VAL_2)
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #endif to #if`() {
+    doTest(
+      "%",
+      """
+        #if !defined (VAL_1)
+          #define VAL_1 1
+        #elif !defined (VAL_2)
+          #define VAL_2 2
+        #else
+          #define VAL_3 3
+        ${c}#endif
+      """.trimIndent(),
+      """
+        ${c}#if !defined (VAL_1)
+          #define VAL_1 1
+        #elif !defined (VAL_2)
+          #define VAL_2 2
+        #else
+          #define VAL_3 3
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #ifdef to #endif`() {
+    doTest(
+      "%",
+      """
+        ${c}#ifdef DEBUG
+        #endif
+      """.trimIndent(),
+      """
+        #ifdef DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #ifdef to #elif`() {
+    doTest(
+      "%",
+      """
+        ${c}#ifdef DEBUG
+        #elif PROD
+      """.trimIndent(),
+      """
+        #ifdef DEBUG
+        ${c}#elif PROD
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #ifdef to #else`() {
+    doTest(
+      "%",
+      """
+        ${c}#ifdef DEBUG
+        #else
+      """.trimIndent(),
+      """
+        #ifdef DEBUG
+        ${c}#else
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #endif to #ifdef`() {
+    doTest(
+      "%",
+      """
+        #ifdef DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      """
+        ${c}#ifdef DEBUG
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #ifndef to #endif`() {
+    doTest(
+      "%",
+      """
+        ${c}#ifndef DEBUG
+        #endif
+      """.trimIndent(),
+      """
+        #ifndef DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #ifndef to #elif`() {
+    doTest(
+      "%",
+      """
+        ${c}#ifndef DEBUG
+        #elif PROD
+      """.trimIndent(),
+      """
+        #ifndef DEBUG
+        ${c}#elif PROD
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #ifndef to #else`() {
+    doTest(
+      "%",
+      """
+        ${c}#ifndef DEBUG
+        #else
+      """.trimIndent(),
+      """
+        #ifndef DEBUG
+        ${c}#else
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #endif to #ifndef`() {
+    doTest(
+      "%",
+      """
+        #ifndef DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      """
+        ${c}#ifndef DEBUG
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test don't jump from malformed #if`() {
+    doTest(
+      "%",
+      """
+        ${c}#ifff DEBUG
+        #endif
+      """.trimIndent(),
+      """
+        ${c}#ifff DEBUG
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from #if with whitespace to #endif`() {
+    doTest(
+      "%",
+      """
+        # $c if DEBUG
+        #endif
+      """.trimIndent(),
+      """
+        #  if DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from nested #if to #endif`() {
+    doTest(
+      "%",
+      """
+        #ifdef CONDITION1
+        #  ${c}ifdef CONDITION2
+        #  endif
+        #endif
+      """.trimIndent(),
+      """
+        #ifdef CONDITION1
+        #  ifdef CONDITION2
+        ${c}#  endif
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  /*
+   * Tests for reverse g% motion
+   */
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #if to #endif`() {
+    doTest(
+      "g%",
+      """
+        ${c}#if !defined (VAL_1)
+        #endif
+      """.trimIndent(),
+      """
+        #if !defined (VAL_1)
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from whitespace before #if to #endif`() {
+    doTest(
+      "g%",
+      """
+        $c   #if !defined (VAL_1)
+        #endif
+      """.trimIndent(),
+      """
+           #if !defined (VAL_1)
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #endif to #if with whitespace`() {
+    doTest(
+      "g%",
+      """
+        #  if DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      """
+        ${c}#  if DEBUG
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #endif to #else`() {
+    doTest(
+      "g%",
+      """
+        #else
+          #define VAL_3 3
+        ${c}#endif
+      """.trimIndent(),
+      """
+        ${c}#else
+          #define VAL_3 3
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #else to #elif`() {
+    doTest(
+      "g%",
+      """
+        #elif !defined (VAL_2)
+          #define VAL_2 2
+        ${c}#else
+          #define VAL_3 3
+        #endif
+      """.trimIndent(),
+      """
+        ${c}#elif !defined (VAL_2)
+          #define VAL_2 2
+        #else
+          #define VAL_3 3
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from whitespace before #else to #elif`() {
+    doTest(
+      "g%",
+      """
+        #elif !defined (VAL_2)
+            #define VAL_2 2
+        $c  #else
+            #define VAL_3 3
+        #endif
+      """.trimIndent(),
+      """
+        ${c}#elif !defined (VAL_2)
+            #define VAL_2 2
+          #else
+            #define VAL_3 3
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #elif to #if`() {
+    doTest(
+      "g%",
+      """
+        #if !defined (VAL_1)
+          #define VAL_1 1
+        ${c}#elif !defined (VAL_2)
+          #define VAL_2 2
+      """.trimIndent(),
+      """
+        ${c}#if !defined (VAL_1)
+          #define VAL_1 1
+        #elif !defined (VAL_2)
+          #define VAL_2 2
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #ifdef to #endif`() {
+    doTest(
+      "g%",
+      """
+        ${c}#ifdef DEBUG
+        #endif
+      """.trimIndent(),
+      """
+        #ifdef DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #endif to #ifdef`() {
+    doTest(
+      "g%",
+      """
+        #ifdef DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      """
+        ${c}#ifdef DEBUG
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #else to #ifdef`() {
+    doTest(
+      "g%",
+      """
+        #ifdef DEBUG
+        ${c}#else
+      """.trimIndent(),
+      """
+        ${c}#ifdef DEBUG
+        #else
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #elif to #ifdef`() {
+    doTest(
+      "g%",
+      """
+        #ifdef DEBUG
+        ${c}#elif PROD
+      """.trimIndent(),
+      """
+        ${c}#ifdef DEBUG
+        #elif PROD
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #ifndef to #endif`() {
+    doTest(
+      "g%",
+      """
+        ${c}#ifndef DEBUG
+        #endif
+      """.trimIndent(),
+      """
+        #ifndef DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #endif to #ifndef`() {
+    doTest(
+      "g%",
+      """
+        #ifndef DEBUG
+        ${c}#endif
+      """.trimIndent(),
+      """
+        ${c}#ifndef DEBUG
+        #endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #elif to #ifndef`() {
+    doTest(
+      "g%",
+      """
+        #ifndef DEBUG
+        ${c}#elif PROD
+      """.trimIndent(),
+      """
+        ${c}#ifndef DEBUG
+        #elif PROD
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from #else to #ifndef`() {
+    doTest(
+      "g%",
+      """
+        #ifndef DEBUG
+        ${c}#else
+      """.trimIndent(),
+      """
+        ${c}#ifndef DEBUG
+        #else
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "main.c"
+    )
+  }
+
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGNUMakeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGNUMakeTest.kt
@@ -1,0 +1,959 @@
+/*
+ * IdeaVim - Vim emulator for IDEs based on the IntelliJ platform
+ * Copyright (C) 2003-2021 The IdeaVim authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.matchit
+
+import com.maddyhome.idea.vim.command.CommandState
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+
+class MatchitGNUMakeTest : VimTestCase() {
+  @Throws(Exception::class)
+  override fun setUp() {
+    super.setUp()
+    enableExtensions("matchit")
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from define to endef`() {
+    doTest(
+      "%",
+      """
+        ${c}define VAR
+          first line
+          second line
+        endef
+      """.trimIndent(),
+      """
+        define VAR
+          first line
+          second line
+        ${c}endef
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endef to define`() {
+    doTest(
+      "%",
+      """
+        define VAR
+          first line
+          second line
+        ${c}endef
+      """.trimIndent(),
+      """
+        ${c}define VAR
+          first line
+          second line
+        endef
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ifdef to endif`() {
+    doTest(
+      "%",
+      """
+        ${c}ifdef var
+          $(info defined)
+        endif
+      """.trimIndent(),
+      """
+        ifdef var
+          $(info defined)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endif to ifdef`() {
+    doTest(
+      "%",
+      """
+        ifdef var
+          $(info defined)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifdef var
+          $(info defined)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ifndef to endif`() {
+    doTest(
+      "%",
+      """
+        ${c}ifndef VAR
+          $(info not defined)
+        endif
+      """.trimIndent(),
+      """
+        ifndef VAR
+          $(info not defined)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endif to ifndef`() {
+    doTest(
+      "%",
+      """
+        ifndef VAR
+          $(info not defined)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifndef VAR
+          $(info not defined)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ifeq to endif`() {
+    doTest(
+      "%",
+      """
+        ${c}ifeq (, $(var))
+          $(info empty)
+        endif
+      """.trimIndent(),
+      """
+        ifeq (, $(var))
+          $(info empty)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endif to ifeq`() {
+    doTest(
+      "%",
+      """
+        ifeq (, $(var))
+          $(info empty)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifeq (, $(var))
+          $(info empty)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ifneq to endif`() {
+    doTest(
+      "%",
+      """
+        ${c}ifneq (, $(var))
+          $(info not empty)
+        endif
+      """.trimIndent(),
+      """
+        ifneq (, $(var))
+          $(info not empty)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endif to ifneq`() {
+    doTest(
+      "%",
+      """
+        ifneq (, $(var))
+          $(info not empty)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifneq (, $(var))
+          $(info not empty)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ifneq to else`() {
+    doTest(
+      "%",
+      """
+        ifneq (, $(var))
+          $(info not empty)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifneq (, $(var))
+          $(info not empty)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ifeq to else in ifeq-else block`() {
+    doTest(
+      "%",
+      """
+        ${c}ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        ${c}else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from else ifeq to else`() {
+    doTest(
+      "%",
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        ${c}else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        ${c}else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ifeq in else block to else`() {
+    doTest(
+      "%",
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ${c}ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        ${c}else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from else to endif in ifeq-else block`() {
+    doTest(
+      "%",
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        ${c}else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endif to ifeq in ifeq-else block`() {
+    doTest(
+      "%",
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ifneq to else in ifneq-else block`() {
+    doTest(
+      "%",
+      """
+        ${c}ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        ${c}else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from else ifneq to else`() {
+    doTest(
+      "%",
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        ${c}else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        ${c}else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from ifneq in else block to else`() {
+    doTest(
+      "%",
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ${c}ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        ${c}else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from else to endif in ifneq-else block`() {
+    doTest(
+      "%",
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        ${c}else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from endif to ifneq in ifneq-else block`() {
+    doTest(
+      "%",
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  // Reverse tests
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from define to endef`() {
+    doTest(
+      "g%",
+      """
+        ${c}define VAR
+          first line
+          second line
+        endef
+      """.trimIndent(),
+      """
+        define VAR
+          first line
+          second line
+        ${c}endef
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endef to define`() {
+    doTest(
+      "g%",
+      """
+        define VAR
+          first line
+          second line
+        ${c}endef
+      """.trimIndent(),
+      """
+        ${c}define VAR
+          first line
+          second line
+        endef
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ifdef to endif`() {
+    doTest(
+      "g%",
+      """
+        ${c}ifdef var
+          $(info defined)
+        endif
+      """.trimIndent(),
+      """
+        ifdef var
+          $(info defined)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endif to ifdef`() {
+    doTest(
+      "g%",
+      """
+        ifdef var
+          $(info defined)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifdef var
+          $(info defined)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ifndef to endif`() {
+    doTest(
+      "g%",
+      """
+        ${c}ifndef VAR
+          $(info not defined)
+        endif
+      """.trimIndent(),
+      """
+        ifndef VAR
+          $(info not defined)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endif to ifndef`() {
+    doTest(
+      "g%",
+      """
+        ifndef VAR
+          $(info not defined)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifndef VAR
+          $(info not defined)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ifeq to endif`() {
+    doTest(
+      "g%",
+      """
+        ${c}ifeq (, $(var))
+          $(info empty)
+        endif
+      """.trimIndent(),
+      """
+        ifeq (, $(var))
+          $(info empty)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endif to ifeq`() {
+    doTest(
+      "g%",
+      """
+        ifeq (, $(var))
+          $(info empty)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifeq (, $(var))
+          $(info empty)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ifneq to endif`() {
+    doTest(
+      "g%",
+      """
+        ${c}ifneq (, $(var))
+          $(info not empty)
+        endif
+      """.trimIndent(),
+      """
+        ifneq (, $(var))
+          $(info not empty)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endif to ifneq`() {
+    doTest(
+      "g%",
+      """
+        ifneq (, $(var))
+          $(info not empty)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ${c}ifneq (, $(var))
+          $(info not empty)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ifneq to else`() {
+    doTest(
+      "g%",
+      """
+        ifneq (, $(var))
+          $(info not empty)
+        ${c}else
+      """.trimIndent(),
+      """
+        ${c}ifneq (, $(var))
+          $(info not empty)
+        else
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ifeq to endif in ifeq-else block`() {
+    doTest(
+      "g%",
+      """
+        ${c}ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from else ifeq to ifeq`() {
+    doTest(
+      "g%",
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        ${c}else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ${c}ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ifeq in else block to ifeq`() {
+    doTest(
+      "g%",
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ${c}ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ${c}ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from else to else in ifeq-else block`() {
+    doTest(
+      "g%",
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        ${c}else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        ${c}else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endif to else in ifeq-else block`() {
+    doTest(
+      "g%",
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        else
+          $(info not x86 based)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ifeq ($(TARGET),x86)
+          $(info x86)
+        else ifeq ($(TARGET),x86_64)
+          $(info x86_64)
+        ${c}else
+          $(info not x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ifneq to endif in ifneq-else block`() {
+    doTest(
+      "g%",
+      """
+        ${c}ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        ${c}endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from else ifneq to ifneq`() {
+    doTest(
+      "g%",
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        ${c}else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ${c}ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from ifneq in else block to ifneq`() {
+    doTest(
+      "g%",
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ${c}ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ${c}ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from else to else in ifneq-else block`() {
+    doTest(
+      "g%",
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        ${c}else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        ${c}else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from endif to else in ifneq-else block`() {
+    doTest(
+      "g%",
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        else
+          $(info x86 based)
+        ${c}endif
+      """.trimIndent(),
+      """
+        ifneq ($(TARGET),x86)
+          $(info not x86)
+        else ifneq ($(TARGET),x86_64)
+          $(info not x86_64)
+        ${c}else
+          $(info x86 based)
+        endif
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "Makefile"
+    )
+  }
+
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGeneralTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGeneralTest.kt
@@ -258,6 +258,30 @@ class MatchitGeneralTest : VimTestCase() {
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test delete from else to elsif with reverse motion`() {
+    doTest(
+      "dg%",
+      """
+        if x == 0
+          puts "Zero"
+        elsif x < -1
+          puts "Negative"
+        ${c}else
+          puts "Positive"
+        end
+      """.trimIndent(),
+      """
+        if x == 0
+          puts "Zero"
+        ${c}lse
+          puts "Positive"
+        end
+      """.trimIndent(),
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
   fun `test delete from opening to closing div`() {
     doTest(
       "d%",

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitRubyTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitRubyTest.kt
@@ -639,6 +639,17 @@ class MatchitRubyTest : VimTestCase() {
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test jump from one line condition to if`() {
+    doTest(
+      "%",
+      """if tr${c}ue puts "true" end""",
+      """${c}if true puts "true" end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
+
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
   fun `test jump from end to unless after a semicolon`() {
     doTest(
       "%",
@@ -1204,12 +1215,12 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """
         $c=begin
-          Multiline comment
+          end comment
         =end
       """.trimIndent(),
       """
         =begin
-          Multiline comment
+          end comment
         =${c}end
       """.trimIndent(),
       CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
@@ -1222,12 +1233,12 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """
         =begin
-          Multiline comment
+          begin comment
         $c=end
       """.trimIndent(),
       """
         =${c}begin
-          Multiline comment
+          begin comment
         =end
       """.trimIndent(),
       CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
@@ -1853,6 +1864,16 @@ class MatchitRubyTest : VimTestCase() {
       CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
     )
   }
+  
+  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
+  fun `test reverse jump from one line condition to if`() {
+    doTest(
+      "g%",
+      """if tr${c}ue puts "true" end""",
+      """${c}if true puts "true" end""",
+      CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
+    )
+  }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
   fun `test reverse jump from do to end`() {
@@ -2434,12 +2455,12 @@ class MatchitRubyTest : VimTestCase() {
       "g%",
       """
         $c=begin
-          Multiline comment
+          end comment
         =end
       """.trimIndent(),
       """
         =begin
-          Multiline comment
+          end comment
         =${c}end
       """.trimIndent(),
       CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"
@@ -2452,12 +2473,12 @@ class MatchitRubyTest : VimTestCase() {
       "g%",
       """
         =begin
-          Multiline comment
+          begin comment
         $c=end
       """.trimIndent(),
       """
         =${c}begin
-          Multiline comment
+          begin comment
         =end
       """.trimIndent(),
       CommandState.Mode.COMMAND, CommandState.SubMode.NONE, "ruby.rb"


### PR DESCRIPTION
Following up on https://github.com/JetBrains/ideavim/pull/343, this PR adds Matchit support for the C family of languages. The plugin now supports jumps on C-style preprocessor directives (found in C, C++, C#, ObjC), Makefiles, and CMake files.

I also refactored the code to be simpler and to make language configuration easier. Sorry for the large diff though! The changes are split into distinct commits with more detailed notes in the commit messages.
To sum up, I:
- Simplified the search code in `findClosingPair()` and `findOpeningPair()`
- Refactored `parsePatternAtOffset()` to return both the pattern start and end offsets
  - This is was necessary to support the `else if` conditional in Makefiles
- Created the `LanguagePatterns` class to make language configuration easy
  - The new languages in this PR were configured just by calling that class's constructor

Thank you in advance for your time.