### PR TITLE
Matchit: Add more Rider file types

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -233,8 +233,9 @@ private object FileTypePatterns {
   }
 
   private val htmlLikeFileTypes = setOf(
-    "HTML", "XML", "XHTML", "JSP", "JavaScript", "JSX Harmony", "TypeScript",
-    "TypeScript JSX", "Vue.js", "Handlebars/Mustache", "Razor"
+    "HTML", "XML", "XHTML", "JSP", "JavaScript", "JSX Harmony",
+    "TypeScript", "TypeScript JSX", "Vue.js", "Handlebars/Mustache",
+    "Asp", "Razor", "UXML", "Xaml"
   )
 
   private val htmlPatterns = createHtmlPatterns()


### PR DESCRIPTION
Rider supports a few other file types that are flavors of HTML/XML:
- `Asp`: templating language for .NET web apps, Razor's predecessor
- `UXML`: XML files for Unity game development
- `Xaml`: XML files for .NET Core UI development 

I should have included these in https://github.com/JetBrains/ideavim/pull/579, but I'm not a C# guy so they're new to me. 🙂
