### PR TITLE
Fix(VIM-2577) paste not working at end of notebook cell

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/copy/PutTestAfterCursorActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/copy/PutTestAfterCursorActionTest.kt
@@ -19,6 +19,7 @@ import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.SelectionType
 import com.maddyhome.idea.vim.command.VimStateMachine
+import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.helper.VimBehaviorDiffers
 import com.maddyhome.idea.vim.newapi.vim
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -93,6 +94,40 @@ class PutTestAfterCursorActionTest : VimTestCase() {
             hard by the torrent of a mountain pass.
             ${c}A Discovery
 
+    """.trimIndent()
+    assertState(after)
+  }
+
+  @VimBehaviorDiffers(
+    originalVimAfter = """
+            A Discovery
+            ${c}I found it in a legendary land
+            GUARD
+            I found it in a legendary land
+            all rocks and lavender and tufted grass,
+    """
+  )
+  @Test
+  fun `test put visual text line before Guard`() {
+    val before = """
+            A ${c}Discovery
+            GUARD
+            I found it in a legendary land
+            all rocks and lavender and tufted grass,
+    """.trimIndent()
+    val editor = configureByText(before)
+    // Add Guard to simulate Notebook behaviour. See (VIM-2577)
+    val guardRange = before rangeOf "\nGUARD\n"
+    editor.document.createGuardedBlock(guardRange.startOffset, guardRange.endOffset)
+    VimPlugin.getRegister().storeText(editor.vim, before rangeOf "I found it in a legendary land\n", SelectionType.LINE_WISE, false)
+    typeText(injector.parser.parseKeys("p"))
+    val after = """
+            A Discovery
+            ${c}I found it in a legendary land
+            
+            GUARD
+            I found it in a legendary land
+            all rocks and lavender and tufted grass,
     """.trimIndent()
     assertState(after)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
@@ -25,6 +25,7 @@ import com.maddyhome.idea.vim.command.VimStateMachine
 import com.maddyhome.idea.vim.command.isBlock
 import com.maddyhome.idea.vim.command.isChar
 import com.maddyhome.idea.vim.command.isLine
+import com.maddyhome.idea.vim.common.Offset
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.common.offset
 import com.maddyhome.idea.vim.diagnostic.vimLogger
@@ -433,6 +434,11 @@ abstract class VimPutBase : VimPut {
         SelectionType.LINE_WISE -> {
           startOffset =
             min(vimEditor.text().length, injector.motion.moveCaretToLineEnd(vimEditor, line, true) + 1)
+          // At the end of a notebook cell the next symbol is a guard,
+          // so we add a newline to be able to paste. Fixes VIM-2577
+          if (vimEditor.document.getOffsetGuard(Offset(startOffset))!= null) {
+            application.runWriteAction { (vimEditor as MutableVimEditor).insertText((startOffset-1).offset, "\n") }
+          }
           if (startOffset > 0 && startOffset == vimEditor.text().length && vimEditor.text()[startOffset - 1] != '\n') {
             application.runWriteAction { (vimEditor as MutableVimEditor).insertText(startOffset.offset, "\n") }
             startOffset++

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
@@ -436,7 +436,7 @@ abstract class VimPutBase : VimPut {
             min(vimEditor.text().length, injector.motion.moveCaretToLineEnd(vimEditor, line, true) + 1)
           // At the end of a notebook cell the next symbol is a guard,
           // so we add a newline to be able to paste. Fixes VIM-2577
-          if (vimEditor.document.getOffsetGuard(Offset(startOffset))!= null) {
+          if (startOffset > 0 && vimEditor.document.getOffsetGuard(Offset(startOffset))!= null) {
             application.runWriteAction { (vimEditor as MutableVimEditor).insertText((startOffset-1).offset, "\n") }
           }
           if (startOffset > 0 && startOffset == vimEditor.text().length && vimEditor.text()[startOffset - 1] != '\n') {


### PR DESCRIPTION
Improves the situation at [VIM-2577](https://youtrack.jetbrains.com/issue/VIM-2577/PyCharm-2021.3-EAP-IdeaVim-1.10.0-Cannot-paste-at-end-of-cell) with the same "fix" that is done at the end of the file.

Technically that behavior is not the same as in vim. Pasting at the end of the file should not result in an empty line bellow the inserted text.
