### PR TITLE
VIM-2773: Prevent viewport displacement on undo

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/UndoRedoHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/UndoRedoHelper.kt
@@ -42,6 +42,9 @@ class UndoRedoHelper : UndoRedoBase() {
     val fileEditor = TextEditorProvider.getInstance().getTextEditor(editor.ij)
     val undoManager = UndoManager.getInstance(project)
     if (undoManager.isUndoAvailable(fileEditor)) {
+      val scrollingModel = editor.getScrollingModel()
+      scrollingModel.accumulateViewportChanges()
+
       if (injector.globalOptions().isSet(IjOptionConstants.oldundo)) {
         SelectionVimListenerSuppressor.lock().use { undoManager.undo(fileEditor) }
       } else {
@@ -59,6 +62,8 @@ class UndoRedoHelper : UndoRedoBase() {
           }
         }
       }
+
+      scrollingModel.flushViewportChanges()
 
       return true
     }

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.editor.VisualPosition
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
 import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.editor.ex.ScrollingModelEx
 import com.intellij.openapi.editor.ex.util.EditorUtil
 import com.intellij.openapi.editor.impl.EditorImpl
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -27,6 +28,7 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimCaretListener
 import com.maddyhome.idea.vim.api.VimDocument
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.VimScrollingModel
 import com.maddyhome.idea.vim.api.VimSelectionModel
 import com.maddyhome.idea.vim.api.VimVisualPosition
 import com.maddyhome.idea.vim.api.VirtualFile
@@ -261,6 +263,20 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor() {
 
       override fun hasSelection(): Boolean {
         return sm.hasSelection()
+      }
+    }
+  }
+
+  override fun getScrollingModel(): VimScrollingModel {
+    return object : VimScrollingModel {
+      private val sm = editor.scrollingModel as ScrollingModelEx
+
+      override fun accumulateViewportChanges() {
+        sm.accumulateViewportChanges()
+      }
+
+      override fun flushViewportChanges() {
+        sm.flushViewportChanges()
       }
     }
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
@@ -221,6 +221,7 @@ interface VimEditor {
   }
 
   fun getSelectionModel(): VimSelectionModel
+  fun getScrollingModel(): VimScrollingModel
 
   fun removeCaret(caret: VimCaret)
   fun removeSecondaryCarets()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimScrollingModel.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimScrollingModel.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2003-2023 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.api
+
+interface VimScrollingModel {
+  fun accumulateViewportChanges()
+  fun flushViewportChanges()
+}


### PR DESCRIPTION
Small bug fix for [VIM-2773](https://youtrack.jetbrains.com/issue/VIM-2773/Undoing-text-deletion-forces-the-editor-view-upwards-when-deleted-from-Visual-Line-or-via-dd) which I raised on YouTrack.

Fixes viewport displacement when undoing deletion of lines or blocks that are immediately followed by a space character.

Before:

![before_scrollback](https://user-images.githubusercontent.com/32597988/221440732-e6a30f61-5389-4241-8698-3fdab669d041.gif)

After:

![after_scrollback](https://user-images.githubusercontent.com/32597988/221440735-0d116173-2b96-4e06-a002-e168e9eaa8fe.gif)
