### PR TITLE
Rename VimLogicalPosition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -270,7 +270,7 @@ tasks {
         dependsOn("generateGrammarSource")
     }
     named("compileTestKotlin") {
-        dependsOn("generateGrammarSource")
+        dependsOn("generateTestGrammarSource")
     }
 
     // Add plugin open API sources to the plugin ZIP

--- a/src/main/java/com/maddyhome/idea/vim/action/internal/AddInlineInlaysAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/internal/AddInlineInlaysAction.kt
@@ -16,7 +16,7 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.VisualPosition
 import com.maddyhome.idea.vim.api.lineLength
-import com.maddyhome.idea.vim.api.visualLineToLogicalLine
+import com.maddyhome.idea.vim.api.visualLineToBufferLine
 import com.maddyhome.idea.vim.helper.VimNlsSafe
 import com.maddyhome.idea.vim.newapi.vim
 import java.util.*
@@ -34,7 +34,7 @@ class AddInlineInlaysAction : AnAction() {
     val inlayModel = editor.inlayModel
     val currentVisualLine = editor.caretModel.primaryCaret.visualPosition.line
     var i = random.nextInt(10)
-    val lineLength = vimEditor.lineLength(vimEditor.visualLineToLogicalLine(currentVisualLine))
+    val lineLength = vimEditor.lineLength(vimEditor.visualLineToBufferLine(currentVisualLine))
     while (i < lineLength) {
       val relatesToPrecedingText = random.nextInt(10) > 7
 

--- a/src/main/java/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.kt
@@ -202,9 +202,9 @@ class CommentaryExtension : VimExtension {
       val file = PsiHelper.getFile(nativeEditor) ?: return null
       val lastLine = editor.lineCount()
 
-      var startLine = caret.getLogicalPosition().line
+      var startLine = caret.getBufferPosition().line
       while (startLine > 0 && isCommentLine(file, nativeEditor, startLine - 1)) startLine--
-      var endLine = caret.getLogicalPosition().line - 1
+      var endLine = caret.getBufferPosition().line - 1
       while (endLine < lastLine && isCommentLine(file, nativeEditor, endLine + 1)) endLine++
 
       if (startLine <= endLine) {

--- a/src/main/java/com/maddyhome/idea/vim/extension/exchange/VimExchangeExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/exchange/VimExchangeExtension.kt
@@ -129,7 +129,7 @@ class VimExchangeExtension : VimExtension {
   }
 
   private class Operator(private val isVisual: Boolean) : OperatorFunction {
-    fun Editor.getMarkOffset(mark: Mark) = IjVimEditor(this).getOffset(mark.logicalLine, mark.col)
+    fun Editor.getMarkOffset(mark: Mark) = IjVimEditor(this).getOffset(mark.line, mark.col)
     fun VimStateMachine.SubMode.getString() = when (this) {
       VimStateMachine.SubMode.VISUAL_CHARACTER -> "v"
       VimStateMachine.SubMode.VISUAL_LINE -> "V"
@@ -208,19 +208,19 @@ class VimExchangeExtension : VimExtension {
         if (reverse) {
           primaryCaret.moveToInlayAwareOffset(editor.getMarkOffset(ex1.start))
         } else {
-          if (ex1.start.logicalLine == ex2.start.logicalLine) {
+          if (ex1.start.line == ex2.start.line) {
             val horizontalOffset = ex1.end.col - ex2.end.col
             primaryCaret.moveToInlayAwareLogicalPosition(
               LogicalPosition(
-                ex1.start.logicalLine,
+                ex1.start.line,
                 ex1.start.col - horizontalOffset
               )
             )
-          } else if (ex1.end.logicalLine - ex1.start.logicalLine != ex2.end.logicalLine - ex2.start.logicalLine) {
-            val verticalOffset = ex1.end.logicalLine - ex2.end.logicalLine
+          } else if (ex1.end.line - ex1.start.line != ex2.end.line - ex2.start.line) {
+            val verticalOffset = ex1.end.line - ex2.end.line
             primaryCaret.moveToInlayAwareLogicalPosition(
               LogicalPosition(
-                ex1.start.logicalLine - verticalOffset,
+                ex1.start.line - verticalOffset,
                 ex1.start.col
               )
             )
@@ -253,16 +253,16 @@ class VimExchangeExtension : VimExtension {
 
     private fun compareExchanges(x: Exchange, y: Exchange): ExchangeCompareResult {
       fun intersects(x: Exchange, y: Exchange) =
-        x.end.logicalLine < y.start.logicalLine ||
-          x.start.logicalLine > y.end.logicalLine ||
+        x.end.line < y.start.line ||
+          x.start.line > y.end.line ||
           x.end.col < y.start.col ||
           x.start.col > y.end.col
 
       fun comparePos(x: Mark, y: Mark): Int =
-        if (x.logicalLine == y.logicalLine) {
+        if (x.line == y.line) {
           x.col - y.col
         } else {
-          x.logicalLine - y.logicalLine
+          x.line - y.line
         }
 
       return if (x.type == VimStateMachine.SubMode.VISUAL_BLOCK && y.type == VimStateMachine.SubMode.VISUAL_BLOCK) {

--- a/src/main/java/com/maddyhome/idea/vim/extension/replacewithregister/ReplaceWithRegister.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/replacewithregister/ReplaceWithRegister.kt
@@ -85,7 +85,7 @@ class ReplaceWithRegister : VimExtension {
     override fun execute(editor: VimEditor, context: ExecutionContext) {
       val caretsAndSelections = mutableMapOf<VimCaret, VimSelection>()
       editor.forEachCaret { caret ->
-        val logicalLine = caret.getLogicalPosition().line
+        val logicalLine = caret.getBufferPosition().line
         val lineStart = editor.getLineStartOffset(logicalLine)
         val lineEnd = editor.getLineEndOffset(logicalLine, true)
 

--- a/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -197,8 +197,8 @@ public class ChangeGroup extends VimChangeGroupBase {
     }
     final Command motion = argument.getMotion();
     if (!isChange && !motion.isLinewiseMotion()) {
-      BufferPosition start = editor.offsetToLogicalPosition(range.getStartOffset());
-      BufferPosition end = editor.offsetToLogicalPosition(range.getEndOffset());
+      BufferPosition start = editor.offsetToBufferPosition(range.getStartOffset());
+      BufferPosition end = editor.offsetToBufferPosition(range.getEndOffset());
       if (start.getLine() != end.getLine()) {
         @NotNull Editor editor2 = ((IjVimEditor)editor).getEditor();
         int offset1 = range.getStartOffset();
@@ -351,7 +351,7 @@ public class ChangeGroup extends VimChangeGroupBase {
                              boolean append,
                              @NotNull OperatorArguments operatorArguments) {
     final int lines = VimChangeGroupBase.Companion.getLinesCountInVisualBlock(editor, range);
-    final BufferPosition startPosition = editor.offsetToLogicalPosition(range.getStartOffset());
+    final BufferPosition startPosition = editor.offsetToBufferPosition(range.getStartOffset());
 
     boolean visualBlockMode = operatorArguments.getMode() == VimStateMachine.Mode.VISUAL &&
                               operatorArguments.getSubMode() == VimStateMachine.SubMode.VISUAL_BLOCK;
@@ -459,14 +459,14 @@ public class ChangeGroup extends VimChangeGroupBase {
     int lines = 0;
     if (type == SelectionType.BLOCK_WISE) {
       lines = VimChangeGroupBase.Companion.getLinesCountInVisualBlock(editor, range);
-      col = editor.offsetToLogicalPosition(range.getStartOffset()).getColumn();
+      col = editor.offsetToBufferPosition(range.getStartOffset()).getColumn();
       if (caret.getVimLastColumn() == VimMotionGroupBase.LAST_COLUMN) {
         col = VimMotionGroupBase.LAST_COLUMN;
       }
     }
     boolean after = range.getEndOffset() >= editor.fileSize();
 
-    final BufferPosition lp = editor.offsetToLogicalPosition(injector.getMotion().moveCaretToCurrentLineStartSkipLeading(editor, caret));
+    final BufferPosition lp = editor.offsetToBufferPosition(injector.getMotion().moveCaretToCurrentLineStartSkipLeading(editor, caret));
 
     boolean res = deleteRange(editor, caret, range, type, true, operatorArguments);
     if (res) {
@@ -545,7 +545,7 @@ public class ChangeGroup extends VimChangeGroupBase {
   private boolean reformatCodeRange(@NotNull VimEditor editor, @NotNull VimCaret caret, @NotNull TextRange range) {
     int[] starts = range.getStartOffsets();
     int[] ends = range.getEndOffsets();
-    final int firstLine = editor.offsetToLogicalPosition(range.getStartOffset()).getLine();
+    final int firstLine = editor.offsetToBufferPosition(range.getStartOffset()).getLine();
     for (int i = ends.length - 1; i >= 0; i--) {
       @NotNull final Editor editor1 = ((IjVimEditor) editor).getEditor();
       final int startOffset = EngineEditorHelperKt.getLineStartForOffset(new IjVimEditor(editor1), starts[i]);
@@ -601,7 +601,7 @@ public class ChangeGroup extends VimChangeGroupBase {
       return null;
     };
     Function0<Unit> afterAction = () -> {
-      final int firstLine = editor.offsetToLogicalPosition(Math.min(startOffset, endOffset)).getLine();
+      final int firstLine = editor.offsetToBufferPosition(Math.min(startOffset, endOffset)).getLine();
       final int newOffset = VimPlugin.getMotion().moveCaretToLineStartSkipLeading(editor, firstLine);
       injector.getMotion().moveCaret(editor, caret, newOffset);
       restoreCursor(editor, caret, ((IjVimCaret)caret).getCaret().getLogicalPosition().line);
@@ -676,13 +676,13 @@ public class ChangeGroup extends VimChangeGroupBase {
 
     IndentConfig indentConfig = IndentConfig.create(((IjVimEditor) editor).getEditor(), ((IjExecutionContext) context).getContext());
 
-    final int sline = editor.offsetToLogicalPosition(range.getStartOffset()).getLine();
-    final BufferPosition endLogicalPosition = editor.offsetToLogicalPosition(range.getEndOffset());
+    final int sline = editor.offsetToBufferPosition(range.getStartOffset()).getLine();
+    final BufferPosition endLogicalPosition = editor.offsetToBufferPosition(range.getEndOffset());
     final int eline =
       endLogicalPosition.getColumn() == 0 ? Math.max(endLogicalPosition.getLine() - 1, 0) : endLogicalPosition.getLine();
 
     if (range.isMultiple()) {
-      final int from = editor.offsetToLogicalPosition(range.getStartOffset()).getColumn();
+      final int from = editor.offsetToBufferPosition(range.getStartOffset()).getColumn();
       if (dir == 1) {
         // Right shift blockwise selection
         final String indent = indentConfig.createIndentByCount(count);
@@ -703,8 +703,8 @@ public class ChangeGroup extends VimChangeGroupBase {
           if (len > from) {
             BufferPosition spos = new BufferPosition(l, from, false);
             BufferPosition epos = new BufferPosition(l, from + indentConfig.getTotalIndent(count) - 1, false);
-            int wsoff = editor.logicalPositionToOffset(spos);
-            int weoff = editor.logicalPositionToOffset(epos);
+            int wsoff = editor.bufferPositionToOffset(spos);
+            int weoff = editor.bufferPositionToOffset(epos);
             int pos;
             for (pos = wsoff; pos <= weoff; pos++) {
               if (CharacterHelper.charType(chars.charAt(pos), false) != CharacterHelper.CharacterType.WHITESPACE) {

--- a/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -197,8 +197,8 @@ public class ChangeGroup extends VimChangeGroupBase {
     }
     final Command motion = argument.getMotion();
     if (!isChange && !motion.isLinewiseMotion()) {
-      VimLogicalPosition start = editor.offsetToLogicalPosition(range.getStartOffset());
-      VimLogicalPosition end = editor.offsetToLogicalPosition(range.getEndOffset());
+      BufferPosition start = editor.offsetToLogicalPosition(range.getStartOffset());
+      BufferPosition end = editor.offsetToLogicalPosition(range.getEndOffset());
       if (start.getLine() != end.getLine()) {
         @NotNull Editor editor2 = ((IjVimEditor)editor).getEditor();
         int offset1 = range.getStartOffset();
@@ -351,7 +351,7 @@ public class ChangeGroup extends VimChangeGroupBase {
                              boolean append,
                              @NotNull OperatorArguments operatorArguments) {
     final int lines = VimChangeGroupBase.Companion.getLinesCountInVisualBlock(editor, range);
-    final VimLogicalPosition startPosition = editor.offsetToLogicalPosition(range.getStartOffset());
+    final BufferPosition startPosition = editor.offsetToLogicalPosition(range.getStartOffset());
 
     boolean visualBlockMode = operatorArguments.getMode() == VimStateMachine.Mode.VISUAL &&
                               operatorArguments.getSubMode() == VimStateMachine.SubMode.VISUAL_BLOCK;
@@ -466,7 +466,7 @@ public class ChangeGroup extends VimChangeGroupBase {
     }
     boolean after = range.getEndOffset() >= editor.fileSize();
 
-    final VimLogicalPosition lp = editor.offsetToLogicalPosition(injector.getMotion().moveCaretToCurrentLineStartSkipLeading(editor, caret));
+    final BufferPosition lp = editor.offsetToLogicalPosition(injector.getMotion().moveCaretToCurrentLineStartSkipLeading(editor, caret));
 
     boolean res = deleteRange(editor, caret, range, type, true, operatorArguments);
     if (res) {
@@ -677,7 +677,7 @@ public class ChangeGroup extends VimChangeGroupBase {
     IndentConfig indentConfig = IndentConfig.create(((IjVimEditor) editor).getEditor(), ((IjExecutionContext) context).getContext());
 
     final int sline = editor.offsetToLogicalPosition(range.getStartOffset()).getLine();
-    final VimLogicalPosition endLogicalPosition = editor.offsetToLogicalPosition(range.getEndOffset());
+    final BufferPosition endLogicalPosition = editor.offsetToLogicalPosition(range.getEndOffset());
     final int eline =
       endLogicalPosition.getColumn() == 0 ? Math.max(endLogicalPosition.getLine() - 1, 0) : endLogicalPosition.getLine();
 
@@ -690,7 +690,7 @@ public class ChangeGroup extends VimChangeGroupBase {
         for (int l = sline; l <= eline; l++) {
           int len = EngineEditorHelperKt.lineLength(editor, l);
           if (len > from) {
-            VimLogicalPosition spos = new VimLogicalPosition(l, from, false);
+            BufferPosition spos = new BufferPosition(l, from, false);
             insertText(editor, caret, spos, indent);
           }
         }
@@ -701,8 +701,8 @@ public class ChangeGroup extends VimChangeGroupBase {
         for (int l = sline; l <= eline; l++) {
           int len = EngineEditorHelperKt.lineLength(editor, l);
           if (len > from) {
-            VimLogicalPosition spos = new VimLogicalPosition(l, from, false);
-            VimLogicalPosition epos = new VimLogicalPosition(l, from + indentConfig.getTotalIndent(count) - 1, false);
+            BufferPosition spos = new BufferPosition(l, from, false);
+            BufferPosition epos = new BufferPosition(l, from + indentConfig.getTotalIndent(count) - 1, false);
             int wsoff = editor.logicalPositionToOffset(spos);
             int weoff = editor.logicalPositionToOffset(epos);
             int pos;

--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -294,8 +294,8 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
         return lineNumber;
       }
       else {
-        final int visualLine = new IjVimEditor(editor).logicalLineToVisualLine(lineNumber - 1);
-        final int currentVisualLine = new IjVimEditor(editor).logicalLineToVisualLine(caretLine);
+        final int visualLine = new IjVimEditor(editor).bufferLineToVisualLine(lineNumber - 1);
+        final int currentVisualLine = new IjVimEditor(editor).bufferLineToVisualLine(caretLine);
         return Math.abs(currentVisualLine - visualLine);
       }
     }

--- a/src/main/java/com/maddyhome/idea/vim/group/MarkGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MarkGroup.java
@@ -121,7 +121,7 @@ public class MarkGroup extends VimMarkGroupBase implements PersistentStateCompon
         if (!mark.isClear()) {
           Element markElem = new Element("mark");
           markElem.setAttribute("key", Character.toString(mark.getKey()));
-          markElem.setAttribute("line", Integer.toString(mark.getLogicalLine()));
+          markElem.setAttribute("line", Integer.toString(mark.getLine()));
           markElem.setAttribute("column", Integer.toString(mark.getCol()));
           markElem.setAttribute("filename", StringUtil.notNullize(mark.getFilename()));
           markElem.setAttribute("protocol", StringUtil.notNullize(mark.getProtocol(), "file"));
@@ -157,7 +157,7 @@ public class MarkGroup extends VimMarkGroupBase implements PersistentStateCompon
           if (!mark.isClear() && !Character.isUpperCase(mark.getKey()) && SAVE_FILE_MARKS.indexOf(mark.getKey()) >= 0) {
             Element markElem = new Element("mark");
             markElem.setAttribute("key", Character.toString(mark.getKey()));
-            markElem.setAttribute("line", Integer.toString(mark.getLogicalLine()));
+            markElem.setAttribute("line", Integer.toString(mark.getLine()));
             markElem.setAttribute("column", Integer.toString(mark.getCol()));
             fileMarkElem.addContent(markElem);
           }
@@ -170,7 +170,7 @@ public class MarkGroup extends VimMarkGroupBase implements PersistentStateCompon
     Element jumpsElem = new Element("jumps");
     for (Jump jump : jumps) {
       Element jumpElem = new Element("jump");
-      jumpElem.setAttribute("line", Integer.toString(jump.getLogicalLine()));
+      jumpElem.setAttribute("line", Integer.toString(jump.getLine()));
       jumpElem.setAttribute("column", Integer.toString(jump.getCol()));
       jumpElem.setAttribute("filename", StringUtil.notNullize(jump.getFilepath()));
       jumpsElem.addContent(jumpElem);

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -656,7 +656,7 @@ public class MotionGroup extends VimMotionGroupBase {
     final int line = mark.getLogicalLine();
     return toLineStart
            ? moveCaretToLineStartSkipLeading(editor, line)
-           : editor.logicalPositionToOffset(new VimLogicalPosition(line, mark.getCol(), false));
+           : editor.logicalPositionToOffset(new BufferPosition(line, mark.getCol(), false));
   }
 
   @Override
@@ -671,7 +671,7 @@ public class MotionGroup extends VimMotionGroupBase {
     if (vf.getPath().equals(mark.getFilename())) {
       return toLineStart
              ? moveCaretToLineStartSkipLeading(editor, line)
-             : editor.logicalPositionToOffset(new VimLogicalPosition(line, mark.getCol(), false));
+             : editor.logicalPositionToOffset(new BufferPosition(line, mark.getCol(), false));
     }
 
     final Editor selectedEditor = selectEditor(((IjVimEditor)editor).getEditor(), mark);
@@ -700,7 +700,7 @@ public class MotionGroup extends VimMotionGroupBase {
       return -1;
     }
 
-    final VimLogicalPosition lp = new VimLogicalPosition(jump.getLogicalLine(), jump.getCol(), false);
+    final BufferPosition lp = new BufferPosition(jump.getLogicalLine(), jump.getCol(), false);
     final LogicalPosition lpnative = new LogicalPosition(jump.getLogicalLine(), jump.getCol(), false);
     final String fileName = jump.getFilepath();
     if (!vf.getPath().equals(fileName)) {
@@ -742,7 +742,7 @@ public class MotionGroup extends VimMotionGroupBase {
   public Motion moveCaretToColumn(@NotNull VimEditor editor, @NotNull VimCaret caret, int count, boolean allowEnd) {
     final int line = caret.getLine().getLine();
     final int column = EngineEditorHelperKt.normalizeColumn(editor, line, count, allowEnd);
-    final int offset = editor.logicalPositionToOffset(new VimLogicalPosition(line, column, false));
+    final int offset = editor.logicalPositionToOffset(new BufferPosition(line, column, false));
     if (column != count) {
       return new Motion.AdjustedOffset(offset, count);
     }

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -821,7 +821,7 @@ public class MotionGroup extends VimMotionGroupBase {
 
     if (caretVisualLine != ijCaret.getVisualPosition().line) {
       final int offset =
-        moveCaretToLineWithStartOfLineOption(editor, EngineEditorHelperKt.visualLineToLogicalLine(editor, caretVisualLine), caret);
+        moveCaretToLineWithStartOfLineOption(editor, EngineEditorHelperKt.visualLineToBufferLine(editor, caretVisualLine), caret);
       moveCaret(ijEditor, ijCaret, offset);
       return result.getFirst();
     }
@@ -845,7 +845,7 @@ public class MotionGroup extends VimMotionGroupBase {
 
     if (caretVisualLine != ijCaret.getVisualPosition().line && caretVisualLine != -1) {
       final int offset =
-        moveCaretToLineWithStartOfLineOption(editor, EngineEditorHelperKt.visualLineToLogicalLine(editor, caretVisualLine), caret);
+        moveCaretToLineWithStartOfLineOption(editor, EngineEditorHelperKt.visualLineToBufferLine(editor, caretVisualLine), caret);
       moveCaret(ijEditor, ijCaret, offset);
       return result.getFirst();
     }
@@ -935,7 +935,7 @@ public class MotionGroup extends VimMotionGroupBase {
       targetCaretVisualLine = max(visualTop, min(visualBottom, targetCaretVisualLine));
     }
 
-    int logicalLine = EngineEditorHelperKt.visualLineToLogicalLine(editor, targetCaretVisualLine);
+    int logicalLine = EngineEditorHelperKt.visualLineToBufferLine(editor, targetCaretVisualLine);
     int caretOffset = moveCaretToLineWithStartOfLineOption(editor, logicalLine, caret);
     moveCaret(ijEditor, ijCaret, caretOffset);
 
@@ -978,12 +978,12 @@ public class MotionGroup extends VimMotionGroupBase {
     if (visualLine != editor.getCaretModel().getVisualPosition().line || start) {
       int offset;
       if (start) {
-        offset = moveCaretToLineStartSkipLeading(new IjVimEditor(editor), EngineEditorHelperKt.visualLineToLogicalLine(
+        offset = moveCaretToLineStartSkipLeading(new IjVimEditor(editor), EngineEditorHelperKt.visualLineToBufferLine(
           new IjVimEditor(editor), visualLine));
       }
       else {
         offset = moveCaretToLineWithSameColumn(new IjVimEditor(editor),
-                                               EngineEditorHelperKt.visualLineToLogicalLine(new IjVimEditor(editor), visualLine),
+                                               EngineEditorHelperKt.visualLineToBufferLine(new IjVimEditor(editor), visualLine),
                                                new IjVimCaret(editor.getCaretModel().getPrimaryCaret()));
       }
 
@@ -1096,7 +1096,7 @@ public class MotionGroup extends VimMotionGroupBase {
         break;
     }
 
-    final int targetLogicalLine = EngineEditorHelperKt.visualLineToLogicalLine(new IjVimEditor(editor), targetVisualLine);
+    final int targetLogicalLine = EngineEditorHelperKt.visualLineToBufferLine(new IjVimEditor(editor), targetVisualLine);
     return moveCaretToLineWithStartOfLineOption(new IjVimEditor(editor), targetLogicalLine, new IjVimCaret(caret));
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -177,7 +177,7 @@ public class MotionGroup extends VimMotionGroupBase {
 
     final int oldColumn = editor.getCaretModel().getVisualPosition().column;
     int col = oldColumn;
-    if (col >= EngineEditorHelperKt.lineLength(new IjVimEditor(editor), new IjVimEditor(editor).currentCaret().getLogicalPosition().getLine()) - 1) {
+    if (col >= EngineEditorHelperKt.lineLength(new IjVimEditor(editor), new IjVimEditor(editor).currentCaret().getBufferPosition().getLine()) - 1) {
       col = UserDataManager.getVimLastColumn(editor.getCaretModel().getPrimaryCaret());
     }
 
@@ -733,7 +733,7 @@ public class MotionGroup extends VimMotionGroupBase {
   @Override
   public @NotNull Motion moveCaretToCurrentDisplayLineMiddle(@NotNull VimEditor editor, @NotNull VimCaret caret) {
     final int width = getApproximateScreenWidth(((IjVimEditor)editor).getEditor()) / 2;
-    final int len = EngineEditorHelperKt.lineLength(editor, editor.currentCaret().getLogicalPosition().getLine());
+    final int len = EngineEditorHelperKt.lineLength(editor, editor.currentCaret().getBufferPosition().getLine());
 
     return moveCaretToColumn(editor, caret, max(0, min(len - 1, width)), false);
   }

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -878,13 +878,13 @@ public class MotionGroup extends VimMotionGroupBase {
 
   @Override
   public @Range(from = 0, to = Integer.MAX_VALUE) int moveCaretToLineWithStartOfLineOption(@NotNull VimEditor editor,
-                                                                                           int logicalLine,
+                                                                                           int line,
                                                                                            @NotNull VimCaret caret) {
     if (VimPlugin.getOptionService().isSet(new OptionScope.LOCAL(editor), OptionConstants.startoflineName, OptionConstants.startoflineName)) {
-      return moveCaretToLineStartSkipLeading(editor, logicalLine);
+      return moveCaretToLineStartSkipLeading(editor, line);
     }
     else {
-      return moveCaretToLineWithSameColumn(editor, logicalLine, caret);
+      return moveCaretToLineWithSameColumn(editor, line, caret);
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -653,7 +653,7 @@ public class MotionGroup extends VimMotionGroupBase {
     final Mark mark = VimPlugin.getMark().getFileMark(editor, ch);
     if (mark == null) return -1;
 
-    final int line = mark.getLogicalLine();
+    final int line = mark.getLine();
     return toLineStart
            ? moveCaretToLineStartSkipLeading(editor, line)
            : editor.bufferPositionToOffset(new BufferPosition(line, mark.getCol(), false));
@@ -667,7 +667,7 @@ public class MotionGroup extends VimMotionGroupBase {
     final VirtualFile vf = getVirtualFile(((IjVimEditor)editor).getEditor());
     if (vf == null) return -1;
 
-    final int line = mark.getLogicalLine();
+    final int line = mark.getLine();
     if (vf.getPath().equals(mark.getFilename())) {
       return toLineStart
              ? moveCaretToLineStartSkipLeading(editor, line)
@@ -700,8 +700,8 @@ public class MotionGroup extends VimMotionGroupBase {
       return -1;
     }
 
-    final BufferPosition lp = new BufferPosition(jump.getLogicalLine(), jump.getCol(), false);
-    final LogicalPosition lpnative = new LogicalPosition(jump.getLogicalLine(), jump.getCol(), false);
+    final BufferPosition lp = new BufferPosition(jump.getLine(), jump.getCol(), false);
+    final LogicalPosition lpnative = new LogicalPosition(jump.getLine(), jump.getCol(), false);
     final String fileName = jump.getFilepath();
     if (!vf.getPath().equals(fileName)) {
       final VirtualFile newFile =

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.java
@@ -656,7 +656,7 @@ public class MotionGroup extends VimMotionGroupBase {
     final int line = mark.getLogicalLine();
     return toLineStart
            ? moveCaretToLineStartSkipLeading(editor, line)
-           : editor.logicalPositionToOffset(new BufferPosition(line, mark.getCol(), false));
+           : editor.bufferPositionToOffset(new BufferPosition(line, mark.getCol(), false));
   }
 
   @Override
@@ -671,7 +671,7 @@ public class MotionGroup extends VimMotionGroupBase {
     if (vf.getPath().equals(mark.getFilename())) {
       return toLineStart
              ? moveCaretToLineStartSkipLeading(editor, line)
-             : editor.logicalPositionToOffset(new BufferPosition(line, mark.getCol(), false));
+             : editor.bufferPositionToOffset(new BufferPosition(line, mark.getCol(), false));
     }
 
     final Editor selectedEditor = selectEditor(((IjVimEditor)editor).getEditor(), mark);
@@ -726,7 +726,7 @@ public class MotionGroup extends VimMotionGroupBase {
         VimPlugin.getMark().addJump(editor, false);
       }
 
-      return editor.logicalPositionToOffset(lp);
+      return editor.bufferPositionToOffset(lp);
     }
   }
 
@@ -742,7 +742,7 @@ public class MotionGroup extends VimMotionGroupBase {
   public Motion moveCaretToColumn(@NotNull VimEditor editor, @NotNull VimCaret caret, int count, boolean allowEnd) {
     final int line = caret.getLine().getLine();
     final int column = EngineEditorHelperKt.normalizeColumn(editor, line, count, allowEnd);
-    final int offset = editor.logicalPositionToOffset(new BufferPosition(line, column, false));
+    final int offset = editor.bufferPositionToOffset(new BufferPosition(line, column, false));
     if (column != count) {
       return new Motion.AdjustedOffset(offset, count);
     }
@@ -956,7 +956,7 @@ public class MotionGroup extends VimMotionGroupBase {
     }
     else {
       final int line = EngineEditorHelperKt.normalizeLine(new IjVimEditor(editor), rawCount - 1);
-      visualLine = new IjVimEditor(editor).logicalLineToVisualLine(line);
+      visualLine = new IjVimEditor(editor).bufferLineToVisualLine(line);
     }
 
     // This method moves the current (or [count]) line to the specified screen location

--- a/src/main/java/com/maddyhome/idea/vim/group/SearchGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/SearchGroup.java
@@ -861,7 +861,7 @@ public class SearchGroup extends VimSearchGroupBase implements PersistentStateCo
     if (!got_quit) {
       if (lastMatch != -1) {
         injector.getMotion().moveCaret(editor, caret,
-          VimPlugin.getMotion().moveCaretToLineStartSkipLeading(editor, editor.offsetToLogicalPosition(lastMatch).getLine()));
+          VimPlugin.getMotion().moveCaretToLineStartSkipLeading(editor, editor.offsetToBufferPosition(lastMatch).getLine()));
       }
       else {
         VimPlugin.showMessage(MessageHelper.message(Msg.e_patnotf2, pattern));

--- a/src/main/java/com/maddyhome/idea/vim/group/copy/PutGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/copy/PutGroup.kt
@@ -95,7 +95,7 @@ class PutGroup : VimPutBase() {
 
     logger.debug("Perform put via plugin")
     val myCarets = if (visualSelection != null) {
-      visualSelection.caretsAndSelections.keys.sortedByDescending { it.getLogicalPosition() }
+      visualSelection.caretsAndSelections.keys.sortedByDescending { it.getBufferPosition() }
     } else {
       EditorHelper.getOrderedCaretsList(editor.ij).map { IjVimCaret(it) }
     }

--- a/src/main/java/com/maddyhome/idea/vim/group/copy/PutGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/copy/PutGroup.kt
@@ -319,8 +319,8 @@ class PutGroup : VimPutBase() {
     startOffset: Int,
     endOffset: Int,
   ): Int {
-    val startLine = editor.offsetToLogicalPosition(startOffset).line
-    val endLine = editor.offsetToLogicalPosition(endOffset - 1).line
+    val startLine = editor.offsetToBufferPosition(startOffset).line
+    val endLine = editor.offsetToBufferPosition(endOffset - 1).line
     val startLineOffset = (editor as IjVimEditor).editor.document.getLineStartOffset(startLine)
     val endLineOffset = editor.editor.document.getLineEndOffset(endLine)
 

--- a/src/main/java/com/maddyhome/idea/vim/mark/IntellijMark.kt
+++ b/src/main/java/com/maddyhome/idea/vim/mark/IntellijMark.kt
@@ -20,7 +20,7 @@ class IntellijMark(bookmark: LineBookmark, override val col: Int, project: Proje
   private val project: WeakReference<Project?> = WeakReference(project)
 
   override val key = BookmarksManager.getInstance(project)?.getType(bookmark)?.mnemonic!!
-  override val logicalLine: Int
+  override val line: Int
     get() = getMark()?.line ?: 0
   override val filename: String
     get() = getMark()?.file?.path ?: ""

--- a/src/main/java/com/maddyhome/idea/vim/newapi/ChangeGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/ChangeGroup.kt
@@ -165,7 +165,7 @@ fun insertLineAround(editor: VimEditor, context: ExecutionContext, shift: Int) {
       } else {
         VimPlugin.getMotion().moveCaretToCurrentLineStart(editor, caret.vim)
       }
-      val position = EditorLine.Offset.init(editor.offsetToLogicalPosition(lineEndOffset).line + shift, editor)
+      val position = EditorLine.Offset.init(editor.offsetToBufferPosition(lineEndOffset).line + shift, editor)
 
       val insertedLine = editor.addLine(position)
       VimPlugin.getChange().saveStrokes("\n")

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimCaret.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimCaret.kt
@@ -16,7 +16,7 @@ import com.maddyhome.idea.vim.api.CaretRegisterStorageBase
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimCaretBase
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.VimLogicalPosition
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.VimVisualPosition
 import com.maddyhome.idea.vim.common.EditorLine
 import com.maddyhome.idea.vim.common.LiveRange
@@ -87,7 +87,7 @@ class IjVimCaret(val caret: Caret) : VimCaretBase() {
     caret.moveToOffset(offset)
   }
 
-  override fun moveToLogicalPosition(logicalPosition: VimLogicalPosition) {
+  override fun moveToLogicalPosition(logicalPosition: BufferPosition) {
     this.caret.moveToLogicalPosition(LogicalPosition(logicalPosition.line, logicalPosition.column, logicalPosition.leansForward))
   }
 
@@ -116,9 +116,9 @@ class IjVimCaret(val caret: Caret) : VimCaretBase() {
     caret.vimSetSelection(start, end, moveCaretToSelectionEnd)
   }
 
-  override fun getLogicalPosition(): VimLogicalPosition {
+  override fun getLogicalPosition(): BufferPosition {
     val logicalPosition = caret.logicalPosition
-    return VimLogicalPosition(logicalPosition.line, logicalPosition.column, logicalPosition.leansForward)
+    return BufferPosition(logicalPosition.line, logicalPosition.column, logicalPosition.leansForward)
   }
 
   override fun getVisualPosition(): VimVisualPosition {

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimCaret.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimCaret.kt
@@ -87,8 +87,8 @@ class IjVimCaret(val caret: Caret) : VimCaretBase() {
     caret.moveToOffset(offset)
   }
 
-  override fun moveToLogicalPosition(logicalPosition: BufferPosition) {
-    this.caret.moveToLogicalPosition(LogicalPosition(logicalPosition.line, logicalPosition.column, logicalPosition.leansForward))
+  override fun moveToBufferPosition(position: BufferPosition) {
+    this.caret.moveToLogicalPosition(LogicalPosition(position.line, position.column, position.leansForward))
   }
 
   override fun getLine(): EditorLine.Pointer {
@@ -116,7 +116,7 @@ class IjVimCaret(val caret: Caret) : VimCaretBase() {
     caret.vimSetSelection(start, end, moveCaretToSelectionEnd)
   }
 
-  override fun getLogicalPosition(): BufferPosition {
+  override fun getBufferPosition(): BufferPosition {
     val logicalPosition = caret.logicalPosition
     return BufferPosition(logicalPosition.line, logicalPosition.column, logicalPosition.leansForward)
   }

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
@@ -229,11 +229,11 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
     return editor.offsetToVisualPosition(offset).let { VimVisualPosition(it.line, it.column, it.leansRight) }
   }
 
-  override fun offsetToLogicalPosition(offset: Int): BufferPosition {
+  override fun offsetToBufferPosition(offset: Int): BufferPosition {
     return editor.offsetToLogicalPosition(offset).let { BufferPosition(it.line, it.column, it.leansForward) }
   }
 
-  override fun logicalPositionToOffset(position: BufferPosition): Int {
+  override fun bufferPositionToOffset(position: BufferPosition): Int {
     val logicalPosition = LogicalPosition(position.line, position.column, position.leansForward)
     return editor.logicalPositionToOffset(logicalPosition)
   }
@@ -372,7 +372,7 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
       return EditorUtil.getLastVisualLineColumnNumber(this.ij, line)
   }
 
-  override fun visualToLogicalPosition(visualPosition: VimVisualPosition): BufferPosition {
+  override fun visualPositionToBufferPosition(visualPosition: VimVisualPosition): BufferPosition {
       val logPosition = editor.visualToLogicalPosition(
           VisualPosition(
               visualPosition.line,
@@ -383,9 +383,9 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
       return BufferPosition(logPosition.line, logPosition.column, logPosition.leansForward)
   }
 
-  override fun logicalToVisualPosition(logicalPosition: BufferPosition): VimVisualPosition {
+  override fun bufferPositionToVisualPosition(position: BufferPosition): VimVisualPosition {
     val visualPosition =
-      editor.logicalToVisualPosition(logicalPosition.run { LogicalPosition(line, column, leansForward) })
+      editor.logicalToVisualPosition(position.run { LogicalPosition(line, column, leansForward) })
     return visualPosition.run { VimVisualPosition(line, column, leansRight) }
   }
 
@@ -397,12 +397,12 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
    * Converts a logical line number to a visual line number. Several logical lines can map to the same
    * visual line when there are collapsed fold regions.
    */
-  override fun logicalLineToVisualLine(line: Int): Int {
+  override fun bufferLineToVisualLine(line: Int): Int {
     if (editor is EditorImpl) {
       // This is faster than simply calling Editor#logicalToVisualPosition
       return editor.offsetToVisualLine(editor.document.getLineStartOffset(line))
     }
-    return super.logicalLineToVisualLine(line)
+    return super.bufferLineToVisualLine(line)
   }
 
   override var insertMode: Boolean

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
@@ -25,7 +25,7 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimCaretListener
 import com.maddyhome.idea.vim.api.VimDocument
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.VimLogicalPosition
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.VimSelectionModel
 import com.maddyhome.idea.vim.api.VimVisualPosition
 import com.maddyhome.idea.vim.api.VirtualFile
@@ -229,11 +229,11 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
     return editor.offsetToVisualPosition(offset).let { VimVisualPosition(it.line, it.column, it.leansRight) }
   }
 
-  override fun offsetToLogicalPosition(offset: Int): VimLogicalPosition {
-    return editor.offsetToLogicalPosition(offset).let { VimLogicalPosition(it.line, it.column, it.leansForward) }
+  override fun offsetToLogicalPosition(offset: Int): BufferPosition {
+    return editor.offsetToLogicalPosition(offset).let { BufferPosition(it.line, it.column, it.leansForward) }
   }
 
-  override fun logicalPositionToOffset(position: VimLogicalPosition): Int {
+  override fun logicalPositionToOffset(position: BufferPosition): Int {
     val logicalPosition = LogicalPosition(position.line, position.column, position.leansForward)
     return editor.logicalPositionToOffset(logicalPosition)
   }
@@ -271,7 +271,7 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
     editor.caretModel.removeSecondaryCarets()
   }
 
-  override fun vimSetSystemBlockSelectionSilently(start: VimLogicalPosition, end: VimLogicalPosition) {
+  override fun vimSetSystemBlockSelectionSilently(start: BufferPosition, end: BufferPosition) {
     val startPosition = LogicalPosition(start.line, start.column, start.leansForward)
     val endPosition = LogicalPosition(end.line, end.column, end.leansForward)
     editor.selectionModel.vimSetSystemBlockSelectionSilently(startPosition, endPosition)
@@ -372,7 +372,7 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
       return EditorUtil.getLastVisualLineColumnNumber(this.ij, line)
   }
 
-  override fun visualToLogicalPosition(visualPosition: VimVisualPosition): VimLogicalPosition {
+  override fun visualToLogicalPosition(visualPosition: VimVisualPosition): BufferPosition {
       val logPosition = editor.visualToLogicalPosition(
           VisualPosition(
               visualPosition.line,
@@ -380,10 +380,10 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
               visualPosition.leansRight
           )
       )
-      return VimLogicalPosition(logPosition.line, logPosition.column, logPosition.leansForward)
+      return BufferPosition(logPosition.line, logPosition.column, logPosition.leansForward)
   }
 
-  override fun logicalToVisualPosition(logicalPosition: VimLogicalPosition): VimVisualPosition {
+  override fun logicalToVisualPosition(logicalPosition: BufferPosition): VimVisualPosition {
     val visualPosition =
       editor.logicalToVisualPosition(logicalPosition.run { LogicalPosition(line, column, leansForward) })
     return visualPosition.run { VimVisualPosition(line, column, leansRight) }

--- a/src/main/java/com/maddyhome/idea/vim/regexp/RegExp.kt
+++ b/src/main/java/com/maddyhome/idea/vim/regexp/RegExp.kt
@@ -1822,7 +1822,7 @@ class RegExp {
           CURSOR -> {
                         /* Check if the buffer is in a window and compare the
                          * reg_win->w_cursor position to the match position. */
-            val curpos = reg_buf!!.currentCaret().getLogicalPosition()
+            val curpos = reg_buf!!.currentCaret().getBufferPosition()
             if (reglnum + reg_firstlnum != curpos.line ||
               reginput!!.pointer() - regline!!.pointer() != curpos.column
             ) {

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/commands/CmdFilterCommand.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/commands/CmdFilterCommand.kt
@@ -80,8 +80,8 @@ data class CmdFilterCommand(val ranges: Ranges, val argument: String) : Command.
         val input = editor.ij.document.charsSequence.subSequence(range.startOffset, range.endOffset)
         VimPlugin.getProcess().executeCommand(editor, command, input, workingDirectory)?.let {
           ApplicationManager.getApplication().runWriteAction {
-            val start = editor.offsetToLogicalPosition(range.startOffset)
-            val end = editor.offsetToLogicalPosition(range.endOffset)
+            val start = editor.offsetToBufferPosition(range.startOffset)
+            val end = editor.offsetToBufferPosition(range.endOffset)
             editor.ij.document.replaceString(range.startOffset, range.endOffset, it)
             val linesFiltered = end.line - start.line
             if (linesFiltered > 2) {

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/ColLineFunctionHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/ColLineFunctionHandler.kt
@@ -123,7 +123,7 @@ private fun variableToPosition(editor: VimEditor, variable: VimDataType, dollarF
   // Mark
   if (name.length >= 2 && name[0] == '\'') {
     val mark = VimPlugin.getMark().getMark(editor, name[1]) ?: return null
-    val markLogicalLine = (mark.logicalLine + 1).asVimInt()
+    val markLogicalLine = (mark.line + 1).asVimInt()
     val markLogicalCol = (mark.col + 1).asVimInt()
     return markLogicalLine to markLogicalCol
   }

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/ColLineFunctionHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/ColLineFunctionHandler.kt
@@ -12,7 +12,7 @@ import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.lineLength
-import com.maddyhome.idea.vim.api.visualLineToLogicalLine
+import com.maddyhome.idea.vim.api.visualLineToBufferLine
 import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.inVisualMode
 import com.maddyhome.idea.vim.helper.vimLine
@@ -132,7 +132,7 @@ private fun variableToPosition(editor: VimEditor, variable: VimDataType, dollarF
   if (name.length >= 2 && name[0] == 'w' && name[1] == '0') {
     if (!dollarForLine) return null
     val actualVisualTop = EditorHelper.getVisualLineAtTopOfScreen(editor.ij)
-    val actualLogicalTop = editor.visualLineToLogicalLine(actualVisualTop)
+    val actualLogicalTop = editor.visualLineToBufferLine(actualVisualTop)
     return (actualLogicalTop + 1).asVimInt() to currentCol(editor)
   }
 
@@ -140,7 +140,7 @@ private fun variableToPosition(editor: VimEditor, variable: VimDataType, dollarF
   if (name.length >= 2 && name[0] == 'w' && name[1] == '$') {
     if (!dollarForLine) return null
     val actualVisualBottom = EditorHelper.getVisualLineAtBottomOfScreen(editor.ij)
-    val actualLogicalBottom = editor.visualLineToLogicalLine(actualVisualBottom)
+    val actualLogicalBottom = editor.visualLineToBufferLine(actualVisualBottom)
     return (actualLogicalBottom + 1).asVimInt() to currentCol(editor)
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/ColLineFunctionHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/ColLineFunctionHandler.kt
@@ -64,7 +64,7 @@ object ColFunctionHandler : FunctionHandler() {
 }
 
 private fun currentCol(editor: VimEditor): VimInt {
-  val logicalPosition = editor.currentCaret().getLogicalPosition()
+  val logicalPosition = editor.currentCaret().getBufferPosition()
   var lineLength = editor.lineLength(logicalPosition.line)
 
   // If virtualedit is set, the col is one more
@@ -149,7 +149,7 @@ private fun variableToPosition(editor: VimEditor, variable: VimDataType, dollarF
     return if (dollarForLine) {
       editor.lineCount().asVimInt() to VimInt.ZERO
     } else {
-      val line = editor.currentCaret().getLogicalPosition().line
+      val line = editor.currentCaret().getBufferPosition().line
       val lineLength = editor.lineLength(line)
       (line + 1).asVimInt() to lineLength.asVimInt()
     }

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/ColLineFunctionHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/ColLineFunctionHandler.kt
@@ -114,8 +114,8 @@ private fun variableToPosition(editor: VimEditor, variable: VimDataType, dollarF
     }
 
     val vimStart = editor.currentCaret().vimSelectionStart
-    val visualLine = (editor.offsetToLogicalPosition(vimStart).line + 1).asVimInt()
-    val visualCol = (editor.offsetToLogicalPosition(vimStart).column + 1).asVimInt()
+    val visualLine = (editor.offsetToBufferPosition(vimStart).line + 1).asVimInt()
+    val visualCol = (editor.offsetToBufferPosition(vimStart).column + 1).asVimInt()
 
     return visualLine to visualCol
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -39,7 +39,7 @@ import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.action.VimShortcutKeyAction
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.api.visualLineToLogicalLine
+import com.maddyhome.idea.vim.api.visualLineToBufferLine
 import com.maddyhome.idea.vim.command.MappingMode
 import com.maddyhome.idea.vim.command.VimStateMachine
 import com.maddyhome.idea.vim.command.VimStateMachine.SubMode
@@ -283,7 +283,7 @@ abstract class VimTestCase : UsefulTestCase() {
     assertPosition(caretLogicalLine, caretLogicalColumn)
 
     // Belt and braces. Let's make sure that the caret is fully onscreen
-    val bottomLogicalLine = myFixture.editor.vim.visualLineToLogicalLine(
+    val bottomLogicalLine = myFixture.editor.vim.visualLineToBufferLine(
       EditorHelper.getVisualLineAtBottomOfScreen(myFixture.editor)
     )
     assertTrue(bottomLogicalLine >= caretLogicalLine)
@@ -377,14 +377,14 @@ abstract class VimTestCase : UsefulTestCase() {
 
   fun assertTopLogicalLine(topLogicalLine: Int) {
     val actualVisualTop = EditorHelper.getVisualLineAtTopOfScreen(myFixture.editor)
-    val actualLogicalTop = myFixture.editor.vim.visualLineToLogicalLine(actualVisualTop)
+    val actualLogicalTop = myFixture.editor.vim.visualLineToBufferLine(actualVisualTop)
 
     Assert.assertEquals("Top logical lines don't match", topLogicalLine, actualLogicalTop)
   }
 
   fun assertBottomLogicalLine(bottomLogicalLine: Int) {
     val actualVisualBottom = EditorHelper.getVisualLineAtBottomOfScreen(myFixture.editor)
-    val actualLogicalBottom = myFixture.editor.vim.visualLineToLogicalLine(actualVisualBottom)
+    val actualLogicalBottom = myFixture.editor.vim.visualLineToBufferLine(actualVisualBottom)
 
     Assert.assertEquals("Bottom logical lines don't match", bottomLogicalLine, actualLogicalBottom)
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -390,7 +390,7 @@ abstract class VimTestCase : UsefulTestCase() {
   }
 
   fun assertVisibleLineBounds(logicalLine: Int, leftLogicalColumn: Int, rightLogicalColumn: Int) {
-    val visualLine = IjVimEditor(myFixture.editor).logicalLineToVisualLine(logicalLine)
+    val visualLine = IjVimEditor(myFixture.editor).bufferLineToVisualLine(logicalLine)
     val actualLeftVisualColumn = EditorHelper.getVisualColumnAtLeftOfDisplay(myFixture.editor, visualLine)
     val actualLeftLogicalColumn =
       myFixture.editor.visualToLogicalPosition(VisualPosition(visualLine, actualLeftVisualColumn)).column

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/MarkTest.java
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/MarkTest.java
@@ -27,7 +27,7 @@ public class MarkTest extends VimTestCase {
     typeTextInFile(VimInjectorKt.getInjector().getParser().parseKeys("ma"), "    foo\n" + "    ba<caret>r\n" + "    baz\n");
     Mark mark = VimPlugin.getMark().getMark(new IjVimEditor(myFixture.getEditor()), 'a');
     assertNotNull(mark);
-    assertEquals(1, mark.getLogicalLine());
+    assertEquals(1, mark.getLine());
     assertEquals(6, mark.getCol());
   }
 
@@ -36,7 +36,7 @@ public class MarkTest extends VimTestCase {
     typeTextInFile(VimInjectorKt.getInjector().getParser().parseKeys("mG"), "    foo\n" + "    ba<caret>r\n" + "    baz\n");
     Mark mark = VimPlugin.getMark().getMark(new IjVimEditor(myFixture.getEditor()), 'G');
     assertNotNull(mark);
-    assertEquals(1, mark.getLogicalLine());
+    assertEquals(1, mark.getLine());
     assertEquals(6, mark.getCol());
   }
 
@@ -66,7 +66,7 @@ public class MarkTest extends VimTestCase {
     typeTextInFile(VimInjectorKt.getInjector().getParser().parseKeys("mx" + "2k" + "dd" + "0dw"), "    foo\n" + "    bar\n" + "    ba<caret>z\n");
     Mark mark = VimPlugin.getMark().getMark(new IjVimEditor(myFixture.getEditor()), 'x');
     assertNotNull(mark);
-    assertEquals(1, mark.getLogicalLine());
+    assertEquals(1, mark.getLine());
     assertEquals(6, mark.getCol());
   }
 
@@ -75,7 +75,7 @@ public class MarkTest extends VimTestCase {
     typeTextInFile(VimInjectorKt.getInjector().getParser().parseKeys("mx" + "2k" + "2dd"), "    foo\n" + "    bar\n" + "    ba<caret>z\n");
     Mark mark = VimPlugin.getMark().getMark(new IjVimEditor(myFixture.getEditor()), 'x');
     assertNotNull(mark);
-    assertEquals(0, mark.getLogicalLine());
+    assertEquals(0, mark.getLine());
     assertEquals(6, mark.getCol());
   }
 
@@ -84,7 +84,7 @@ public class MarkTest extends VimTestCase {
     typeTextInFile(VimInjectorKt.getInjector().getParser().parseKeys("mY" + "Obiff"), "foo\n" + "ba<caret>r\n" + "baz\n");
     Mark mark = VimPlugin.getMark().getMark(new IjVimEditor(myFixture.getEditor()), 'Y');
     assertNotNull(mark);
-    assertEquals(2, mark.getLogicalLine());
+    assertEquals(2, mark.getLine());
     assertEquals(2, mark.getCol());
   }
 
@@ -93,7 +93,7 @@ public class MarkTest extends VimTestCase {
     typeTextInFile(VimInjectorKt.getInjector().getParser().parseKeys("mY" + "Obiff"), "    foo\n" + "    ba<caret>r\n" + "    baz\n");
     Mark mark = VimPlugin.getMark().getMark(new IjVimEditor(myFixture.getEditor()), 'Y');
     assertNotNull(mark);
-    assertEquals(2, mark.getLogicalLine());
+    assertEquals(2, mark.getLine());
     assertEquals(6, mark.getCol());
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/mark/MotionMarkActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/mark/MotionMarkActionTest.kt
@@ -129,7 +129,7 @@ class MotionMarkActionTest : VimOptionTestCase(IjVimOptionService.ideamarksName)
     val vimMarks = VimPlugin.getMark().getMarks(myFixture.editor.vim)
     TestCase.assertEquals(1, vimMarks.size)
     TestCase.assertEquals('A', vimMarks[0].key)
-    TestCase.assertEquals(4, vimMarks[0].logicalLine)
+    TestCase.assertEquals(4, vimMarks[0].line)
   }
 
   private fun checkMarks(vararg marks: Pair<Char, Int>) {

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MarkCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MarkCommandTest.kt
@@ -27,7 +27,7 @@ class MarkCommandTest : VimTestCase() {
     )
     typeText(commandToKeys("mark a"))
     VimPlugin.getMark().getMark(myFixture.editor.vim, 'a')?.let {
-      assertEquals(2, it.logicalLine)
+      assertEquals(2, it.line)
       assertEquals(0, it.col)
     } ?: TestCase.fail("Mark is null")
   }
@@ -42,7 +42,7 @@ class MarkCommandTest : VimTestCase() {
     )
     typeText(commandToKeys("mark G"))
     VimPlugin.getMark().getMark(myFixture.editor.vim, 'G')?.let {
-      assertEquals(2, it.logicalLine)
+      assertEquals(2, it.line)
       assertEquals(0, it.col)
     } ?: TestCase.fail("Mark is null")
   }
@@ -57,7 +57,7 @@ class MarkCommandTest : VimTestCase() {
     )
     typeText(commandToKeys("k a"))
     VimPlugin.getMark().getMark(myFixture.editor.vim, 'a')?.let {
-      assertEquals(2, it.logicalLine)
+      assertEquals(2, it.line)
       assertEquals(0, it.col)
     } ?: TestCase.fail("Mark is null")
   }
@@ -72,7 +72,7 @@ class MarkCommandTest : VimTestCase() {
     )
     typeText(commandToKeys("1,2 mark a"))
     VimPlugin.getMark().getMark(myFixture.editor.vim, 'a')?.let {
-      assertEquals(1, it.logicalLine)
+      assertEquals(1, it.line)
       assertEquals(0, it.col)
     } ?: TestCase.fail("Mark is null")
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCharacterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCharacterAction.kt
@@ -53,9 +53,9 @@ private val logger = vimLogger<ChangeCharacterAction>()
  * @return true if able to change count characters, false if not
  */
 private fun changeCharacter(editor: VimEditor, caret: VimCaret, count: Int, ch: Char): Boolean {
-  val col = caret.getLogicalPosition().column
+  val col = caret.getBufferPosition().column
   // TODO: Is this correct? Should we really use only current caret? We have a caret as an argument
-  val len = editor.lineLength(editor.currentCaret().getLogicalPosition().line)
+  val len = editor.lineLength(editor.currentCaret().getBufferPosition().line)
   val offset = caret.offset.point
   if (len - col < count) {
     return false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCharacterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCharacterAction.kt
@@ -66,7 +66,7 @@ private fun changeCharacter(editor: VimEditor, caret: VimCaret, count: Int, ch: 
   var space: String? = null
   if (ch == '\n') {
     num = 1
-    space = editor.getLeadingWhitespace(editor.offsetToLogicalPosition(offset).line)
+    space = editor.getLeadingWhitespace(editor.offsetToBufferPosition(offset).line)
     logger.debug { "space='$space'" }
   }
   val repl = StringBuilder(count)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeLastSearchReplaceAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeLastSearchReplaceAction.kt
@@ -28,7 +28,7 @@ class ChangeLastSearchReplaceAction : ChangeEditorActionHandler.SingleExecution(
   ): Boolean {
     var result = true
     for (caret in editor.carets()) {
-      val line = caret.getLogicalPosition().line
+      val line = caret.getBufferPosition().line
       if (!injector.searchGroup
         .processSubstituteCommand(editor, caret, LineRange(line, line), "s", "//~/", Script(listOf()))
       ) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/FilterMotionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/FilterMotionAction.kt
@@ -32,8 +32,8 @@ class FilterMotionAction : VimActionHandler.SingleExecution(), DuplicableOperato
       ?: return false
 
     val current = editor.currentCaret().getLogicalPosition()
-    val start = editor.offsetToLogicalPosition(range.startOffset)
-    val end = editor.offsetToLogicalPosition(range.endOffsetInclusive)
+    val start = editor.offsetToBufferPosition(range.startOffset)
+    val end = editor.offsetToBufferPosition(range.endOffsetInclusive)
     if (current.line != start.line) {
       injector.motion.moveCaret(editor, editor.primaryCaret(), range.startOffset)
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/FilterMotionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/FilterMotionAction.kt
@@ -31,7 +31,7 @@ class FilterMotionAction : VimActionHandler.SingleExecution(), DuplicableOperato
     val range = injector.motion.getMotionRange(editor, editor.primaryCaret(), context, argument, operatorArguments)
       ?: return false
 
-    val current = editor.currentCaret().getLogicalPosition()
+    val current = editor.currentCaret().getBufferPosition()
     val start = editor.offsetToBufferPosition(range.startOffset)
     val end = editor.offsetToBufferPosition(range.endOffsetInclusive)
     if (current.line != start.line) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertCharacterAroundCursorAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertCharacterAroundCursorAction.kt
@@ -14,7 +14,7 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimVisualPosition
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.lineLength
-import com.maddyhome.idea.vim.api.visualLineToLogicalLine
+import com.maddyhome.idea.vim.api.visualLineToBufferLine
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
@@ -64,7 +64,7 @@ private fun insertCharacterAroundCursor(editor: VimEditor, caret: VimCaret, dir:
   var res = false
   var vp = caret.getVisualPosition()
   vp = VimVisualPosition(vp.line + dir, vp.column, false)
-  val len = editor.lineLength(editor.visualLineToLogicalLine(vp.line))
+  val len = editor.lineLength(editor.visualLineToBufferLine(vp.line))
   if (vp.column < len) {
     val offset = editor.visualPositionToOffset(VimVisualPosition(vp.line, vp.column, false)).point
     val charsSequence = editor.text()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertDeletePreviousWordAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertDeletePreviousWordAction.kt
@@ -48,7 +48,7 @@ class InsertDeletePreviousWordAction : ChangeEditorActionHandler.ForEachCaret() 
  * @return true if able to delete text, false if not
  */
 fun insertDeletePreviousWord(editor: VimEditor, caret: VimCaret, operatorArguments: OperatorArguments): Boolean {
-  val deleteTo: Int = if (caret.getLogicalPosition().column == 0) {
+  val deleteTo: Int = if (caret.getBufferPosition().column == 0) {
     caret.offset.point - 1
   } else {
     var pointer = caret.offset.point - 1

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertNewLineBelowAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertNewLineBelowAction.kt
@@ -87,7 +87,7 @@ private fun insertNewLineAbove(editor: VimEditor, context: ExecutionContext) {
       offset = injector.motion.moveCaretToCurrentLineStartSkipLeading(editor, caret)
       firstLiners.add(caret)
     } else {
-      offset = injector.motion.moveCaretToLineEnd(editor, caret.getLogicalPosition().line - 1, true)
+      offset = injector.motion.moveCaretToLineEnd(editor, caret.getBufferPosition().line - 1, true)
     }
     moves.add(Pair(caret, offset))
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLinePageStartAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollFirstScreenLinePageStartAction.kt
@@ -11,7 +11,7 @@ import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.normalizeVisualLine
-import com.maddyhome.idea.vim.api.visualLineToLogicalLine
+import com.maddyhome.idea.vim.api.visualLineToBufferLine
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
@@ -35,7 +35,7 @@ class MotionScrollFirstScreenLinePageStartAction : VimActionHandler.SingleExecut
       val nextVisualLine = editor.normalizeVisualLine(
         injector.engineEditorHelper.getVisualLineAtBottomOfScreen(editor) + 1
       )
-      rawCount = editor.visualLineToLogicalLine(nextVisualLine) + 1 // rawCount is 1 based
+      rawCount = editor.visualLineToBufferLine(nextVisualLine) + 1 // rawCount is 1 based
     }
     return injector.motion.scrollCurrentLineToDisplayTop(editor, rawCount, true)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLinePageStartAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLinePageStartAction.kt
@@ -12,7 +12,7 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.normalizeLine
 import com.maddyhome.idea.vim.api.normalizeVisualLine
-import com.maddyhome.idea.vim.api.visualLineToLogicalLine
+import com.maddyhome.idea.vim.api.visualLineToBufferLine
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
@@ -37,7 +37,7 @@ class MotionScrollLastScreenLinePageStartAction : VimActionHandler.SingleExecuti
     // line, at the first non-blank in the line.
     if (cmd.rawCount == 0) {
       val prevVisualLine = editor.normalizeVisualLine(injector.engineEditorHelper.getVisualLineAtTopOfScreen(editor) - 1)
-      val logicalLine = editor.visualLineToLogicalLine(prevVisualLine)
+      val logicalLine = editor.visualLineToBufferLine(prevVisualLine)
       return motion.scrollCurrentLineToDisplayBottom(editor, logicalLine + 1, true)
     }
 
@@ -45,7 +45,7 @@ class MotionScrollLastScreenLinePageStartAction : VimActionHandler.SingleExecuti
     // the top, and then move that line to the bottom of the window
     var logicalLine = editor.normalizeLine(cmd.rawCount - 1)
     if (motion.scrollCurrentLineToDisplayBottom(editor, logicalLine + 1, false)) {
-      logicalLine = editor.visualLineToLogicalLine(injector.engineEditorHelper.getVisualLineAtTopOfScreen(editor))
+      logicalLine = editor.visualLineToBufferLine(injector.engineEditorHelper.getVisualLineAtTopOfScreen(editor))
       return motion.scrollCurrentLineToDisplayBottom(editor, logicalLine + 1, true)
     }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLinePageStartAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollLastScreenLinePageStartAction.kt
@@ -37,16 +37,16 @@ class MotionScrollLastScreenLinePageStartAction : VimActionHandler.SingleExecuti
     // line, at the first non-blank in the line.
     if (cmd.rawCount == 0) {
       val prevVisualLine = editor.normalizeVisualLine(injector.engineEditorHelper.getVisualLineAtTopOfScreen(editor) - 1)
-      val logicalLine = editor.visualLineToBufferLine(prevVisualLine)
-      return motion.scrollCurrentLineToDisplayBottom(editor, logicalLine + 1, true)
+      val bufferLine = editor.visualLineToBufferLine(prevVisualLine)
+      return motion.scrollCurrentLineToDisplayBottom(editor, bufferLine + 1, true)
     }
 
     // [count]z^ first scrolls [count] to the bottom of the window, then moves the caret to the line that is now at
     // the top, and then move that line to the bottom of the window
-    var logicalLine = editor.normalizeLine(cmd.rawCount - 1)
-    if (motion.scrollCurrentLineToDisplayBottom(editor, logicalLine + 1, false)) {
-      logicalLine = editor.visualLineToBufferLine(injector.engineEditorHelper.getVisualLineAtTopOfScreen(editor))
-      return motion.scrollCurrentLineToDisplayBottom(editor, logicalLine + 1, true)
+    var bufferLine = editor.normalizeLine(cmd.rawCount - 1)
+    if (motion.scrollCurrentLineToDisplayBottom(editor, bufferLine + 1, false)) {
+      bufferLine = editor.visualLineToBufferLine(injector.engineEditorHelper.getVisualLineAtTopOfScreen(editor))
+      return motion.scrollCurrentLineToDisplayBottom(editor, bufferLine + 1, true)
     }
 
     return false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
@@ -11,13 +11,14 @@ package com.maddyhome.idea.vim.api
 import com.maddyhome.idea.vim.common.TextRange
 import java.nio.CharBuffer
 
+// TODO: [visual] try to remove all uses of visual line/position. This is an IntelliJ concept
 interface EngineEditorHelper {
   // Keep it for now. See the IJ implementation, there are some hacks regarding that
   fun amountOfInlaysBeforeVisualPosition(editor: VimEditor, pos: VimVisualPosition): Int
   fun getVisualLineAtTopOfScreen(editor: VimEditor): Int
+  fun getVisualLineAtBottomOfScreen(editor: VimEditor): Int
   fun getApproximateScreenWidth(editor: VimEditor): Int
   fun handleWithReadonlyFragmentModificationHandler(editor: VimEditor, exception: java.lang.Exception)
-  fun getVisualLineAtBottomOfScreen(editor: VimEditor): Int
   fun pad(editor: VimEditor, context: ExecutionContext, line: Int, to: Int): String
   fun inlayAwareOffsetToVisualPosition(editor: VimEditor, offset: Int): VimVisualPosition
 }
@@ -65,15 +66,19 @@ fun VimEditor.normalizeColumn(line: Int, col: Int, allowEnd: Boolean): Int {
 }
 
 /**
- * Gets the number of characters on the specified visual line. This will be different than the number of visual
- * characters if there are "real" tabs in the line.
+ * Gets the number of characters on the buffer line equivalent to the specified visual line.
+ *
+ * This will be different than the number of visual characters if there are "real" tabs in the line.
  *
  * @param this@getVisualLineLength The editor
  * @param line   The visual line within the file
  * @return The number of characters in the specified line
  */
+// TODO: [visual] try to get rid of this. It's probably not doing what you think it's doing
+// This gets the length of the visual line's buffer line, not the length of the visual line. With soft wraps, these can
+// be very different values.
 fun VimEditor.getVisualLineLength(line: Int): Int {
-    return lineLength(visualLineToLogicalLine(line))
+    return lineLength(visualLineToBufferLine(line))
 }
 
 /**
@@ -91,13 +96,13 @@ fun VimEditor.lineLength(logicalLine: Int): Int {
 }
 
 /**
- * Converts a visual line number to a logical line number.
+ * Converts a visual line number to a buffer line number.
  *
- * @param this@visualLineToLogicalLine The editor
+ * @param this@visualLineToBufferLine The editor
  * @param line   The visual line number to convert
- * @return The logical line number
+ * @return The buffer line number
  */
-fun VimEditor.visualLineToLogicalLine(line: Int): Int {
+fun VimEditor.visualLineToBufferLine(line: Int): Int {
     val logicalLine: Int = visualPositionToBufferPosition(VimVisualPosition(line, 0)).line
     return normalizeLine(logicalLine)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
@@ -86,7 +86,7 @@ fun VimEditor.lineLength(logicalLine: Int): Int {
     return if (lineCount() == 0) {
         0
     } else {
-        offsetToLogicalPosition(getLineEndOffset(logicalLine)).column.coerceAtLeast(0)
+        offsetToBufferPosition(getLineEndOffset(logicalLine)).column.coerceAtLeast(0)
     }
 }
 
@@ -98,7 +98,7 @@ fun VimEditor.lineLength(logicalLine: Int): Int {
  * @return The logical line number
  */
 fun VimEditor.visualLineToLogicalLine(line: Int): Int {
-    val logicalLine: Int = visualToLogicalPosition(VimVisualPosition(line, 0)).line
+    val logicalLine: Int = visualPositionToBufferPosition(VimVisualPosition(line, 0)).line
     return normalizeLine(logicalLine)
 }
 
@@ -175,7 +175,7 @@ fun VimEditor.normalizeOffset(offset: Int, allowEnd: Boolean = true): Int {
   if (offset > textLength) {
     offset = textLength
   }
-  val line: Int = offsetToLogicalPosition(offset).line
+  val line: Int = offsetToBufferPosition(offset).line
   return normalizeOffset(line, offset, allowEnd)
 }
 
@@ -200,11 +200,11 @@ fun VimEditor.normalizeVisualLine(line: Int): Int {
  */
 fun VimEditor.getVisualLineCount(): Int {
   val count = lineCount()
-  return if (count == 0) 0 else this.logicalLineToVisualLine(count - 1) + 1
+  return if (count == 0) 0 else this.bufferLineToVisualLine(count - 1) + 1
 }
 
 fun VimEditor.getLineStartForOffset(offset: Int): Int {
-  val pos = offsetToLogicalPosition(normalizeOffset(offset, true))
+  val pos = offsetToBufferPosition(normalizeOffset(offset, true))
   return getLineStartOffset(pos.line)
 }
 
@@ -216,7 +216,7 @@ fun VimEditor.getLineStartForOffset(offset: Int): Int {
  * @return The offset of the line end
  */
 fun VimEditor.getLineEndForOffset(offset: Int): Int {
-  val pos = offsetToLogicalPosition(normalizeOffset(offset, true))
+  val pos = offsetToBufferPosition(normalizeOffset(offset, true))
   return getLineEndOffset(pos.line)
 }
 
@@ -264,7 +264,7 @@ fun VimEditor.getText(range: TextRange): String {
 }
 
 fun VimEditor.getOffset(line: Int, column: Int): Int {
-  return logicalPositionToOffset(BufferPosition(line, column))
+  return bufferPositionToOffset(BufferPosition(line, column))
 }
 fun VimEditor.getLineBuffer(line: Int): CharBuffer {
   val start: Int = getLineStartOffset(line)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
@@ -264,7 +264,7 @@ fun VimEditor.getText(range: TextRange): String {
 }
 
 fun VimEditor.getOffset(line: Int, column: Int): Int {
-  return logicalPositionToOffset(VimLogicalPosition(line, column))
+  return logicalPositionToOffset(BufferPosition(line, column))
 }
 fun VimEditor.getLineBuffer(line: Int): CharBuffer {
   val start: Int = getLineStartOffset(line)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/EngineEditorHelper.kt
@@ -47,16 +47,16 @@ fun VimEditor.getLeadingCharacterOffset(line: Int, col: Int = 0): Int {
 }
 
 
-fun VimEditor.normalizeVisualColumn(line: Int, col: Int, allowEnd: Boolean): Int {
-    return (this.getVisualLineLength(line) - if (allowEnd) 0 else 1).coerceIn(0..col)
+fun VimEditor.normalizeVisualColumn(visualLine: Int, col: Int, allowEnd: Boolean): Int {
+    return (this.getVisualLineLength(visualLine) - if (allowEnd) 0 else 1).coerceIn(0..col)
 }
 
 /**
- * Ensures that the supplied column number for the given logical line is within the range 0 (incl) and the
+ * Ensures that the supplied column number for the given buffer line is within the range 0 (incl) and the
  * number of columns in the line (excl).
  *
  * @param this@normalizeColumn   The editor
- * @param line     The logical line number
+ * @param line     The buffer line number
  * @param col      The column number to normalize
  * @param allowEnd True if newline allowed
  * @return The normalized column number
@@ -71,27 +71,27 @@ fun VimEditor.normalizeColumn(line: Int, col: Int, allowEnd: Boolean): Int {
  * This will be different than the number of visual characters if there are "real" tabs in the line.
  *
  * @param this@getVisualLineLength The editor
- * @param line   The visual line within the file
+ * @param visualLine   The visual line within the file
  * @return The number of characters in the specified line
  */
 // TODO: [visual] try to get rid of this. It's probably not doing what you think it's doing
 // This gets the length of the visual line's buffer line, not the length of the visual line. With soft wraps, these can
 // be very different values.
-fun VimEditor.getVisualLineLength(line: Int): Int {
-    return lineLength(visualLineToBufferLine(line))
+fun VimEditor.getVisualLineLength(visualLine: Int): Int {
+    return lineLength(visualLineToBufferLine(visualLine))
 }
 
 /**
- * Gets the number of characters on the specified logical line. This will be different than the number of visual
+ * Gets the number of characters on the specified buffer line. This will be different than the number of visual
  * characters if there are "real" tabs in the line.
  *
  * @return The number of characters in the specified line
  */
-fun VimEditor.lineLength(logicalLine: Int): Int {
+fun VimEditor.lineLength(line: Int): Int {
     return if (lineCount() == 0) {
         0
     } else {
-        offsetToBufferPosition(getLineEndOffset(logicalLine)).column.coerceAtLeast(0)
+        offsetToBufferPosition(getLineEndOffset(line)).column.coerceAtLeast(0)
     }
 }
 
@@ -99,32 +99,31 @@ fun VimEditor.lineLength(logicalLine: Int): Int {
  * Converts a visual line number to a buffer line number.
  *
  * @param this@visualLineToBufferLine The editor
- * @param line   The visual line number to convert
+ * @param visualLine   The visual line number to convert
  * @return The buffer line number
  */
-fun VimEditor.visualLineToBufferLine(line: Int): Int {
-    val logicalLine: Int = visualPositionToBufferPosition(VimVisualPosition(line, 0)).line
-    return normalizeLine(logicalLine)
+fun VimEditor.visualLineToBufferLine(visualLine: Int): Int {
+    val bufferLine: Int = visualPositionToBufferPosition(VimVisualPosition(visualLine, 0)).line
+    return normalizeLine(bufferLine)
 }
 
 /**
- * Ensures that the supplied logical line is within the range 0 (incl) and the number of logical lines in the file
- * (excl).
+ * Ensures that the supplied buffer line is within the range 0 (incl) and the number of buffer lines in the file (excl).
  *
  * @param this@normalizeLine The editor
- * @param line   The logical line number to normalize
- * @return The normalized logical line number
+ * @param line   The buffer line number to normalize
+ * @return The normalized buffer line number
  */
 fun VimEditor.normalizeLine(line: Int): Int {
   return line.coerceIn(0 until lineCount().coerceAtLeast(1))
 }
 
 /**
- * Ensures that the supplied offset for the given logical line is within the range for the line. If allowEnd
- * is true, the range will allow for the offset to be one past the last character on the line.
+ * Ensures that the supplied offset for the given buffer line is within the range for the line. If allowEnd is true, the
+ * range will allow for the offset to be one past the last character on the line.
  *
  * @param this@normalizeOffset   The editor
- * @param line     The logical line number
+ * @param line     The buffer line number
  * @param offset   The offset to normalize
  * @param allowEnd true if the offset can be one past the last character on the line, false if not
  * @return The normalized column number
@@ -142,7 +141,7 @@ fun VimEditor.normalizeOffset(line: Int, offset: Int, allowEnd: Boolean): Int {
  * Returns the offset of the end of the requested line.
  *
  * @param this@getLineEndOffset   The editor
- * @param line     The logical line to get the end offset for
+ * @param line     The buffer line to get the end offset for
  * @param allowEnd True include newline
  * @return 0 if line is &lt 0, file size of line is bigger than file, else the end offset for the line
  */
@@ -189,11 +188,11 @@ fun VimEditor.normalizeOffset(offset: Int, allowEnd: Boolean = true): Int {
  * (excl).
  *
  * @param this@normalizeVisualLine The editor
- * @param line   The visual line number to normalize
+ * @param visualLine   The visual line number to normalize
  * @return The normalized visual line number
  */
-fun VimEditor.normalizeVisualLine(line: Int): Int {
-  return line.coerceIn(0 until getVisualLineCount().coerceAtLeast(1))
+fun VimEditor.normalizeVisualLine(visualLine: Int): Int {
+  return visualLine.coerceIn(0 until getVisualLineCount().coerceAtLeast(1))
 }
 
 /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCaret.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCaret.kt
@@ -24,7 +24,7 @@ interface VimCaret {
   val isValid: Boolean
   val isPrimary: Boolean
 
-  fun getLogicalPosition(): VimLogicalPosition
+  fun getLogicalPosition(): BufferPosition
   fun getVisualPosition(): VimVisualPosition
 
   fun getLine(): EditorLine.Pointer
@@ -53,7 +53,7 @@ interface VimCaret {
   fun moveToOffsetNative(offset: Int)
   fun moveToInlayAwareOffset(newOffset: Int)
   fun moveToVisualPosition(position: VimVisualPosition)
-  fun moveToLogicalPosition(logicalPosition: VimLogicalPosition)
+  fun moveToLogicalPosition(logicalPosition: BufferPosition)
 
   val visualLineStart: Int
   var vimInsertStart: LiveRange

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCaret.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCaret.kt
@@ -24,7 +24,9 @@ interface VimCaret {
   val isValid: Boolean
   val isPrimary: Boolean
 
-  fun getLogicalPosition(): BufferPosition
+  fun getBufferPosition(): BufferPosition
+
+  // TODO: [visual] Try to remove this. Visual position is an IntelliJ concept and Vim doesn't have a direct equivalent
   fun getVisualPosition(): VimVisualPosition
 
   fun getLine(): EditorLine.Pointer
@@ -52,8 +54,10 @@ interface VimCaret {
   fun moveToOffset(offset: Int)
   fun moveToOffsetNative(offset: Int)
   fun moveToInlayAwareOffset(newOffset: Int)
+  fun moveToBufferPosition(position: BufferPosition)
+
+  // TODO: [visual] Try to remove this. Visual position is an IntelliJ concept and Vim doesn't have a direct equivalent
   fun moveToVisualPosition(position: VimVisualPosition)
-  fun moveToLogicalPosition(logicalPosition: BufferPosition)
 
   val visualLineStart: Int
   var vimInsertStart: LiveRange

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -104,7 +104,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
         operatorArguments
       )
       val pos = caret.offset.point
-      val norm = editor.normalizeOffset(caret.getLogicalPosition().line, pos, isChange)
+      val norm = editor.normalizeOffset(caret.getBufferPosition().line, pos, isChange)
       if (norm != pos ||
         editor.offsetToVisualPosition(norm) !==
         injector.engineEditorHelper.inlayAwareOffsetToVisualPosition(editor, norm)
@@ -115,7 +115,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
       // location, or deleting the character(s) might have caused us to scroll sideways in long files. Moving the caret
       // will make sure it's in the right place, and visible
       val offset = editor.normalizeOffset(
-        caret.getLogicalPosition().line,
+        caret.getBufferPosition().line,
         caret.offset.point,
         isChange
       )
@@ -264,7 +264,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     for (caret in editor.nativeCarets()) {
       if (repeatLines > 0) {
         val visualLine = caret.getVisualPosition().line
-        val logicalLine = caret.getLogicalPosition().line
+        val logicalLine = caret.getBufferPosition().line
         val position = editor.bufferPositionToOffset(BufferPosition(logicalLine, repeatColumn, false))
         for (i in 0 until repeatLines) {
           if (repeatAppend &&
@@ -687,7 +687,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
   ): Boolean {
     var myCount = count
     if (myCount < 2) myCount = 2
-    val lline = caret.getLogicalPosition().line
+    val lline = caret.getBufferPosition().line
     val total = editor.lineCount()
     return if (lline + myCount > total) {
       false
@@ -773,7 +773,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
   override fun joinViaIdeaByCount(editor: VimEditor, context: ExecutionContext, count: Int): Boolean {
     val executions = if (count > 1) count - 1 else 1
     val allowedExecution = editor.nativeCarets().any { caret: VimCaret ->
-      val lline = caret.getLogicalPosition().line
+      val lline = caret.getBufferPosition().line
       val total = editor.lineCount()
       lline + count <= total
     }
@@ -958,8 +958,8 @@ abstract class VimChangeGroupBase : VimChangeGroup {
   override fun changeCharacters(editor: VimEditor, caret: VimCaret, operatorArguments: OperatorArguments): Boolean {
     val count = operatorArguments.count1
     // TODO  is it correct to use primary caret? There is a caret as an argument
-    val len = editor.lineLength(editor.primaryCaret().getLogicalPosition().line)
-    val col = caret.getLogicalPosition().column
+    val len = editor.lineLength(editor.primaryCaret().getBufferPosition().line)
+    val col = caret.getBufferPosition().column
     if (col + count >= len) {
       return changeEndOfLine(editor, caret, 1, operatorArguments)
     }
@@ -1015,7 +1015,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
       val offset: Int = if (spaces) {
         injector.motion.moveCaretToRelativeLineStartSkipLeading(editor, caret, 1)
       } else {
-        injector.motion.moveCaretToLineStart(editor, caret.getLogicalPosition().line + 1)
+        injector.motion.moveCaretToLineStart(editor, caret.getBufferPosition().line + 1)
       }
       deleteText(editor, TextRange(caret.offset.point, offset), null, caret, operatorArguments)
       if (spaces && !hasTrailingWhitespace) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -203,7 +203,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     insertText(editor, caret, caret.offset.point, str)
   }
 
-  open fun insertText(editor: VimEditor, caret: VimCaret, start: VimLogicalPosition, str: String) {
+  open fun insertText(editor: VimEditor, caret: VimCaret, start: BufferPosition, str: String) {
     insertText(editor, caret, editor.logicalPositionToOffset(start), str)
   }
 
@@ -265,7 +265,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
       if (repeatLines > 0) {
         val visualLine = caret.getVisualPosition().line
         val logicalLine = caret.getLogicalPosition().line
-        val position = editor.logicalPositionToOffset(VimLogicalPosition(logicalLine, repeatColumn, false))
+        val position = editor.logicalPositionToOffset(BufferPosition(logicalLine, repeatColumn, false))
         for (i in 0 until repeatLines) {
           if (repeatAppend &&
             (repeatColumn < VimMotionGroupBase.LAST_COLUMN) &&

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -264,22 +264,22 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     for (caret in editor.nativeCarets()) {
       if (repeatLines > 0) {
         val visualLine = caret.getVisualPosition().line
-        val logicalLine = caret.getBufferPosition().line
-        val position = editor.bufferPositionToOffset(BufferPosition(logicalLine, repeatColumn, false))
+        val bufferLine = caret.getBufferPosition().line
+        val position = editor.bufferPositionToOffset(BufferPosition(bufferLine, repeatColumn, false))
         for (i in 0 until repeatLines) {
           if (repeatAppend &&
             (repeatColumn < VimMotionGroupBase.LAST_COLUMN) &&
             (editor.getVisualLineLength(visualLine + i) < repeatColumn)
           ) {
-            val pad = injector.engineEditorHelper.pad(editor, context, logicalLine + i, repeatColumn)
+            val pad = injector.engineEditorHelper.pad(editor, context, bufferLine + i, repeatColumn)
             if (pad.isNotEmpty()) {
-              val offset = editor.getLineEndOffset(logicalLine + i)
+              val offset = editor.getLineEndOffset(bufferLine + i)
               insertText(editor, caret, offset, pad)
             }
           }
           val updatedCount = if (started) (if (i == 0) count else count + 1) else count
           if (repeatColumn >= VimMotionGroupBase.LAST_COLUMN) {
-            caret.moveToOffset(injector.motion.moveCaretToLineEnd(editor, logicalLine + i, true))
+            caret.moveToOffset(injector.motion.moveCaretToLineEnd(editor, bufferLine + i, true))
             repeatInsertText(editor, context, updatedCount, operatorArguments)
           } else if (editor.getVisualLineLength(visualLine + i) >= repeatColumn) {
             val visualPosition = VimVisualPosition(visualLine + i, repeatColumn, false)
@@ -988,7 +988,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
    *
    * @param editor    The editor to join the lines in
    * @param caret     The caret on the starting line (to be moved)
-   * @param startLine The starting logical line
+   * @param startLine The starting buffer line
    * @param count     The number of lines to join including startLine
    * @param spaces    If true the joined lines will have one space between them and any leading space on the second line
    * will be removed. If false, only the newline is removed to join the lines.

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -204,7 +204,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
   }
 
   open fun insertText(editor: VimEditor, caret: VimCaret, start: BufferPosition, str: String) {
-    insertText(editor, caret, editor.logicalPositionToOffset(start), str)
+    insertText(editor, caret, editor.bufferPositionToOffset(start), str)
   }
 
   /**
@@ -265,7 +265,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
       if (repeatLines > 0) {
         val visualLine = caret.getVisualPosition().line
         val logicalLine = caret.getLogicalPosition().line
-        val position = editor.logicalPositionToOffset(BufferPosition(logicalLine, repeatColumn, false))
+        val position = editor.bufferPositionToOffset(BufferPosition(logicalLine, repeatColumn, false))
         for (i in 0 until repeatLines) {
           if (repeatAppend &&
             (repeatColumn < VimMotionGroupBase.LAST_COLUMN) &&
@@ -804,8 +804,8 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     spaces: Boolean,
     operatorArguments: OperatorArguments
   ): Boolean {
-    val startLine = editor.offsetToLogicalPosition(range.startOffset).line
-    val endLine = editor.offsetToLogicalPosition(range.endOffset).line
+    val startLine = editor.offsetToBufferPosition(range.startOffset).line
+    val endLine = editor.offsetToBufferPosition(range.endOffset).line
     var count = endLine - startLine + 1
     if (count < 2) count = 2
     return deleteJoinNLines(editor, caret, startLine, count, spaces, operatorArguments)
@@ -858,8 +858,8 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     }
     val motion = argument.motion
     if (!isChange && !motion.isLinewiseMotion()) {
-      val start = editor.offsetToLogicalPosition(range.startOffset)
-      val end = editor.offsetToLogicalPosition(range.endOffset)
+      val start = editor.offsetToBufferPosition(range.startOffset)
+      val end = editor.offsetToBufferPosition(range.endOffset)
       if (start.line != end.line) {
         if (!editor.anyNonWhitespace(range.startOffset, -1) && !editor.anyNonWhitespace(range.endOffset, 1)) {
           type = SelectionType.LINE_WISE
@@ -905,7 +905,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
         caret.vimLastColumn = intendedColumn
         pos = injector.motion
           .moveCaretToLineWithStartOfLineOption(
-            editor, editor.offsetToLogicalPosition(pos).line,
+            editor, editor.offsetToBufferPosition(pos).line,
             caret
           )
       }
@@ -1058,8 +1058,8 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     fun getLinesCountInVisualBlock(editor: VimEditor, range: TextRange): Int {
       val startOffsets = range.startOffsets
       if (startOffsets.isEmpty()) return 0
-      val firstStart = editor.offsetToLogicalPosition(startOffsets[0])
-      val lastStart = editor.offsetToLogicalPosition(startOffsets[range.size() - 1])
+      val firstStart = editor.offsetToBufferPosition(startOffsets[0])
+      val lastStart = editor.offsetToBufferPosition(startOffsets[range.size() - 1])
       return lastStart.line - firstStart.line + 1
     }
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
@@ -177,8 +177,8 @@ interface VimEditor {
   fun updateCaretsVisualAttributes()
   fun updateCaretsVisualPosition()
 
-  fun offsetToLogicalPosition(offset: Int): VimLogicalPosition
-  fun logicalPositionToOffset(position: VimLogicalPosition): Int
+  fun offsetToLogicalPosition(offset: Int): BufferPosition
+  fun logicalPositionToOffset(position: BufferPosition): Int
 
   fun offsetToVisualPosition(offset: Int): VimVisualPosition
   fun visualPositionToOffset(position: VimVisualPosition): Offset
@@ -196,7 +196,7 @@ interface VimEditor {
 
   fun removeCaret(caret: VimCaret)
   fun removeSecondaryCarets()
-  fun vimSetSystemBlockSelectionSilently(start: VimLogicalPosition, end: VimLogicalPosition)
+  fun vimSetSystemBlockSelectionSilently(start: BufferPosition, end: BufferPosition)
 
   fun getLineStartOffset(line: Int): Int
   fun getLineEndOffset(line: Int): Int
@@ -226,8 +226,8 @@ interface VimEditor {
 
   fun getLastVisualLineColumnNumber(line: Int): Int
 
-  fun visualToLogicalPosition(visualPosition: VimVisualPosition): VimLogicalPosition
-  fun logicalToVisualPosition(logicalPosition: VimLogicalPosition): VimVisualPosition
+  fun visualToLogicalPosition(visualPosition: VimVisualPosition): BufferPosition
+  fun logicalToVisualPosition(logicalPosition: BufferPosition): VimVisualPosition
 
   fun createLiveMarker(start: Offset, end: Offset): LiveRange
   var insertMode: Boolean
@@ -235,7 +235,7 @@ interface VimEditor {
   val document: VimDocument
 
   fun logicalLineToVisualLine(line: Int): Int {
-    return logicalToVisualPosition(VimLogicalPosition(line, 0)).line
+    return logicalToVisualPosition(BufferPosition(line, 0)).line
   }
 
   fun charAt(offset: Pointer): Char {
@@ -342,14 +342,15 @@ enum class LineDeleteShift {
   NO_NL,
 }
 
-class VimLogicalPosition(
+class BufferPosition(
   val line: Int,
   val column: Int,
   val leansForward: Boolean = false,
-) : Comparable<VimLogicalPosition> {
-  override fun compareTo(other: VimLogicalPosition): Int {
+) : Comparable<BufferPosition> {
+  override fun compareTo(other: BufferPosition): Int {
     return if (line != other.line) line - other.line else column - other.column
   }
 }
 
+// TODO: [visual] Try to remove this. It's an IntelliJ concept and doesn't have a Vim equivalent
 data class VimVisualPosition(val line: Int, val column: Int, val leansRight: Boolean = false)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
@@ -177,11 +177,19 @@ interface VimEditor {
   fun updateCaretsVisualAttributes()
   fun updateCaretsVisualPosition()
 
-  fun offsetToLogicalPosition(offset: Int): BufferPosition
-  fun logicalPositionToOffset(position: BufferPosition): Int
+  fun offsetToBufferPosition(offset: Int): BufferPosition
+  fun bufferPositionToOffset(position: BufferPosition): Int
 
+  // TODO: [visual] Try to remove these. Visual position is an IntelliJ concept and doesn't have a Vim equivalent
   fun offsetToVisualPosition(offset: Int): VimVisualPosition
   fun visualPositionToOffset(position: VimVisualPosition): Offset
+
+  fun visualPositionToBufferPosition(position: VimVisualPosition): BufferPosition
+  fun bufferPositionToVisualPosition(position: BufferPosition): VimVisualPosition
+
+  fun bufferLineToVisualLine(line: Int): Int {
+    return bufferPositionToVisualPosition(BufferPosition(line, 0)).line
+  }
 
   fun getVirtualFile(): VirtualFile?
   fun deleteString(range: TextRange)
@@ -226,17 +234,10 @@ interface VimEditor {
 
   fun getLastVisualLineColumnNumber(line: Int): Int
 
-  fun visualToLogicalPosition(visualPosition: VimVisualPosition): BufferPosition
-  fun logicalToVisualPosition(logicalPosition: BufferPosition): VimVisualPosition
-
   fun createLiveMarker(start: Offset, end: Offset): LiveRange
   var insertMode: Boolean
 
   val document: VimDocument
-
-  fun logicalLineToVisualLine(line: Int): Int {
-    return logicalToVisualPosition(BufferPosition(line, 0)).line
-  }
 
   fun charAt(offset: Pointer): Char {
     return text()[offset.point]

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroup.kt
@@ -31,9 +31,9 @@ interface VimMotionGroup {
   // Move caret to specific buffer line
   fun moveCaretToLineStart(editor: VimEditor, line: Int): Int
   fun moveCaretToLineStartSkipLeading(editor: VimEditor, line: Int): Int
-  fun moveCaretToLineWithStartOfLineOption(editor: VimEditor, logicalLine: Int, caret: VimCaret): Int
+  fun moveCaretToLineWithStartOfLineOption(editor: VimEditor, line: Int, caret: VimCaret): Int
   fun moveCaretToLineEnd(editor: VimEditor, line: Int, allowPastEnd: Boolean): Int
-  fun moveCaretToLineWithSameColumn(editor: VimEditor, logicalLine: Int, caret: VimCaret): Int
+  fun moveCaretToLineWithSameColumn(editor: VimEditor, line: Int, caret: VimCaret): Int
   fun moveCaretToLinePercent(editor: VimEditor, caret: VimCaret, count: Int): Int
 
   // Move caret relative to current line

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
@@ -188,8 +188,8 @@ abstract class VimMotionGroupBase : VimMotionGroup {
   }
 
   override fun moveCaretToCurrentLineStart(editor: VimEditor, caret: VimCaret): Int {
-    val logicalLine = caret.getLine().line
-    return moveCaretToLineStart(editor, logicalLine)
+    val line = caret.getLine().line
+    return moveCaretToLineStart(editor, line)
   }
 
   override fun moveCaretToRelativeLineEnd(
@@ -255,8 +255,8 @@ abstract class VimMotionGroupBase : VimMotionGroup {
   }
 
   override fun moveCaretToCurrentLineStartSkipLeading(editor: VimEditor, caret: VimCaret): Int {
-    val logicalLine = caret.getLine().line
-    return moveCaretToLineStartSkipLeading(editor, logicalLine)
+    val line = caret.getLine().line
+    return moveCaretToLineStartSkipLeading(editor, line)
   }
 
   override fun getMotionRange(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
@@ -350,7 +350,7 @@ abstract class VimMotionGroupBase : VimMotionGroup {
     val (line) = caret.getVisualPosition()
     val lastVisualLineColumn = editor.getLastVisualLineColumnNumber(line)
     val visualEndOfLine = VimVisualPosition(line, lastVisualLineColumn, true)
-    return moveCaretToLineEnd(editor, editor.visualToLogicalPosition(visualEndOfLine).line, true)
+    return moveCaretToLineEnd(editor, editor.visualPositionToBufferPosition(visualEndOfLine).line, true)
   }
 
     override fun moveCaretToLineStartSkipLeading(editor: VimEditor, line: Int): Int {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
@@ -322,7 +322,7 @@ abstract class VimMotionGroupBase : VimMotionGroup {
       // If we are a linewise motion we need to normalize the start and stop then move the start to the beginning
       // of the line and move the end to the end of the line.
       if (cmd.isLinewiseMotion()) {
-        if (caret.getLogicalPosition().line != editor.lineCount() - 1) {
+        if (caret.getBufferPosition().line != editor.lineCount() - 1) {
           start = editor.getLineStartForOffset(start)
           end = min((editor.getLineEndForOffset(end) + 1).toLong(), editor.fileSize()).toInt()
         } else {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
@@ -132,7 +132,7 @@ abstract class VimMotionGroupBase : VimMotionGroup {
     linesOffset: Int,
   ): Int {
     val line = editor.normalizeVisualLine(caret.getVisualPosition().line + linesOffset)
-    return moveCaretToLineStartSkipLeading(editor, editor.visualLineToLogicalLine(line))
+    return moveCaretToLineStartSkipLeading(editor, editor.visualLineToBufferLine(line))
   }
 
   override fun scrollFullPage(editor: VimEditor, caret: VimCaret, pages: Int): Boolean {
@@ -201,12 +201,12 @@ abstract class VimMotionGroupBase : VimMotionGroup {
     val line = editor.normalizeVisualLine(caret.getVisualPosition().line + cntForward)
 
     return if (line < 0) 0 else {
-      moveCaretToLineEnd(editor, editor.visualLineToLogicalLine(line), allowPastEnd)
+      moveCaretToLineEnd(editor, editor.visualLineToBufferLine(line), allowPastEnd)
     }
   }
 
   override fun moveCaretToRelativeLineEndSkipTrailing(editor: VimEditor, caret: VimCaret, linesOffset: Int): Int {
-    val line = editor.visualLineToLogicalLine(
+    val line = editor.visualLineToBufferLine(
       editor.normalizeVisualLine(caret.getVisualPosition().line + linesOffset)
     )
     val start = editor.getLineStartOffset(line)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
@@ -57,7 +57,7 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
           val intendedColumn = if (range.columns == VimMotionGroupBase.LAST_COLUMN) {
             VimMotionGroupBase.LAST_COLUMN
           } else {
-            editor.offsetToLogicalPosition(end).column
+            editor.offsetToBufferPosition(end).column
           }
           // Set the intended column before moving the caret, then reset because we've moved the caret
           it.vimLastColumn = intendedColumn
@@ -88,26 +88,26 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
 
   protected fun seemsLikeBlockMode(editor: VimEditor): Boolean {
     val selections = editor.nativeCarets().map {
-      val adj = if (editor.offsetToLogicalPosition(it.selectionEnd).column == 0) 1 else 0
+      val adj = if (editor.offsetToBufferPosition(it.selectionEnd).column == 0) 1 else 0
       it.selectionStart to (it.selectionEnd - adj).coerceAtLeast(0)
     }.sortedBy { it.first }
-    val selectionStartColumn = editor.offsetToLogicalPosition(selections.first().first).column
-    val selectionStartLine = editor.offsetToLogicalPosition(selections.first().first).line
+    val selectionStartColumn = editor.offsetToBufferPosition(selections.first().first).column
+    val selectionStartLine = editor.offsetToBufferPosition(selections.first().first).line
 
-    val maxColumn = selections.maxOfOrNull { editor.offsetToLogicalPosition(it.second).column } ?: return false
+    val maxColumn = selections.maxOfOrNull { editor.offsetToBufferPosition(it.second).column } ?: return false
     selections.forEachIndexed { i, it ->
-      if (editor.offsetToLogicalPosition(it.first).line != editor.offsetToLogicalPosition(it.second).line) {
+      if (editor.offsetToBufferPosition(it.first).line != editor.offsetToBufferPosition(it.second).line) {
         return false
       }
-      if (editor.offsetToLogicalPosition(it.first).column != selectionStartColumn) {
+      if (editor.offsetToBufferPosition(it.first).column != selectionStartColumn) {
         return false
       }
       val lineEnd =
-        editor.offsetToLogicalPosition(editor.getLineEndForOffset(it.second)).column
-      if (editor.offsetToLogicalPosition(it.second).column != maxColumn.coerceAtMost(lineEnd)) {
+        editor.offsetToBufferPosition(editor.getLineEndForOffset(it.second)).column
+      if (editor.offsetToBufferPosition(it.second).column != maxColumn.coerceAtMost(lineEnd)) {
         return false
       }
-      if (editor.offsetToLogicalPosition(it.first).line != selectionStartLine + i) {
+      if (editor.offsetToBufferPosition(it.first).line != selectionStartLine + i) {
         return false
       }
     }
@@ -122,8 +122,8 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
       // Detect if visual mode is character wise or line wise
       val selectionStart = caret.selectionStart
       val selectionEnd = caret.selectionEnd
-      val logicalStartLine = editor.offsetToLogicalPosition(selectionStart).line
-      val logicalEnd = editor.offsetToLogicalPosition(selectionEnd)
+      val logicalStartLine = editor.offsetToBufferPosition(selectionStart).line
+      val logicalEnd = editor.offsetToBufferPosition(selectionEnd)
       val logicalEndLine = if (logicalEnd.column == 0) (logicalEnd.line - 1).coerceAtLeast(0) else logicalEnd.line
       val lineStartOfSelectionStart = editor.getLineStartOffset(logicalStartLine)
       val lineEndOfSelectionEnd = editor.getLineEndOffset(logicalEndLine, true)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
@@ -122,11 +122,11 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
       // Detect if visual mode is character wise or line wise
       val selectionStart = caret.selectionStart
       val selectionEnd = caret.selectionEnd
-      val logicalStartLine = editor.offsetToBufferPosition(selectionStart).line
-      val logicalEnd = editor.offsetToBufferPosition(selectionEnd)
-      val logicalEndLine = if (logicalEnd.column == 0) (logicalEnd.line - 1).coerceAtLeast(0) else logicalEnd.line
-      val lineStartOfSelectionStart = editor.getLineStartOffset(logicalStartLine)
-      val lineEndOfSelectionEnd = editor.getLineEndOffset(logicalEndLine, true)
+      val startLine = editor.offsetToBufferPosition(selectionStart).line
+      val endPosition = editor.offsetToBufferPosition(selectionEnd)
+      val endLine = if (endPosition.column == 0) (endPosition.line - 1).coerceAtLeast(0) else endPosition.line
+      val lineStartOfSelectionStart = editor.getLineStartOffset(startLine)
+      val lineEndOfSelectionEnd = editor.getLineEndOffset(endLine, true)
       lineStartOfSelectionStart == selectionStart && (lineEndOfSelectionEnd + 1 == selectionEnd || lineEndOfSelectionEnd == selectionEnd)
     }
     if (all) return VimStateMachine.SubMode.VISUAL_LINE

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimVisualGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimVisualGroup.kt
@@ -58,8 +58,8 @@ fun blockToNativeSelection(
   end: Int,
   mode: VimStateMachine.Mode,
 ): Pair<BufferPosition, BufferPosition> {
-  var blockStart = editor.offsetToLogicalPosition(start)
-  var blockEnd = editor.offsetToLogicalPosition(end)
+  var blockStart = editor.offsetToBufferPosition(start)
+  var blockEnd = editor.offsetToBufferPosition(end)
   if (!isExclusiveSelection() && mode != VimStateMachine.Mode.SELECT) {
     if (blockStart.column > blockEnd.column) {
       if (blockStart.column < editor.lineLength(blockStart.line)) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimVisualGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimVisualGroup.kt
@@ -9,7 +9,7 @@
 package com.maddyhome.idea.vim.group.visual
 
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.VimLogicalPosition
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.getLineEndForOffset
 import com.maddyhome.idea.vim.api.getLineStartForOffset
 import com.maddyhome.idea.vim.api.injector
@@ -57,17 +57,17 @@ fun blockToNativeSelection(
   start: Int,
   end: Int,
   mode: VimStateMachine.Mode,
-): Pair<VimLogicalPosition, VimLogicalPosition> {
+): Pair<BufferPosition, BufferPosition> {
   var blockStart = editor.offsetToLogicalPosition(start)
   var blockEnd = editor.offsetToLogicalPosition(end)
   if (!isExclusiveSelection() && mode != VimStateMachine.Mode.SELECT) {
     if (blockStart.column > blockEnd.column) {
       if (blockStart.column < editor.lineLength(blockStart.line)) {
-        blockStart = VimLogicalPosition(blockStart.line, blockStart.column + 1)
+        blockStart = BufferPosition(blockStart.line, blockStart.column + 1)
       }
     } else {
       if (blockEnd.column < editor.lineLength(blockEnd.line)) {
-        blockEnd = VimLogicalPosition(blockEnd.line, blockEnd.column + 1)
+        blockEnd = BufferPosition(blockEnd.line, blockEnd.column + 1)
       }
     }
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/ex/ranges/ExRanges.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/ex/ranges/ExRanges.kt
@@ -197,7 +197,7 @@ class MarkRange(private val mark: Char, offset: Int, move: Boolean) : Range(offs
    */
   override fun getRangeLine(editor: VimEditor, lastZero: Boolean): Int {
     val mark = injector.markGroup.getFileMark(editor, mark)
-    return mark?.logicalLine ?: -1
+    return mark?.line ?: -1
   }
 
   override fun getRangeLine(editor: VimEditor, caret: VimCaret, lastZero: Boolean): Int = getRangeLine(editor, lastZero)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/ex/ranges/ExRanges.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/ex/ranges/ExRanges.kt
@@ -141,7 +141,7 @@ class LineNumberRange : Range {
    */
   override fun getRangeLine(editor: VimEditor, lastZero: Boolean): Int {
     if (line == CURRENT_LINE) {
-      line = editor.currentCaret().getLogicalPosition().line
+      line = editor.currentCaret().getBufferPosition().line
     } else if (line == LAST_LINE) {
       line = editor.lineCount() - 1
     }
@@ -153,7 +153,7 @@ class LineNumberRange : Range {
     caret: VimCaret,
     lastZero: Boolean,
   ): Int {
-    line = if (line == LAST_LINE) editor.lineCount() - 1 else caret.getLogicalPosition().line
+    line = if (line == LAST_LINE) editor.lineCount() - 1 else caret.getBufferPosition().line
     return line
   }
 
@@ -288,7 +288,7 @@ class SearchRange(pattern: String, offset: Int, move: Boolean) : Range(offset, m
     caret: VimCaret,
     lastZero: Boolean,
   ): Int {
-    var line = caret.getLogicalPosition().line
+    var line = caret.getBufferPosition().line
     var searchOffset = -1
     for (i in patterns.indices) {
       val pattern = patterns[i]

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/ex/ranges/ExRanges.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/ex/ranges/ExRanges.kt
@@ -303,7 +303,7 @@ class SearchRange(pattern: String, offset: Int, move: Boolean) : Range(offset, m
       searchOffset = getSearchOffset(editor, line, direction, lastZero)
       searchOffset = injector.searchGroup.processSearchRange(editor, pattern!!, patternOffset, searchOffset, direction)
       if (searchOffset == -1) break
-      line = editor.offsetToLogicalPosition(searchOffset).line
+      line = editor.offsetToBufferPosition(searchOffset).line
     }
     return if (searchOffset != -1) line else -1
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/ex/ranges/Ranges.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/ex/ranges/Ranges.kt
@@ -131,7 +131,7 @@ class Ranges {
     // Already done
     if (done) return
     // Start with the range being the current line
-    startLine = if (defaultLine == -1) editor.currentCaret().getLogicalPosition().line else defaultLine
+    startLine = if (defaultLine == -1) editor.currentCaret().getBufferPosition().line else defaultLine
     endLine = startLine
     var lastZero = false
     // Now process each range, moving the cursor if appropriate
@@ -156,7 +156,7 @@ class Ranges {
   }
 
   private fun processRange(editor: VimEditor, caret: VimCaret) {
-    startLine = if (defaultLine == -1) caret.getLogicalPosition().line else defaultLine
+    startLine = if (defaultLine == -1) caret.getBufferPosition().line else defaultLine
     endLine = startLine
     var lastZero = false
     for (range in ranges) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VimSelection.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VimSelection.kt
@@ -9,7 +9,7 @@
 package com.maddyhome.idea.vim.group.visual
 
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.VimLogicalPosition
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.getLineEndOffset
 import com.maddyhome.idea.vim.command.SelectionType
 import com.maddyhome.idea.vim.command.SelectionType.BLOCK_WISE
@@ -174,11 +174,11 @@ class VimBlockSelection(
     val lineRange =
       if (logicalStart.line > logicalEnd.line) logicalEnd.line..logicalStart.line else logicalStart.line..logicalEnd.line
     lineRange.map { line ->
-      val start = editor.logicalPositionToOffset(VimLogicalPosition(line, logicalStart.column))
+      val start = editor.logicalPositionToOffset(BufferPosition(line, logicalStart.column))
       val end = if (toLineEnd) {
         editor.getLineEndOffset(line, true)
       } else {
-        editor.logicalPositionToOffset(VimLogicalPosition(line, logicalEnd.column))
+        editor.logicalPositionToOffset(BufferPosition(line, logicalEnd.column))
       }
       action(start, end)
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VimSelection.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VimSelection.kt
@@ -170,15 +170,15 @@ class VimBlockSelection(
   }
 
   private fun forEachLine(action: (start: Int, end: Int) -> Unit) {
-    val (logicalStart, logicalEnd) = blockToNativeSelection(editor, vimStart, vimEnd, VimStateMachine.Mode.VISUAL)
+    val (startPosition, endPosition) = blockToNativeSelection(editor, vimStart, vimEnd, VimStateMachine.Mode.VISUAL)
     val lineRange =
-      if (logicalStart.line > logicalEnd.line) logicalEnd.line..logicalStart.line else logicalStart.line..logicalEnd.line
+      if (startPosition.line > endPosition.line) endPosition.line..startPosition.line else startPosition.line..endPosition.line
     lineRange.map { line ->
-      val start = editor.bufferPositionToOffset(BufferPosition(line, logicalStart.column))
+      val start = editor.bufferPositionToOffset(BufferPosition(line, startPosition.column))
       val end = if (toLineEnd) {
         editor.getLineEndOffset(line, true)
       } else {
-        editor.bufferPositionToOffset(BufferPosition(line, logicalEnd.column))
+        editor.bufferPositionToOffset(BufferPosition(line, endPosition.column))
       }
       action(start, end)
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VimSelection.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VimSelection.kt
@@ -62,8 +62,8 @@ sealed class VimSelection {
 
   @NonNls
   override fun toString(): String {
-    val startLogPosition = editor.offsetToLogicalPosition(vimStart)
-    val endLogPosition = editor.offsetToLogicalPosition(vimEnd)
+    val startLogPosition = editor.offsetToBufferPosition(vimStart)
+    val endLogPosition = editor.offsetToBufferPosition(vimEnd)
     return "Selection [$type]: vim start[offset: $vimStart : col ${startLogPosition.column} line ${startLogPosition.line}]" +
       " vim end[offset: $vimEnd : col ${endLogPosition.column} line ${endLogPosition.line}]"
   }
@@ -154,7 +154,7 @@ class VimBlockSelection(
   private val toLineEnd: Boolean,
 ) : VimSelection() {
   override fun getNativeStartAndEnd() = blockToNativeSelection(editor, vimStart, vimEnd, VimStateMachine.Mode.VISUAL).let {
-    editor.logicalPositionToOffset(it.first) to editor.logicalPositionToOffset(it.second)
+    editor.bufferPositionToOffset(it.first) to editor.bufferPositionToOffset(it.second)
   }
 
   override val type = BLOCK_WISE
@@ -174,11 +174,11 @@ class VimBlockSelection(
     val lineRange =
       if (logicalStart.line > logicalEnd.line) logicalEnd.line..logicalStart.line else logicalStart.line..logicalEnd.line
     lineRange.map { line ->
-      val start = editor.logicalPositionToOffset(BufferPosition(line, logicalStart.column))
+      val start = editor.bufferPositionToOffset(BufferPosition(line, logicalStart.column))
       val end = if (toLineEnd) {
         editor.getLineEndOffset(line, true)
       } else {
-        editor.logicalPositionToOffset(BufferPosition(line, logicalEnd.column))
+        editor.bufferPositionToOffset(BufferPosition(line, logicalEnd.column))
       }
       action(start, end)
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VisualOperation.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VisualOperation.kt
@@ -10,7 +10,7 @@ package com.maddyhome.idea.vim.group.visual
 
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.VimLogicalPosition
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.VimMotionGroupBase
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.lineLength
@@ -75,7 +75,7 @@ object VisualOperation {
       }
       SelectionType.BLOCK_WISE -> {
         val endColumn = min(editor.lineLength(endLine), sp.column + chars - 1)
-        editor.logicalPositionToOffset(VimLogicalPosition(endLine, endColumn))
+        editor.logicalPositionToOffset(BufferPosition(endLine, endColumn))
       }
     }
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VisualOperation.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VisualOperation.kt
@@ -34,8 +34,8 @@ object VisualOperation {
 
     start = editor.normalizeOffset(start, false)
     end = editor.normalizeOffset(end, false)
-    val sp = editor.offsetToLogicalPosition(start)
-    val ep = editor.offsetToLogicalPosition(end)
+    val sp = editor.offsetToBufferPosition(start)
+    val ep = editor.offsetToBufferPosition(end)
     var lines = ep.line - sp.line + 1
     if (type == SelectionType.LINE_WISE && ep.column == 0 && lines > 0) lines--
 
@@ -75,7 +75,7 @@ object VisualOperation {
       }
       SelectionType.BLOCK_WISE -> {
         val endColumn = min(editor.lineLength(endLine), sp.column + chars - 1)
-        editor.logicalPositionToOffset(BufferPosition(endLine, endColumn))
+        editor.bufferPositionToOffset(BufferPosition(endLine, endColumn))
       }
     }
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VisualOperation.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VisualOperation.kt
@@ -63,7 +63,7 @@ object VisualOperation {
     if (type == SelectionType.CHARACTER_WISE && lines == 1 || type == SelectionType.BLOCK_WISE) {
       chars *= count
     }
-    val sp = caret.getLogicalPosition()
+    val sp = caret.getBufferPosition()
     val linesDiff = (lines - 1).coerceAtLeast(0)
     val endLine = (sp.line + linesDiff).coerceAtMost(editor.lineCount() - 1)
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Jump.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Jump.kt
@@ -8,4 +8,4 @@
 
 package com.maddyhome.idea.vim.mark
 
-data class Jump(var logicalLine: Int, val col: Int, var filepath: String)
+data class Jump(var line: Int, val col: Int, var filepath: String)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Marks.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Marks.kt
@@ -9,7 +9,7 @@
 package com.maddyhome.idea.vim.mark
 
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.VimLogicalPosition
+import com.maddyhome.idea.vim.api.BufferPosition
 import org.jetbrains.annotations.NonNls
 
 interface Mark {
@@ -22,7 +22,7 @@ interface Mark {
   fun isClear(): Boolean
   fun clear()
 
-  fun offset(editor: VimEditor): Int = editor.logicalPositionToOffset(VimLogicalPosition(logicalLine, col))
+  fun offset(editor: VimEditor): Int = editor.logicalPositionToOffset(BufferPosition(logicalLine, col))
 
   object KeySorter : Comparator<Mark> {
     @NonNls

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Marks.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Marks.kt
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NonNls
 
 interface Mark {
   val key: Char
-  val logicalLine: Int
+  val line: Int
   val col: Int
   val filename: String
   val protocol: String?
@@ -22,7 +22,7 @@ interface Mark {
   fun isClear(): Boolean
   fun clear()
 
-  fun offset(editor: VimEditor): Int = editor.bufferPositionToOffset(BufferPosition(logicalLine, col))
+  fun offset(editor: VimEditor): Int = editor.bufferPositionToOffset(BufferPosition(line, col))
 
   object KeySorter : Comparator<Mark> {
     @NonNls
@@ -36,7 +36,7 @@ interface Mark {
 
 data class VimMark(
   override val key: Char,
-  override var logicalLine: Int,
+  override var line: Int,
   override val col: Int,
   override val filename: String,
   override val protocol: String?,
@@ -52,10 +52,10 @@ data class VimMark(
 
   companion object {
     @JvmStatic
-    fun create(key: Char?, logicalLine: Int?, col: Int?, filename: String?, protocol: String?): VimMark? {
+    fun create(key: Char?, line: Int?, col: Int?, filename: String?, protocol: String?): VimMark? {
       return VimMark(
         key ?: return null,
-        logicalLine ?: return null,
+        line ?: return null,
         col ?: 0,
         filename ?: return null,
         protocol ?: ""

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Marks.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Marks.kt
@@ -22,7 +22,7 @@ interface Mark {
   fun isClear(): Boolean
   fun clear()
 
-  fun offset(editor: VimEditor): Int = editor.logicalPositionToOffset(BufferPosition(logicalLine, col))
+  fun offset(editor: VimEditor): Int = editor.bufferPositionToOffset(BufferPosition(logicalLine, col))
 
   object KeySorter : Comparator<Mark> {
     @NonNls

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/VimMarkGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/VimMarkGroupBase.kt
@@ -61,8 +61,8 @@ abstract class VimMarkGroupBase : VimMarkGroup {
     if (marks != null && marks.size > 0 && editor != null) {
       // Calculate the logical position of the start and end of the deleted text
       val delEndOff = delStartOff + delLength - 1
-      val delStart = editor.offsetToLogicalPosition(delStartOff)
-      val delEnd = editor.offsetToLogicalPosition(delEndOff + 1)
+      val delStart = editor.offsetToBufferPosition(delStartOff)
+      val delEnd = editor.offsetToBufferPosition(delEndOff + 1)
       logger.debug { "mark delete. delStart = $delStart, delEnd = $delEnd" }
 
       // Now analyze each mark to determine if it needs to be updated or removed
@@ -114,8 +114,8 @@ abstract class VimMarkGroupBase : VimMarkGroup {
   override fun updateMarkFromInsert(editor: VimEditor?, marks: HashMap<Char, Mark>?, insStartOff: Int, insLength: Int) {
     if (marks != null && marks.size > 0 && editor != null) {
       val insEndOff = insStartOff + insLength
-      val insStart = editor.offsetToLogicalPosition(insStartOff)
-      val insEnd = editor.offsetToLogicalPosition(insEndOff)
+      val insStart = editor.offsetToBufferPosition(insStartOff)
+      val insEnd = editor.offsetToBufferPosition(insEndOff)
       logger.debug { "mark insert. insStart = $insStart, insEnd = $insEnd" }
       val lines = insEnd.line - insStart.line
       if (lines == 0) return
@@ -143,7 +143,7 @@ abstract class VimMarkGroupBase : VimMarkGroup {
   private fun addJump(editor: VimEditor, offset: Int, reset: Boolean) {
     val path = editor.getPath() ?: return
 
-    val lp = editor.offsetToLogicalPosition(offset)
+    val lp = editor.offsetToBufferPosition(offset)
     val jump = Jump(lp.line, lp.column, path)
     val filename = jump.filepath
 
@@ -201,7 +201,7 @@ abstract class VimMarkGroupBase : VimMarkGroup {
         false
       )
       offset = editor.normalizeOffset(offset, false)
-      val lp = editor.offsetToLogicalPosition(offset)
+      val lp = editor.offsetToBufferPosition(offset)
       mark = VimMark(myCh, lp.line, lp.column, editorPath, editor.extractProtocol())
     } else if ("()".indexOf(myCh) >= 0 && editorPath != null) {
       var offset = injector.searchHelper
@@ -212,7 +212,7 @@ abstract class VimMarkGroupBase : VimMarkGroup {
         )
 
       offset = editor.normalizeOffset(offset, false)
-      val lp = editor.offsetToLogicalPosition(offset)
+      val lp = editor.offsetToBufferPosition(offset)
       mark = VimMark(myCh, lp.line, lp.column, editorPath, editor.extractProtocol())
     } else if (VimMarkConstants.FILE_MARKS.indexOf(myCh) >= 0) {
       var fmarks: FileMarks<Char, Mark>? = null
@@ -266,7 +266,7 @@ abstract class VimMarkGroupBase : VimMarkGroup {
   override fun setMark(editor: VimEditor, ch: Char, offset: Int): Boolean {
     var myCh = ch
     if (myCh == '`') myCh = '\''
-    val lp = editor.offsetToLogicalPosition(offset)
+    val lp = editor.offsetToBufferPosition(offset)
 
     val path = editor.getPath() ?: return false
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/VimMarkGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/VimMarkGroupBase.kt
@@ -59,7 +59,7 @@ abstract class VimMarkGroupBase : VimMarkGroup {
   override fun updateMarkFromDelete(editor: VimEditor?, marks: HashMap<Char, Mark>?, delStartOff: Int, delLength: Int) {
     // Skip all this work if there are no marks
     if (marks != null && marks.size > 0 && editor != null) {
-      // Calculate the logical position of the start and end of the deleted text
+      // Calculate the buffer position of the start and end of the deleted text
       val delEndOff = delStartOff + delLength - 1
       val delStart = editor.offsetToBufferPosition(delStartOff)
       val delEnd = editor.offsetToBufferPosition(delEndOff + 1)
@@ -143,8 +143,8 @@ abstract class VimMarkGroupBase : VimMarkGroup {
   private fun addJump(editor: VimEditor, offset: Int, reset: Boolean) {
     val path = editor.getPath() ?: return
 
-    val lp = editor.offsetToBufferPosition(offset)
-    val jump = Jump(lp.line, lp.column, path)
+    val position = editor.offsetToBufferPosition(offset)
+    val jump = Jump(position.line, position.column, path)
     val filename = jump.filepath
 
     for (i in jumps.indices) {
@@ -201,8 +201,8 @@ abstract class VimMarkGroupBase : VimMarkGroup {
         false
       )
       offset = editor.normalizeOffset(offset, false)
-      val lp = editor.offsetToBufferPosition(offset)
-      mark = VimMark(myCh, lp.line, lp.column, editorPath, editor.extractProtocol())
+      val position = editor.offsetToBufferPosition(offset)
+      mark = VimMark(myCh, position.line, position.column, editorPath, editor.extractProtocol())
     } else if ("()".indexOf(myCh) >= 0 && editorPath != null) {
       var offset = injector.searchHelper
         .findNextSentenceStart(
@@ -212,8 +212,8 @@ abstract class VimMarkGroupBase : VimMarkGroup {
         )
 
       offset = editor.normalizeOffset(offset, false)
-      val lp = editor.offsetToBufferPosition(offset)
-      mark = VimMark(myCh, lp.line, lp.column, editorPath, editor.extractProtocol())
+      val position = editor.offsetToBufferPosition(offset)
+      mark = VimMark(myCh, position.line, position.column, editorPath, editor.extractProtocol())
     } else if (VimMarkConstants.FILE_MARKS.indexOf(myCh) >= 0) {
       var fmarks: FileMarks<Char, Mark>? = null
       if (editorPath != null) {
@@ -266,7 +266,7 @@ abstract class VimMarkGroupBase : VimMarkGroup {
   override fun setMark(editor: VimEditor, ch: Char, offset: Int): Boolean {
     var myCh = ch
     if (myCh == '`') myCh = '\''
-    val lp = editor.offsetToBufferPosition(offset)
+    val position = editor.offsetToBufferPosition(offset)
 
     val path = editor.getPath() ?: return false
 
@@ -274,14 +274,14 @@ abstract class VimMarkGroupBase : VimMarkGroup {
     if (VimMarkConstants.FILE_MARKS.indexOf(myCh) >= 0) {
       val fmarks = getFileMarks(path)
 
-      val mark = VimMark(myCh, lp.line, lp.column, path, editor.extractProtocol())
+      val mark = VimMark(myCh, position.line, position.column, path, editor.extractProtocol())
       fmarks[myCh] = mark
     } else if (VimMarkConstants.GLOBAL_MARKS.indexOf(myCh) >= 0) {
       val fmarks = getFileMarks(path)
 
-      var mark = createSystemMark(myCh, lp.line, lp.column, editor)
+      var mark = createSystemMark(myCh, position.line, position.column, editor)
       if (mark == null) {
-        mark = VimMark(myCh, lp.line, lp.column, path, editor.extractProtocol())
+        mark = VimMark(myCh, position.line, position.column, path, editor.extractProtocol())
       }
       fmarks[myCh] = mark
       val oldMark = globalMarks.put(myCh, mark)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/VimMarkGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/VimMarkGroupBase.kt
@@ -73,16 +73,16 @@ abstract class VimMarkGroupBase : VimMarkGroup {
         logger.debug { "mark = $myMark" }
         // If the end of the deleted text is prior to the marked line, simply shift the mark up by the
         // proper number of lines.
-        if (delEnd.line < myMark.logicalLine) {
+        if (delEnd.line < myMark.line) {
           val lines = delEnd.line - delStart.line
           logger.debug { "Shifting mark by $lines lines" }
-          myMark.logicalLine = myMark.logicalLine - lines
-        } else if (delStart.line <= myMark.logicalLine/* && delEnd.line >= mark.logicalLine*/) {
+          myMark.line = myMark.line - lines
+        } else if (delStart.line <= myMark.line/* && delEnd.line >= mark.line*/) {
           // Regarding the commented out condition in if: This additional condition was here before moving to kotlin
           // But now it's highlighted as "always true", so I commented it out for case of it's a bug
 
-          val markLineStartOff = editor.getLineStartOffset(myMark.logicalLine)
-          val markLineEndOff = editor.getLineEndOffset(myMark.logicalLine, true)
+          val markLineStartOff = editor.getLineStartOffset(myMark.line)
+          val markLineEndOff = editor.getLineEndOffset(myMark.line, true)
 
           val command = editor.vimStateMachine.executingCommand
           // If text is being changed from the start of the mark line (a special case for mark deletion)
@@ -91,9 +91,9 @@ abstract class VimMarkGroupBase : VimMarkGroup {
           if (delStartOff <= markLineStartOff && delEndOff >= markLineEndOff && !changeFromMarkLineStart) {
             injector.markGroup.removeMark(ch, myMark)
             logger.debug("Removed mark")
-          } else if (delStart.line < myMark.logicalLine) {
+          } else if (delStart.line < myMark.line) {
             // shift mark
-            myMark.logicalLine = delStart.line
+            myMark.line = delStart.line
             logger.debug { "Shifting mark to line " + delStart.line }
           } // The deletion only covers part of the marked line so shift the mark only if the deletion begins
           // on a line prior to the marked line (which means the deletion must end on the marked line).
@@ -123,8 +123,8 @@ abstract class VimMarkGroupBase : VimMarkGroup {
       for (mark in marks.values.filterIsInstance<VimMark>()) {
         logger.debug { "mark = $mark" }
         // Shift the mark if the insertion began on a line prior to the marked line.
-        if (insStart.line < mark.logicalLine) {
-          mark.logicalLine = mark.logicalLine + lines
+        if (insStart.line < mark.line) {
+          mark.line = mark.line + lines
           logger.debug { "Shifting mark by $lines lines" }
         }
       }
@@ -149,7 +149,7 @@ abstract class VimMarkGroupBase : VimMarkGroup {
 
     for (i in jumps.indices) {
       val j = jumps[i]
-      if (filename == j.filepath && j.logicalLine == jump.logicalLine) {
+      if (filename == j.filepath && j.line == jump.line) {
         jumps.removeAt(i)
         break
       }
@@ -355,8 +355,8 @@ abstract class VimMarkGroupBase : VimMarkGroup {
     val start = getMark(editor, startMark)
     val end = getMark(editor, endMark)
     if (start != null && end != null) {
-      val startOffset = editor.getOffset(start.logicalLine, start.col)
-      val endOffset = editor.getOffset(end.logicalLine, end.col)
+      val startOffset = editor.getOffset(start.line, start.col)
+      val endOffset = editor.getOffset(end.line, end.col)
       return TextRange(startOffset, endOffset + 1)
     }
     return null

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
@@ -94,7 +94,7 @@ abstract class VimPutBase : VimPut {
   protected fun deleteSelectedText(editor: VimEditor, data: PutData, operatorArguments: OperatorArguments) {
     if (data.visualSelection == null) return
 
-    data.visualSelection.caretsAndSelections.entries.sortedByDescending { it.key.getLogicalPosition() }
+    data.visualSelection.caretsAndSelections.entries.sortedByDescending { it.key.getBufferPosition() }
       .forEach { (caret, selection) ->
         if (!caret.isValid) return@forEach
         val range = selection.toVimTextRange(false).normalize()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
@@ -11,7 +11,7 @@ package com.maddyhome.idea.vim.put
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.VimLogicalPosition
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.getLineEndForOffset
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.lineLength
@@ -287,7 +287,7 @@ abstract class VimPutBase : VimPut {
 
       val pad = injector.engineEditorHelper.pad(editor, context, currentLine, currentColumn)
 
-      val insertOffset = editor.logicalPositionToOffset(VimLogicalPosition(currentLine, currentColumn))
+      val insertOffset = editor.logicalPositionToOffset(BufferPosition(currentLine, currentColumn))
       caret.moveToOffset(insertOffset)
       val insertedText = origSegment + segment.repeat(count - 1)
       injector.changeGroup.insertText(editor, caret, insertedText)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
@@ -53,8 +53,8 @@ abstract class VimPutBase : VimPut {
   protected fun collectPreModificationData(editor: VimEditor, data: PutData): Map<String, Any> {
     return if (data.visualSelection != null && data.visualSelection.typeInEditor.isBlock) {
       val vimSelection = data.visualSelection.caretsAndSelections.getValue(editor.primaryCaret())
-      val selStart = editor.offsetToLogicalPosition(vimSelection.vimStart)
-      val selEnd = editor.offsetToLogicalPosition(vimSelection.vimEnd)
+      val selStart = editor.offsetToBufferPosition(vimSelection.vimStart)
+      val selEnd = editor.offsetToBufferPosition(vimSelection.vimEnd)
       mapOf(
         "startColumnOfSelection" to min(selStart.column, selEnd.column),
         "selectedLines" to abs(selStart.line - selEnd.line),
@@ -257,7 +257,7 @@ abstract class VimPutBase : VimPut {
     indent: Boolean,
     cursorAfter: Boolean,
   ): Int {
-    val startPosition = editor.offsetToLogicalPosition(startOffset)
+    val startPosition = editor.offsetToBufferPosition(startOffset)
     val currentColumn = if (mode == VimStateMachine.SubMode.VISUAL_LINE) 0 else startPosition.column
     var currentLine = startPosition.line
 
@@ -287,7 +287,7 @@ abstract class VimPutBase : VimPut {
 
       val pad = injector.engineEditorHelper.pad(editor, context, currentLine, currentColumn)
 
-      val insertOffset = editor.logicalPositionToOffset(BufferPosition(currentLine, currentColumn))
+      val insertOffset = editor.bufferPositionToOffset(BufferPosition(currentLine, currentColumn))
       caret.moveToOffset(insertOffset)
       val insertedText = origSegment + segment.repeat(count - 1)
       injector.changeGroup.insertText(editor, caret, insertedText)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
@@ -218,9 +218,9 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
       val smallInlineDeletion =
         (
           (type === SelectionType.CHARACTER_WISE || type === SelectionType.BLOCK_WISE) && (
-            editor.offsetToLogicalPosition(
+            editor.offsetToBufferPosition(
               start
-            ).line == editor.offsetToLogicalPosition(end).line
+            ).line == editor.offsetToBufferPosition(end).line
             )
           )
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/DumpLineCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/DumpLineCommand.kt
@@ -34,7 +34,7 @@ data class DumpLineCommand(val ranges: Ranges, val argument: String) : Command.S
 
       for (i in start..end) {
         logger.debug(
-          "Offset $i, char=${chars[i]}, lp=${editor.offsetToLogicalPosition(i)}, vp=${editor.offsetToVisualPosition(i)}"
+          "Offset $i, char=${chars[i]}, lp=${editor.offsetToBufferPosition(i)}, vp=${editor.offsetToVisualPosition(i)}"
         )
       }
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/JumpsCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/JumpsCommand.kt
@@ -32,7 +32,7 @@ data class JumpsCommand(val ranges: Ranges, val argument: String) : Command.Sing
       text.append(if (jumpSizeMinusSpot == 0) ">" else " ")
       text.append(jumpSizeMinusSpot.absoluteValue.toString().padStart(3))
       text.append(" ")
-      text.append((jump.logicalLine + 1).toString().padStart(5))
+      text.append((jump.line + 1).toString().padStart(5))
 
       text.append("  ")
       text.append(jump.col.toString().padStart(3))
@@ -40,7 +40,7 @@ data class JumpsCommand(val ranges: Ranges, val argument: String) : Command.Sing
       text.append(" ")
       val vf = editor.getVirtualFile()
       if (vf != null && vf.path == jump.filepath) {
-        val line = editor.getLineText(jump.logicalLine).trim().take(200)
+        val line = editor.getLineText(jump.line).trim().take(200)
         val keys = injector.parser.stringToKeys(line)
         text.append(EngineStringHelper.toPrintableCharacters(keys).take(200))
       } else {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/MarksCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/MarksCommand.kt
@@ -30,11 +30,11 @@ data class MarksCommand(val ranges: Ranges, val argument: String) : Command.Sing
       .joinToString("\n", prefix = "mark line  col file/text\n") { mark ->
 
         // Lines are 1 based, columns zero based. See :help :marks
-        val line = (mark.logicalLine + 1).toString().padStart(5)
+        val line = (mark.line + 1).toString().padStart(5)
         val column = mark.col.toString().padStart(3)
         val vf = editor.getVirtualFile()
         val text = if (vf != null && vf.path == mark.filename) {
-          val lineText = editor.getLineText(mark.logicalLine).trim().take(200)
+          val lineText = editor.getLineText(mark.line).trim().take(200)
           EngineStringHelper.toPrintableCharacters(injector.parser.stringToKeys(lineText)).take(200)
         } else {
           mark.filename

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
@@ -43,7 +43,7 @@ data class NormalCommand(val ranges: Ranges, val argument: String) : Command.Sin
         editor.exitVisualModeNative()
         if (!rangeUsed) {
           val selectionStart = injector.markGroup.getMark(editor, '<')!!
-          editor.currentCaret().moveToBufferPosition(BufferPosition(selectionStart.logicalLine, selectionStart.col))
+          editor.currentCaret().moveToBufferPosition(BufferPosition(selectionStart.line, selectionStart.col))
         }
       }
       VimStateMachine.Mode.CMD_LINE -> injector.processGroup.cancelExEntry(editor, false)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
@@ -11,7 +11,7 @@ package com.maddyhome.idea.vim.vimscript.model.commands
 import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.VimLogicalPosition
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.command.VimStateMachine
@@ -43,7 +43,7 @@ data class NormalCommand(val ranges: Ranges, val argument: String) : Command.Sin
         editor.exitVisualModeNative()
         if (!rangeUsed) {
           val selectionStart = injector.markGroup.getMark(editor, '<')!!
-          editor.currentCaret().moveToLogicalPosition(VimLogicalPosition(selectionStart.logicalLine, selectionStart.col))
+          editor.currentCaret().moveToLogicalPosition(BufferPosition(selectionStart.logicalLine, selectionStart.col))
         }
       }
       VimStateMachine.Mode.CMD_LINE -> injector.processGroup.cancelExEntry(editor, false)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
@@ -43,7 +43,7 @@ data class NormalCommand(val ranges: Ranges, val argument: String) : Command.Sin
         editor.exitVisualModeNative()
         if (!rangeUsed) {
           val selectionStart = injector.markGroup.getMark(editor, '<')!!
-          editor.currentCaret().moveToLogicalPosition(BufferPosition(selectionStart.logicalLine, selectionStart.col))
+          editor.currentCaret().moveToBufferPosition(BufferPosition(selectionStart.logicalLine, selectionStart.col))
         }
       }
       VimStateMachine.Mode.CMD_LINE -> injector.processGroup.cancelExEntry(editor, false)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SortCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SortCommand.kt
@@ -73,8 +73,8 @@ data class SortCommand(val ranges: Ranges, val argument: String) : Command.Singl
         val start = selectionModel.selectionStart
         val end = selectionModel.selectionEnd
 
-        val startLine = editor.offsetToLogicalPosition(start).line
-        val endLine = editor.offsetToLogicalPosition(end).line
+        val startLine = editor.offsetToBufferPosition(start).line
+        val endLine = editor.offsetToBufferPosition(end).line
 
         LineRange(startLine, endLine)
       } else {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/DefinedFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/DefinedFunctionHandler.kt
@@ -42,7 +42,7 @@ data class DefinedFunctionHandler(val function: FunctionDeclaration) : FunctionH
     val isRangeGiven = (ranges?.size() ?: 0) > 0
 
     if (!isRangeGiven) {
-      val currentLine = editor.currentCaret().getLogicalPosition().line
+      val currentLine = editor.currentCaret().getBufferPosition().line
       ranges = Ranges()
       ranges!!.addRange(
         arrayOf(
@@ -74,7 +74,7 @@ data class DefinedFunctionHandler(val function: FunctionDeclaration) : FunctionH
   private fun executeBodyForLine(line: Int, isRangeGiven: Boolean, exceptionsCaught: MutableList<ExException>, editor: VimEditor, context: ExecutionContext): VimDataType? {
     var returnValue: VimDataType? = null
     if (isRangeGiven) {
-      editor.currentCaret().moveToLogicalPosition(BufferPosition(line - 1, 0))
+      editor.currentCaret().moveToBufferPosition(BufferPosition(line - 1, 0))
     }
     var result: ExecutionResult = ExecutionResult.Success
     if (function.flags.contains(FunctionFlag.ABORT)) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/DefinedFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/DefinedFunctionHandler.kt
@@ -10,7 +10,7 @@ package com.maddyhome.idea.vim.vimscript.model.functions
 
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.VimLogicalPosition
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.ex.ExException
@@ -74,7 +74,7 @@ data class DefinedFunctionHandler(val function: FunctionDeclaration) : FunctionH
   private fun executeBodyForLine(line: Int, isRangeGiven: Boolean, exceptionsCaught: MutableList<ExException>, editor: VimEditor, context: ExecutionContext): VimDataType? {
     var returnValue: VimDataType? = null
     if (isRangeGiven) {
-      editor.currentCaret().moveToLogicalPosition(VimLogicalPosition(line - 1, 0))
+      editor.currentCaret().moveToLogicalPosition(BufferPosition(line - 1, 0))
     }
     var result: ExecutionResult = ExecutionResult.Success
     if (function.flags.contains(FunctionFlag.ABORT)) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/yank/YankGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/yank/YankGroupBase.kt
@@ -163,10 +163,10 @@ open class YankGroupBase : VimYankGroup {
 
     if (type == SelectionType.LINE_WISE) {
       for (i in 0 until range.size()) {
-        if (editor.offsetToLogicalPosition(range.startOffsets[i]).column != 0) {
+        if (editor.offsetToBufferPosition(range.startOffsets[i]).column != 0) {
           range.startOffsets[i] = editor.getLineStartForOffset(range.startOffsets[i])
         }
-        if (editor.offsetToLogicalPosition(range.endOffsets[i]).column != 0) {
+        if (editor.offsetToBufferPosition(range.endOffsets[i]).column != 0) {
           range.endOffsets[i] =
             (editor.getLineEndForOffset(range.endOffsets[i]) + 1).coerceAtMost(editor.fileSize().toInt())
         }


### PR DESCRIPTION
This PR renames `VimLogicalPosition` to `BufferPosition` and updates related function, parameter and variable names in the engine API. This is to avoid confusion between Vim's "logical lines", which are required for soft wrap support, and IntelliJ's `LogicalPosition`, which is an IntelliJ concept to represent a location in the text buffer.

Vim understands several line types, including "buffer lines" and "logical lines" (see [`:help definitions`](https://vimhelp.org/intro.txt.html#definitions)). Buffer lines are the lines of the text buffer, as stored on disk, and map exactly to IntelliJ's `LogicalPosition`. Vim logical lines are buffer lines with folds applied. A folded range is represented by a single Vim logical line, as is a soft wrapped line. 

Vim motions should be in terms of Vim logical lines. E.g. `j` and `k` should move down or up by one Vim logical line, which is important for wraps and folds. The current implementation moves in terms of IntelliJ visual lines, which works for folds, but not soft wraps. To make wraps work, it will be necessary to introduce a "Vim logical line" type, but naming could be confusing with both `VimLogicalPosition` and `VimLogicalLine`. It makes sense to use Vim's concepts rather than IntelliJ's in the engine API, so we'll use Vim's terminology too.

This PR also tries to make buffer lines the default line type in the API. Unless otherwise stated in the function or parameter name, any API with a name that contains only "line" is a buffer line. Any other line type or a scenario which is ambiguous will use an explicit name, e.g. `visualLine`. (Visual lines are also IntelliJ concepts that don't have Vim equivalent. It should be a goal to remove them from the engine API, and swapping visual lines for Vim logical lines in motions will help with this)