### PR TITLE
Consolidate doTest methods

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/RegisterActionsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/RegisterActionsTest.kt
@@ -20,7 +20,6 @@ package org.jetbrains.plugins.ideavim
 
 import com.maddyhome.idea.vim.RegisterActions.VIM_ACTIONS_EP
 import com.maddyhome.idea.vim.VimPlugin
-import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.MappingMode
 import com.maddyhome.idea.vim.command.VimStateMachine
 import com.maddyhome.idea.vim.handler.ActionBeanClass
@@ -42,10 +41,9 @@ class RegisterActionsTest : VimTestCase() {
       setupChecks {
         caretShape = false
       }
-      val keys = injector.parser.parseKeys("jklwB") // just random keys
       val before = "I ${c}found it in a legendary land"
       val after = "I jklwB${c}found it in a legendary land"
-      doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+      doTest("jklwB", before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
         VimPlugin.setEnabled(false)
       }
     } finally {
@@ -55,10 +53,9 @@ class RegisterActionsTest : VimTestCase() {
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
   fun `test turn plugin off and on`() {
-    val keys = injector.parser.parseKeys("l")
     val before = "I ${c}found it in a legendary land"
     val after = "I f${c}ound it in a legendary land"
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+    doTest("l", before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
       VimPlugin.setEnabled(false)
       VimPlugin.setEnabled(true)
     }
@@ -66,10 +63,9 @@ class RegisterActionsTest : VimTestCase() {
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
   fun `test enable twice`() {
-    val keys = injector.parser.parseKeys("l")
     val before = "I ${c}found it in a legendary land"
     val after = "I f${c}ound it in a legendary land"
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+    doTest("l", before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
       VimPlugin.setEnabled(false)
       VimPlugin.setEnabled(true)
       VimPlugin.setEnabled(true)
@@ -78,11 +74,10 @@ class RegisterActionsTest : VimTestCase() {
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
   fun `test unregister extension`() {
-    val keys = injector.parser.parseKeys("l")
     val before = "I ${c}found it in a legendary land"
     val after = "I f${c}ound it in a legendary land"
     var motionRightAction: ActionBeanClass? = null
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+    doTest("l", before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
       motionRightAction = VIM_ACTIONS_EP.extensions().filter { it.actionId == "VimPreviousTabAction" }.findFirst().get()
 
       assertNotNull(getCommandNode())

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertNewLineBelowActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertNewLineBelowActionTest.kt
@@ -190,6 +190,7 @@ class InsertNewLineBelowActionTest : VimTestCase() {
     performTest("o", after, VimStateMachine.Mode.INSERT, VimStateMachine.SubMode.NONE)
   }
 
+  @TestWithoutNeovim(reason = SkipNeovimReason.FOLDING, "Neovim doesn't support arbitrary folds")
   fun `test insert new line below with folds 2`() {
     val before = """I found it in a legendary land
         |${c}all rocks [and lavender and tufted grass,

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/VisualBlockInsertActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/VisualBlockInsertActionTest.kt
@@ -73,9 +73,7 @@ Xbar
 
                     ba_quux_r
 
-      """.trimIndent(),
-      VimStateMachine.Mode.COMMAND,
-      VimStateMachine.SubMode.NONE
+      """.trimIndent()
     )
   }
 
@@ -97,9 +95,7 @@ Xbar
                     quux spam eggs
 
         """.trimIndent()
-        ),
-      VimStateMachine.Mode.COMMAND,
-      VimStateMachine.SubMode.NONE
+        )
     )
   }
 
@@ -136,9 +132,7 @@ Xbar
                     ba_quux_r
 
         """.trimIndent()
-        ),
-      VimStateMachine.Mode.COMMAND,
-      VimStateMachine.SubMode.NONE
+        )
     )
   }
 
@@ -162,10 +156,7 @@ Xbar
                 where it was settled on some sodden sand
                 hard by the torrent of a mountain pass.
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND,
-      VimStateMachine.SubMode.NONE
     )
-    assertMode(VimStateMachine.Mode.COMMAND)
   }
 
   @TestWithoutNeovim(SkipNeovimReason.VISUAL_BLOCK_MODE)
@@ -179,7 +170,7 @@ Xbar
                 hard by the torrent of a mountain pass.
                     """
     doTest(
-      injector.parser.parseKeys("<C-V>" + "jjI" + " Hello " + "<ESC>"),
+      listOf("<C-V>" + "jjI" + " Hello " + "<ESC>"),
       before.trimIndent(),
       """
                 A Discovery
@@ -189,14 +180,11 @@ Xbar
                 where it was s Hello ettled on some sodden sand
                 hard by the torrent of a mountain pass.
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND,
-      VimStateMachine.SubMode.NONE
     ) {
       it.inlayModel.addInlineElement(before.indexOf("found"), HintRenderer("Hello"))
       it.inlayModel.addInlineElement(before.indexOf("l rocks"), HintRenderer("Hello"))
       it.inlayModel.addInlineElement(before.indexOf("ere it"), HintRenderer("Hello"))
     }
-    assertMode(VimStateMachine.Mode.COMMAND)
   }
 
   @TestWithoutNeovim(SkipNeovimReason.VISUAL_BLOCK_MODE)

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/search/SearchAgainPreviousActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/search/SearchAgainPreviousActionTest.kt
@@ -19,13 +19,10 @@
 package org.jetbrains.plugins.ideavim.action.motion.search
 
 import com.maddyhome.idea.vim.VimPlugin
-import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.command.VimStateMachine
 import com.maddyhome.idea.vim.common.Direction
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
-import javax.swing.KeyStroke
 
 class SearchAgainPreviousActionTest : VimTestCase() {
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
@@ -36,14 +33,13 @@ class SearchAgainPreviousActionTest : VimTestCase() {
   ...${c}all it was settled on some sodden sand
   ...all by the torrent of a mountain pass
     """.trimIndent().dotToTab()
-    val keys = injector.parser.parseKeys("N")
     val after = """
   I found it in a legendary land
   ...${c}all rocks and lavender and tufted grass,
   ...all it was settled on some sodden sand
   ...all by the torrent of a mountain pass
     """.trimIndent().dotToTab()
-    doTestWithSearch(keys, before, after)
+    doTestWithSearch("N", before, after)
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
@@ -54,14 +50,13 @@ class SearchAgainPreviousActionTest : VimTestCase() {
   ...all it was .${c}all settled on some sodden sand
   ...all by the torrent of a mountain pass
     """.trimIndent().dotToTab()
-    val keys = injector.parser.parseKeys("N")
     val after = """
   I found it in a legendary land
   ...all rocks and lavender and tufted grass,
   ...${c}all it was .all settled on some sodden sand
   ...all by the torrent of a mountain pass
     """.trimIndent().dotToTab()
-    doTestWithSearch(keys, before, after)
+    doTestWithSearch("N", before, after)
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
@@ -72,14 +67,13 @@ class SearchAgainPreviousActionTest : VimTestCase() {
   ...all it was .all.${c}all settled on some sodden sand
   ...all by the torrent of a mountain pass
     """.trimIndent().dotToTab()
-    val keys = injector.parser.parseKeys("N")
     val after = """
   I found it in a legendary land
   ...all rocks and lavender and tufted grass,
   ...all it was .${c}all.all settled on some sodden sand
   ...all by the torrent of a mountain pass
     """.trimIndent().dotToTab()
-    doTestWithSearch(keys, before, after)
+    doTestWithSearch("N", before, after)
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
@@ -90,14 +84,13 @@ class SearchAgainPreviousActionTest : VimTestCase() {
   ...all it was settled on some sodden sand
   ...all by the torrent of a mountain pass
     """.trimIndent().dotToTab()
-    val keys = injector.parser.parseKeys("N")
     val after = """
   I found it in a legendary land
   ...all rocks and lavender and tufted grass,
   ...all it was settled on some sodden sand
   ...${c}all by the torrent of a mountain pass
     """.trimIndent().dotToTab()
-    doTestWithSearch(keys, before, after)
+    doTestWithSearch("N", before, after)
   }
 
   fun `test search previous after search command with offset`() {
@@ -174,8 +167,8 @@ class SearchAgainPreviousActionTest : VimTestCase() {
     doTest(listOf(searchCommand("/land/1"), exCommand("s/and/or"), "G", "N"), before, after)
   }
 
-  private fun doTestWithSearch(keys: List<KeyStroke>, before: String, after: String) {
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+  private fun doTestWithSearch(keys: String, before: String, after: String) {
+    doTest(keys, before, after) {
       VimPlugin.getSearch().setLastSearchState(it, "all", "", Direction.FORWARDS)
     }
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionUpActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionUpActionTest.kt
@@ -19,7 +19,6 @@
 package org.jetbrains.plugins.ideavim.action.motion.updown
 
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.command.VimStateMachine
 import com.maddyhome.idea.vim.helper.vimLastColumn
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
@@ -36,12 +35,11 @@ class MotionUpActionTest : VimTestCase() {
             I found it in a le${c}gendary land
             all rocks and lavender and tufted grass,
     """.trimIndent()
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE)
+    doTest(keys, before, after)
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
   fun `test last column is incorrect`() {
-    val keys = injector.parser.parseKeys("k")
     val before = """
             I found it in a legendary land
             all rocks and lave${c}nder and tufted grass,
@@ -50,7 +48,7 @@ class MotionUpActionTest : VimTestCase() {
             I found it in a le${c}gendary land
             all rocks and lavender and tufted grass,
     """.trimIndent()
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+    doTest("k", before, after) {
       it.caretModel.primaryCaret.vimLastColumn = 5
     }
   }
@@ -69,12 +67,11 @@ class MotionUpActionTest : VimTestCase() {
             I found it in a legendary land
             all rocks and lavender and tufted ${c}grass,
     """.trimIndent()
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE)
+    doTest(keys, before, after)
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
   fun `test last column wrong lastColumn`() {
-    val keys = injector.parser.parseKeys("k")
     val before = """
             I found it in a legendary land
             all rocks and lavender and tufted ${c}grass,
@@ -83,7 +80,7 @@ class MotionUpActionTest : VimTestCase() {
             I found it in a legendary lan${c}d
             all rocks and lavender and tufted grass,
     """.trimIndent()
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+    doTest("k", before, after) {
       it.caretModel.primaryCaret.vimLastColumn = 0
     }
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/CommandParserTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/CommandParserTest.kt
@@ -54,20 +54,18 @@ class CommandParserTest : VimTestCase() {
     setupChecks {
       caretShape = false
     }
-    val keys = commandToKeys(">>")
     val before = "I ${c}found it in a legendary land"
     val after = "I :>>${c}found it in a legendary land"
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+    doTest(exCommand(">>"), before, after) {
       VimPlugin.setEnabled(false)
     }
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
   fun `test turn off and on`() {
-    val keys = commandToKeys(">>")
     val before = "I ${c}found it in a legendary land"
     val after = "        ${c}I found it in a legendary land"
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+    doTest(exCommand(">>"), before, after) {
       VimPlugin.setEnabled(false)
       VimPlugin.setEnabled(true)
     }
@@ -75,10 +73,9 @@ class CommandParserTest : VimTestCase() {
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
   fun `test turn off and on twice`() {
-    val keys = commandToKeys(">>")
     val before = "I ${c}found it in a legendary land"
     val after = "        ${c}I found it in a legendary land"
-    doTest(keys, before, after, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE) {
+    doTest(exCommand(">>"), before, after) {
       VimPlugin.setEnabled(false)
       VimPlugin.setEnabled(true)
       VimPlugin.setEnabled(true)

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitCMakeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitCMakeTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.extension.matchit
 
-import com.maddyhome.idea.vim.command.VimStateMachine
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -48,7 +47,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Non-linux system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -70,7 +69,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Non-linux system")
         ${c}endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -92,7 +91,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Non-linux system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -122,7 +121,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -152,7 +151,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -182,7 +181,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -212,7 +211,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         ${c}endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -242,7 +241,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -260,7 +259,7 @@ class MatchitCMakeTest : VimTestCase() {
           message(STATUS "X=${"\${X}"}")
         ${c}endforeach()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -278,7 +277,7 @@ class MatchitCMakeTest : VimTestCase() {
           message(STATUS "X=${"\${X}"}")
         endforeach()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -302,7 +301,7 @@ class MatchitCMakeTest : VimTestCase() {
           message(STATUS "X=${"\${X}"}")
         endforeach()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -326,7 +325,7 @@ class MatchitCMakeTest : VimTestCase() {
           message(STATUS "X=${"\${X}"}")
         ${c}endforeach()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -344,7 +343,7 @@ class MatchitCMakeTest : VimTestCase() {
           MATH(EXPR VAR "${"\${index}"}+1")
         ${c}endwhile()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -362,7 +361,7 @@ class MatchitCMakeTest : VimTestCase() {
           MATH(EXPR VAR "${"\${index}"}+1")
         endwhile()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -386,7 +385,7 @@ class MatchitCMakeTest : VimTestCase() {
           endif()
         endwhile()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -410,7 +409,7 @@ class MatchitCMakeTest : VimTestCase() {
           endif()
         ${c}endwhile()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -428,7 +427,7 @@ class MatchitCMakeTest : VimTestCase() {
           bar(x y z)
         ${c}endfunction()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -446,7 +445,7 @@ class MatchitCMakeTest : VimTestCase() {
           bar(x y z)
         endfunction()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -464,7 +463,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("arg = ${"\${arg}\""}")
         ${c}endmacro()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -482,7 +481,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("arg = ${"\${arg}\""}")
         endmacro()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -506,7 +505,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Non-linux system")
         ${c}endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -528,7 +527,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Non-linux system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -550,7 +549,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Non-linux system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -580,7 +579,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         ${c}endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -610,7 +609,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -640,7 +639,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -670,7 +669,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -700,7 +699,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("Unknown system")
         endif()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -718,7 +717,7 @@ class MatchitCMakeTest : VimTestCase() {
           message(STATUS "X=${"\${X}"}")
         ${c}endforeach()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -736,7 +735,7 @@ class MatchitCMakeTest : VimTestCase() {
           message(STATUS "X=${"\${X}"}")
         endforeach()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -760,7 +759,7 @@ class MatchitCMakeTest : VimTestCase() {
           message(STATUS "X=${"\${X}"}")
         ${c}endforeach()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -784,7 +783,7 @@ class MatchitCMakeTest : VimTestCase() {
           message(STATUS "X=${"\${X}"}")
         endforeach()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -808,7 +807,7 @@ class MatchitCMakeTest : VimTestCase() {
           message(STATUS "X=${"\${X}"}")
         endforeach()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -826,7 +825,7 @@ class MatchitCMakeTest : VimTestCase() {
           MATH(EXPR VAR "${"\${index}"}+1")
         ${c}endwhile()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -844,7 +843,7 @@ class MatchitCMakeTest : VimTestCase() {
           MATH(EXPR VAR "${"\${index}"}+1")
         endwhile()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -868,7 +867,7 @@ class MatchitCMakeTest : VimTestCase() {
           endif()
         ${c}endwhile()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -892,7 +891,7 @@ class MatchitCMakeTest : VimTestCase() {
           endif()
         endwhile()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -916,7 +915,7 @@ class MatchitCMakeTest : VimTestCase() {
           endif()
         endwhile()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -934,7 +933,7 @@ class MatchitCMakeTest : VimTestCase() {
           bar(x y z)
         ${c}endfunction()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -952,7 +951,7 @@ class MatchitCMakeTest : VimTestCase() {
           bar(x y z)
         endfunction()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -970,7 +969,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("arg = ${"\${arg}\""}")
         ${c}endmacro()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 
@@ -988,7 +987,7 @@ class MatchitCMakeTest : VimTestCase() {
           message("arg = ${"\${arg}\""}")
         endmacro()
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "CMakeLists.txt"
+      fileName = "CMakeLists.txt"
     )
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitCTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitCTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.extension.matchit
 
-import com.maddyhome.idea.vim.command.VimStateMachine
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -42,7 +41,7 @@ class MatchitCTest : VimTestCase() {
         #if !defined (VAL_1)
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -58,7 +57,7 @@ class MatchitCTest : VimTestCase() {
            #if !defined (VAL_1)
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -78,7 +77,7 @@ class MatchitCTest : VimTestCase() {
         $c#elif !defined (VAL_2)
           #define VAL_2 2
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -98,7 +97,7 @@ class MatchitCTest : VimTestCase() {
         $c#else
           #define VAL_2 2
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -114,7 +113,7 @@ class MatchitCTest : VimTestCase() {
         #elif !defined (VAL_2)
         $c#else
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -130,7 +129,7 @@ class MatchitCTest : VimTestCase() {
            #elif !defined (VAL_2)
         $c#else
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -146,7 +145,7 @@ class MatchitCTest : VimTestCase() {
         #else
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -162,7 +161,7 @@ class MatchitCTest : VimTestCase() {
            #else !defined (VAL_2)
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -188,7 +187,7 @@ class MatchitCTest : VimTestCase() {
           #define VAL_3 3
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -204,7 +203,7 @@ class MatchitCTest : VimTestCase() {
         #ifdef DEBUG
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -220,7 +219,7 @@ class MatchitCTest : VimTestCase() {
         #ifdef DEBUG
         $c#elif PROD
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -236,7 +235,7 @@ class MatchitCTest : VimTestCase() {
         #ifdef DEBUG
         $c#else
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -252,7 +251,7 @@ class MatchitCTest : VimTestCase() {
         $c#ifdef DEBUG
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -268,7 +267,7 @@ class MatchitCTest : VimTestCase() {
         #ifndef DEBUG
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -284,7 +283,7 @@ class MatchitCTest : VimTestCase() {
         #ifndef DEBUG
         $c#elif PROD
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -300,7 +299,7 @@ class MatchitCTest : VimTestCase() {
         #ifndef DEBUG
         $c#else
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -316,7 +315,7 @@ class MatchitCTest : VimTestCase() {
         $c#ifndef DEBUG
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -332,7 +331,7 @@ class MatchitCTest : VimTestCase() {
         $c#ifff DEBUG
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -348,7 +347,7 @@ class MatchitCTest : VimTestCase() {
         #  if DEBUG
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -368,7 +367,7 @@ class MatchitCTest : VimTestCase() {
         $c#  endif
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -388,7 +387,7 @@ class MatchitCTest : VimTestCase() {
         #if !defined (VAL_1)
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -404,7 +403,7 @@ class MatchitCTest : VimTestCase() {
            #if !defined (VAL_1)
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -420,7 +419,7 @@ class MatchitCTest : VimTestCase() {
         $c#  if DEBUG
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -438,7 +437,7 @@ class MatchitCTest : VimTestCase() {
           #define VAL_3 3
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -460,7 +459,7 @@ class MatchitCTest : VimTestCase() {
           #define VAL_3 3
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -482,7 +481,7 @@ class MatchitCTest : VimTestCase() {
             #define VAL_3 3
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -502,7 +501,7 @@ class MatchitCTest : VimTestCase() {
         #elif !defined (VAL_2)
           #define VAL_2 2
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -518,7 +517,7 @@ class MatchitCTest : VimTestCase() {
         #ifdef DEBUG
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -534,7 +533,7 @@ class MatchitCTest : VimTestCase() {
         $c#ifdef DEBUG
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -550,7 +549,7 @@ class MatchitCTest : VimTestCase() {
         $c#ifdef DEBUG
         #else
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -566,7 +565,7 @@ class MatchitCTest : VimTestCase() {
         $c#ifdef DEBUG
         #elif PROD
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -582,7 +581,7 @@ class MatchitCTest : VimTestCase() {
         #ifndef DEBUG
         $c#endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -598,7 +597,7 @@ class MatchitCTest : VimTestCase() {
         $c#ifndef DEBUG
         #endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -614,7 +613,7 @@ class MatchitCTest : VimTestCase() {
         $c#ifndef DEBUG
         #elif PROD
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 
@@ -630,7 +629,7 @@ class MatchitCTest : VimTestCase() {
         $c#ifndef DEBUG
         #else
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "main.c"
+      fileName = "main.c"
     )
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGNUMakeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGNUMakeTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.extension.matchit
 
-import com.maddyhome.idea.vim.command.VimStateMachine
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -46,7 +45,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           second line
         ${c}endef
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -66,7 +65,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           second line
         endef
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -84,7 +83,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info defined)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -102,7 +101,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info defined)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -120,7 +119,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not defined)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -138,7 +137,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not defined)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -156,7 +155,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info empty)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -174,7 +173,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info empty)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -192,7 +191,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not empty)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -210,7 +209,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not empty)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -228,7 +227,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not empty)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -254,7 +253,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -280,7 +279,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -306,7 +305,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -332,7 +331,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -358,7 +357,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -384,7 +383,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -410,7 +409,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -436,7 +435,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -462,7 +461,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -488,7 +487,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -510,7 +509,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           second line
         ${c}endef
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -530,7 +529,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           second line
         endef
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -548,7 +547,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info defined)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -566,7 +565,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info defined)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -584,7 +583,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not defined)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -602,7 +601,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not defined)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -620,7 +619,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info empty)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -638,7 +637,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info empty)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -656,7 +655,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not empty)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -674,7 +673,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not empty)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -692,7 +691,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not empty)
         else
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -718,7 +717,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -744,7 +743,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -770,7 +769,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -796,7 +795,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -822,7 +821,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info not x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -848,7 +847,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         ${c}endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -874,7 +873,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -900,7 +899,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -926,7 +925,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 
@@ -952,7 +951,7 @@ class MatchitGNUMakeTest : VimTestCase() {
           $(info x86 based)
         endif
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "Makefile"
+      fileName = "Makefile"
     )
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGeneralTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitGeneralTest.kt
@@ -52,7 +52,7 @@ class MatchitGeneralTest : VimTestCase() {
          *
          *$c/
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, JavaFileType.INSTANCE
+      fileType = JavaFileType.INSTANCE
     )
   }
 
@@ -70,7 +70,7 @@ class MatchitGeneralTest : VimTestCase() {
          *
          */
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, JavaFileType.INSTANCE
+      fileType = JavaFileType.INSTANCE
     )
   }
 
@@ -90,7 +90,7 @@ class MatchitGeneralTest : VimTestCase() {
         int c;
         int d;
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, HtmlFileType.INSTANCE
+      fileType = HtmlFileType.INSTANCE
     )
   }
 
@@ -118,7 +118,7 @@ class MatchitGeneralTest : VimTestCase() {
   fun `test delete everything from opening parenthesis to closing parenthesis`() {
     doTest(
       "d%",
-      "$c(x == 123)", "", VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, HtmlFileType.INSTANCE
+      "$c(x == 123)", "", fileType = HtmlFileType.INSTANCE
     )
   }
 
@@ -189,7 +189,7 @@ class MatchitGeneralTest : VimTestCase() {
           puts n
         en${se}d
       """.trimIndent(),
-      VimStateMachine.Mode.VISUAL, VimStateMachine.SubMode.VISUAL_CHARACTER, "ruby.rb"
+      VimStateMachine.Mode.VISUAL, VimStateMachine.SubMode.VISUAL_CHARACTER, fileName = "ruby.rb"
     )
   }
 
@@ -232,7 +232,7 @@ class MatchitGeneralTest : VimTestCase() {
               end
         """.trimIndent()
       },
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -256,7 +256,7 @@ class MatchitGeneralTest : VimTestCase() {
           puts "Positive"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -280,7 +280,7 @@ class MatchitGeneralTest : VimTestCase() {
           puts "Positive"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -293,7 +293,8 @@ class MatchitGeneralTest : VimTestCase() {
           <img src="fff">
         </div>
       """.trimIndent(),
-      "$c<", VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, HtmlFileType.INSTANCE
+      "$c<",
+      fileType = HtmlFileType.INSTANCE
     )
   }
 
@@ -304,7 +305,8 @@ class MatchitGeneralTest : VimTestCase() {
       """
         $c<div></div>
       """.trimIndent(),
-      "$c</div>", VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, HtmlFileType.INSTANCE
+      "$c</div>",
+      fileType = HtmlFileType.INSTANCE
     )
   }
 
@@ -317,7 +319,8 @@ class MatchitGeneralTest : VimTestCase() {
           puts "hello"
         end
       """.trimIndent(),
-      "", VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      "",
+      fileName = "ruby.rb"
     )
   }
 
@@ -330,7 +333,8 @@ class MatchitGeneralTest : VimTestCase() {
           puts "hello"
         end
       """.trimIndent(),
-      "", VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      "",
+      fileName = "ruby.rb"
     )
   }
 
@@ -343,7 +347,8 @@ class MatchitGeneralTest : VimTestCase() {
           puts "hello"
         en${c}d
       """.trimIndent(),
-      "", VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      "",
+      fileName = "ruby.rb"
     )
   }
 
@@ -356,7 +361,8 @@ class MatchitGeneralTest : VimTestCase() {
           puts "hello"
         en${c}d
       """.trimIndent(),
-      "", VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      "",
+      fileName ="ruby.rb"
     )
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitRubyTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitRubyTest.kt
@@ -18,7 +18,6 @@
 
 package org.jetbrains.plugins.ideavim.extension.matchit
 
-import com.maddyhome.idea.vim.command.VimStateMachine
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -44,7 +43,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is true"
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -54,7 +53,7 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """ $c  if some_boolean puts "result is true" end""",
       """   if some_boolean puts "result is true" ${c}end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -64,7 +63,7 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """ $c class Foo end""",
       """  class Foo ${c}end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -82,7 +81,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is true"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -104,7 +103,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -126,7 +125,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is false"
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -148,7 +147,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -174,7 +173,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "both values are false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -200,7 +199,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "both values are false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -222,7 +221,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "second value is true"
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -252,7 +251,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "all values are false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -278,7 +277,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -312,7 +311,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -338,7 +337,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -364,7 +363,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -390,7 +389,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -416,7 +415,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -438,7 +437,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -460,7 +459,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -482,7 +481,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -504,7 +503,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -542,7 +541,7 @@ class MatchitRubyTest : VimTestCase() {
 
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -572,7 +571,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -594,7 +593,7 @@ class MatchitRubyTest : VimTestCase() {
           puts some_boolean
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -604,7 +603,7 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """puts "This line has two statements"; ${c}if true then puts "true" end""",
       """puts "This line has two statements"; if true then puts "true" ${c}end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -614,7 +613,7 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """puts "This line has two statements"; if true then puts "true" ${c}end""",
       """puts "This line has two statements"; ${c}if true then puts "true" end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -624,7 +623,7 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """puts "This line has ${c}two statements"; if true then puts "true" end""",
       """puts "This line has two statements"; if true then puts "true" ${c}end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -634,7 +633,7 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """puts "This line has two statements"; ${c}unless nil then puts "not nil" end""",
       """puts "This line has two statements"; unless nil then puts "not nil" ${c}end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -644,7 +643,7 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """if tr${c}ue puts "true" end""",
       """${c}if true puts "true" end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -654,7 +653,7 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """puts "This line has two statements"; unless nil then puts "not nill" ${c}end""",
       """puts "This line has two statements"; ${c}unless nil then puts "not nill" end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -676,7 +675,7 @@ class MatchitRubyTest : VimTestCase() {
        
         [1, 2, 3].each ${c}do |x| puts x end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -702,7 +701,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -724,7 +723,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -746,7 +745,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -770,7 +769,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}end        
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -800,7 +799,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -830,7 +829,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -860,7 +859,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -890,7 +889,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -914,7 +913,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}retry
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -938,7 +937,7 @@ class MatchitRubyTest : VimTestCase() {
           retry
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -962,7 +961,7 @@ class MatchitRubyTest : VimTestCase() {
           end        
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -990,7 +989,7 @@ class MatchitRubyTest : VimTestCase() {
             puts "Adult"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1018,7 +1017,7 @@ class MatchitRubyTest : VimTestCase() {
             puts "Adult"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1046,7 +1045,7 @@ class MatchitRubyTest : VimTestCase() {
             puts "Adult"
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1074,7 +1073,7 @@ class MatchitRubyTest : VimTestCase() {
             puts "Adult"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1092,7 +1091,7 @@ class MatchitRubyTest : VimTestCase() {
           var = var + 1
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1120,7 +1119,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1148,7 +1147,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1176,7 +1175,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1204,7 +1203,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1222,7 +1221,7 @@ class MatchitRubyTest : VimTestCase() {
           end comment
         =${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1240,7 +1239,7 @@ class MatchitRubyTest : VimTestCase() {
           begin comment
         =end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1270,7 +1269,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1300,7 +1299,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1322,7 +1321,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is true"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1340,7 +1339,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is true"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1362,7 +1361,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1384,7 +1383,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1406,7 +1405,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "result is false"
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1432,7 +1431,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "both values are false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1458,7 +1457,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "both values are false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1480,7 +1479,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "second value is true"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1510,7 +1509,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "all values are false"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1544,7 +1543,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1570,7 +1569,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1596,7 +1595,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1622,7 +1621,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1648,7 +1647,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1670,7 +1669,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1692,7 +1691,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1714,7 +1713,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1748,7 +1747,7 @@ class MatchitRubyTest : VimTestCase() {
           puts "I am func_three"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1770,7 +1769,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1808,7 +1807,7 @@ class MatchitRubyTest : VimTestCase() {
 
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1838,7 +1837,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1860,7 +1859,7 @@ class MatchitRubyTest : VimTestCase() {
           puts some_boolean
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1870,7 +1869,7 @@ class MatchitRubyTest : VimTestCase() {
       "g%",
       """if tr${c}ue puts "true" end""",
       """${c}if true puts "true" end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1896,7 +1895,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1918,7 +1917,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1940,7 +1939,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -1970,7 +1969,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2000,7 +1999,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2030,7 +2029,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2060,7 +2059,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2084,7 +2083,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}retry
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2108,7 +2107,7 @@ class MatchitRubyTest : VimTestCase() {
           retry
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2132,7 +2131,7 @@ class MatchitRubyTest : VimTestCase() {
           ${c}end        
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2156,7 +2155,7 @@ class MatchitRubyTest : VimTestCase() {
           end        
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2184,7 +2183,7 @@ class MatchitRubyTest : VimTestCase() {
             puts "Adult"
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2212,7 +2211,7 @@ class MatchitRubyTest : VimTestCase() {
             puts "Adult"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2240,7 +2239,7 @@ class MatchitRubyTest : VimTestCase() {
             puts "Adult"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2268,7 +2267,7 @@ class MatchitRubyTest : VimTestCase() {
             puts "Adult"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2296,7 +2295,7 @@ class MatchitRubyTest : VimTestCase() {
             puts "Adult"
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2314,7 +2313,7 @@ class MatchitRubyTest : VimTestCase() {
           var = var + 1
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2332,7 +2331,7 @@ class MatchitRubyTest : VimTestCase() {
           var = var + 1
         ${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2360,7 +2359,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2388,7 +2387,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2416,7 +2415,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2444,7 +2443,7 @@ class MatchitRubyTest : VimTestCase() {
           end
         end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2462,7 +2461,7 @@ class MatchitRubyTest : VimTestCase() {
           end comment
         =${c}end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2480,7 +2479,7 @@ class MatchitRubyTest : VimTestCase() {
           begin comment
         =end
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2490,7 +2489,7 @@ class MatchitRubyTest : VimTestCase() {
       "g%",
       """puts "This line has ${c}two statements"; if true then puts "true" end""",
       """puts "This line has two statements"; if true then puts "true" ${c}end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2500,7 +2499,7 @@ class MatchitRubyTest : VimTestCase() {
       "g%",
       """ $c  class Foo end""",
       """   class Foo ${c}end""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby.rb"
+      fileName = "ruby.rb"
     )
   }
 
@@ -2520,7 +2519,7 @@ class MatchitRubyTest : VimTestCase() {
       """
         <div><div>contents<$c/div></div>
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2546,7 +2545,7 @@ class MatchitRubyTest : VimTestCase() {
           <%= render 'layouts/footer' %>
         <$c/div>
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2572,7 +2571,7 @@ class MatchitRubyTest : VimTestCase() {
           <%= render 'layouts/footer' %>
         </div>
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2598,7 +2597,7 @@ class MatchitRubyTest : VimTestCase() {
           <%= render 'layouts/footer' %>
         </div>
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2624,7 +2623,7 @@ class MatchitRubyTest : VimTestCase() {
           <%= render 'layouts/footer' %>
         </div>
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2634,7 +2633,7 @@ class MatchitRubyTest : VimTestCase() {
       "%",
       """<div class="alert alert-$c<%= message_type %>"><%= message %></div>""",
       """<div class="alert alert-<%= message_type %$c>"><%= message %></div>""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2644,7 +2643,7 @@ class MatchitRubyTest : VimTestCase() {
       "g%",
       """<div class="alert alert-$c<%= message_type %>"><%= message %></div>""",
       """<div class="alert alert-<%= message_type %$c>"><%= message %></div>""",
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2682,7 +2681,7 @@ class MatchitRubyTest : VimTestCase() {
           <% ${c}end %>
         </tbody>
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2720,7 +2719,7 @@ class MatchitRubyTest : VimTestCase() {
           <% end %>
         </tbody>
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2758,7 +2757,7 @@ class MatchitRubyTest : VimTestCase() {
           <% end %>
         </tbody>
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 
@@ -2796,7 +2795,7 @@ class MatchitRubyTest : VimTestCase() {
           <% end %>
         </tbody>
       """.trimIndent(),
-      VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE, "ruby-template.html.erb"
+      fileName = "ruby-template.html.erb"
     )
   }
 }


### PR DESCRIPTION
Updates `VimTestCase.kt` to consolidate the various `doTest` functions so everything eventually goes through one `doTest` function. `@JvmOverloads` are added for Java tests, and default arguments means it is no longer necessary to specify the default modes of `COMMAND`/`NONE` at all call sites (not removed in existing tests). Also fixes a minor bug in one of the deleted `doTest` overloads that would pass keys to neovim twice (was fortunately never called).

This is groundwork for extending `doTest` to support testing wrapped and folded text without having to use offsets.