### PR TITLE
Fix(VIM-2778) Remove override of editor scroll setting 

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -59,10 +59,8 @@ import static com.maddyhome.idea.vim.helper.CaretVisualAttributesHelperKt.update
  */
 @State(name = "VimEditorSettings", storages = {@Storage(value = "$APP_CONFIG$/vim_settings.xml")})
 public class EditorGroup implements PersistentStateComponent<Element>, VimEditorGroup {
-  private static final boolean REFRAIN_FROM_SCROLLING_VIM_VALUE = true;
   public static final @NonNls String EDITOR_STORE_ELEMENT = "editor";
 
-  private boolean isRefrainFromScrolling = false;
   private Boolean isKeyRepeat = null;
 
   private final CaretListener myLineNumbersCaretListener = new CaretListener() {
@@ -219,7 +217,6 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
   }
 
   public void editorCreated(@NotNull Editor editor) {
-    isRefrainFromScrolling = editor.getSettings().isRefrainFromScrolling();
     DocumentManager.INSTANCE.addListeners(editor.getDocument());
     VimPlugin.getKey().registerRequiredShortcutKeys(new IjVimEditor(editor));
 
@@ -232,14 +229,12 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
       KeyHandler.getInstance().reset(new IjVimEditor(editor));
     }
     updateCaretsVisualAttributes(editor);
-    editor.getSettings().setRefrainFromScrolling(REFRAIN_FROM_SCROLLING_VIM_VALUE);
   }
 
   public void editorDeinit(@NotNull Editor editor, boolean isReleased) {
     deinitLineNumbers(editor, isReleased);
     UserDataManager.unInitializeEditor(editor);
     VimPlugin.getKey().unregisterShortcutKeys(new IjVimEditor(editor));
-    editor.getSettings().setRefrainFromScrolling(isRefrainFromScrolling);
     DocumentManager.INSTANCE.removeListeners(editor.getDocument());
     CaretVisualAttributesHelperKt.removeCaretsVisualAttributes(editor);
   }

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
@@ -21,7 +21,6 @@ package com.maddyhome.idea.vim.newapi
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.openapi.editor.LogicalPosition
-import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.editor.VisualPosition
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
@@ -46,7 +45,6 @@ import com.maddyhome.idea.vim.common.LiveRange
 import com.maddyhome.idea.vim.common.Offset
 import com.maddyhome.idea.vim.common.Pointer
 import com.maddyhome.idea.vim.common.TextRange
-import com.maddyhome.idea.vim.common.VimScrollType
 import com.maddyhome.idea.vim.common.offset
 import com.maddyhome.idea.vim.group.visual.vimSetSystemBlockSelectionSilently
 import com.maddyhome.idea.vim.helper.EditorHelper
@@ -400,17 +398,6 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
     set(value) {
       editor.vimLastSelectionType = value
     }
-
-  override fun scrollToCaret(type: VimScrollType) {
-    val scrollType = when (type) {
-      VimScrollType.RELATIVE -> ScrollType.RELATIVE
-      VimScrollType.CENTER -> ScrollType.CENTER
-      VimScrollType.MAKE_VISIBLE -> ScrollType.MAKE_VISIBLE
-      VimScrollType.CENTER_UP -> ScrollType.CENTER_UP
-      VimScrollType.CENTER_DOWN -> ScrollType.CENTER_DOWN
-    }
-    editor.scrollingModel.scrollToCaret(scrollType)
-  }
 
   override fun isTemplateActive(): Boolean {
     return editor.isTemplateActive()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualSelectPreviousAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualSelectPreviousAction.kt
@@ -23,7 +23,6 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.command.VimStateMachine
-import com.maddyhome.idea.vim.common.VimScrollType
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.vimStateMachine
 
@@ -54,7 +53,7 @@ private fun selectPreviousVisualMode(editor: VimEditor): Boolean {
   val primaryCaret = editor.primaryCaret()
   primaryCaret.vimSetSelection(visualMarks.startOffset, visualMarks.endOffset - 1, true)
 
-  editor.scrollToCaret(VimScrollType.CENTER)
+  injector.motion.scrollCaretIntoView(editor)
 
   return true
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualSwapSelectionsAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualSwapSelectionsAction.kt
@@ -24,7 +24,6 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.command.SelectionType
 import com.maddyhome.idea.vim.common.TextRange
-import com.maddyhome.idea.vim.common.VimScrollType
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.subMode
 
@@ -59,7 +58,7 @@ private fun swapVisualSelections(editor: VimEditor): Boolean {
   editor.subMode = lastSelectionType.toSubMode()
   primaryCaret.vimSetSelection(lastVisualRange.startOffset, lastVisualRange.endOffset, true)
 
-  editor.scrollToCaret(VimScrollType.CENTER)
+  injector.motion.scrollCaretIntoView(editor)
 
   return true
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
@@ -28,7 +28,6 @@ import com.maddyhome.idea.vim.common.OperatedRange
 import com.maddyhome.idea.vim.common.Pointer
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.common.VimRange
-import com.maddyhome.idea.vim.common.VimScrollType
 import com.maddyhome.idea.vim.common.offset
 import com.maddyhome.idea.vim.common.pointer
 import java.util.*
@@ -231,7 +230,6 @@ interface VimEditor {
 
   var vimLastSelectionType: SelectionType?
 
-  fun scrollToCaret(type: VimScrollType)
   fun isTemplateActive(): Boolean
 
   fun startGuardedBlockChecking()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimScrollType.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimScrollType.kt
@@ -1,5 +1,0 @@
-package com.maddyhome.idea.vim.common
-
-enum class VimScrollType {
-  RELATIVE, CENTER, MAKE_VISIBLE, CENTER_UP, CENTER_DOWN
-}


### PR DESCRIPTION
Previously, IdeaVim would enable the "refrain from scrolling" setting in each editor. This appears to be historical, as all IdeaVim scrolling is explicit and to an exact location. This setting now only affects the scroll location when IntelliJ navigates, such as with Go To Member when the target is already visible.

The default setting is "keep the caret in place, scroll editor canvas" (refrain from scrolling disabled - hooray for double negatives!), which will scroll the editor and place the caret about 1/3rd of the way down the editor. IdeaVim would previously override this to "move caret, minimise editor scrolling", which will move the caret without scrolling if the target is already visible.

Even though this overridden behaviour is more Vim-like (Vim prefers to move the caret if the target is visible, and scroll to centre otherwise - see `gv`), this setting does not affect IdeaVim navigation, and only applies to IntelliJ navigation.

This fixes [VIM-2778](https://youtrack.jetbrains.com/issue/VIM-2778), so the Find Usages preview window will now correctly use the setting.

This PR also replaces non-exact scrolling (`scrollTo(CENTER)`) in the `gv` handlers. The default `scrollCaretIntoView` behaviour is more Vim-like, and will scroll only if necessary. This removes some unnecessary code from `VimEditor`.