### PR TITLE
Fix `dispose` operation

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/main/java/com/maddyhome/idea/vim/VimPlugin.java
@@ -362,7 +362,9 @@ public class VimPlugin implements PersistentStateComponent<Element>, Disposable 
     // Unregister vim actions in command mode
     RegisterActions.unregisterActions();
 
-    Disposer.dispose(onOffDisposable);
+    if (onOffDisposable != null) {
+      Disposer.dispose(onOffDisposable);
+    }
   }
 
   private void updateState() {


### PR DESCRIPTION
If you open the IDE but exit without loading the project.

<details open>
  <summary>StackTrace</summary>
  <pre>
java.lang.IllegalArgumentException: Argument for @NotNull parameter 'disposable' of com/intellij/openapi/util/Disposer.dispose must not be null
	at com.intellij.openapi.util.Disposer.$$$reportNull$$$0(Disposer.java)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java)
	at com.maddyhome.idea.vim.VimPlugin.turnOffPlugin(VimPlugin.java:358)
	at com.maddyhome.idea.vim.VimPlugin.dispose(VimPlugin.java:107)
	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:127)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:159)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:264)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:252)
	at com.intellij.serviceContainer.ComponentManagerImpl.dispose(ComponentManagerImpl.kt:1241)
	at com.intellij.openapi.application.impl.ApplicationImpl.dispose(ApplicationImpl.java:355)
	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:127)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:159)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:264)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:252)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$disposeContainer$2(ApplicationImpl.java:201)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:958)
	at com.intellij.openapi.application.impl.ApplicationImpl.disposeContainer(ApplicationImpl.java:199)
	at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:624)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:563)
	at com.intellij.openapi.application.impl.ApplicationImpl.restart(ApplicationImpl.java:547)
	at com.intellij.openapi.application.impl.ApplicationImpl.restart(ApplicationImpl.java:522)
	at com.intellij.openapi.application.impl.ApplicationImpl.restart(ApplicationImpl.java:510)
	at com.intellij.ide.plugins.PluginManagerConfigurable.shutdownOrRestartAppAfterInstall(PluginManagerConfigurable.java:1464)
	at com.intellij.ide.plugins.PluginManagerConfigurable.shutdownOrRestartApp(PluginManagerConfigurable.java:1458)
	at com.intellij.ide.plugins.PluginManagerConfigurable.shutdownOrRestartApp(PluginManagerConfigurable.java:1454)
	at com.intellij.ide.plugins.PluginManagerConfigurable.lambda$apply$9(PluginManagerConfigurable.java:1795)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:209)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:21)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:191)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:831)
	at com.intellij.openapi.application.impl.ApplicationImpl$3.run(ApplicationImpl.java:456)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:79)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:122)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:41)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:788)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:739)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:731)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:758)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:666)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$7(IdeEventQueue.kt:570)
	at com.intellij.openapi.application.impl.ApplicationImpl.withoutImplicitRead(ApplicationImpl.java:1446)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:570)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:68)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:349)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:348)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:787)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:348)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:343)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:994)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:994)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$4(IdeEventQueue.kt:343)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:831)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:385)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
  </pre>
</details>