### PR TITLE
Fix some local options being used as global options

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.java
@@ -454,7 +454,7 @@ public class ChangeGroup extends VimChangeGroupBase {
             int weoff = editor.bufferPositionToOffset(epos);
             int pos;
             for (pos = wsoff; pos <= weoff; pos++) {
-              if (CharacterHelper.charType(chars.charAt(pos), false) != CharacterHelper.CharacterType.WHITESPACE) {
+              if (CharacterHelper.charType(editor, chars.charAt(pos), false) != CharacterHelper.CharacterType.WHITESPACE) {
                 break;
               }
             }

--- a/src/main/java/com/maddyhome/idea/vim/group/IjOptionProperties.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjOptionProperties.kt
@@ -30,13 +30,6 @@ public open class GlobalIjOptions(scope: OptionScope = OptionScope.GLOBAL) : Glo
   public var trackactionids: Boolean by optionProperty(IjOptions.trackactionids)
   public var visualdelay: Int by optionProperty(IjOptions.visualdelay)
 
-  // TODO: Handle these options as global-local
-  // Decide if they should live in global or effective options when we support global-local
-  // (I suspect they should live in effective, because we'll always want to read the local value. We are unlikely to
-  // ever set from code, but we'd expect normal `:set` behaviour, which appears to be to write to the global value).
-  // Also double check that these options should be global-local
-  public var idearefactormode: String by optionProperty(IjOptions.idearefactormode)
-
   // Temporary options to control work-in-progress behaviour
   public var octopushandler: Boolean by optionProperty(IjOptions.octopushandler)
   public var oldundo: Boolean by optionProperty(IjOptions.oldundo)
@@ -51,4 +44,5 @@ public open class GlobalIjOptions(scope: OptionScope = OptionScope.GLOBAL) : Glo
 public class EffectiveIjOptions(scope: OptionScope.LOCAL): GlobalIjOptions(scope) {
   public var ideacopypreprocess: Boolean by optionProperty(IjOptions.ideacopypreprocess)
   public var ideajoin: Boolean by optionProperty(IjOptions.ideajoin)
+  public var idearefactormode: String by optionProperty(IjOptions.idearefactormode)
 }

--- a/src/main/java/com/maddyhome/idea/vim/group/IjOptionProperties.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjOptionProperties.kt
@@ -35,7 +35,6 @@ public open class GlobalIjOptions(scope: OptionScope = OptionScope.GLOBAL) : Glo
   // (I suspect they should live in effective, because we'll always want to read the local value. We are unlikely to
   // ever set from code, but we'd expect normal `:set` behaviour, which appears to be to write to the global value).
   // Also double check that these options should be global-local
-  public var ideajoin: Boolean by optionProperty(IjOptions.ideajoin)
   public var idearefactormode: String by optionProperty(IjOptions.idearefactormode)
 
   // Temporary options to control work-in-progress behaviour
@@ -51,4 +50,5 @@ public open class GlobalIjOptions(scope: OptionScope = OptionScope.GLOBAL) : Glo
  */
 public class EffectiveIjOptions(scope: OptionScope.LOCAL): GlobalIjOptions(scope) {
   public var ideacopypreprocess: Boolean by optionProperty(IjOptions.ideacopypreprocess)
+  public var ideajoin: Boolean by optionProperty(IjOptions.ideajoin)
 }

--- a/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
@@ -36,8 +36,10 @@ import com.maddyhome.idea.vim.key.ShortcutOwner
 import com.maddyhome.idea.vim.key.ShortcutOwnerInfo
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.options.OptionConstants
+import com.maddyhome.idea.vim.options.OptionScope
 import com.maddyhome.idea.vim.statistic.ActionTracker
 import com.maddyhome.idea.vim.ui.VimEmulationConfigurable
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import com.maddyhome.idea.vim.vimscript.services.VimRcService
 import java.awt.datatransfer.StringSelection
 import java.io.File
@@ -95,7 +97,8 @@ internal class NotificationService(private val project: Project?) {
         "set ideajoin",
         "idejoin"
       ) {
-        injector.globalIjOptions().ideajoin = true
+        // 'ideajoin' is global-local, so we'll set it as a global value
+        injector.optionGroup.setOptionValue(IjOptions.ideajoin, OptionScope.GLOBAL, VimInt.ONE)
       },
     )
 

--- a/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
@@ -95,7 +95,7 @@ internal class NotificationService(private val project: Project?) {
       AppendToIdeaVimRcAction(
         notification,
         "set ideajoin",
-        "idejoin"
+        "ideajoin"
       ) {
         // 'ideajoin' is global-local, so we'll set it as a global value
         injector.optionGroup.setOptionValue(IjOptions.ideajoin, OptionScope.GLOBAL, VimInt.ONE)

--- a/src/main/java/com/maddyhome/idea/vim/group/visual/IdeaSelectionControl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/visual/IdeaSelectionControl.kt
@@ -32,6 +32,8 @@ import com.maddyhome.idea.vim.listener.VimListenerManager
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.options.OptionConstants
 import com.maddyhome.idea.vim.vimscript.model.options.helpers.IdeaRefactorModeHelper
+import com.maddyhome.idea.vim.vimscript.model.options.helpers.isIdeaRefactorModeKeep
+import com.maddyhome.idea.vim.vimscript.model.options.helpers.isIdeaRefactorModeSelect
 
 internal object IdeaSelectionControl {
   /**
@@ -123,7 +125,7 @@ internal object IdeaSelectionControl {
   }
 
   private fun dontChangeMode(editor: Editor): Boolean =
-    editor.isTemplateActive() && (IdeaRefactorModeHelper.keepMode() || editor.editorMode.hasVisualSelection)
+    editor.isTemplateActive() && (editor.vim.isIdeaRefactorModeKeep || editor.editorMode.hasVisualSelection)
 
   private fun chooseNonSelectionMode(editor: Editor): VimStateMachine.Mode {
     val templateActive = editor.isTemplateActive()
@@ -148,7 +150,7 @@ internal object IdeaSelectionControl {
         if (logReason) logger.debug("Enter select mode. Selection source is mouse and selectMode option has mouse")
         VimStateMachine.Mode.SELECT
       }
-      editor.isTemplateActive() && IdeaRefactorModeHelper.selectMode() -> {
+      editor.isTemplateActive() && editor.vim.isIdeaRefactorModeSelect -> {
         if (logReason) logger.debug("Enter select mode. Template is active and selectMode has template")
         VimStateMachine.Mode.SELECT
       }

--- a/src/main/java/com/maddyhome/idea/vim/group/visual/VisualGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/visual/VisualGroup.kt
@@ -22,7 +22,7 @@ import com.maddyhome.idea.vim.newapi.vim
 
 internal fun moveCaretOneCharLeftFromSelectionEnd(editor: Editor, predictedMode: VimStateMachine.Mode) {
   if (predictedMode != VimStateMachine.Mode.VISUAL) {
-    if (!predictedMode.isEndAllowed) {
+    if (!editor.vim.isEndAllowed(predictedMode)) {
       editor.caretModel.allCarets.forEach { caret ->
         val lineEnd = IjVimEditor(editor).getLineEndForOffset(caret.offset)
         val lineStart = IjVimEditor(editor).getLineStartForOffset(caret.offset)

--- a/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
@@ -59,7 +59,6 @@ internal fun Editor.hasBlockOrUnderscoreCaret() = isBlockCursorOverride() ||
 internal object GuicursorChangeListener : OptionChangeListener<VimString> {
   override fun processGlobalValueChange(oldValue: VimString?) {
     AttributesCache.clear()
-    GuiCursorOptionHelper.clearEffectiveValues()
     localEditors().forEach { it.updatePrimaryCaretVisualAttributes() }
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/helper/CommandStateExtensions.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/CommandStateExtensions.kt
@@ -11,11 +11,16 @@
 package com.maddyhome.idea.vim.helper
 
 import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.api.Options
+import com.maddyhome.idea.vim.api.hasValue
+import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.CommandState
 import com.maddyhome.idea.vim.command.VimStateMachine
 import com.maddyhome.idea.vim.command.engine
 import com.maddyhome.idea.vim.command.ij
 import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.options.OptionConstants
+import com.maddyhome.idea.vim.options.OptionScope
 
 internal val VimStateMachine.Mode.hasVisualSelection
   get() = when (this) {
@@ -40,8 +45,21 @@ public val Editor.mode: CommandState.Mode
  * COMPATIBILITY-LAYER: New method
  * Please see: https://jb.gg/zo8n0r
  */
+@Deprecated("Please migrate to VimEditor.isEndAllowed which can correctly access virtualedit at the right scope",
+  replaceWith = ReplaceWith("VimEditor.isEndAllowed"))
 public val CommandState.Mode.isEndAllowed: Boolean
-  get() = this.engine.isEndAllowed
+  get() {
+    fun possiblyUsesVirtualSpace(): Boolean {
+      // virtualedit is GLOBAL_OR_LOCAL_TO_WINDOW. We should NOT be using the global value!
+      return injector.optionGroup.hasValue(Options.virtualedit, OptionScope.GLOBAL, OptionConstants.virtualedit_onemore)
+    }
+
+    return when (this.engine) {
+      VimStateMachine.Mode.INSERT, VimStateMachine.Mode.VISUAL, VimStateMachine.Mode.SELECT -> true
+      VimStateMachine.Mode.COMMAND, VimStateMachine.Mode.CMD_LINE, VimStateMachine.Mode.REPLACE, VimStateMachine.Mode.OP_PENDING -> possiblyUsesVirtualSpace()
+      VimStateMachine.Mode.INSERT_NORMAL, VimStateMachine.Mode.INSERT_VISUAL, VimStateMachine.Mode.INSERT_SELECT -> possiblyUsesVirtualSpace()
+    }
+  }
 
 internal var Editor.subMode
   get() = this.vim.vimStateMachine.subMode

--- a/src/main/java/com/maddyhome/idea/vim/helper/SearchHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/SearchHelper.java
@@ -1256,16 +1256,16 @@ public class SearchHelper {
       CharacterHelper.CharacterType.PUNCTUATION};
     for (int i = 0; i < 2; i++) {
       start = pos;
-      CharacterHelper.CharacterType type = CharacterHelper.charType(chars.charAt(start), false);
+      CharacterHelper.CharacterType type = CharacterHelper.charType(vimEditor, chars.charAt(start), false);
       if (type == types[i]) {
         // Search back for start of word
-        while (start > 0 && CharacterHelper.charType(chars.charAt(start - 1), false) == types[i]) {
+        while (start > 0 && CharacterHelper.charType(vimEditor, chars.charAt(start - 1), false) == types[i]) {
           start--;
         }
       }
       else {
         // Search forward for start of word
-        while (start < stop && CharacterHelper.charType(chars.charAt(start), false) != types[i]) {
+        while (start < stop && CharacterHelper.charType(vimEditor, chars.charAt(start), false) != types[i]) {
           start++;
         }
       }
@@ -1283,7 +1283,7 @@ public class SearchHelper {
     // Special case 1 character words because 'findNextWordEnd' returns one to many chars
     if (start < stop &&
         (start >= chars.length() - 1 ||
-         CharacterHelper.charType(chars.charAt(start + 1), false) != CharacterHelper.CharacterType.KEYWORD)) {
+         CharacterHelper.charType(vimEditor, chars.charAt(start + 1), false) != CharacterHelper.CharacterType.KEYWORD)) {
       end = start + 1;
     }
     else {
@@ -1325,11 +1325,11 @@ public class SearchHelper {
     if (chars.length() <= pos) return new TextRange(chars.length() - 1, chars.length() - 1);
 
     final IjVimEditor vimEditor = new IjVimEditor(editor);
-    boolean startSpace = CharacterHelper.charType(chars.charAt(pos), isBig) == CharacterHelper.CharacterType.WHITESPACE;
+    boolean startSpace = CharacterHelper.charType(vimEditor, chars.charAt(pos), isBig) == CharacterHelper.CharacterType.WHITESPACE;
     // Find word start
     boolean onWordStart = pos == min ||
-                          CharacterHelper.charType(chars.charAt(pos - 1), isBig) !=
-                          CharacterHelper.charType(chars.charAt(pos), isBig);
+                          CharacterHelper.charType(vimEditor, chars.charAt(pos - 1), isBig) !=
+                          CharacterHelper.charType(vimEditor, chars.charAt(pos), isBig);
     int start = pos;
 
     if (logger.isDebugEnabled()) {
@@ -1352,8 +1352,8 @@ public class SearchHelper {
 
     // Find word end
     boolean onWordEnd = pos >= max - 1 ||
-                        CharacterHelper.charType(chars.charAt(pos + 1), isBig) !=
-                        CharacterHelper.charType(chars.charAt(pos), isBig);
+                        CharacterHelper.charType(vimEditor, chars.charAt(pos + 1), isBig) !=
+                        CharacterHelper.charType(vimEditor, chars.charAt(pos), isBig);
 
     if (logger.isDebugEnabled()) logger.debug("onWordEnd=" + onWordEnd);
 
@@ -1377,14 +1377,14 @@ public class SearchHelper {
         firstEnd = injector.getSearchHelper().findNextWordEnd(vimEditor, pos, 1, isBig, false);
       }
       if (firstEnd < max - 1) {
-        if (CharacterHelper.charType(chars.charAt(firstEnd + 1), false) != CharacterHelper.CharacterType.WHITESPACE) {
+        if (CharacterHelper.charType(vimEditor, chars.charAt(firstEnd + 1), false) != CharacterHelper.CharacterType.WHITESPACE) {
           goBack = true;
         }
       }
     }
     if (dir == -1 && isOuter && startSpace) {
       if (pos > min) {
-        if (CharacterHelper.charType(chars.charAt(pos - 1), false) != CharacterHelper.CharacterType.WHITESPACE) {
+        if (CharacterHelper.charType(vimEditor, chars.charAt(pos - 1), false) != CharacterHelper.CharacterType.WHITESPACE) {
           goBack = true;
         }
       }
@@ -1398,15 +1398,15 @@ public class SearchHelper {
         firstEnd = injector.getSearchHelper().findNextWordEnd(vimEditor, pos, 1, isBig, false);
       }
       if (firstEnd < max - 1) {
-        if (CharacterHelper.charType(chars.charAt(firstEnd + 1), false) != CharacterHelper.CharacterType.WHITESPACE) {
+        if (CharacterHelper.charType(vimEditor, chars.charAt(firstEnd + 1), false) != CharacterHelper.CharacterType.WHITESPACE) {
           goForward = true;
         }
       }
     }
     if (!goForward && dir == 1 && isOuter && !startSpace && !hasSelection) {
       if (end < max - 1) {
-        if (CharacterHelper.charType(chars.charAt(end + 1), !isBig) !=
-            CharacterHelper.charType(chars.charAt(end), !isBig)) {
+        if (CharacterHelper.charType(vimEditor, chars.charAt(end + 1), !isBig) !=
+            CharacterHelper.charType(vimEditor, chars.charAt(end), !isBig)) {
           goForward = true;
         }
       }
@@ -1420,7 +1420,7 @@ public class SearchHelper {
     if (goForward) {
       if (EngineEditorHelperKt.anyNonWhitespace(vimEditor, end, 1)) {
         while (end + 1 < max &&
-               CharacterHelper.charType(chars.charAt(end + 1), false) == CharacterHelper.CharacterType.WHITESPACE) {
+               CharacterHelper.charType(vimEditor, chars.charAt(end + 1), false) == CharacterHelper.CharacterType.WHITESPACE) {
           end++;
         }
       }
@@ -1428,7 +1428,7 @@ public class SearchHelper {
     if (goBack) {
       if (EngineEditorHelperKt.anyNonWhitespace(vimEditor, start, -1)) {
         while (start > min &&
-               CharacterHelper.charType(chars.charAt(start - 1), false) == CharacterHelper.CharacterType.WHITESPACE) {
+               CharacterHelper.charType(vimEditor, chars.charAt(start - 1), false) == CharacterHelper.CharacterType.WHITESPACE) {
           start--;
         }
       }

--- a/src/main/java/com/maddyhome/idea/vim/helper/SearchHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/SearchHelper.java
@@ -22,7 +22,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.api.EngineEditorHelperKt;
-import com.maddyhome.idea.vim.api.Options;
+import com.maddyhome.idea.vim.api.VimEditor;
 import com.maddyhome.idea.vim.api.VimSearchHelperBase;
 import com.maddyhome.idea.vim.command.VimStateMachine;
 import com.maddyhome.idea.vim.common.CharacterPosition;
@@ -30,10 +30,8 @@ import com.maddyhome.idea.vim.common.Direction;
 import com.maddyhome.idea.vim.common.TextRange;
 import com.maddyhome.idea.vim.newapi.IjVimCaret;
 import com.maddyhome.idea.vim.newapi.IjVimEditor;
-import com.maddyhome.idea.vim.options.OptionChangeListener;
 import com.maddyhome.idea.vim.regexp.CharPointer;
 import com.maddyhome.idea.vim.regexp.RegExp;
-import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString;
 import kotlin.Pair;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -44,8 +42,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.maddyhome.idea.vim.api.VimInjectorKt.globalOptions;
-import static com.maddyhome.idea.vim.api.VimInjectorKt.injector;
+import static com.maddyhome.idea.vim.api.VimInjectorKt.*;
 import static com.maddyhome.idea.vim.helper.SearchHelperKtKt.checkInString;
 import static com.maddyhome.idea.vim.helper.SearchHelperKtKt.shouldIgnoreCase;
 
@@ -611,7 +608,8 @@ public class SearchHelper {
     }
 
     int line = caret.getLogicalPosition().line;
-    int end = EngineEditorHelperKt.getLineEndOffset(new IjVimEditor(editor), line, true);
+    final IjVimEditor vimEditor = new IjVimEditor(editor);
+    int end = EngineEditorHelperKt.getLineEndOffset(vimEditor, line, true);
 
     // To handle the case where visual mode allows the user to go past the end of the line,
     // which will prevent loc from finding a pairable character below
@@ -619,11 +617,13 @@ public class SearchHelper {
       pos = end - 1;
     }
 
+    final String pairChars = parseMatchPairsOption(vimEditor);
+
     CharSequence chars = editor.getDocument().getCharsSequence();
     int loc = -1;
     // Search the remainder of the current line for one of the candidate characters
     while (pos < end) {
-      loc = getPairChars().indexOf(chars.charAt(pos));
+      loc = pairChars.indexOf(chars.charAt(pos));
       if (loc >= 0) {
         break;
       }
@@ -637,8 +637,8 @@ public class SearchHelper {
       // What direction should we go now (-1 is backward, 1 is forward)
       Direction dir = loc % 2 == 0 ? Direction.FORWARDS : Direction.BACKWARDS;
       // Which character did we find and which should we now search for
-      char found = getPairChars().charAt(loc);
-      char match = getPairChars().charAt(loc + dir.toInt());
+      char found = pairChars.charAt(loc);
+      char match = pairChars.charAt(loc + dir.toInt());
       res = findBlockLocation(chars, found, match, dir, pos, 1, true);
     }
 
@@ -2047,25 +2047,8 @@ public class SearchHelper {
     return PsiHelper.findMethodEnd(editor, caret.getOffset(), count);
   }
 
-  private static @NotNull String getPairChars() {
-    if (pairsChars == null) {
-      VimPlugin.getOptionGroup().addListener(
-        Options.matchpairs,
-        new OptionChangeListener<VimString>() {
-          @Override
-          public void processGlobalValueChange(@Nullable VimString oldValue) {
-            pairsChars = parseMatchPairsOption();
-          }
-        },
-        true
-      );
-    }
-
-    return pairsChars;
-  }
-
-  private static @NotNull String parseMatchPairsOption() {
-    List<String> pairs = globalOptions(injector).getMatchpairs();
+  private static @NotNull String parseMatchPairsOption(final VimEditor vimEditor) {
+    List<String> pairs = options(injector, vimEditor).getMatchpairs();
     StringBuilder res = new StringBuilder();
     for (String s : pairs) {
       if (s.length() == 3) {
@@ -2094,7 +2077,6 @@ public class SearchHelper {
     private final int position;
   }
 
-  private static @Nullable String pairsChars = null;
   private static final @NotNull String blockChars = "{}()[]<>";
 
   private static final Logger logger = Logger.getInstance(SearchHelper.class.getName());

--- a/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
@@ -41,6 +41,7 @@ import com.maddyhome.idea.vim.helper.vimStateMachine
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.vimscript.model.options.helpers.IdeaRefactorModeHelper
+import com.maddyhome.idea.vim.vimscript.model.options.helpers.isIdeaRefactorModeKeep
 import org.jetbrains.annotations.NonNls
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
@@ -149,13 +150,13 @@ internal object IdeaSpecifics {
           oldIndex: Int,
           newIndex: Int,
         ) {
-          if (IdeaRefactorModeHelper.keepMode()) {
-            IdeaRefactorModeHelper.correctSelection(editor)
+          if (templateState.editor.vim.isIdeaRefactorModeKeep) {
+            IdeaRefactorModeHelper.correctSelection(templateState.editor)
           }
         }
       })
 
-      if (IdeaRefactorModeHelper.keepMode()) {
+      if (state.editor.vim.isIdeaRefactorModeKeep) {
         IdeaRefactorModeHelper.correctSelection(editor)
       } else {
         if (!editor.selectionModel.hasSelection()) {

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -478,7 +478,7 @@ internal object VimListenerManager {
         1 -> {
           // If you click after the line, the caret is placed by IJ after the last symbol.
           // This is not allowed in some vim modes, so we move the caret over the last symbol.
-          if (!predictedMode.isEndAllowed) {
+          if (!editor.vim.isEndAllowed(predictedMode)) {
             @Suppress("ideavimRunForEachCaret")
             editor.caretModel.runForEachCaret { caret ->
               val lineEnd = IjVimEditor(editor).getLineEndForOffset(caret.offset)

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -75,7 +75,6 @@ import com.maddyhome.idea.vim.listener.MouseEventsDataHolder.skipNDragEvents
 import com.maddyhome.idea.vim.listener.VimListenerManager.EditorListeners.add
 import com.maddyhome.idea.vim.newapi.IjVimEditor
 import com.maddyhome.idea.vim.newapi.vim
-import com.maddyhome.idea.vim.options.helpers.KeywordOptionChangeListener
 import com.maddyhome.idea.vim.ui.ShowCmdOptionChangeListener
 import com.maddyhome.idea.vim.ui.ex.ExEntryPanel
 import java.awt.event.MouseAdapter
@@ -116,7 +115,6 @@ internal object VimListenerManager {
       optionGroup.addListener(Options.scrolloff, ScrollGroup.ScrollOptionsChangeListener)
       optionGroup.addListener(Options.showcmd, ShowCmdOptionChangeListener)
       optionGroup.addListener(Options.guicursor, GuicursorChangeListener)
-      optionGroup.addListener(Options.iskeyword, KeywordOptionChangeListener, true)
 
       EventFacade.getInstance().addEditorFactoryListener(VimEditorFactoryListener, VimPlugin.getInstance().onOffDisposable)
 
@@ -132,7 +130,6 @@ internal object VimListenerManager {
       optionGroup.removeListener(Options.scrolloff, ScrollGroup.ScrollOptionsChangeListener)
       optionGroup.removeListener(Options.showcmd, ShowCmdOptionChangeListener)
       optionGroup.removeListener(Options.guicursor, GuicursorChangeListener)
-      optionGroup.removeListener(Options.iskeyword, KeywordOptionChangeListener)
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/statistic/OptionsState.kt
+++ b/src/main/java/com/maddyhome/idea/vim/statistic/OptionsState.kt
@@ -20,6 +20,7 @@ import com.maddyhome.idea.vim.group.IjOptionConstants
 import com.maddyhome.idea.vim.group.IjOptions
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.options.OptionConstants
+import com.maddyhome.idea.vim.options.OptionScope
 
 internal class OptionsState : ApplicationUsagesCollector() {
 
@@ -30,8 +31,10 @@ internal class OptionsState : ApplicationUsagesCollector() {
     val globalIjOptions = injector.globalIjOptions()
 
     return setOf(
+      // ideajoin is global-local. We're only interested in the global value, not the effective value, which a) might
+      // be set at local scope and b) isn't accessible without an editor
       OPTIONS.metric(
-        IDEAJOIN with globalIjOptions.ideajoin,
+        IDEAJOIN with injector.optionGroup.getOptionValue(IjOptions.ideajoin, OptionScope.GLOBAL).asBoolean(),
         IDEAMARKS with globalIjOptions.ideamarks,
         IDEAREFACTOR with globalIjOptions.idearefactormode,
         IDEAPUT with globalOptions.clipboard.contains(OptionConstants.clipboard_ideaput),

--- a/src/main/java/com/maddyhome/idea/vim/statistic/OptionsState.kt
+++ b/src/main/java/com/maddyhome/idea/vim/statistic/OptionsState.kt
@@ -31,12 +31,12 @@ internal class OptionsState : ApplicationUsagesCollector() {
     val globalIjOptions = injector.globalIjOptions()
 
     return setOf(
-      // ideajoin is global-local. We're only interested in the global value, not the effective value, which a) might
-      // be set at local scope and b) isn't accessible without an editor
+      // ideajoin and idearefactor area global-local. We're only interested in the global value, not the effective
+      // value, which a) might be set at local scope and b) isn't accessible without an editor
       OPTIONS.metric(
         IDEAJOIN with injector.optionGroup.getOptionValue(IjOptions.ideajoin, OptionScope.GLOBAL).asBoolean(),
         IDEAMARKS with globalIjOptions.ideamarks,
-        IDEAREFACTOR with globalIjOptions.idearefactormode,
+        IDEAREFACTOR with injector.optionGroup.getOptionValue(IjOptions.idearefactormode, OptionScope.GLOBAL).asString(),
         IDEAPUT with globalOptions.clipboard.contains(OptionConstants.clipboard_ideaput),
         IDEASTATUSICON with globalIjOptions.ideastatusicon,
         IDEAWRITE with globalIjOptions.ideawrite,

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExActions.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExActions.kt
@@ -12,8 +12,11 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.textarea.TextComponentEditorImpl
 import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.api.Options
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.group.EditorHolderService
 import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.options.OptionScope
 import java.awt.event.ActionEvent
 import java.awt.event.KeyEvent
 import javax.swing.Action
@@ -233,8 +236,17 @@ internal class DeletePreviousWordAction : TextAction(DefaultEditorKit.deletePrev
 
     // Note that we need an editor when searching because we need per-editor options (i.e. 'iskeyword')
     // TODO: We also need to initialise the options when creating TextComponentImpl
-    val editor = TextComponentEditorImpl(project, target)
-    val offset = injector.searchHelper.findNextWord(editor.vim, caret.dot, -1, bigWord = false, spaceWords = false)
+    val editor = TextComponentEditorImpl(project, target).vim
+
+    // TODO: This copying should be automatic
+    // findNextWord eventually requires the 'iskeyword' option, which is local-to-buffer. Vim's command line uses the
+    // option from the owning editor, but in order to use findNextWord, we have to treat the command line as its own
+    // editor. We'll copy the option across explicitly for now, but this should be automatically handled when
+    // initialising editors (even temporary editors for the text field)
+    val isKeyword = injector.optionGroup.getOptionValue(Options.iskeyword, OptionScope.LOCAL(EditorHolderService.getInstance().editor!!.vim))
+    injector.optionGroup.setOptionValue(Options.iskeyword, OptionScope.LOCAL(editor), isKeyword)
+
+    val offset = injector.searchHelper.findNextWord(editor, caret.dot, -1, bigWord = false, spaceWords = false)
     if (logger.isDebugEnabled) logger.debug("offset=$offset")
     try {
       val pos = caret.dot

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.java
@@ -11,7 +11,6 @@ package com.maddyhome.idea.vim.ui.ex;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.project.Project;
 import com.intellij.ui.paint.PaintUtil;
 import com.intellij.util.ui.JBUI;
 import com.maddyhome.idea.vim.VimPlugin;
@@ -221,7 +220,6 @@ public class ExTextField extends JTextField {
 
   void setEditor(@NotNull Editor editor, DataContext context) {
     this.context = context;
-    Project project = editor.getProject();
     EditorHolderService.getInstance().setEditor(editor);
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/options/helpers/IdeaRefactorModeHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/options/helpers/IdeaRefactorModeHelper.kt
@@ -15,6 +15,7 @@ import com.intellij.codeInsight.lookup.impl.LookupImpl
 import com.intellij.codeInsight.template.impl.TemplateManagerImpl
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.group.IjOptionConstants
 import com.maddyhome.idea.vim.helper.editorMode
@@ -22,15 +23,16 @@ import com.maddyhome.idea.vim.helper.hasBlockOrUnderscoreCaret
 import com.maddyhome.idea.vim.helper.hasVisualSelection
 import com.maddyhome.idea.vim.helper.subMode
 import com.maddyhome.idea.vim.listener.SelectionVimListenerSuppressor
-import com.maddyhome.idea.vim.newapi.globalIjOptions
+import com.maddyhome.idea.vim.newapi.ijOptions
 import com.maddyhome.idea.vim.newapi.vim
 
-internal object IdeaRefactorModeHelper {
+public val VimEditor.isIdeaRefactorModeKeep: Boolean
+  get() = injector.ijOptions(this).idearefactormode.contains(IjOptionConstants.idearefactormode_keep)
 
-  fun keepMode() =
-    injector.globalIjOptions().idearefactormode.contains(IjOptionConstants.idearefactormode_keep)
-  fun selectMode() =
-    injector.globalIjOptions().idearefactormode.contains(IjOptionConstants.idearefactormode_select)
+public val VimEditor.isIdeaRefactorModeSelect: Boolean
+  get() = injector.ijOptions(this).idearefactormode.contains(IjOptionConstants.idearefactormode_select)
+
+internal object IdeaRefactorModeHelper {
 
   fun correctSelection(editor: Editor) {
     val action: () -> Unit = {

--- a/src/test/java/org/jetbrains/plugins/ideavim/helper/SearchHelperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/helper/SearchHelperTest.kt
@@ -7,9 +7,10 @@
  */
 package org.jetbrains.plugins.ideavim.helper
 
-import com.maddyhome.idea.vim.api.VimSearchHelperBase.Companion.findNextWord
+import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.VimStateMachine
 import com.maddyhome.idea.vim.helper.checkInString
+import com.maddyhome.idea.vim.newapi.vim
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -21,7 +22,9 @@ class SearchHelperTest : VimTestCase() {
   @Test
   fun testFindNextWord() {
     val text = "first second"
-    val nextWordPosition = findNextWord(text, 0, text.length.toLong(), 1, bigWord = true, spaceWords = false).toInt()
+    configureByText(text)
+    val nextWordPosition =
+      injector.searchHelper.findNextWord(fixture.editor.vim, 0, 1, bigWord = true, spaceWords = false)
     kotlin.test.assertEquals(nextWordPosition, text.indexOf("second"))
   }
 
@@ -29,7 +32,8 @@ class SearchHelperTest : VimTestCase() {
   @Test
   fun testFindSecondNextWord() {
     val text = "first second third"
-    val nextWordPosition = findNextWord(text, 0, text.length.toLong(), 2, bigWord = true, false).toInt()
+    configureByText(text)
+    val nextWordPosition = injector.searchHelper.findNextWord(fixture.editor.vim, 0, 2, bigWord = true, false)
     kotlin.test.assertEquals(nextWordPosition, text.indexOf("third"))
   }
 
@@ -37,7 +41,8 @@ class SearchHelperTest : VimTestCase() {
   @Test
   fun testFindAfterLastWord() {
     val text = "first second"
-    val nextWordPosition = findNextWord(text, 0, text.length.toLong(), 3, bigWord = true, false).toInt()
+    configureByText(text)
+    val nextWordPosition = injector.searchHelper.findNextWord(fixture.editor.vim, 0, 3, bigWord = true, false)
     kotlin.test.assertEquals(nextWordPosition, text.length)
   }
 
@@ -45,8 +50,9 @@ class SearchHelperTest : VimTestCase() {
   @Test
   fun testFindPreviousWord() {
     val text = "first second"
+    configureByText(text)
     val previousWordPosition =
-      findNextWord(text, text.indexOf("second").toLong(), text.length.toLong(), -1, bigWord = true, false).toInt()
+      injector.searchHelper.findNextWord(fixture.editor.vim, text.indexOf("second"), -1, bigWord = true, false)
     kotlin.test.assertEquals(previousWordPosition, text.indexOf("first"))
   }
 
@@ -54,15 +60,15 @@ class SearchHelperTest : VimTestCase() {
   @Test
   fun testFindSecondPreviousWord() {
     val text = "first second third"
+    configureByText(text)
     val previousWordPosition =
-      findNextWord(
-        text,
-        text.indexOf("third").toLong(),
-        text.length.toLong(),
+      injector.searchHelper.findNextWord(
+        fixture.editor.vim,
+        text.indexOf("third"),
         -2,
         bigWord = true,
         spaceWords = false,
-      ).toInt()
+      )
     kotlin.test.assertEquals(previousWordPosition, text.indexOf("first"))
   }
 
@@ -70,15 +76,15 @@ class SearchHelperTest : VimTestCase() {
   @Test
   fun testFindBeforeFirstWord() {
     val text = "first second"
+    configureByText(text)
     val previousWordPosition =
-      findNextWord(
-        text,
-        text.indexOf("second").toLong(),
-        text.length.toLong(),
+      injector.searchHelper.findNextWord(
+        fixture.editor.vim,
+        text.indexOf("second"),
         -3,
         bigWord = true,
         spaceWords = false,
-      ).toInt()
+      )
     kotlin.test.assertEquals(previousWordPosition, text.indexOf("first"))
   }
 
@@ -86,8 +92,9 @@ class SearchHelperTest : VimTestCase() {
   @Test
   fun testFindPreviousWordWhenCursorOutOfBound() {
     val text = "first second"
+    configureByText(text)
     val previousWordPosition =
-      findNextWord(text, text.length.toLong(), text.length.toLong(), -1, bigWord = true, spaceWords = false).toInt()
+      injector.searchHelper.findNextWord(fixture.editor.vim, text.length, -1, bigWord = true, spaceWords = false)
     kotlin.test.assertEquals(previousWordPosition, text.indexOf("second"))
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/KeywordOptionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/KeywordOptionTest.kt
@@ -10,8 +10,8 @@ package org.jetbrains.plugins.ideavim.option
 import com.intellij.testFramework.UsefulTestCase.assertDoesntContain
 import com.maddyhome.idea.vim.helper.CharacterHelper
 import com.maddyhome.idea.vim.helper.CharacterHelper.charType
+import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.options.helpers.KeywordOptionHelper
-import com.maddyhome.idea.vim.options.helpers.KeywordOptionHelper.toRegex
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,12 +35,12 @@ class KeywordOptionTest : VimTestCase() {
   }
 
   private fun assertIsKeyword(c: Char) {
-    val charType = charType(c, false)
+    val charType = charType(fixture.editor.vim, c, false)
     assertSame(CharacterHelper.CharacterType.KEYWORD, charType)
   }
 
   private fun assertIsNotKeyword(c: Char) {
-    val charType = charType(c, false)
+    val charType = charType(fixture.editor.vim, c, false)
     assertSame(CharacterHelper.CharacterType.PUNCTUATION, charType)
   }
 
@@ -177,19 +177,21 @@ class KeywordOptionTest : VimTestCase() {
     assertIsKeyword('Ź')
   }
 
+  @Suppress("DEPRECATION")
   @Test
   fun testToRegex() {
     setKeyword("-,a-c")
-    val res = toRegex()
+    val res = KeywordOptionHelper.toRegex()
     assertEquals(2, res.size)
     assertTrue(res.contains("-"))
     assertTrue(res.contains("[a-c]"))
   }
 
+  @Suppress("DEPRECATION")
   @Test
   fun testAllLettersToRegex() {
     setKeyword("@")
-    val res = toRegex()
+    val res = KeywordOptionHelper.toRegex()
     assertEquals(res[0], "\\p{L}")
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionArrowRightAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionArrowRightAction.kt
@@ -39,7 +39,7 @@ public class MotionArrowRightAction : NonShiftedSpecialKeyHandler(), Complicated
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Motion {
-    val allowPastEnd = usesVirtualSpace || editor.isEndAllowed ||
+    val allowPastEnd = editor.usesVirtualSpace || editor.isEndAllowed ||
       operatorArguments.isOperatorPending // because of `d<Right>` removing the last character
     val allowWrap = injector.options(editor).whichwrap.contains(">")
     return injector.motion.getHorizontalMotion(editor, caret, operatorArguments.count1, allowPastEnd, allowWrap)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionRightAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionRightAction.kt
@@ -35,7 +35,7 @@ public class MotionRightAction : MotionActionHandler.ForEachCaret() {
     operatorArguments: OperatorArguments,
   ): Motion {
     val allowWrap = injector.options(editor).whichwrap.contains("l")
-    val allowEnd = usesVirtualSpace || editor.isEndAllowed ||
+    val allowEnd = editor.usesVirtualSpace || editor.isEndAllowed ||
       operatorArguments.isOperatorPending // because of `dl` removing the last character
     return injector.motion.getHorizontalMotion(editor, caret, operatorArguments.count1, allowPastEnd = allowEnd, allowWrap)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/text/MotionBigWordEndLeftAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/text/MotionBigWordEndLeftAction.kt
@@ -46,7 +46,7 @@ private fun moveCaretToNextWordEnd(editor: VimEditor, caret: ImmutableVimCaret, 
   // If we are doing this move as part of a change command (e.q. cw), we need to count the current end of
   // word if the cursor happens to be on the end of a word already. If this is a normal move, we don't count
   // the current word.
-  val pos = injector.searchHelper.findNextWordEnd(editor, caret, count, bigWord)
+  val pos = injector.searchHelper.findNextWordEnd(editor, caret.offset.point, count, bigWord, false)
   return if (pos == -1) {
     if (count < 0) {
       AbsoluteOffset(injector.motion.moveCaretToLineStart(editor, 0))

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
@@ -48,9 +48,6 @@ public open class GlobalOptions(scope: OptionScope = OptionScope.GLOBAL): Option
   public val whichwrap: StringListOptionValue by optionProperty(Options.whichwrap)
   public var wrapscan: Boolean by optionProperty(Options.wrapscan)
 
-  // TODO: Make these options local
-  public val iskeyword: StringListOptionValue by optionProperty(Options.iskeyword)
-
   // IdeaVim specific options. Put any editor or IDE specific options in IjVimOptionService
   public var ideaglobalmode: Boolean by optionProperty(Options.ideaglobalmode)
   public var ideastrictmode: Boolean by optionProperty(Options.ideastrictmode)
@@ -65,7 +62,7 @@ public open class GlobalOptions(scope: OptionScope = OptionScope.GLOBAL): Option
  */
 @Suppress("unused")
 public open class EffectiveOptions(scope: OptionScope.LOCAL): GlobalOptions(scope) {
-//  public val iskeyword: StringListOptionValue by optionProperty(Options.iskeyword)
+  public val iskeyword: StringListOptionValue by optionProperty(Options.iskeyword)
   public val matchpairs: StringListOptionValue by optionProperty(Options.matchpairs)
   public val nrformats: StringListOptionValue by optionProperty(Options.nrformats)
   public var number: Boolean by optionProperty(Options.number)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
@@ -50,7 +50,6 @@ public open class GlobalOptions(scope: OptionScope = OptionScope.GLOBAL): Option
 
   // TODO: Make these options local
   public val iskeyword: StringListOptionValue by optionProperty(Options.iskeyword)
-  public val matchpairs: StringListOptionValue by optionProperty(Options.matchpairs)
   public val virtualedit: StringListOptionValue by optionProperty(Options.virtualedit)
 
   // IdeaVim specific options. Put any editor or IDE specific options in IjVimOptionService
@@ -68,7 +67,7 @@ public open class GlobalOptions(scope: OptionScope = OptionScope.GLOBAL): Option
 @Suppress("unused")
 public open class EffectiveOptions(scope: OptionScope.LOCAL): GlobalOptions(scope) {
 //  public val iskeyword: StringListOptionValue by optionProperty(Options.iskeyword)
-//  public val matchpairs: StringListOptionValue by optionProperty(Options.matchpairs)
+  public val matchpairs: StringListOptionValue by optionProperty(Options.matchpairs)
   public val nrformats: StringListOptionValue by optionProperty(Options.nrformats)
   public var number: Boolean by optionProperty(Options.number)
   public var relativenumber: Boolean by optionProperty(Options.relativenumber)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
@@ -50,7 +50,6 @@ public open class GlobalOptions(scope: OptionScope = OptionScope.GLOBAL): Option
 
   // TODO: Make these options local
   public val iskeyword: StringListOptionValue by optionProperty(Options.iskeyword)
-  public val virtualedit: StringListOptionValue by optionProperty(Options.virtualedit)
 
   // IdeaVim specific options. Put any editor or IDE specific options in IjVimOptionService
   public var ideaglobalmode: Boolean by optionProperty(Options.ideaglobalmode)
@@ -75,5 +74,5 @@ public open class EffectiveOptions(scope: OptionScope.LOCAL): GlobalOptions(scop
   public var scrolloff: Int by optionProperty(Options.scrolloff)
   public var sidescrolloff: Int by optionProperty(Options.sidescrolloff)
   public var undolevels: Int by optionProperty(Options.undolevels)
-//  public val virtualedit: StringListOptionValue by optionProperty(Options.virtualedit)
+  public val virtualedit: StringListOptionValue by optionProperty(Options.virtualedit)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -226,7 +226,7 @@ public object Options {
     }
   })
 
-  @JvmField public val matchpairs: StringListOption = addOption(object : StringListOption("matchpairs", "mps", "(:),{:},[:]") {
+   public val matchpairs: StringListOption = addOption(object : StringListOption("matchpairs", "mps", "(:),{:},[:]") {
     override fun checkIfValueValid(value: VimDataType, token: String) {
       super.checkIfValueValid(value, token)
       for (v in split((value as VimString).value)) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -8,9 +8,9 @@
 
 package com.maddyhome.idea.vim.api
 
-import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.ex.exExceptionMessage
+import com.maddyhome.idea.vim.helper.StrictMode
 import com.maddyhome.idea.vim.options.NumberOption
 import com.maddyhome.idea.vim.options.Option
 import com.maddyhome.idea.vim.options.OptionConstants
@@ -27,7 +27,6 @@ import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 
 @Suppress("unused", "SpellCheckingInspection")
 public object Options {
-  private val logger = vimLogger<Options>()
   private val options = MultikeyMap()
 
   public fun initialise() {
@@ -217,11 +216,8 @@ public object Options {
 
     override fun split(value: String): List<String> {
       val result = KeywordOptionHelper.parseValues(value)
-      if (result == null) {
-        logger.error("KeywordOptionHelper failed to parse $value")
-        injector.messages.indicateError()
-        injector.messages.showStatusBarMessage(editor = null, "Failed to parse iskeyword option value")
-      }
+      StrictMode.assert(result != null, "Cannot split iskeyword value: $ value")
+
       return result ?: split(defaultValue.value)
     }
   })

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -668,7 +668,7 @@ public abstract class VimChangeGroupBase : VimChangeGroup {
       editor.nativeCarets().filter { it != caret && rangeToDelete.contains(it.offset.point) }
         .forEach { editor.removeCaret(it) }
       val res = deleteText(editor, rangeToDelete, SelectionType.CHARACTER_WISE, caret, operatorArguments)
-      if (usesVirtualSpace) {
+      if (editor.usesVirtualSpace) {
         caret.moveToOffset(startOffset)
       } else {
         val pos = injector.motion.getHorizontalMotion(editor, caret, -1, false)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -1144,9 +1144,9 @@ public abstract class VimChangeGroupBase : VimChangeGroup {
     val offset = caret.offset.point
     val fileSize = editor.fileSize().toInt()
     if (fileSize > 0 && offset < fileSize) {
-      val charType = charType(chars[offset], bigWord)
+      val charType = charType(editor, chars[offset], bigWord)
       if (charType !== CharacterHelper.CharacterType.WHITESPACE) {
-        val lastWordChar = offset >= fileSize - 1 || charType(chars[offset + 1], bigWord) !== charType
+        val lastWordChar = offset >= fileSize - 1 || charType(editor, chars[offset + 1], bigWord) !== charType
         if (wordMotions.contains(id) && lastWordChar && motion.count == 1) {
           val res = deleteCharacter(editor, caret, 1, true, operatorArguments)
           if (res) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -1174,8 +1174,8 @@ public abstract class VimChangeGroupBase : VimChangeGroup {
     }
     if (kludge) {
       val cnt = operatorArguments.count1 * motion.count
-      val pos1 = injector.searchHelper.findNextWordEnd(chars, offset, fileSize, cnt, bigWord, false)
-      val pos2 = injector.searchHelper.findNextWordEnd(chars, pos1, fileSize, -cnt, bigWord, false)
+      val pos1 = injector.searchHelper.findNextWordEnd(editor, offset, cnt, bigWord, false)
+      val pos2 = injector.searchHelper.findNextWordEnd(editor, pos1, -cnt, bigWord, false)
       if (logger.isDebug()) {
         logger.debug("pos=$offset")
         logger.debug("pos1=$pos1")

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
@@ -130,6 +130,13 @@ public interface VimEditor {
   public var vimKeepingVisualOperatorAction: Boolean
 
   public fun fileSize(): Long
+
+  /**
+   * Return the text of the document
+   *
+   * This function should expect to be called multiple times, and therefore should not allocate and copy the entire text
+   * of the document. For example, the search helpers call this function repeatedly.
+   */
   public fun text(): CharSequence
 
   /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
@@ -100,7 +100,7 @@ public abstract class VimMotionGroupBase : VimMotionGroup {
     if ((searchFrom == 0 && count < 0) || (searchFrom >= size - 1 && count > 0)) {
       return Motion.Error
     }
-    return (injector.searchHelper.findNextWord(editor, searchFrom, count, bigWord)).toMotionOrError()
+    return (injector.searchHelper.findNextWord(editor, searchFrom, count, bigWord, false)).toMotionOrError()
   }
 
   override fun getHorizontalMotion(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroup.kt
@@ -144,3 +144,11 @@ public fun VimOptionGroup.invertToggleOption(option: ToggleOption, scope: Option
   val optionValue = getOptionValue(option, scope)
   setOptionValue(option, scope, if (optionValue.asBoolean()) VimInt.ZERO else VimInt.ONE)
 }
+
+/**
+ * Checks a string list option to see if it contains a specific value
+ */
+public fun VimOptionGroup.hasValue(option: StringListOption, scope: OptionScope, value: String): Boolean {
+  val optionValue = getOptionValue(option, scope)
+  return option.split(optionValue.asString()).contains(value)
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroup.kt
@@ -45,6 +45,28 @@ public interface VimOptionGroup {
   public fun <T : VimDataType> setOptionValue(option: Option<T>, scope: OptionScope, value: T)
 
   /**
+   * Get or create cached, parsed data for the option value effective for the editor
+   *
+   * The parsed data is created by the given [provider], based on the effective value of the option in the given
+   * [scope] (there is no reason to parse global/local data unless it is the effective value). The parsed data is then
+   * cached, and the cache is cleared when the effective option value is changed.
+   *
+   * It is not expected for this function to be used by general purpose use code, but by helper objects that will parse
+   * complex options and provide a user facing API for the data. E.g. for `'guicursor'` and `'iskeyword'` options.
+   *
+   * @param option  The option to return parsed data for
+   * @param scope The option scope to use to get the effective option value
+   * @param provider  If the parsed value does not exist, the effective option value is retrieved and passed to the
+   *                  provider. The resulting value is cached.
+   * @return The cached, parsed option value, ready to be used by code.
+   */
+  public fun <T : VimDataType, TData : Any> getParsedEffectiveOptionValue(
+    option: Option<T>,
+    scope: OptionScope,
+    provider: (T) -> TData,
+  ): TData
+
+  /**
    * Resets all options back to default values.
    */
   public fun resetAllOptions()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
@@ -66,10 +66,7 @@ public abstract class VimOptionGroupBase : VimOptionGroup {
     val cachedValues = when (scope) {
       is OptionScope.GLOBAL -> globalParsedValues
       is OptionScope.LOCAL -> {
-        injector.vimStorageService.getDataFromEditor(scope.editor, parsedEffectiveValueKey)
-          ?: mutableMapOf<String, Any>().also {
-            injector.vimStorageService.putDataToEditor(scope.editor, parsedEffectiveValueKey, it)
-          }
+        injector.vimStorageService.getOrPutEditorData(scope.editor, parsedEffectiveValueKey) { mutableMapOf() }
       }
     }
 
@@ -86,16 +83,8 @@ public abstract class VimOptionGroupBase : VimOptionGroup {
     globalValues[optionName] = value
   }
 
-  private fun getLocalOptions(editor: VimEditor): MutableMap<String, VimDataType> {
-    val storageService = injector.vimStorageService
-    val storedData = storageService.getDataFromEditor(editor, localOptionsKey)
-    if (storedData != null) {
-      return storedData
-    }
-    val localOptions = mutableMapOf<String, VimDataType>()
-    storageService.putDataToEditor(editor, localOptionsKey, localOptions)
-    return localOptions
-  }
+  private fun getLocalOptions(editor: VimEditor) =
+    injector.vimStorageService.getOrPutEditorData(editor, localOptionsKey) { mutableMapOf() }
 
   private fun setLocalOptionValue(optionName: String, value: VimDataType, editor: VimEditor) {
     val localOptions = getLocalOptions(editor)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchHelper.kt
@@ -103,23 +103,31 @@ public interface VimSearchHelper {
     count: Int,
   ): Int
 
-  public fun findNextWordEnd(
-    editor: VimEditor,
-    caret: ImmutableVimCaret,
-    count: Int,
-    bigWord: Boolean,
-  ): Int
+  /**
+   * Find the next word in the editor's document, from the given starting point
+   *
+   * @param editor The editor's document to search in. Editor is required because word boundaries depend on
+   *               local-to-buffer options
+   * @param searchFrom The offset in the document to search from
+   * @param count      Return an offset to the [count] word from the starting position. Will search backwards if negative
+   * @param bigWord    Use WORD instead of word boundaries
+   * @param spaceWords Include whitespace as part of a word, e.g. the difference between `iw` and `aw` motions
+   * @return The offset of the [count] next word, or `0` or the offset of the end of file if not found
+   */
+  public fun findNextWord(editor: VimEditor, searchFrom: Int, count: Int, bigWord: Boolean, spaceWords: Boolean): Int
 
-  public fun findNextWordEnd(
-    chars: CharSequence,
-    pos: Int,
-    size: Int,
-    count: Int,
-    bigWord: Boolean,
-    spaceWords: Boolean,
-  ): Int
-
-  public fun findNextWord(editor: VimEditor, searchFrom: Int, count: Int, bigWord: Boolean): Long
+  /**
+   * Find the end offset of the next word in the editor's document, from the given starting point
+   *
+   * @param editor The editor's document to search in. Editor is required because word boundaries depend on
+   *               local-to-buffer options
+   * @param searchFrom The offset in the document to search from
+   * @param count      Return an offset to the [count] word from the starting position. Will search backwards if negative
+   * @param bigWord    Use WORD instead of word boundaries
+   * @param spaceWords Include whitespace as part of a word, e.g. the difference between `iw` and `aw` motions
+   * @return The offset of the [count] next word, or `0` or the offset of the end of file if not found
+   */
+  public fun findNextWordEnd(editor: VimEditor, searchFrom: Int, count: Int, bigWord: Boolean, spaceWords: Boolean): Int
 
   public fun findPattern(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchHelperBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchHelperBase.kt
@@ -79,10 +79,10 @@ public abstract class VimSearchHelperBase : VimSearchHelper {
     var _pos = if (pos < size) pos else min(size, (chars.length - 1))
     // For back searches, skip any current whitespace so we start at the end of a word
     if (step < 0 && _pos > 0) {
-      if (charType(chars[_pos - 1], bigWord) === CharacterHelper.CharacterType.WHITESPACE && !spaceWords) {
-        _pos = skipSpace(chars, _pos - 1, step, size) + 1
+      if (charType(editor, chars[_pos - 1], bigWord) === CharacterHelper.CharacterType.WHITESPACE && !spaceWords) {
+        _pos = skipSpace(editor, chars, _pos - 1, step, size) + 1
       }
-      if (_pos > 0 && charType(chars[_pos], bigWord) !== charType(chars[_pos - 1], bigWord)) {
+      if (_pos > 0 && charType(editor, chars[_pos], bigWord) !== charType(editor, chars[_pos - 1], bigWord)) {
         _pos += step
       }
     }
@@ -90,23 +90,23 @@ public abstract class VimSearchHelperBase : VimSearchHelper {
     if (_pos < 0 || _pos >= size) {
       return _pos
     }
-    var type = charType(chars[_pos], bigWord)
+    var type = charType(editor, chars[_pos], bigWord)
     if (type === CharacterHelper.CharacterType.WHITESPACE && step < 0 && _pos > 0 && !spaceWords) {
-      type = charType(chars[_pos - 1], bigWord)
+      type = charType(editor, chars[_pos - 1], bigWord)
     }
     _pos += step
     while (_pos in 0 until size && !found) {
-      val newType = charType(chars[_pos], bigWord)
+      val newType = charType(editor, chars[_pos], bigWord)
       if (newType !== type) {
         if (newType === CharacterHelper.CharacterType.WHITESPACE && step >= 0 && !spaceWords) {
-          _pos = skipSpace(chars, _pos, step, size)
+          _pos = skipSpace(editor, chars, _pos, step, size)
           res = _pos
         } else if (step < 0) {
           res = _pos + 1
         } else {
           res = _pos
         }
-        type = charType(chars[res], bigWord)
+        type = charType(editor, chars[res], bigWord)
         found = true
       }
       _pos += step
@@ -138,14 +138,14 @@ public abstract class VimSearchHelperBase : VimSearchHelper {
     var found = false
     // For forward searches, skip any current whitespace so we start at the start of a word
     if (step > 0 && pos < size - 1) {
-      if (charType(chars[pos + 1], bigWord) === CharacterHelper.CharacterType.WHITESPACE &&
+      if (charType(editor, chars[pos + 1], bigWord) === CharacterHelper.CharacterType.WHITESPACE &&
         !spaceWords
       ) {
-        pos = skipSpace(chars, pos + 1, step, size) - 1
+        pos = skipSpace(editor, chars, pos + 1, step, size) - 1
       }
       if (pos < size - 1 &&
-        charType(chars[pos], bigWord) !==
-        charType(chars[pos + 1], bigWord)
+        charType(editor, chars[pos], bigWord) !==
+        charType(editor, chars[pos + 1], bigWord)
       ) {
         pos += step
       }
@@ -154,18 +154,18 @@ public abstract class VimSearchHelperBase : VimSearchHelper {
     if (pos < 0 || pos >= size) {
       return pos
     }
-    var type = charType(chars[pos], bigWord)
+    var type = charType(editor, chars[pos], bigWord)
     if (type === CharacterHelper.CharacterType.WHITESPACE && step >= 0 && pos < size - 1 && !spaceWords) {
-      type = charType(chars[pos + 1], bigWord)
+      type = charType(editor, chars[pos + 1], bigWord)
     }
     pos += step
     while (pos >= 0 && pos < size && !found) {
-      val newType = charType(chars[pos], bigWord)
+      val newType = charType(editor, chars[pos], bigWord)
       if (newType !== type) {
         if (step >= 0) {
           res = pos - 1
         } else if (newType === CharacterHelper.CharacterType.WHITESPACE && step < 0 && !spaceWords) {
-          pos = skipSpace(chars, pos, step, size)
+          pos = skipSpace(editor, chars, pos, step, size)
           res = pos
         } else {
           res = pos
@@ -186,13 +186,13 @@ public abstract class VimSearchHelperBase : VimSearchHelper {
     return res
   }
 
-  private fun skipSpace(chars: CharSequence, offset: Int, step: Int, size: Int): Int {
+  private fun skipSpace(editor: VimEditor, chars: CharSequence, offset: Int, step: Int, size: Int): Int {
     var _offset = offset
     var prev = 0.toChar()
     while (_offset in 0 until size) {
       val c = chars[_offset]
       if (c == '\n' && c == prev) break
-      if (charType(c, false) !== CharacterHelper.CharacterType.WHITESPACE) break
+      if (charType(editor, c, false) !== CharacterHelper.CharacterType.WHITESPACE) break
       prev = c
       _offset += step
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchHelperBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchHelperBase.kt
@@ -18,215 +18,185 @@ import kotlin.math.min
 
 // todo all this methods should return Long since editor.fileSize is long
 // todo same for TextRange and motions
+// However, editor.text() returns a CharSequence, which can only be indexed by Int
 public abstract class VimSearchHelperBase : VimSearchHelper {
-  override fun findNextWord(editor: VimEditor, searchFrom: Int, count: Int, bigWord: Boolean): Long {
-    return findNextWord(editor.text(), searchFrom.toLong(), editor.fileSize(), count, bigWord, false)
+  public companion object {
+    private val logger = vimLogger<VimSearchHelperBase>()
   }
 
-  override fun findNextWordEnd(editor: VimEditor, caret: ImmutableVimCaret, count: Int, bigWord: Boolean): Int {
-    val chars = editor.text()
-    val pos = caret.offset.point
-    val size = editor.fileSize().toInt()
-    return findNextWordEnd(chars, pos, size, count, bigWord, false)
-  }
-
-  override fun findNextWordEnd(
-    chars: CharSequence,
-    pos: Int,
-    size: Int,
+  override fun findNextWord(
+    editor: VimEditor,
+    searchFrom: Int,
     count: Int,
     bigWord: Boolean,
     spaceWords: Boolean,
   ): Int {
-    return VimSearchHelperBase.findNextWordEnd(chars, pos, size, count, bigWord, spaceWords)
+    return doFindNext(editor, searchFrom, count, bigWord, spaceWords, ::findNextWordOne)
   }
 
-  public companion object {
-    private val logger = vimLogger<VimSearchHelperBase>()
+  override fun findNextWordEnd(
+    editor: VimEditor,
+    searchFrom: Int,
+    count: Int,
+    bigWord: Boolean,
+    spaceWords: Boolean,
+  ): Int {
+    return doFindNext(editor, searchFrom, count, bigWord, spaceWords, ::findNextWordEndOne)
+  }
 
-    public fun findNextWord(
-      chars: CharSequence,
-      pos: Long,
-      size: Long,
-      count: Int,
-      bigWord: Boolean,
-      spaceWords: Boolean,
-    ): Long {
-      var _count = count
-      val step = if (_count >= 0) 1 else -1
-      _count = abs(_count)
-      var res = pos
-      for (i in 0 until _count) {
-        res = findNextWordOne(chars, res, size, step, bigWord, spaceWords)
-        if (res == pos || res == 0L || res == size - 1) {
-          break
-        }
+  private fun doFindNext(
+    editor: VimEditor,
+    searchFrom: Int,
+    countDirection: Int,
+    bigWord: Boolean,
+    spaceWords: Boolean,
+    action: (VimEditor, pos: Int, size: Int, step: Int, bigWord: Boolean, spaceWords: Boolean) -> Int
+  ): Int {
+    var count = countDirection
+    val step = if (count >= 0) 1 else -1
+    count = abs(count)
+    val size = editor.fileSize().toInt()  // editor.text() returns CharSequence, which only supports Int indexing
+    var pos = searchFrom
+    for (i in 0 until count) {
+      pos = action(editor, pos, size, step, bigWord, spaceWords)
+      if (pos == searchFrom || pos == 0 || pos == size - 1) {
+        break
       }
-      return res
     }
+    return pos
+  }
 
-    // TODO: 18.08.2022 Make private
-    public fun findNextWordOne(
-      chars: CharSequence,
-      pos: Long,
-      size: Long,
-      step: Int,
-      bigWord: Boolean,
-      spaceWords: Boolean,
-    ): Long {
-      var found = false
-      var _pos = if (pos < size) pos else min(size, (chars.length - 1).toLong())
-      // For back searches, skip any current whitespace so we start at the end of a word
-      if (step < 0 && _pos > 0) {
-        if (charType(chars[_pos - 1], bigWord) === CharacterHelper.CharacterType.WHITESPACE && !spaceWords) {
-          _pos = skipSpace(chars, _pos - 1, step, size) + 1
-        }
-        if (_pos > 0 && charType(chars[_pos], bigWord) !== charType(chars[_pos - 1], bigWord)) {
-          _pos += step
-        }
+  private fun findNextWordOne(
+    editor: VimEditor,
+    pos: Int,
+    size: Int,
+    step: Int,
+    bigWord: Boolean,
+    spaceWords: Boolean,
+  ): Int {
+    val chars = editor.text()
+    var found = false
+    var _pos = if (pos < size) pos else min(size, (chars.length - 1))
+    // For back searches, skip any current whitespace so we start at the end of a word
+    if (step < 0 && _pos > 0) {
+      if (charType(chars[_pos - 1], bigWord) === CharacterHelper.CharacterType.WHITESPACE && !spaceWords) {
+        _pos = skipSpace(chars, _pos - 1, step, size) + 1
       }
-      var res = _pos
-      if (_pos < 0 || _pos >= size) {
-        return _pos
-      }
-      var type = charType(chars[_pos], bigWord)
-      if (type === CharacterHelper.CharacterType.WHITESPACE && step < 0 && _pos > 0 && !spaceWords) {
-        type = charType(chars[_pos - 1], bigWord)
-      }
-      _pos += step
-      while (_pos in 0 until size && !found) {
-        val newType = charType(chars[_pos], bigWord)
-        if (newType !== type) {
-          if (newType === CharacterHelper.CharacterType.WHITESPACE && step >= 0 && !spaceWords) {
-            _pos = skipSpace(chars, _pos, step, size)
-            res = _pos
-          } else if (step < 0) {
-            res = _pos + 1
-          } else {
-            res = _pos
-          }
-          type = charType(chars[res], bigWord)
-          found = true
-        }
+      if (_pos > 0 && charType(chars[_pos], bigWord) !== charType(chars[_pos - 1], bigWord)) {
         _pos += step
       }
-      if (found) {
-        if (res < 0) { // (pos <= 0)
-          res = 0
-        } else if (res >= size) { // (pos >= size)
-          res = size - 1
+    }
+    var res = _pos
+    if (_pos < 0 || _pos >= size) {
+      return _pos
+    }
+    var type = charType(chars[_pos], bigWord)
+    if (type === CharacterHelper.CharacterType.WHITESPACE && step < 0 && _pos > 0 && !spaceWords) {
+      type = charType(chars[_pos - 1], bigWord)
+    }
+    _pos += step
+    while (_pos in 0 until size && !found) {
+      val newType = charType(chars[_pos], bigWord)
+      if (newType !== type) {
+        if (newType === CharacterHelper.CharacterType.WHITESPACE && step >= 0 && !spaceWords) {
+          _pos = skipSpace(chars, _pos, step, size)
+          res = _pos
+        } else if (step < 0) {
+          res = _pos + 1
+        } else {
+          res = _pos
         }
-      } else if (_pos <= 0) {
+        type = charType(chars[res], bigWord)
+        found = true
+      }
+      _pos += step
+    }
+    if (found) {
+      if (res < 0) { // (pos <= 0)
         res = 0
-      } else if (_pos >= size) {
-        res = size
-      }
-      return res
-    }
-
-    /**
-     * Skip whitespace starting with the supplied position.
-     *
-     * An empty line is considered a whitespace break.
-     */
-    // TODO: 18.08.2022 Make private
-    // todo refactor
-    public fun skipSpace(chars: CharSequence, offset: Long, step: Int, size: Long): Long {
-      var _offset = offset
-      var prev = 0.toChar()
-      while (_offset in 0 until size) {
-        val c = chars[_offset.toInt()]
-        if (c == '\n' && c == prev) break
-        if (charType(c, false) !== CharacterHelper.CharacterType.WHITESPACE) break
-        prev = c
-        _offset += step
-      }
-      return if (_offset < size) _offset else size - 1
-    }
-
-    public operator fun CharSequence.get(index: Long): Char {
-      return this[index.toInt()]
-    }
-
-    public fun findNextWordEndOne(
-      chars: CharSequence,
-      pos: Int,
-      size: Int,
-      step: Int,
-      bigWord: Boolean,
-      spaceWords: Boolean,
-    ): Int {
-      var pos = pos
-      var found = false
-      // For forward searches, skip any current whitespace so we start at the start of a word
-      if (step > 0 && pos < size - 1) {
-        if (charType(chars[pos + 1], bigWord) === CharacterHelper.CharacterType.WHITESPACE &&
-          !spaceWords
-        ) {
-          pos = (skipSpace(chars, (pos + 1).toLong(), step, size.toLong()) - 1).toInt()
-        }
-        if (pos < size - 1 &&
-          charType(chars[pos], bigWord) !==
-          charType(chars[pos + 1], bigWord)
-        ) {
-          pos += step
-        }
-      }
-      var res = pos
-      if (pos < 0 || pos >= size) {
-        return pos
-      }
-      var type = charType(chars[pos], bigWord)
-      if (type === CharacterHelper.CharacterType.WHITESPACE && step >= 0 && pos < size - 1 && !spaceWords) {
-        type = charType(chars[pos + 1], bigWord)
-      }
-      pos += step
-      while (pos >= 0 && pos < size && !found) {
-        val newType = charType(chars[pos], bigWord)
-        if (newType !== type) {
-          if (step >= 0) {
-            res = pos - 1
-          } else if (newType === CharacterHelper.CharacterType.WHITESPACE && step < 0 && !spaceWords) {
-            pos = skipSpace(chars, pos.toLong(), step, size.toLong()).toInt()
-            res = pos
-          } else {
-            res = pos
-          }
-          found = true
-        }
-        pos += step
-      }
-      if (found) {
-        if (res < 0) {
-          res = 0
-        } else if (res >= size) {
-          res = size - 1
-        }
-      } else if (pos == size) {
+      } else if (res >= size) { // (pos >= size)
         res = size - 1
       }
-      return res
+    } else if (_pos <= 0) {
+      res = 0
+    } else if (_pos >= size) {
+      res = size
     }
-    public fun findNextWordEnd(
-      chars: CharSequence,
-      pos: Int,
-      size: Int,
-      count: Int,
-      bigWord: Boolean,
-      spaceWords: Boolean,
-    ): Int {
-      var count = count
-      val step = if (count >= 0) 1 else -1
-      count = abs(count)
-      var res = pos
-      for (i in 0 until count) {
-        res = findNextWordEndOne(chars, res, size, step, bigWord, spaceWords)
-        if (res == pos || res == 0 || res == size - 1) {
-          break
-        }
+    return res
+  }
+
+  private fun findNextWordEndOne(
+    editor: VimEditor,
+    pos: Int,
+    size: Int,
+    step: Int,
+    bigWord: Boolean,
+    spaceWords: Boolean,
+  ): Int {
+    val chars = editor.text()
+    var pos = pos
+    var found = false
+    // For forward searches, skip any current whitespace so we start at the start of a word
+    if (step > 0 && pos < size - 1) {
+      if (charType(chars[pos + 1], bigWord) === CharacterHelper.CharacterType.WHITESPACE &&
+        !spaceWords
+      ) {
+        pos = skipSpace(chars, pos + 1, step, size) - 1
       }
-      return res
+      if (pos < size - 1 &&
+        charType(chars[pos], bigWord) !==
+        charType(chars[pos + 1], bigWord)
+      ) {
+        pos += step
+      }
     }
+    var res = pos
+    if (pos < 0 || pos >= size) {
+      return pos
+    }
+    var type = charType(chars[pos], bigWord)
+    if (type === CharacterHelper.CharacterType.WHITESPACE && step >= 0 && pos < size - 1 && !spaceWords) {
+      type = charType(chars[pos + 1], bigWord)
+    }
+    pos += step
+    while (pos >= 0 && pos < size && !found) {
+      val newType = charType(chars[pos], bigWord)
+      if (newType !== type) {
+        if (step >= 0) {
+          res = pos - 1
+        } else if (newType === CharacterHelper.CharacterType.WHITESPACE && step < 0 && !spaceWords) {
+          pos = skipSpace(chars, pos, step, size)
+          res = pos
+        } else {
+          res = pos
+        }
+        found = true
+      }
+      pos += step
+    }
+    if (found) {
+      if (res < 0) {
+        res = 0
+      } else if (res >= size) {
+        res = size - 1
+      }
+    } else if (pos == size) {
+      res = size - 1
+    }
+    return res
+  }
+
+  private fun skipSpace(chars: CharSequence, offset: Int, step: Int, size: Int): Int {
+    var _offset = offset
+    var prev = 0.toChar()
+    while (_offset in 0 until size) {
+      val c = chars[_offset]
+      if (c == '\n' && c == prev) break
+      if (charType(c, false) !== CharacterHelper.CharacterType.WHITESPACE) break
+      prev = c
+      _offset += step
+    }
+    return if (_offset < size) _offset else size - 1
   }
 
   override fun findNextCamelStart(chars: CharSequence, startIndex: Int, count: Int): Int? {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimStorageService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimStorageService.kt
@@ -70,3 +70,12 @@ public interface VimStorageService {
 }
 
 public data class Key<T>(val name: String)
+
+public fun <T> VimStorageService.getOrPutEditorData(editor: VimEditor, key: Key<T>, provider: () -> T): T =
+  getDataFromEditor(editor, key) ?: provider().also { putDataToEditor(editor, key, it) }
+
+public fun <T> VimStorageService.getOrPutBufferData(editor: VimEditor, key: Key<T>, provider: () -> T): T =
+  getDataFromBuffer(editor, key) ?: provider().also { putDataToBuffer(editor, key, it) }
+
+public fun <T> VimStorageService.getOrPutTabData(editor: VimEditor, key: Key<T>, provider: () -> T): T =
+  getDataFromTab(editor, key) ?: provider().also { putDataToTab(editor, key, it) }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CharacterHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CharacterHelper.kt
@@ -7,6 +7,7 @@
  */
 package com.maddyhome.idea.vim.helper
 
+import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.options.helpers.KeywordOptionHelper
 import java.lang.Character.UnicodeBlock
 
@@ -30,7 +31,7 @@ public object CharacterHelper {
    * @return The type of the character
    */
   @JvmStatic
-  public fun charType(ch: Char, punctuationAsLetters: Boolean): CharacterType {
+  public fun charType(editor: VimEditor, ch: Char, punctuationAsLetters: Boolean): CharacterType {
     val block = UnicodeBlock.of(ch)
     return if (Character.isWhitespace(ch)) {
       CharacterType.WHITESPACE
@@ -42,7 +43,7 @@ public object CharacterHelper {
       CharacterType.HALF_WIDTH_KATAKANA
     } else if (block == UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS) {
       CharacterType.CJK_UNIFIED_IDEOGRAPHS
-    } else if (punctuationAsLetters || KeywordOptionHelper.isKeyword(ch)) {
+    } else if (punctuationAsLetters || KeywordOptionHelper.isKeyword(editor, ch)) {
       CharacterType.KEYWORD
     } else {
       CharacterType.PUNCTUATION

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
@@ -9,8 +9,8 @@
 package com.maddyhome.idea.vim.helper
 
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.api.options
 import com.maddyhome.idea.vim.command.VimStateMachine
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.options.OptionConstants
@@ -45,30 +45,21 @@ public val VimStateMachine.Mode.inVisualMode: Boolean
 public val VimEditor.inBlockSubMode: Boolean
   get() = this.subMode == VimStateMachine.SubMode.VISUAL_BLOCK
 
-/**
- * Please use `isEndAllowed` based on `Editor` (another extension function)
- * It takes "single command" into account.
- */
-public val VimStateMachine.Mode.isEndAllowed: Boolean
-  get() = when (this) {
-    VimStateMachine.Mode.INSERT, VimStateMachine.Mode.VISUAL, VimStateMachine.Mode.SELECT -> true
-    VimStateMachine.Mode.COMMAND, VimStateMachine.Mode.CMD_LINE, VimStateMachine.Mode.REPLACE, VimStateMachine.Mode.OP_PENDING -> usesVirtualSpace
-    VimStateMachine.Mode.INSERT_NORMAL -> usesVirtualSpace
-    VimStateMachine.Mode.INSERT_VISUAL -> usesVirtualSpace
-    VimStateMachine.Mode.INSERT_SELECT -> usesVirtualSpace
-  }
-
-public val usesVirtualSpace: Boolean
-  get() = injector.globalOptions().virtualedit.contains(OptionConstants.virtualedit_onemore)
+public val VimEditor.usesVirtualSpace: Boolean
+  get() = injector.options(this).virtualedit.contains(OptionConstants.virtualedit_onemore)
 
 public val VimEditor.isEndAllowed: Boolean
-  get() = when (this.mode) {
+  get() = this.isEndAllowed(this.mode)
+
+public fun VimEditor.isEndAllowed(mode: VimStateMachine.Mode): Boolean {
+  return when (mode) {
     VimStateMachine.Mode.INSERT, VimStateMachine.Mode.VISUAL, VimStateMachine.Mode.SELECT, VimStateMachine.Mode.INSERT_VISUAL, VimStateMachine.Mode.INSERT_SELECT -> true
     VimStateMachine.Mode.COMMAND, VimStateMachine.Mode.CMD_LINE, VimStateMachine.Mode.REPLACE, VimStateMachine.Mode.OP_PENDING, VimStateMachine.Mode.INSERT_NORMAL -> {
       // One day we'll use a proper insert_normal mode
-      if (this.mode.inSingleMode) true else usesVirtualSpace
+      if (mode.inSingleMode) true else usesVirtualSpace
     }
   }
+}
 
 public val VimStateMachine.Mode.inSingleMode: Boolean
   get() = when (this) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/helpers/KeywordOptionHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/helpers/KeywordOptionHelper.kt
@@ -11,7 +11,6 @@ package com.maddyhome.idea.vim.options.helpers
 import com.maddyhome.idea.vim.api.Options
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.api.options
 import com.maddyhome.idea.vim.options.OptionScope
 import java.util.regex.Pattern
 
@@ -32,9 +31,10 @@ public object KeywordOptionHelper {
       return true
     }
 
-    // TODO: This value should not be re-parsed on each check
-    val isKeyword = injector.options(editor).iskeyword
-    val specs = valuesToValidatedAndReversedSpecs(isKeyword) ?: return false
+    val specs =
+      injector.optionGroup.getParsedEffectiveOptionValue(Options.iskeyword, OptionScope.LOCAL(editor)) { optionValue ->
+        valuesToValidatedAndReversedSpecs(parseValues(optionValue.asString()))!!
+      }
     for (spec in specs) {
       if (spec.contains(c.code)) {
         return !spec.negate()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/services/VimVariableServiceBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/services/VimVariableServiceBase.kt
@@ -11,6 +11,9 @@ package com.maddyhome.idea.vim.vimscript.services
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.Key
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.getOrPutBufferData
+import com.maddyhome.idea.vim.api.getOrPutEditorData
+import com.maddyhome.idea.vim.api.getOrPutTabData
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.VimStateMachine
 import com.maddyhome.idea.vim.common.Direction
@@ -30,35 +33,14 @@ public abstract class VimVariableServiceBase : VariableService {
   private val bufferVariablesKey = Key<MutableMap<String, VimDataType>>("BufferVariables")
   private val tabVariablesKey = Key<MutableMap<String, VimDataType>>("WindowVariables")
 
-  private fun getWindowVariables(editor: VimEditor): MutableMap<String, VimDataType> {
-    val storedVariableMap = injector.vimStorageService.getDataFromEditor(editor, windowVariablesKey)
-    if (storedVariableMap != null) {
-      return storedVariableMap
-    }
-    val windowVariables = mutableMapOf<String, VimDataType>()
-    injector.vimStorageService.putDataToEditor(editor, windowVariablesKey, windowVariables)
-    return windowVariables
-  }
+  private fun getWindowVariables(editor: VimEditor) =
+    injector.vimStorageService.getOrPutEditorData(editor, windowVariablesKey) { mutableMapOf() }
 
-  private fun getBufferVariables(editor: VimEditor): MutableMap<String, VimDataType> {
-    val storedVariableMap = injector.vimStorageService.getDataFromBuffer(editor, bufferVariablesKey)
-    if (storedVariableMap != null) {
-      return storedVariableMap
-    }
-    val bufferVariables = mutableMapOf<String, VimDataType>()
-    injector.vimStorageService.putDataToBuffer(editor, bufferVariablesKey, bufferVariables)
-    return bufferVariables
-  }
+  private fun getBufferVariables(editor: VimEditor) =
+    injector.vimStorageService.getOrPutBufferData(editor, bufferVariablesKey) { mutableMapOf() }
 
-  private fun getTabVariables(editor: VimEditor): MutableMap<String, VimDataType> {
-    val storedVariableMap = injector.vimStorageService.getDataFromTab(editor, tabVariablesKey)
-    if (storedVariableMap != null) {
-      return storedVariableMap
-    }
-    val tabVariables = mutableMapOf<String, VimDataType>()
-    injector.vimStorageService.putDataToTab(editor, tabVariablesKey, tabVariables)
-    return tabVariables
-  }
+  private fun getTabVariables(editor: VimEditor) =
+    injector.vimStorageService.getOrPutTabData(editor, tabVariablesKey) { mutableMapOf() }
 
   protected fun getDefaultVariableScope(executable: VimLContext): Scope {
     return when (executable.getExecutableContext(executable)) {


### PR DESCRIPTION
~~This PR is based on #616, and therefore includes all commits from that PR. I will rebase and update the PR after #616 is  merged (or maybe GitHub automatically manages it. Let's find out!).~~ (Rebased and force pushed on top of `master`)

Some options that should be treated as local options by the accessor APIs introduced in #616 are accessed as global options because there is no `editor` available. This includes `'iskeyword'`, `'matchpairs'`, and `'virtualedit'` as well as `'ideajoin'` and `'idearefactor'`. 

This PR passes the current editor around so that these local options can be properly used as local options. Note that `'virtualedit'` is documented to be a global-local option, which means it's global, but can be overridden locally. We treat it as a local option, and the current implementation means we read the local value if set, and fall back to global value if not, which gives us a good approximation (`:set` writes to the global value, which also helps). The same applies to `'ideajoin'` and `'idearefactor'`.

I've also introduced `VimOptionGroup.getParsedEffectiveOptionValue` as a simple cache for parsed values. If the cached, parsed value exists, it is returned. If not, the effective value is passed to a given provider to produce a parsed value, which is cached until the option is next changed. This reduces the need for a couple of listeners.