### PR TITLE
VIM-2799: Add Matchit support for cshtml files

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -233,7 +233,8 @@ private object FileTypePatterns {
   }
 
   private val htmlLikeFileTypes = setOf(
-    "HTML", "XML", "XHTML", "JSP", "JavaScript", "JSX Harmony", "TypeScript", "TypeScript JSX", "Vue.js", "Handlebars/Mustache"
+    "HTML", "XML", "XHTML", "JSP", "JavaScript", "JSX Harmony", "TypeScript",
+    "TypeScript JSX", "Vue.js", "Handlebars/Mustache", "Razor"
   )
 
   private val htmlPatterns = createHtmlPatterns()


### PR DESCRIPTION
This enables HTML jumps in [Razor templates][razor] to fix [VIM-2799][issue]. I confirmed this works in the latest version of Rider.

[issue]: https://youtrack.jetbrains.com/issue/VIM-2799/matchit-support-for-cshtml-files

[razor]: https://learn.microsoft.com/en-us/aspnet/core/mvc/views/razor?view=aspnetcore-7.0