### PR TITLE
VIM-2887: Fix:Include escaped character in search target

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/SearchHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/SearchHelper.java
@@ -675,7 +675,7 @@ public class SearchHelper {
     // Search to start or end of file, as appropriate
     Set<Character> charsToSearch = new HashSet<>(Arrays.asList('\'', '"', '\n', match, found));
     while (pos >= 0 && pos < chars.length() && cnt > 0) {
-      @Nullable Pair<Character, Integer> ci = findPositionOfFirstCharacter(chars, pos, charsToSearch, false, dir);
+      @Nullable Pair<Character, Integer> ci = findPositionOfFirstCharacter(chars, pos, charsToSearch, true, dir);
       if (ci == null) {
         return -1;
       }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionPercentOrMatchActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionPercentOrMatchActionTest.kt
@@ -227,6 +227,34 @@ class MotionPercentOrMatchActionTest : VimTestCase() {
     )
   }
 
+  fun `test motion in text with escape (outer forward)`() {
+    doTest(
+      "%", """ debugPrint$c(\(var)) """,
+      """ debugPrint(\(var)$c) """, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE
+    )
+  }
+
+  fun `test motion in text with escape (outer backward)`() {
+    doTest(
+      "%", """ debugPrint(\(var)$c) """,
+      """ debugPrint$c(\(var)) """, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE
+    )
+  }
+
+  fun `test motion in text with escape (inner forward)`() {
+    doTest(
+      "%", """ debugPrint(\$c(var)) """,
+      """ debugPrint(\(var$c)) """, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE
+    )
+  }
+
+  fun `test motion in text with escape (inner backward)`() {
+    doTest(
+      "%", """ debugPrint(\$c(var)) """,
+      """ debugPrint(\(var$c)) """, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE
+    )
+  }
+
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN, description = "Matchit plugin affects neovim")
   fun `test deleting with percent motion backward`() {
     doTest("d%", "(foo bar$c)", c, VimStateMachine.Mode.COMMAND, VimStateMachine.SubMode.NONE)


### PR DESCRIPTION
A fix for an issue I reported on YouTrack.
The Issue link is:
https://youtrack.jetbrains.com/issue/VIM-2887/action-leads-to-unexpected-destination-in-codes-containing-escaped-parentheses


I did `%` several times on parentheses below moives.

## before

https://user-images.githubusercontent.com/45124565/223920790-4fd2bfd5-e974-4e48-9fc0-ac3fb55007d4.mp4


## after

https://user-images.githubusercontent.com/45124565/223920819-d58b4501-108c-4d75-aa4d-8f5798a8a4b0.mp4

