### PR TITLE
Improve handling of fractional width fonts

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -34,7 +34,6 @@ import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.VisualPosition
 import com.intellij.openapi.editor.colors.EditorColors
 import com.intellij.openapi.editor.ex.EditorEx
-import com.intellij.openapi.editor.ex.util.EditorUtil
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.PlainTextFileType
@@ -82,6 +81,7 @@ import org.junit.Assert
 import java.awt.event.KeyEvent
 import java.util.*
 import javax.swing.KeyStroke
+import kotlin.math.roundToInt
 
 /**
  * @author vlan
@@ -169,7 +169,9 @@ abstract class VimTestCase : UsefulTestCase() {
     get() = 35
 
   protected fun setEditorVisibleSize(width: Int, height: Int) {
-    EditorTestUtil.setEditorVisibleSize(myFixture.editor, width, height)
+    val w = (width * EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)).roundToInt()
+    val h = height * myFixture.editor.lineHeight
+    EditorTestUtil.setEditorVisibleSizeInPixels(myFixture.editor, w, h)
   }
 
   protected fun setEditorVirtualSpace() {
@@ -609,7 +611,7 @@ abstract class VimTestCase : UsefulTestCase() {
   // per platform (e.g. Windows is 7, Mac is 8) so we can't guarantee correct positioning for tests if we use hard coded
   // pixel widths
   protected fun addInlay(offset: Int, relatesToPrecedingText: Boolean, widthInColumns: Int): Inlay<*> {
-    val widthInPixels = EditorUtil.getPlainSpaceWidth(myFixture.editor) * widthInColumns
+    val widthInPixels = (EditorHelper.getPlainSpaceWidthFloat(myFixture.editor) * widthInColumns).roundToInt()
     return EditorTestUtil.addInlay(myFixture.editor, offset, relatesToPrecedingText, widthInPixels)
   }
 
@@ -619,7 +621,7 @@ abstract class VimTestCase : UsefulTestCase() {
   // float if necessary. We'd still be working scaled to the line height, so fractional values should still work.
   protected fun addBlockInlay(offset: Int, showAbove: Boolean, heightInRows: Int): Inlay<*> {
     val widthInColumns = 10 // Arbitrary width. We don't care.
-    val widthInPixels = EditorUtil.getPlainSpaceWidth(myFixture.editor) * widthInColumns
+    val widthInPixels = (EditorHelper.getPlainSpaceWidthFloat(myFixture.editor) * widthInColumns).roundToInt()
     val heightInPixels = myFixture.editor.lineHeight * heightInRows
     return EditorTestUtil.addBlockInlay(myFixture.editor, offset, false, showAbove, widthInPixels, heightInPixels)
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollFirstScreenColumnActionTest.kt
@@ -19,15 +19,16 @@
 package org.jetbrains.plugins.ideavim.action.scroll
 
 import com.intellij.openapi.editor.Inlay
-import com.intellij.openapi.editor.ex.util.EditorUtil
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.options.OptionConstants
 import com.maddyhome.idea.vim.options.OptionScope
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.Assert
+import kotlin.math.roundToInt
 
 /*
                                                        *zs*
@@ -77,7 +78,7 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
     typeText(injector.parser.parseKeys("100|" + "zs"))
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
     val textWidth = visibleArea.width - inlay.widthInPixels
-    val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+    val availableColumns = (textWidth / EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)).roundToInt()
 
     // The first visible text column will be 99, with the inlay positioned to the left of it
     assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
@@ -112,6 +113,6 @@ class ScrollFirstScreenColumnActionTest : VimTestCase() {
 
   private fun getAvailableColumns(inlay: Inlay<*>): Int {
     val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
-    return textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+    return (textWidth / EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)).roundToInt()
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollLastScreenColumnActionTest.kt
@@ -19,14 +19,15 @@
 package org.jetbrains.plugins.ideavim.action.scroll
 
 import com.intellij.openapi.editor.Inlay
-import com.intellij.openapi.editor.ex.util.EditorUtil
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.options.OptionConstants
 import com.maddyhome.idea.vim.options.OptionScope
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.Assert
+import kotlin.math.roundToInt
 
 /*
                                                        *ze*
@@ -109,14 +110,15 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
     typeText(injector.parser.parseKeys("100|" + "ze"))
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
     val textWidth = visibleArea.width - inlay.widthInPixels
-    val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+    val availableColumns = (textWidth / EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)).roundToInt()
 
     // The last visible text column will be 99, but it will be positioned before the inlay
     assertVisibleLineBounds(0, 99 - availableColumns + 1, 99)
 
     // We have to assert the location of the inlay
-    Assert.assertEquals(visibleArea.x + textWidth, inlay.bounds!!.x)
-    Assert.assertEquals(visibleArea.x + visibleArea.width, inlay.bounds!!.x + inlay.bounds!!.width)
+    val inlayX = myFixture.editor.visualPositionToPoint2D(inlay.visualPosition).x.roundToInt()
+    Assert.assertEquals(visibleArea.x + textWidth, inlayX)
+    Assert.assertEquals(visibleArea.x + visibleArea.width, inlayX + inlay.widthInPixels)
   }
 
   fun `test last screen column does not include subsequent inline inlay associated with following text`() {
@@ -130,6 +132,6 @@ class ScrollLastScreenColumnActionTest : VimTestCase() {
 
   private fun getAvailableColumns(inlay: Inlay<*>): Int {
     val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
-    return textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+    return (textWidth / EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)).roundToInt()
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewHorizontally_Test.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/group/motion/MotionGroup_ScrollCaretIntoViewHorizontally_Test.kt
@@ -18,15 +18,16 @@
 
 package org.jetbrains.plugins.ideavim.group.motion
 
-import com.intellij.openapi.editor.ex.util.EditorUtil
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.options.OptionConstants
 import com.maddyhome.idea.vim.options.OptionScope
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
+import kotlin.math.roundToInt
 
 @Suppress("ClassName")
 class MotionGroup_ScrollCaretIntoViewHorizontally_Test : VimTestCase() {
@@ -110,7 +111,7 @@ class MotionGroup_ScrollCaretIntoViewHorizontally_Test : VimTestCase() {
     // These columns are hard to calculate, because the visible offset depends on the rendered width of the inlay
     // Also, because we're scrolling right (adding columns to the right) we make the right most column line up
     val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
-    val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+    val availableColumns = (textWidth / EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)).roundToInt()
     assertVisibleLineBounds(0, 119 - availableColumns + 1, 119)
   }
 
@@ -185,7 +186,7 @@ class MotionGroup_ScrollCaretIntoViewHorizontally_Test : VimTestCase() {
     typeText(injector.parser.parseKeys("120|zs" + "20h"))
     // These columns are hard to calculate, because the visible offset depends on the rendered width of the inlay
     val textWidth = myFixture.editor.scrollingModel.visibleArea.width - inlay.widthInPixels
-    val availableColumns = textWidth / EditorUtil.getPlainSpaceWidth(myFixture.editor)
+    val availableColumns = (textWidth / EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)).roundToInt()
     assertVisibleLineBounds(0, 99, 99 + availableColumns - 1)
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/helper/EditorHelperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/helper/EditorHelperTest.kt
@@ -23,6 +23,7 @@ import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.Assert
+import kotlin.math.roundToInt
 
 class EditorHelperTest : VimTestCase() {
   @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
@@ -30,8 +31,8 @@ class EditorHelperTest : VimTestCase() {
     configureByColumns(100)
     EditorHelper.scrollColumnToLeftOfScreen(myFixture.editor, 0, 2)
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
-    val columnWidth = visibleArea.width / screenWidth
-    Assert.assertEquals(2 * columnWidth, visibleArea.x)
+    val columnWidth = EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)
+    Assert.assertEquals((2 * columnWidth).roundToInt(), visibleArea.x)
   }
 
   @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
@@ -40,8 +41,8 @@ class EditorHelperTest : VimTestCase() {
     val column = screenWidth + 2
     EditorHelper.scrollColumnToRightOfScreen(myFixture.editor, 0, column)
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
-    val columnWidth = visibleArea.width / screenWidth
-    Assert.assertEquals((column - screenWidth + 1) * columnWidth, visibleArea.x)
+    val columnWidth = EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)
+    Assert.assertEquals(((column - screenWidth + 1) * columnWidth).roundToInt(), visibleArea.x)
   }
 
   @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
@@ -52,8 +53,8 @@ class EditorHelperTest : VimTestCase() {
     // Put column 100 into position 41 -> offset is 59 columns
     EditorHelper.scrollColumnToMiddleOfScreen(myFixture.editor, 0, 99)
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
-    val columnWidth = visibleArea.width / screenWidth
-    Assert.assertEquals(59 * columnWidth, visibleArea.x)
+    val columnWidth = EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)
+    Assert.assertEquals((59 * columnWidth).roundToInt(), visibleArea.x)
   }
 
   @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
@@ -65,7 +66,7 @@ class EditorHelperTest : VimTestCase() {
     // Put column 100 into position 41 -> offset is 59 columns
     EditorHelper.scrollColumnToMiddleOfScreen(myFixture.editor, 0, 99)
     val visibleArea = myFixture.editor.scrollingModel.visibleArea
-    val columnWidth = visibleArea.width / screenWidth
-    Assert.assertEquals(59 * columnWidth, visibleArea.x)
+    val columnWidth = EditorHelper.getPlainSpaceWidthFloat(myFixture.editor)
+    Assert.assertEquals((59 * columnWidth).roundToInt(), visibleArea.x)
   }
 }


### PR DESCRIPTION
The default font for the `corretto-11` JDK (at least on my Mac) is Menlo 12 point. This results in nice 8 pixel character widths and integer maths. If `jbr-11` is used, the font is JetBrains Mono 13 point, which has characters that are 7.8 pixels wide (I don't know why a larger font has a smaller pixel side, but that's not really the problem here). 

Most APIs to work with editor positions uses integers, which can cause rounding errors. I don't think this caused any obvious issues in production - possibly some minor off-by-one (or two) errors in column positioning, but it does cause issues with tests, where we need reproducibility.

This PR updates `EditorHelper` to overcome rounding errors in scrolling, and updates tests to correctly calculate expected offsets. Tests now run on both `corretto-11` and `jbr-11`.