### PR TITLE
Refactor "last column" calculations

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -735,8 +735,6 @@ public class ChangeGroup extends VimChangeGroupBase {
         injector.getMotion().moveCaret(editor, caret, range.getStartOffset());
       }
     }
-
-    UserDataManager.setVimLastColumn(((IjVimCaret) caret).getCaret(), caret.getVisualPosition().getColumn());
   }
 
 

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -886,10 +886,13 @@ public class MotionGroup extends VimMotionGroupBase {
 
   @Override
   public Motion moveCaretToColumn(@NotNull VimEditor editor, @NotNull VimCaret caret, int count, boolean allowEnd) {
-    int line = caret.getLine().getLine();
-    int pos = normalizeColumn(((IjVimEditor)editor).getEditor(), line, count, allowEnd);
-
-    return new Motion.AbsoluteOffset(editor.logicalPositionToOffset(new VimLogicalPosition(line, pos, false)));
+    final int line = caret.getLine().getLine();
+    final int column = normalizeColumn(((IjVimEditor)editor).getEditor(), line, count, allowEnd);
+    final int offset = editor.logicalPositionToOffset(new VimLogicalPosition(line, column, false));
+    if (column != count) {
+      return new Motion.AdjustedOffset(offset, count);
+    }
+    return new Motion.AbsoluteOffset(offset);
   }
 
   @Override

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -368,6 +368,12 @@ public class MotionGroup extends VimMotionGroupBase {
     moveCaret(((IjVimEditor) editor).getEditor(), ((IjVimCaret) caret).getCaret(), offset);
   }
 
+  /** Move the caret to the given offset
+   * <p>
+   * Note that <code>Caret.vimLastColumn</code> might be valid for visual block mode, if moving the primary caret after
+   * using the end of line motion (<code>$</code>).
+   * </p>
+   */
   public static void moveCaret(@NotNull Editor editor, @NotNull Caret caret, int offset) {
     if (offset < 0 || offset > editor.getDocument().getTextLength() || !caret.isValid()) return;
 
@@ -377,9 +383,6 @@ public class MotionGroup extends VimMotionGroupBase {
 
       // Note that this call replaces ALL carets, so any local caret instances will be invalid!
       VisualGroupKt.vimMoveBlockSelectionToOffset(editor, offset);
-
-      Caret primaryCaret = editor.getCaretModel().getPrimaryCaret();
-      UserDataManager.setVimLastColumn(primaryCaret, primaryCaret.getVisualPosition().column);
       scrollCaretIntoView(editor);
       return;
     }

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -74,6 +74,7 @@ public class MotionGroup extends VimMotionGroupBase {
                                             @NotNull OperatorArguments operatorArguments) {
     return getMotionRange(((IjVimEditor) editor).getEditor(), ((IjVimCaret) caret).getCaret(), ((IjExecutionContext) context).getContext(), argument, operatorArguments);
   }
+
   /**
    * This helper method calculates the complete range a motion will move over taking into account whether
    * the motion is FLAG_MOT_LINEWISE or FLAG_MOT_CHARACTERWISE (FLAG_MOT_INCLUSIVE or FLAG_MOT_EXCLUSIVE).
@@ -387,14 +388,6 @@ public class MotionGroup extends VimMotionGroupBase {
     // changes in surrounding text, especially with inline inlays.
     final int oldOffset = caret.getOffset();
     InlayHelperKt.moveToInlayAwareOffset(caret, offset);
-
-    // TODO: Remove this. If setting LAST_COLUMN, we have to set it both before and after moveCaret
-    // But not all handlers set vimLastColumn (e.g. ShiftedArrowKeyHandler). It would be better if all handlers reset
-    // vimLastColumn so that it is either calculated on demand (current column) or explicitly set by a handler that needs
-    // special handling
-    if (oldOffset != offset) {
-      UserDataManager.setVimLastColumn(caret, InlayHelperKt.getInlayAwareVisualColumn(caret));
-    }
 
     // Similarly, always make sure the caret is positioned within the view. Adding or removing text could move the caret
     // position relative to the view, without changing offset.
@@ -1132,9 +1125,9 @@ public class MotionGroup extends VimMotionGroupBase {
         offset = moveCaretToLineStartSkipLeading(new IjVimEditor(editor), visualLineToLogicalLine(editor, visualLine));
       }
       else {
-        offset = getVerticalMotionOffset(new IjVimEditor(editor), new IjVimCaret(editor.getCaretModel().getPrimaryCaret()),
-                                   visualLineToLogicalLine(editor, visualLine) -
-                                   editor.getCaretModel().getLogicalPosition().line);
+        offset = moveCaretToLineWithSameColumn(new IjVimEditor(editor),
+                                               visualLineToLogicalLine(editor, visualLine),
+                                               new IjVimCaret(editor.getCaretModel().getPrimaryCaret()));
       }
 
       moveCaret(editor, editor.getCaretModel().getPrimaryCaret(), offset);

--- a/src/main/java/com/maddyhome/idea/vim/helper/IjEditorHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/IjEditorHelper.kt
@@ -16,11 +16,9 @@ import com.intellij.openapi.editor.ex.util.EditorUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.maddyhome.idea.vim.api.EngineEditorHelper
 import com.maddyhome.idea.vim.api.ExecutionContext
-import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimVisualPosition
 import com.maddyhome.idea.vim.common.TextRange
-import com.maddyhome.idea.vim.newapi.IjVimCaret
 import com.maddyhome.idea.vim.newapi.IjVimEditor
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.newapi.vim
@@ -68,14 +66,6 @@ class IjEditorHelper : EngineEditorHelper {
 
   override fun getVisualLineCount(editor: VimEditor): Int {
     return EditorHelper.getVisualLineCount(editor)
-  }
-
-  override fun prepareLastColumn(caret: VimCaret): Int {
-    return EditorHelper.prepareLastColumn((caret as IjVimCaret).caret)
-  }
-
-  override fun updateLastColumn(caret: VimCaret, prevLastColumn: Int) {
-    EditorHelper.updateLastColumn((caret as IjVimCaret).caret, prevLastColumn)
   }
 
   override fun getLineEndOffset(editor: VimEditor, line: Int, allowEnd: Boolean): Int {

--- a/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
@@ -74,6 +74,9 @@ var Caret.vimLastColumn: Int
     _vimLastColumn = value
     _vimLastColumnPos = visualPosition
   }
+fun Caret.resetVimLastColumn() {
+  _vimLastColumnPos = null
+}
 private var Caret._vimLastColumn: Int by userDataCaretToEditorOr { (this as Caret).inlayAwareVisualColumn }
 private var Caret._vimLastColumnPos: VisualPosition? by userDataCaretToEditor()
 

--- a/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
@@ -31,6 +31,10 @@ import kotlin.reflect.KProperty
  * @author Alex Plate
  */
 
+// NOTE: Carets, including the primary caret, can be replaced when the caret is moved in visual block mode.
+// No attempt is made to maintain this user data (apart from vimLastColum which is set during caret movement)
+// Non-transient data will be lost!
+
 //region Vim selection start ----------------------------------------------------
 /**
  * Caret's offset when entering visual mode
@@ -55,15 +59,18 @@ fun Caret.vimSelectionStartClear() {
 private var Caret._vimSelectionStart: Int? by userDataCaretToEditor()
 //endregion ----------------------------------------------------
 
-// Last column excluding inlays before the caret
+// Last column excluding inlays before the caret. Reset during visual block motion
 var Caret.vimLastColumn: Int by userDataCaretToEditorOr { (this as Caret).inlayAwareVisualColumn }
+
+// TODO: Is this a per-caret setting? This data is non-transient, so could be lost during visual block motion
 var Caret.vimLastVisualOperatorRange: VisualChange? by userDataCaretToEditor()
+
+// Transient data. Does not need to be restored during visual block motion
 var Caret.vimInsertStart: RangeMarker by userDataOr {
-  (this as Caret).editor.document.createRangeMarker(
-    this.offset,
-    this.offset
-  )
+  (this as Caret).editor.document.createRangeMarker(this.offset, this.offset)
 }
+
+// TODO: Data could be lost during visual block motion
 var Caret.registerStorage: CaretRegisterStorageBase? by userDataCaretToEditor()
 
 // ------------------ Editor

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -398,7 +398,6 @@ object VimListenerManager {
 
           // Reset caret after forceBarShape while dragging
           editor.updateCaretsVisualAttributes()
-          caret.vimLastColumn = editor.caretModel.visualPosition.column
         }
 
         mouseDragging = false
@@ -439,9 +438,6 @@ object VimListenerManager {
             KeyHandler.getInstance().reset(editor.vim)
           }
         }
-
-        // TODO: 2019-03-22 Multi?
-        caretModel.primaryCaret.vimLastColumn = caretModel.visualPosition.column
       } else if (event.area != EditorMouseEventArea.ANNOTATIONS_AREA &&
         event.area != EditorMouseEventArea.FOLDING_OUTLINE_AREA &&
         event.mouseEvent.button != MouseEvent.BUTTON3

--- a/src/main/java/com/maddyhome/idea/vim/newapi/ChangeGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/ChangeGroup.kt
@@ -33,7 +33,6 @@ import com.maddyhome.idea.vim.common.including
 import com.maddyhome.idea.vim.common.offset
 import com.maddyhome.idea.vim.group.MotionGroup
 import com.maddyhome.idea.vim.helper.EditorHelper
-import com.maddyhome.idea.vim.helper.inlayAwareVisualColumn
 import com.maddyhome.idea.vim.helper.vimChangeActionSwitchMode
 import com.maddyhome.idea.vim.helper.vimLastColumn
 
@@ -107,7 +106,6 @@ fun deleteRange(
 ): Boolean {
   val vimRange = toVimRange(range, type)
 
-  (caret as IjVimCaret).caret.vimLastColumn = caret.caret.inlayAwareVisualColumn
   val deletedInfo = injector.vimMachine.delete(vimRange, editor, caret)
   if (deletedInfo != null) {
     when (deletedInfo) {

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimCaret.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimCaret.kt
@@ -28,7 +28,6 @@ import com.maddyhome.idea.vim.group.visual.vimLeadSelectionOffset
 import com.maddyhome.idea.vim.group.visual.vimSetSelection
 import com.maddyhome.idea.vim.group.visual.vimSetSystemSelectionSilently
 import com.maddyhome.idea.vim.group.visual.vimUpdateEditorSelection
-import com.maddyhome.idea.vim.helper.inlayAwareVisualColumn
 import com.maddyhome.idea.vim.helper.moveToInlayAwareOffset
 import com.maddyhome.idea.vim.helper.registerStorage
 import com.maddyhome.idea.vim.helper.resetVimLastColumn
@@ -58,8 +57,6 @@ class IjVimCaret(val caret: Caret) : VimCaretBase() {
       caret.vimLastColumn = value
     }
   override fun resetLastColumn() = caret.resetVimLastColumn()
-  override val inlayAwareVisualColumn: Int
-    get() = caret.inlayAwareVisualColumn
   override val selectionStart: Int
     get() = caret.selectionStart
   override val selectionEnd: Int

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimCaret.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimCaret.kt
@@ -31,6 +31,7 @@ import com.maddyhome.idea.vim.group.visual.vimUpdateEditorSelection
 import com.maddyhome.idea.vim.helper.inlayAwareVisualColumn
 import com.maddyhome.idea.vim.helper.moveToInlayAwareOffset
 import com.maddyhome.idea.vim.helper.registerStorage
+import com.maddyhome.idea.vim.helper.resetVimLastColumn
 import com.maddyhome.idea.vim.helper.vimInsertStart
 import com.maddyhome.idea.vim.helper.vimLastColumn
 import com.maddyhome.idea.vim.helper.vimLastVisualOperatorRange
@@ -56,6 +57,7 @@ class IjVimCaret(val caret: Caret) : VimCaretBase() {
     set(value) {
       caret.vimLastColumn = value
     }
+  override fun resetLastColumn() = caret.resetVimLastColumn()
   override val inlayAwareVisualColumn: Int
     get() = caret.inlayAwareVisualColumn
   override val selectionStart: Int

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionUpActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionUpActionTest.kt
@@ -8,7 +8,6 @@
 
 package org.jetbrains.plugins.ideavim.action.motion.updown
 
-import com.maddyhome.idea.vim.helper.vimLastColumn
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -25,21 +24,6 @@ class MotionUpActionTest : VimTestCase() {
             all rocks and lavender and tufted grass,
     """.trimIndent()
     doTest(keys, before, after)
-  }
-
-  @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
-  fun `test last column is incorrect`() {
-    val before = """
-            I found it in a legendary land
-            all rocks and lave${c}nder and tufted grass,
-    """.trimIndent()
-    val after = """
-            I found it in a le${c}gendary land
-            all rocks and lavender and tufted grass,
-    """.trimIndent()
-    doTest("k", before, after) {
-      it.caretModel.primaryCaret.vimLastColumn = 5
-    }
   }
 
   fun `test last column to shorter line`() {
@@ -60,17 +44,21 @@ class MotionUpActionTest : VimTestCase() {
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
-  fun `test last column wrong lastColumn`() {
-    val before = """
-            I found it in a legendary land
-            all rocks and lavender and tufted ${c}grass,
-    """.trimIndent()
-    val after = """
-            I found it in a legendary lan${c}d
-            all rocks and lavender and tufted grass,
-    """.trimIndent()
-    doTest("k", before, after) {
-      it.caretModel.primaryCaret.vimLastColumn = 0
+  fun `test caret moved outside of IdeaVim control`() {
+    doTest(
+      "k",
+      """
+        I found it in a legendary land
+        all rock${c}s and lavender and tufted grass,
+      """.trimIndent(),
+      """
+        I found it in a le${c}gendary land
+        all rocks and lavender and tufted grass,
+      """.trimIndent()
+    ) {
+      // Simulate the caret being moved without IdeaVim knowing and therefore without vimLastColumn being updated
+      // This offset is effectively "lave${c}nder"
+      it.caretModel.primaryCaret.moveToOffset(49)
     }
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/CommonExtensionTests.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/CommonExtensionTests.kt
@@ -26,6 +26,7 @@ import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMapping
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMappingIfMissing
 import com.maddyhome.idea.vim.extension.VimExtensionRegistrar
 import com.maddyhome.idea.vim.group.MotionGroup
+import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.helper.isEndAllowed
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.newapi.vim
@@ -369,7 +370,7 @@ private class TestExtension : VimExtension {
       VimPlugin.getVisualMotion().enterVisualMode(editor, VimStateMachine.SubMode.VISUAL_LINE)
       val caret = editor.ij.caretModel.currentCaret
       val newOffset = VimPlugin.getMotion().getVerticalMotionOffset(editor, caret.vim, 1)
-      MotionGroup.moveCaret(editor.ij, caret, newOffset)
+      MotionGroup.moveCaret(editor.ij, caret, (newOffset as Motion.AbsoluteOffset).offset)
     }
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionArrowLeftAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionArrowLeftAction.kt
@@ -15,7 +15,9 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.MotionType
+import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.NonShiftedSpecialKeyHandler
+import com.maddyhome.idea.vim.handler.toMotionOrError
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
@@ -25,14 +27,14 @@ class MotionArrowLeftAction : NonShiftedSpecialKeyHandler(), ComplicatedKeysActi
   override val keyStrokesSet: Set<List<KeyStroke>> =
     setOf(injector.parser.parseKeys("<Left>"), listOf(KeyStroke.getKeyStroke(KeyEvent.VK_KP_LEFT, 0)))
 
-  override fun offset(
+  override fun motion(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
     count: Int,
     rawCount: Int,
     argument: Argument?,
-  ): Int {
-    return injector.motion.getOffsetOfHorizontalMotion(editor, caret, -count, false)
+  ): Motion {
+    return injector.motion.getOffsetOfHorizontalMotion(editor, caret, -count, false).toMotionOrError()
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionArrowRightAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionArrowRightAction.kt
@@ -15,7 +15,9 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.MotionType
+import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.NonShiftedSpecialKeyHandler
+import com.maddyhome.idea.vim.handler.toMotionOrError
 import com.maddyhome.idea.vim.helper.isEndAllowed
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
@@ -28,15 +30,15 @@ class MotionArrowRightAction : NonShiftedSpecialKeyHandler(), ComplicatedKeysAct
     listOf(KeyStroke.getKeyStroke(KeyEvent.VK_KP_RIGHT, 0))
   )
 
-  override fun offset(
+  override fun motion(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
     count: Int,
     rawCount: Int,
     argument: Argument?,
-  ): Int {
+  ): Motion {
     val allowPastEnd = editor.isEndAllowed
-    return injector.motion.getOffsetOfHorizontalMotion(editor, caret, count, allowPastEnd)
+    return injector.motion.getOffsetOfHorizontalMotion(editor, caret, count, allowPastEnd).toMotionOrError()
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionColumnAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionColumnAction.kt
@@ -27,10 +27,6 @@ class MotionColumnAction : MotionActionHandler.ForEachCaret() {
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Motion {
-    val motion = injector.motion.moveCaretToColumn(editor, caret, operatorArguments.count1 - 1, false)
-    return when (motion) {
-      is Motion.AbsoluteOffset -> Motion.AdjustedOffset(motion.offset, operatorArguments.count1 - 1)
-      else -> motion
-    }
+    return injector.motion.moveCaretToColumn(editor, caret, operatorArguments.count1 - 1, false)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionColumnAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionColumnAction.kt
@@ -12,13 +12,14 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.MotionActionHandler
 
 class MotionColumnAction : MotionActionHandler.ForEachCaret() {
+  override val motionType: MotionType = MotionType.EXCLUSIVE
+
   override fun getOffset(
     editor: VimEditor,
     caret: VimCaret,
@@ -26,17 +27,10 @@ class MotionColumnAction : MotionActionHandler.ForEachCaret() {
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Motion {
-    return injector.motion.moveCaretToColumn(editor, caret, operatorArguments.count1 - 1, false)
+    val motion = injector.motion.moveCaretToColumn(editor, caret, operatorArguments.count1 - 1, false)
+    return when (motion) {
+      is Motion.AbsoluteOffset -> Motion.AdjustedOffset(motion.offset, operatorArguments.count1 - 1)
+      else -> motion
+    }
   }
-
-  override fun postMove(
-    editor: VimEditor,
-    caret: VimCaret,
-    context: ExecutionContext,
-    cmd: Command,
-  ) {
-    caret.vimLastColumn = cmd.count - 1
-  }
-
-  override val motionType: MotionType = MotionType.EXCLUSIVE
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionEndAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionEndAction.kt
@@ -14,7 +14,6 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimMotionGroupBase
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.NonShiftedSpecialKeyHandler
@@ -51,9 +50,5 @@ class MotionEndAction : NonShiftedSpecialKeyHandler() {
 
     val offset = injector.motion.moveCaretToRelativeLineEnd(editor, caret, count - 1, allow)
     return Motion.AdjustedOffset(offset, VimMotionGroupBase.LAST_COLUMN)
-  }
-
-  override fun preMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
-    caret.vimLastColumn = VimMotionGroupBase.LAST_COLUMN
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionEndAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionEndAction.kt
@@ -16,6 +16,7 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
+import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.NonShiftedSpecialKeyHandler
 import com.maddyhome.idea.vim.helper.inInsertMode
 import com.maddyhome.idea.vim.helper.inSelectMode
@@ -27,14 +28,14 @@ import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 class MotionEndAction : NonShiftedSpecialKeyHandler() {
   override val motionType: MotionType = MotionType.INCLUSIVE
 
-  override fun offset(
+  override fun motion(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
     count: Int,
     rawCount: Int,
     argument: Argument?,
-  ): Int {
+  ): Motion {
     var allow = false
     if (editor.inInsertMode) {
       allow = true
@@ -48,14 +49,11 @@ class MotionEndAction : NonShiftedSpecialKeyHandler() {
       }
     }
 
-    return injector.motion.moveCaretToRelativeLineEnd(editor, caret, count - 1, allow)
+    val offset = injector.motion.moveCaretToRelativeLineEnd(editor, caret, count - 1, allow)
+    return Motion.AdjustedOffset(offset, VimMotionGroupBase.LAST_COLUMN)
   }
 
   override fun preMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
-    caret.vimLastColumn = VimMotionGroupBase.LAST_COLUMN
-  }
-
-  override fun postMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
     caret.vimLastColumn = VimMotionGroupBase.LAST_COLUMN
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionHomeAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionHomeAction.kt
@@ -14,19 +14,21 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.MotionType
+import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.NonShiftedSpecialKeyHandler
+import com.maddyhome.idea.vim.handler.toMotionOrError
 
 class MotionHomeAction : NonShiftedSpecialKeyHandler() {
   override val motionType: MotionType = MotionType.EXCLUSIVE
 
-  override fun offset(
+  override fun motion(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
     count: Int,
     rawCount: Int,
     argument: Argument?,
-  ): Int {
-    return injector.motion.moveCaretToCurrentLineStart(editor, caret)
+  ): Motion {
+    return injector.motion.moveCaretToCurrentLineStart(editor, caret).toMotionOrError()
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionLastColumnAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionLastColumnAction.kt
@@ -20,7 +20,6 @@ import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.MotionActionHandler
-import com.maddyhome.idea.vim.handler.toMotion
 import com.maddyhome.idea.vim.helper.enumSetOf
 import com.maddyhome.idea.vim.helper.inVisualMode
 import com.maddyhome.idea.vim.helper.isEndAllowed
@@ -55,11 +54,8 @@ open class MotionLastColumnAction : MotionActionHandler.ForEachCaret() {
       if (operatorArguments.isOperatorPending) false else editor.isEndAllowed
     }
 
-    return injector.motion.moveCaretToRelativeLineEnd(editor, caret, operatorArguments.count1 - 1, allow).toMotion()
-  }
-
-  override fun postMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
-    caret.vimLastColumn = VimMotionGroupBase.LAST_COLUMN
+    val offset = injector.motion.moveCaretToRelativeLineEnd(editor, caret, operatorArguments.count1 - 1, allow)
+    return Motion.AdjustedOffset(offset, VimMotionGroupBase.LAST_COLUMN)
   }
 
   override fun preMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionLastColumnAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionLastColumnAction.kt
@@ -14,7 +14,6 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimMotionGroupBase
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.command.OperatorArguments
@@ -56,9 +55,5 @@ open class MotionLastColumnAction : MotionActionHandler.ForEachCaret() {
 
     val offset = injector.motion.moveCaretToRelativeLineEnd(editor, caret, operatorArguments.count1 - 1, allow)
     return Motion.AdjustedOffset(offset, VimMotionGroupBase.LAST_COLUMN)
-  }
-
-  override fun preMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
-    caret.vimLastColumn = VimMotionGroupBase.LAST_COLUMN
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionLastScreenColumnAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionLastScreenColumnAction.kt
@@ -13,7 +13,6 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimMotionGroupBase
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.Motion
@@ -46,16 +45,11 @@ class MotionLastScreenColumnAction : MotionActionHandler.ForEachCaret() {
         allow = true
       }
     }
-    return injector.motion.moveCaretToCurrentDisplayLineEnd(editor, caret, allow)
-  }
-
-  override fun postMove(
-    editor: VimEditor,
-    caret: VimCaret,
-    context: ExecutionContext,
-    cmd: Command,
-  ) {
-    caret.vimLastColumn = VimMotionGroupBase.LAST_COLUMN
+    val motion = injector.motion.moveCaretToCurrentDisplayLineEnd(editor, caret, allow)
+    return when (motion) {
+      is Motion.AbsoluteOffset -> Motion.AdjustedOffset(motion.offset, VimMotionGroupBase.LAST_COLUMN)
+      else -> motion
+    }
   }
 
   override val motionType: MotionType = MotionType.INCLUSIVE

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionShiftEndAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionShiftEndAction.kt
@@ -43,7 +43,7 @@ class MotionShiftEndAction : ShiftedSpecialKeyHandler() {
     }
 
     val newOffset = injector.motion.moveCaretToRelativeLineEnd(editor, caret, cmd.count - 1, allow)
-    caret.vimLastColumn = VimMotionGroupBase.LAST_COLUMN
+
     caret.moveToOffset(newOffset)
     caret.vimLastColumn = VimMotionGroupBase.LAST_COLUMN
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/screen/MotionFirstScreenLineAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/screen/MotionFirstScreenLineAction.kt
@@ -12,7 +12,6 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.command.OperatorArguments
@@ -51,13 +50,6 @@ abstract class MotionFirstScreenLineActionBase(private val operatorPending: Bool
     // This is inside scrolloff, so Vim scrolls
     return injector.motion.moveCaretToFirstDisplayLine(editor, caret, operatorArguments.count1, !operatorPending)
       .toMotion()
-  }
-
-  override fun postMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
-    if (operatorPending) {
-      // Convert current caret line from a 0-based logical line to a 1-based logical line
-      injector.motion.scrollCurrentLineToDisplayTop(editor, caret.vimLine, false)
-    }
   }
 }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/screen/MotionLastScreenLineAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/screen/MotionLastScreenLineAction.kt
@@ -12,7 +12,6 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.command.OperatorArguments
@@ -47,13 +46,6 @@ abstract class MotionLastScreenLineActionBase(private val operatorPending: Boole
   ): Motion {
     return injector.motion.moveCaretToLastDisplayLine(editor, caret, operatorArguments.count1, !operatorPending)
       .toMotion()
-  }
-
-  override fun postMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
-    if (operatorPending) {
-      // Convert current caret line from a 0-based logical line to a 1-based logical line
-      injector.motion.scrollCurrentLineToDisplayTop(editor, caret.vimLine, false)
-    }
   }
 }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectEnableBlockModeAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectEnableBlockModeAction.kt
@@ -35,7 +35,6 @@ class SelectEnableBlockModeAction : VimActionHandler.SingleExecution() {
     editor.primaryCaret().run {
       vimSetSystemSelectionSilently(offset.point, (offset.point + 1).coerceAtMost(lineEnd))
       moveToInlayAwareOffset((offset.point + 1).coerceAtMost(lineEnd))
-      vimLastColumn = getVisualPosition().column
     }
     return injector.visualMotionGroup.enterSelectMode(editor, VimStateMachine.SubMode.VISUAL_BLOCK)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectEnableCharacterModeAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectEnableCharacterModeAction.kt
@@ -35,7 +35,6 @@ class SelectEnableCharacterModeAction : VimActionHandler.SingleExecution() {
       caret.run {
         vimSetSystemSelectionSilently(offset.point, (offset.point + 1).coerceAtMost(lineEnd))
         moveToInlayAwareOffset((offset.point + 1).coerceAtMost(lineEnd))
-        vimLastColumn = getVisualPosition().column
       }
     }
     return injector.visualMotionGroup.enterSelectMode(editor, VimStateMachine.SubMode.VISUAL_CHARACTER)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionArrowDownAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionArrowDownAction.kt
@@ -16,7 +16,9 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
+import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.NonShiftedSpecialKeyHandler
+import com.maddyhome.idea.vim.handler.toAdjustedMotionOrError
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
@@ -28,23 +30,20 @@ class MotionArrowDownAction : NonShiftedSpecialKeyHandler(), ComplicatedKeysActi
 
   private var col: Int = 0
 
-  override fun offset(
+  override fun motion(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
     count: Int,
     rawCount: Int,
     argument: Argument?,
-  ): Int {
-    return injector.motion.getVerticalMotionOffset(editor, caret, count)
+  ): Motion {
+    val offset = injector.motion.getVerticalMotionOffset(editor, caret, count)
+    return offset.toAdjustedMotionOrError(col)
   }
 
   override fun preOffsetComputation(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command): Boolean {
     col = injector.engineEditorHelper.prepareLastColumn(caret)
     return true
-  }
-
-  override fun postMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
-    injector.engineEditorHelper.updateLastColumn(caret, col)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionArrowDownAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionArrowDownAction.kt
@@ -14,11 +14,9 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.NonShiftedSpecialKeyHandler
-import com.maddyhome.idea.vim.handler.toAdjustedMotionOrError
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
@@ -28,8 +26,6 @@ class MotionArrowDownAction : NonShiftedSpecialKeyHandler(), ComplicatedKeysActi
   override val keyStrokesSet: Set<List<KeyStroke>> =
     setOf(injector.parser.parseKeys("<Down>"), listOf(KeyStroke.getKeyStroke(KeyEvent.VK_KP_DOWN, 0)))
 
-  private var col: Int = 0
-
   override fun motion(
     editor: VimEditor,
     caret: VimCaret,
@@ -38,12 +34,6 @@ class MotionArrowDownAction : NonShiftedSpecialKeyHandler(), ComplicatedKeysActi
     rawCount: Int,
     argument: Argument?,
   ): Motion {
-    val offset = injector.motion.getVerticalMotionOffset(editor, caret, count)
-    return offset.toAdjustedMotionOrError(col)
-  }
-
-  override fun preOffsetComputation(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command): Boolean {
-    col = injector.engineEditorHelper.prepareLastColumn(caret)
-    return true
+    return injector.motion.getVerticalMotionOffset(editor, caret, count)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionArrowUpAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionArrowUpAction.kt
@@ -14,11 +14,9 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.NonShiftedSpecialKeyHandler
-import com.maddyhome.idea.vim.handler.toAdjustedMotionOrError
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
@@ -28,8 +26,6 @@ class MotionArrowUpAction : NonShiftedSpecialKeyHandler(), ComplicatedKeysAction
   override val keyStrokesSet: Set<List<KeyStroke>> =
     setOf(injector.parser.parseKeys("<Up>"), listOf(KeyStroke.getKeyStroke(KeyEvent.VK_KP_UP, 0)))
 
-  private var col: Int = 0
-
   override fun motion(
     editor: VimEditor,
     caret: VimCaret,
@@ -38,12 +34,6 @@ class MotionArrowUpAction : NonShiftedSpecialKeyHandler(), ComplicatedKeysAction
     rawCount: Int,
     argument: Argument?,
   ): Motion {
-    val offset = injector.motion.getVerticalMotionOffset(editor, caret, -count)
-    return offset.toAdjustedMotionOrError(col)
-  }
-
-  override fun preOffsetComputation(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command): Boolean {
-    col = injector.engineEditorHelper.prepareLastColumn(caret)
-    return true
+    return injector.motion.getVerticalMotionOffset(editor, caret, -count)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionArrowUpAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionArrowUpAction.kt
@@ -16,7 +16,9 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
+import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.NonShiftedSpecialKeyHandler
+import com.maddyhome.idea.vim.handler.toAdjustedMotionOrError
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
@@ -28,23 +30,20 @@ class MotionArrowUpAction : NonShiftedSpecialKeyHandler(), ComplicatedKeysAction
 
   private var col: Int = 0
 
-  override fun offset(
+  override fun motion(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
     count: Int,
     rawCount: Int,
     argument: Argument?,
-  ): Int {
-    return injector.motion.getVerticalMotionOffset(editor, caret, -count)
+  ): Motion {
+    val offset = injector.motion.getVerticalMotionOffset(editor, caret, -count)
+    return offset.toAdjustedMotionOrError(col)
   }
 
   override fun preOffsetComputation(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command): Boolean {
     col = injector.engineEditorHelper.prepareLastColumn(caret)
     return true
-  }
-
-  override fun postMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
-    injector.engineEditorHelper.updateLastColumn(caret, col)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionDownActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionDownActions.kt
@@ -13,17 +13,13 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.MotionActionHandler
 import com.maddyhome.idea.vim.handler.toMotion
-import com.maddyhome.idea.vim.handler.toMotionOrError
 
 sealed class MotionDownBase : MotionActionHandler.ForEachCaret() {
-  private var col: Int = 0
-
   final override fun getOffset(
     editor: VimEditor,
     caret: VimCaret,
@@ -31,11 +27,7 @@ sealed class MotionDownBase : MotionActionHandler.ForEachCaret() {
     argument: Argument?,
     operatorArguments: OperatorArguments
   ): Motion {
-    val motion = getMotion(editor, caret, context, argument, operatorArguments)
-    return when (motion) {
-      is Motion.AbsoluteOffset -> Motion.AdjustedOffset(motion.offset, col)
-      else -> motion
-    }
+    return getMotion(editor, caret, context, argument, operatorArguments)
   }
 
   abstract fun getMotion(
@@ -45,16 +37,6 @@ sealed class MotionDownBase : MotionActionHandler.ForEachCaret() {
     argument: Argument?,
     operatorArguments: OperatorArguments
   ): Motion
-
-  override fun preOffsetComputation(
-    editor: VimEditor,
-    caret: VimCaret,
-    context: ExecutionContext,
-    cmd: Command,
-  ): Boolean {
-    col = injector.engineEditorHelper.prepareLastColumn(caret)
-    return true
-  }
 }
 
 open class MotionDownAction : MotionDownBase() {
@@ -68,7 +50,7 @@ open class MotionDownAction : MotionDownBase() {
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Motion {
-    return injector.motion.getVerticalMotionOffset(editor, caret, operatorArguments.count1).toMotionOrError()
+    return injector.motion.getVerticalMotionOffset(editor, caret, operatorArguments.count1)
   }
 }
 
@@ -104,6 +86,6 @@ class MotionDownNotLineWiseAction : MotionDownBase() {
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Motion {
-    return injector.motion.getVerticalMotionOffset(editor, caret, operatorArguments.count1).toMotionOrError()
+    return injector.motion.getVerticalMotionOffset(editor, caret, operatorArguments.count1)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionDownActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionDownActions.kt
@@ -19,31 +19,10 @@ import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.MotionActionHandler
 import com.maddyhome.idea.vim.handler.toMotion
 
-sealed class MotionDownBase : MotionActionHandler.ForEachCaret() {
-  final override fun getOffset(
-    editor: VimEditor,
-    caret: VimCaret,
-    context: ExecutionContext,
-    argument: Argument?,
-    operatorArguments: OperatorArguments
-  ): Motion {
-    return getMotion(editor, caret, context, argument, operatorArguments)
-  }
-
-  abstract fun getMotion(
-    editor: VimEditor,
-    caret: VimCaret,
-    context: ExecutionContext,
-    argument: Argument?,
-    operatorArguments: OperatorArguments
-  ): Motion
-}
-
-open class MotionDownAction : MotionDownBase() {
-
+open class MotionDownAction : MotionActionHandler.ForEachCaret() {
   override val motionType: MotionType = MotionType.LINE_WISE
 
-  override fun getMotion(
+  override fun getOffset(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
@@ -55,7 +34,7 @@ open class MotionDownAction : MotionDownBase() {
 }
 
 class MotionDownCtrlNAction : MotionDownAction() {
-  override fun getMotion(
+  override fun getOffset(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
@@ -75,11 +54,10 @@ class MotionDownCtrlNAction : MotionDownAction() {
   }
 }
 
-class MotionDownNotLineWiseAction : MotionDownBase() {
-
+class MotionDownNotLineWiseAction : MotionActionHandler.ForEachCaret() {
   override val motionType: MotionType = MotionType.EXCLUSIVE
 
-  override fun getMotion(
+  override fun getOffset(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionShiftDownAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionShiftDownAction.kt
@@ -13,6 +13,7 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.ShiftedArrowKeyHandler
 
 /**
@@ -25,10 +26,16 @@ class MotionShiftDownAction : ShiftedArrowKeyHandler(false) {
 
   override fun motionWithKeyModel(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {
     val vertical = injector.motion.getVerticalMotionOffset(editor, caret, cmd.count)
-    val col = injector.engineEditorHelper.prepareLastColumn(caret)
-    caret.moveToOffset(vertical)
+    when (vertical) {
+      is Motion.AdjustedOffset -> {
+        caret.moveToOffset(vertical.offset)
+        caret.vimLastColumn = vertical.intendedColumn
+      }
 
-    injector.engineEditorHelper.updateLastColumn(caret, col)
+      is Motion.AbsoluteOffset -> caret.moveToOffset(vertical.offset)
+      is Motion.NoMotion -> {}
+      is Motion.Error -> injector.messages.indicateError()
+    }
   }
 
   override fun motionWithoutKeyModel(editor: VimEditor, context: ExecutionContext, cmd: Command) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionUpActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionUpActions.kt
@@ -13,17 +13,13 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.MotionType
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.MotionActionHandler
 import com.maddyhome.idea.vim.handler.toMotion
-import com.maddyhome.idea.vim.handler.toMotionOrError
 
 sealed class MotionUpBase : MotionActionHandler.ForEachCaret() {
-  private var col: Int = 0
-
   final override fun getOffset(
     editor: VimEditor,
     caret: VimCaret,
@@ -31,11 +27,7 @@ sealed class MotionUpBase : MotionActionHandler.ForEachCaret() {
     argument: Argument?,
     operatorArguments: OperatorArguments
   ): Motion {
-    val motion = getMotion(editor, caret, context, argument, operatorArguments)
-    return when (motion) {
-      is Motion.AbsoluteOffset -> Motion.AdjustedOffset(motion.offset, col)
-      else -> motion
-    }
+    return getMotion(editor, caret, context, argument, operatorArguments)
   }
 
   abstract fun getMotion(
@@ -45,16 +37,6 @@ sealed class MotionUpBase : MotionActionHandler.ForEachCaret() {
     argument: Argument?,
     operatorArguments: OperatorArguments
   ): Motion
-
-  override fun preOffsetComputation(
-    editor: VimEditor,
-    caret: VimCaret,
-    context: ExecutionContext,
-    cmd: Command,
-  ): Boolean {
-    col = injector.engineEditorHelper.prepareLastColumn(caret)
-    return true
-  }
 }
 
 open class MotionUpAction : MotionUpBase() {
@@ -67,7 +49,7 @@ open class MotionUpAction : MotionUpBase() {
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Motion {
-    return injector.motion.getVerticalMotionOffset(editor, caret, -operatorArguments.count1).toMotionOrError()
+    return injector.motion.getVerticalMotionOffset(editor, caret, -operatorArguments.count1)
   }
 }
 
@@ -102,6 +84,6 @@ class MotionUpNotLineWiseAction : MotionUpBase() {
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Motion {
-    return injector.motion.getVerticalMotionOffset(editor, caret, -operatorArguments.count1).toMotionOrError()
+    return injector.motion.getVerticalMotionOffset(editor, caret, -operatorArguments.count1)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionUpActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionUpActions.kt
@@ -19,30 +19,10 @@ import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.MotionActionHandler
 import com.maddyhome.idea.vim.handler.toMotion
 
-sealed class MotionUpBase : MotionActionHandler.ForEachCaret() {
-  final override fun getOffset(
-    editor: VimEditor,
-    caret: VimCaret,
-    context: ExecutionContext,
-    argument: Argument?,
-    operatorArguments: OperatorArguments
-  ): Motion {
-    return getMotion(editor, caret, context, argument, operatorArguments)
-  }
-
-  abstract fun getMotion(
-    editor: VimEditor,
-    caret: VimCaret,
-    context: ExecutionContext,
-    argument: Argument?,
-    operatorArguments: OperatorArguments
-  ): Motion
-}
-
-open class MotionUpAction : MotionUpBase() {
+open class MotionUpAction : MotionActionHandler.ForEachCaret() {
   override val motionType: MotionType = MotionType.LINE_WISE
 
-  override fun getMotion(
+  override fun getOffset(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
@@ -54,7 +34,7 @@ open class MotionUpAction : MotionUpBase() {
 }
 
 class MotionUpCtrlPAction : MotionUpAction() {
-  override fun getMotion(
+  override fun getOffset(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
@@ -74,10 +54,10 @@ class MotionUpCtrlPAction : MotionUpAction() {
   }
 }
 
-class MotionUpNotLineWiseAction : MotionUpBase() {
+class MotionUpNotLineWiseAction : MotionActionHandler.ForEachCaret() {
   override val motionType: MotionType = MotionType.EXCLUSIVE
 
-  override fun getMotion(
+  override fun getOffset(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
@@ -21,8 +21,6 @@ interface EngineEditorHelper {
   fun normalizeVisualColumn(editor: VimEditor, line: Int, col: Int, allowEnd: Boolean): Int
   fun amountOfInlaysBeforeVisualPosition(editor: VimEditor, pos: VimVisualPosition): Int
   fun getVisualLineCount(editor: VimEditor): Int
-  fun prepareLastColumn(caret: VimCaret): Int
-  fun updateLastColumn(caret: VimCaret, prevLastColumn: Int)
   fun getLineEndOffset(editor: VimEditor, line: Int, allowEnd: Boolean): Int
   fun getLineStartOffset(editor: VimEditor, line: Int): Int
   fun getLineStartForOffset(editor: VimEditor, line: Int): Int

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCaret.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCaret.kt
@@ -36,7 +36,6 @@ interface VimCaret {
 
   var vimLastColumn: Int
   fun resetLastColumn()
-  val inlayAwareVisualColumn: Int
 
   fun hasSelection(): Boolean
   val selectionStart: Int

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCaret.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCaret.kt
@@ -35,6 +35,7 @@ interface VimCaret {
   val vimLine: Int
 
   var vimLastColumn: Int
+  fun resetLastColumn()
   val inlayAwareVisualColumn: Int
 
   fun hasSelection(): Boolean

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -903,7 +903,8 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     if (res) {
       var pos = injector.engineEditorHelper.normalizeOffset(editor, range.startOffset, isChange)
       if (type === SelectionType.LINE_WISE) {
-        // Deleting text will move the caret, which invalidates the last column. Reset it before trying to use it
+        // Reset the saved intended column cache, which has been invalidated by the caret moving due to deleted text.
+        // This value will be used to reposition the caret if 'startofline' is false
         caret.vimLastColumn = intendedColumn
         pos = injector.motion
           .moveCaretToLineWithStartOfLineOption(
@@ -912,6 +913,10 @@ abstract class VimChangeGroupBase : VimChangeGroup {
           )
       }
       injector.motion.moveCaret(editor, caret, pos)
+
+      // Ensure the intended column cache is invalidated - it will only happen automatically if the caret actually moves
+      // If 'startofline' is true and we've just deleted text, it's likely we haven't moved
+      caret.resetLastColumn()
     }
     return res
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroup.kt
@@ -24,7 +24,7 @@ interface VimMotionGroup {
 
   // Note that the following methods require the caret to access the intended vertical position, such as "end of line"
   fun getOffsetOfHorizontalMotion(editor: VimEditor, caret: VimCaret, count: Int, allowPastEnd: Boolean): Int
-  fun getVerticalMotionOffset(editor: VimEditor, caret: VimCaret, count: Int): Int
+  fun getVerticalMotionOffset(editor: VimEditor, caret: VimCaret, count: Int): Motion
 
   // TODO: Consider naming. These don't move the caret, but calculate offsets. Also consider returning Motion
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
@@ -54,12 +54,15 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
         editor.forEachCaret {
           val range = it.vimLastVisualOperatorRange ?: VisualChange.default(subMode)
           val end = VisualOperation.calculateRange(editor, range, count, it)
-          val lastColumn =
-            if (range.columns == VimMotionGroupBase.LAST_COLUMN) VimMotionGroupBase.LAST_COLUMN else editor.offsetToLogicalPosition(
-              end
-            ).column
-          it.vimLastColumn = lastColumn
+          val intendedColumn = if (range.columns == VimMotionGroupBase.LAST_COLUMN) {
+            VimMotionGroupBase.LAST_COLUMN
+          } else {
+            editor.offsetToLogicalPosition(end).column
+          }
+          // Set the intended column before moving the caret, then reset because we've moved the caret
+          it.vimLastColumn = intendedColumn
           it.vimSetSelection(it.offset.point, end, true)
+          it.vimLastColumn = intendedColumn
         }
       } else {
         editor.vimStateMachine.pushVisualMode(subMode)
@@ -136,7 +139,7 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
    *
    * it:
    * - Updates command state
-   * - Updates [vimSelectionStart] property
+   * - Updates [VimCaret.vimSelectionStart] property
    * - Updates caret colors
    * - Updates care shape
    *

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimRange.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimRange.kt
@@ -97,9 +97,6 @@ abstract class VimMachineBase : VimMachine {
    * - What caret?
    */
   override fun delete(range: VimRange, editor: VimEditor, caret: VimCaret): OperatedRange? {
-    // Update the last column before we delete, or we might be retrieving the data for a line that no longer exists
-    caret.vimLastColumn = caret.inlayAwareVisualColumn
-
     val operatedText = editor.deleteDryRun(range) ?: return null
 
     val normalizedRange = operatedText.toNormalizedTextRange(editor)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/ChangeEditorActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/ChangeEditorActionHandler.kt
@@ -144,7 +144,6 @@ sealed class ChangeEditorActionHandler : EditorActionHandlerBase(false) {
     if (worked[0]) {
       VimRepeater.saveLastChange(cmd)
       VimRepeater.repeatHandler = false
-      editor.forEachNativeCaret({ it.vimLastColumn = it.getVisualPosition().column })
     }
 
     val toSwitch = editor.vimChangeActionSwitchMode

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/Motion.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/Motion.kt
@@ -11,7 +11,21 @@ package com.maddyhome.idea.vim.handler
 sealed class Motion {
   object Error : Motion()
   object NoMotion : Motion()
-  class AbsoluteOffset(val offset: Int) : Motion()
+  open class AbsoluteOffset(val offset: Int) : Motion()
+
+  /**
+   * Represents a motion to an absolute offset that has been horizontally adjusted to avoid virtual text.
+   *
+   * This is most often used during vertical motion, which aims to move the caret to the character column above/below
+   * the current location, but also has to avoid virtual text. The intended caret location is remembered as the count of
+   * columns from the start of the buffer line (even if wrapped), including the effective column width of all virtual
+   * text. This value is used for subsequent vertical motions to correctly re-position the caret in the correct column.
+   *
+   * @param offset          The absolute offset that the caret will be moved to.
+   * @param intendedColumn  The index of the intended location of the caret, as counted in columns from the start of the
+   *                        buffer line, including the column width of all virtual text.
+   */
+  class AdjustedOffset(offset: Int, val intendedColumn: Int) : AbsoluteOffset(offset)
 }
 
 fun Int.toMotion(): Motion.AbsoluteOffset {
@@ -22,3 +36,4 @@ fun Int.toMotion(): Motion.AbsoluteOffset {
 fun Int.toMotionOrError(): Motion = if (this < 0) Motion.Error else Motion.AbsoluteOffset(this)
 fun Long.toMotionOrError(): Motion = if (this < 0) Motion.Error else Motion.AbsoluteOffset(this.toInt())
 fun Int.toMotionOrNoMotion(): Motion = if (this < 0) Motion.NoMotion else Motion.AbsoluteOffset(this)
+fun Int.toAdjustedMotionOrError(intendedColumn: Int): Motion = if (this < 0) Motion.Error else Motion.AdjustedOffset(this, intendedColumn)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
@@ -61,13 +61,6 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
     open fun preOffsetComputation(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command): Boolean = true
 
     /**
-     * This method is called after [getOffset], but before caret motion.
-     *
-     * The method executes for each caret, but only once it there is block selection.
-     */
-    open fun preMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {}
-
-    /**
      * This method is called after [getOffset] and after caret motion.
      *
      * The method executes for each caret, but only once it there is block selection.
@@ -226,7 +219,6 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
                                                 cmd: Command,
                                                 offset: Motion.AbsoluteOffset) {
     val normalisedOffset = prepareMoveToAbsoluteOffset(editor, cmd, offset)
-    preMove(editor, caret, context, cmd)
     caret.moveToOffset(normalisedOffset)
 
     // Block selection mode might cause IntelliJ to invalidate/replace/add a new primary caret. Refresh if necessary

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
@@ -111,9 +111,10 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
       is SingleExecution -> run {
         val offset = getOffset(editor, context, cmd.argument, operatorArguments)
 
+        // In this scenario, caret is the primary caret
         when (offset) {
           is Motion.AdjustedOffset -> moveToAdjustedOffset(editor, caret, cmd, offset)
-          is Motion.AbsoluteOffset -> moveToAbsoluteOffset(editor, cmd, offset)
+          is Motion.AbsoluteOffset -> moveToAbsoluteOffset(editor, caret, cmd, offset)
           is Motion.Error -> injector.messages.indicateError()
           is Motion.NoMotion -> Unit
         }
@@ -160,7 +161,7 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
 
     when (offset) {
       is Motion.AdjustedOffset -> moveToAdjustedOffset(editor, caret, cmd, offset)
-      is Motion.AbsoluteOffset -> moveToAbsoluteOffset(editor, caret, context, cmd, offset)
+      is Motion.AbsoluteOffset -> moveToAbsoluteOffset(editor, caret, cmd, offset)
       is Motion.Error -> injector.messages.indicateError()
       is Motion.NoMotion -> Unit
     }
@@ -197,20 +198,7 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
     }
   }
 
-  private fun moveToAbsoluteOffset(
-    editor: VimEditor,
-    cmd: Command,
-    offset: Motion.AbsoluteOffset
-  ) {
-    val normalisedOffset = prepareMoveToAbsoluteOffset(editor, cmd, offset)
-    editor.primaryCaret().moveToOffset(normalisedOffset)
-  }
-
-  private fun ForEachCaret.moveToAbsoluteOffset(editor: VimEditor,
-                                                caret: VimCaret,
-                                                context: ExecutionContext,
-                                                cmd: Command,
-                                                offset: Motion.AbsoluteOffset) {
+  private fun moveToAbsoluteOffset(editor: VimEditor, caret: VimCaret, cmd: Command, offset: Motion.AbsoluteOffset) {
     val normalisedOffset = prepareMoveToAbsoluteOffset(editor, cmd, offset)
     caret.moveToOffset(normalisedOffset)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
@@ -59,13 +59,6 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
      * The method executes only once it there is block selection.
      */
     open fun preOffsetComputation(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command): Boolean = true
-
-    /**
-     * This method is called after [getOffset] and after caret motion.
-     *
-     * The method executes for each caret, but only once it there is block selection.
-     */
-    open fun postMove(editor: VimEditor, caret: VimCaret, context: ExecutionContext, cmd: Command) {}
   }
 
   /**
@@ -220,10 +213,6 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
                                                 offset: Motion.AbsoluteOffset) {
     val normalisedOffset = prepareMoveToAbsoluteOffset(editor, cmd, offset)
     caret.moveToOffset(normalisedOffset)
-
-    // Block selection mode might cause IntelliJ to invalidate/replace/add a new primary caret. Refresh if necessary
-    val postMoveCaret = if (editor.inBlockSubMode) editor.primaryCaret() else caret
-    postMove(editor, postMoveCaret, context, cmd)
   }
 
   private fun prepareMoveToAbsoluteOffset(editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
@@ -92,26 +92,6 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
       argument: Argument?,
       operatorArguments: OperatorArguments
     ): Motion
-
-    /**
-     * This method is called before [getOffset].
-     * The method executes only once.
-     */
-    open fun preOffsetComputation(editor: VimEditor, context: ExecutionContext, cmd: Command): Boolean = true
-
-    /**
-     * This method is called after [getOffset], but before caret motion.
-     *
-     * The method executes only once.
-     */
-    open fun preMove(editor: VimEditor, context: ExecutionContext, cmd: Command) = Unit
-
-    /**
-     * This method is called after [getOffset] and after caret motion.
-     *
-     * The method executes only once it there is block selection.
-     */
-    open fun postMove(editor: VimEditor, context: ExecutionContext, cmd: Command) = Unit
   }
 
   abstract val motionType: MotionType
@@ -142,12 +122,10 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
 
     when (this) {
       is SingleExecution -> run {
-        if (!preOffsetComputation(editor, context, cmd)) return@run
-
         val offset = getOffset(editor, context, cmd.argument, operatorArguments)
 
         when (offset) {
-          is Motion.AbsoluteOffset -> moveToAbsoluteOffset(editor, context, cmd, offset)
+          is Motion.AbsoluteOffset -> moveToAbsoluteOffset(editor, cmd, offset)
           is Motion.Error -> injector.messages.indicateError()
           is Motion.NoMotion -> Unit
         }
@@ -200,13 +178,11 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
   }
 
   private fun SingleExecution.moveToAbsoluteOffset(editor: VimEditor,
-                                                   context: ExecutionContext,
+
                                                    cmd: Command,
                                                    offset: Motion.AbsoluteOffset) {
     val normalisedOffset = prepareMoveToAbsoluteOffset(editor, cmd, offset)
-    preMove(editor, context, cmd)
     editor.primaryCaret().moveToOffset(normalisedOffset)
-    postMove(editor, context, cmd)
   }
 
   private fun ForEachCaret.moveToAbsoluteOffset(editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/SpecialKeyHandlers.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/SpecialKeyHandlers.kt
@@ -183,18 +183,18 @@ abstract class NonShiftedSpecialKeyHandler : MotionActionHandler.ForEachCaret() 
       editor.exitVisualModeNative()
     }
 
-    return offset(editor, caret, context, operatorArguments.count1, operatorArguments.count0, argument).toMotionOrError()
+    return motion(editor, caret, context, operatorArguments.count1, operatorArguments.count0, argument)
   }
 
   /**
    * Calculate new offset for current [caret]
    */
-  abstract fun offset(
+  abstract fun motion(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
     count: Int,
     rawCount: Int,
     argument: Argument?,
-  ): Int
+  ): Motion
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
@@ -268,7 +268,6 @@ sealed class VisualOperatorActionHandler : EditorActionHandlerBase(false) {
             caret.vimLastVisualOperatorRange = visualChange
           }
         }
-        editor.forEachCaret({ it.vimLastColumn = it.getVisualPosition().column })
       }
 
       editor.vimKeepingVisualOperatorAction = false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/helpers/StrictMode.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/helpers/StrictMode.kt
@@ -5,6 +5,7 @@ import com.maddyhome.idea.vim.options.OptionConstants
 import com.maddyhome.idea.vim.options.OptionScope
 
 object StrictMode {
+  @JvmName("assertTrue")
   fun assert(condition: Boolean, message: String) {
     if (!condition) {
       fail(message)


### PR DESCRIPTION
This PR refactors how IdeaVim handles tracking the "last column" value. This value is the intended location of the caret, when that value might be adjusted before actually moving the caret. For example, if the caret is on a long line and moved to a shorter line, the original column value is stored as the "last column" (intended) value, so that the original column can be used when moving back to a longer line. Similarly, it can be set to the `LAST_COLUMN` magic value by the `$` command to always put the caret at the end of the line, regardless of length.

This PR:
- [x] Introduces a `Motion.AdjustedOffset` that can be returned from motion action handlers and helpers. This allows the handlers and helpers to calculate the adjustment, which will be important for soft wrap support. The base motion action handler understands this new type and will move the caret and update the saved value
- [x] Removes the `preOffsetComputation`, `preMove` and `postMove` hooks in the action handlers. These were mostly used to set and reset the `LAST_COLUMN` magic value. It is simpler to return these as part of the motion, which reduces the places that set the "last column" value
- [x] Simplify invalidating and resetting the value. Moving the caret invalidates the set value (handling any changes external to IdeaVim) and the value is only set if it is different to the current location

Only handlers that use `Motion` (i.e. motion action handlers) get this automatic setting of "last column". Other handlers such as operators still have to set the value manually, as before. However, they need to be careful to reset the value if the caret is moved as part of the operation (e.g. delete will move the caret, so the value needs to be stored in a variable before deleting, and reset before moving).