### PR TITLE
Fix(VIM-2760) notebookCommandMode detection

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/HandlerInjector.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/HandlerInjector.kt
@@ -50,13 +50,13 @@ class HandlerInjector {
     fun notebookCommandMode(editor: Editor?): Boolean {
       return if (editor != null) {
         val inEditor = EditorHelper.getVirtualFile(editor)?.extension == "ipynb"
-        return if (TypedAction.getInstance().rawHandler::class.java.simpleName.equals("JupyterCommandModeTypingBlocker")){
+        return if (TypedAction.getInstance().rawHandler::class.java.simpleName.equals("JupyterCommandModeTypingBlocker")) {
           inEditor
         } else {
           // only true in command mode.
           // Set by `org.jetbrains.plugins.notebooks.ui.editor.actions.command.mode.NotebookEditorModeListenerAdapter`
           // appears to be null in non Notebook editors
-          val allow_plain_letter_shortcuts =  editor.contentComponent.getClientProperty(ActionUtil.ALLOW_PlAIN_LETTER_SHORTCUTS)
+          val allow_plain_letter_shortcuts = editor.contentComponent.getClientProperty(ActionUtil.ALLOW_PlAIN_LETTER_SHORTCUTS)
           inEditor && (allow_plain_letter_shortcuts != null && allow_plain_letter_shortcuts as Boolean)
         }
       } else {

--- a/src/main/java/com/maddyhome/idea/vim/helper/HandlerInjector.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/HandlerInjector.kt
@@ -8,6 +8,7 @@
 
 package com.maddyhome.idea.vim.helper
 
+import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.TypedAction
 import com.intellij.openapi.editor.actionSystem.TypedActionHandler
@@ -49,7 +50,15 @@ class HandlerInjector {
     fun notebookCommandMode(editor: Editor?): Boolean {
       return if (editor != null) {
         val inEditor = EditorHelper.getVirtualFile(editor)?.extension == "ipynb"
-        TypedAction.getInstance().rawHandler::class.java.simpleName.equals("JupyterCommandModeTypingBlocker") && inEditor
+        return if (TypedAction.getInstance().rawHandler::class.java.simpleName.equals("JupyterCommandModeTypingBlocker")){
+          inEditor
+        } else {
+          // only true in command mode.
+          // Set by `org.jetbrains.plugins.notebooks.ui.editor.actions.command.mode.NotebookEditorModeListenerAdapter`
+          // appears to be null in non Notebook editors
+          val allow_plain_letter_shortcuts =  editor.contentComponent.getClientProperty(ActionUtil.ALLOW_PlAIN_LETTER_SHORTCUTS)
+          inEditor && (allow_plain_letter_shortcuts != null && allow_plain_letter_shortcuts as Boolean)
+        }
       } else {
         TypedAction.getInstance().rawHandler::class.java.simpleName.equals("JupyterCommandModeTypingBlocker")
       }


### PR DESCRIPTION
Hi,
I tried to fix  [VIM-2760](https://youtrack.jetbrains.com/issue/VIM-2760/Jupyter-Notebooks-unable-to-enter-the-edit-mode-with-keyboard-after-pressing-Esc) because it really annoyed me :D

`notebookCommandMode` always returns false which results in handling the enter key wrong when in command mode of the notebook.
I tried to fix that by checking the client property ActionUtil.ALLOW_PlAIN_LETTER_SHORTCUTS that is set by [NotebookEditorModeListenerAdapter](https://github.com/JetBrains/intellij-community/blob/323891923c39ffb58a8e760c03ec4de0f4c9e4ca/notebooks/notebook-ui/src/org/jetbrains/plugins/notebooks/ui/editor/actions/command/mode/NotebookEditorMode.kt#L93).

I don't know if this is just a hack or a viable way to do it.
Another option to fix the issue would be to create our own listener. Sadly, I can't manage to register one:
```kotlin
import org.jetbrains.plugins.notebooks.ui.editor.actions.command.mode.NOTEBOOK_EDITOR_MODE

NOTEBOOK_EDITOR_MODE.subscribe(null, MyNotebookEditorModeListenerAdapter())
```
results in the following error:
```
 Class org.jetbrains.plugins.notebooks.ui.editor.actions.command.mode.NotebookEditorModeKt must not be requested from main classloader of com.intellij plugin
```


If the client property method is ok, I think we can remove the `HandlerInjector` Class and move the static `notebookCommandMode` function somewhere else (maybe into helper/EditorHelper.kt).

Let me know if I should do that refactoring or if there is a better way to detect the command mode.

Thanks,
Runinho

