### PR TITLE
VIM-1735: fix too many carets being added when in visual line mode

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/CommandStateExtensions.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/CommandStateExtensions.kt
@@ -91,6 +91,10 @@ val Editor.inVisualMode
 val Editor.inSelectMode
   get() = this.editorMode == VimStateMachine.Mode.SELECT || this.editorMode == VimStateMachine.Mode.INSERT_SELECT
 
+@get:JvmName("inLineSubMode")
+val Editor.inLineSubMode
+  get() = this.subMode == VimStateMachine.SubMode.VISUAL_LINE
+
 @get:JvmName("inBlockSubMode")
 val Editor.inBlockSubMode
   get() = this.subMode == VimStateMachine.SubMode.VISUAL_BLOCK

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionTest.kt
@@ -546,4 +546,44 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
     val after = "test ${s}t.*st$se toast tallest ${s}t.*st$se"
     assertState(after)
   }
+
+  fun `test visual line mode adds the correct number of cursors`() {
+    val before = """
+      ${c}A well regulated Militia, 
+      being necessary to the security of a free State, 
+      the right of the people to keep and bear Arms,
+      shall not be infringed.
+    """.trimIndent()
+    configureByText(before)
+
+    typeText(injector.parser.parseKeys("Vjj<A-n>"))
+
+    val after = """
+      ${c}A well regulated Militia, 
+      ${c}being necessary to the security of a free State, 
+      ${c}the right of the people to keep and bear Arms,
+      shall not be infringed.
+    """.trimIndent()
+    assertState(after)
+  }
+
+  fun `test visual line mode adds the correct number of cursors when last line of file is selected`() {
+    val before = """
+      ${c}A well regulated Militia, 
+      being necessary to the security of a free State, 
+      the right of the people to keep and bear Arms,
+      shall not be infringed.
+    """.trimIndent()
+    configureByText(before)
+
+    typeText(injector.parser.parseKeys("Vjjj<A-n>"))
+
+    val after = """
+      ${c}A well regulated Militia, 
+      ${c}being necessary to the security of a free State, 
+      ${c}the right of the people to keep and bear Arms,
+      ${c}shall not be infringed.
+    """.trimIndent()
+    assertState(after)
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionTest.kt
@@ -572,8 +572,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       ${c}A well regulated Militia, 
       being necessary to the security of a free State, 
       the right of the people to keep and bear Arms,
-      shall not be infringed.
-    """.trimIndent()
+      shall not be infringed.""".trimIndent()
     configureByText(before)
 
     typeText(injector.parser.parseKeys("Vjjj<A-n>"))
@@ -582,8 +581,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       ${c}A well regulated Militia, 
       ${c}being necessary to the security of a free State, 
       ${c}the right of the people to keep and bear Arms,
-      ${c}shall not be infringed.
-    """.trimIndent()
+      ${c}shall not be infringed.""".trimIndent()
     assertState(after)
   }
 }


### PR DESCRIPTION
Closes #VIM-1735 (https://youtrack.jetbrains.com/issue/VIM-1735/IdeaVim-multiple-cursors-visual-block-to-multi-cursor-ads-one-caret-too-much).

There might be a better way to determine whether the last selected line is the last line of the file, but I'm not familiar enough with the codebase. Feel free to suggest a better solution.