### PR TITLE
Minor bug fixes

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -740,7 +740,7 @@ public class MotionGroup extends VimMotionGroupBase {
     final boolean allowSidescroll = !flags.contains(CommandFlags.FLAG_IGNORE_SIDE_SCROLL_JUMP);
     int sidescroll = ((VimInt) VimPlugin.getOptionService().getOptionValue(new OptionScope.LOCAL(new IjVimEditor(editor)), OptionConstants.sidescrollName, OptionConstants.sidescrollName)).getValue();
 
-    final int offsetLeft = caretColumn - currentVisualLeftColumn - scrollOffset;
+    final int offsetLeft = caretColumn - (currentVisualLeftColumn + scrollOffset);
     final int offsetRight = caretColumn - (currentVisualRightColumn - scrollOffset);
     if (offsetLeft < 0 || offsetRight > 0) {
       int diff = offsetLeft < 0 ? -offsetLeft : offsetRight;

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -807,7 +807,7 @@ public class EditorHelper {
     // of columns. It also works with inline inlays and folds. It is slightly inaccurate for proportional fonts, but is
     // still a good solution. Besides, what kind of monster uses Vim with proportional fonts?
     final int standardColumnWidth = EditorUtil.getPlainSpaceWidth(editor);
-    final int x = point.x - (screenWidth / standardColumnWidth / 2 * standardColumnWidth);
+    final int x = max(0, point.x - (screenWidth / standardColumnWidth / 2 * standardColumnWidth));
     scrollHorizontally(editor, x);
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/services/OptionServiceImpl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/services/OptionServiceImpl.kt
@@ -159,10 +159,11 @@ internal class OptionServiceImpl : OptionService {
       override fun getDefaultValue(): VimString {
         val shell = (getGlobalOptionValue(OptionConstants.shellName) as VimString).value
         return VimString(
-          if (SystemInfo.isWindows && !shell.contains("sh"))
-            "/c"
-          else
-            "-c"
+          when {
+              SystemInfo.isWindows && shell.contains("powershell") -> "-Command"
+              SystemInfo.isWindows && !shell.contains("sh") -> "/c"
+              else -> "-c"
+          }
         )
       }
     },


### PR DESCRIPTION
This PR fixes a couple of tiny bugs:

- [x] [VIM-2622](https://youtrack.jetbrains.com/issue/VIM-2622) If `'shell'` contains `powershell` on Windows, then `'shellcmdflags'` will default to `-Command`
- [x] Fix incorrect animation when scrolling one line, e.g. with `j`. If the caret was inside `'sidescrolloff'` columns of the left of the screen, then IdeaVim would try to put the caret column in the middle of the screen, asking the scrolling system to scroll to a negative horizontal offset. This was capped at 0, but the animation system would include the negative value in its calculation of distance scrolled. This puts the distance over a threshold and the scroll is animated. If the caret is in any column greater than `'sidescrolloff'` then it is not animated.