### PR TITLE
Matchit bug fixes

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -261,7 +261,7 @@ private object FileTypePatterns {
     val closingTagPattern = String.format("(?<=<)/%s(?=>)", tagNamePattern)
 
     // The tag name is left as %s so we can substitute the back reference we captured.
-    val htmlSearchPair = Pair("(?<=<)%s(?:\\s[^<>]*(\".*\")?)?", "(?<=<)/%s>")
+    val htmlSearchPair = Pair("(?<=<)%s(?:\\s[^<>]*(\".*\")?)?(?=>)", "(?<=<)/%s>")
 
     return (
       LanguagePatterns("<", ">") +

--- a/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/matchit/Matchit.kt
@@ -443,16 +443,14 @@ private fun findMatchingPair(
       targetClosingPattern = closestSearchPair.second
     }
 
-    // HTML attributes are a special case where the cursor is inside of quotes, but we want to jump as if we were
-    // anywhere else inside the opening tag.
-    val currentPsiElement = PsiHelper.getFile(editor)!!.findElementAt(caretOffset)
-    val skipComments = !isComment(currentPsiElement)
-    val skipQuotes = !isQuoted(currentPsiElement) || isHtmlAttribute(currentPsiElement)
-
     val initialPatternStart = currentLineStart + closestMatchStart
     val initialPatternEnd = currentLineStart + closestMatchEnd
-    val searchParams = MatchitSearchParams(initialPatternStart, initialPatternEnd, targetOpeningPattern, targetClosingPattern, skipComments, skipQuotes)
 
+    val initialPsiElement = PsiHelper.getFile(editor)!!.findElementAt(initialPatternStart)
+    val skipComments = !isComment(initialPsiElement)
+    val skipQuotes = !isQuoted(initialPsiElement)
+
+    val searchParams = MatchitSearchParams(initialPatternStart, initialPatternEnd, targetOpeningPattern, targetClosingPattern, skipComments, skipQuotes)
     val matchingPairOffset = if (direction == Direction.FORWARDS) {
       findClosingPair(editor, isInOpPending, searchParams)
     } else {
@@ -603,9 +601,4 @@ private fun isQuoted(psiElement: PsiElement?): Boolean {
   val elementType = psiElement?.elementType?.debugName
   return elementType == "STRING_LITERAL" || elementType == "XML_ATTRIBUTE_VALUE_TOKEN" ||
     elementType == "string content" // Ruby specific.
-}
-
-private fun isHtmlAttribute(psiElement: PsiElement?): Boolean {
-  val elementType = psiElement?.elementType?.debugName
-  return elementType == "XML_ATTRIBUTE_VALUE_TOKEN"
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitHtmlTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitHtmlTest.kt
@@ -641,6 +641,46 @@ class MatchitHtmlTest : VimTestCase() {
     )
   }
 
+  @Test
+  fun `test jump from opening tag to closing tag ignoring inner tag with similar name`() {
+    doTest(
+      "%",
+      """
+        <${c}Box>
+          <BoxHeading></BoxHeading>
+        </Box>
+      """.trimIndent(),
+      """
+        <Box>
+          <BoxHeading></BoxHeading>
+        <${c}/Box>
+      """.trimIndent(),
+      VimStateMachine.Mode.COMMAND,
+      VimStateMachine.SubMode.NONE,
+      HtmlFileType.INSTANCE,
+    )
+  }
+
+  @Test
+  fun `test jump from closing tag to opening tag ignoring inner tag with similar name`() {
+    doTest(
+      "%",
+      """
+        <Box>
+          <BoxHeading></BoxHeading>
+        <${c}/Box>
+      """.trimIndent(),
+      """
+        <${c}Box>
+          <BoxHeading></BoxHeading>
+        </Box>
+      """.trimIndent(),
+      VimStateMachine.Mode.COMMAND,
+      VimStateMachine.SubMode.NONE,
+      HtmlFileType.INSTANCE,
+    )
+  }
+
   /*
    *  g% motion tests. For HTML, g% should behave the same as %.
    */
@@ -1163,6 +1203,46 @@ class MatchitHtmlTest : VimTestCase() {
       "g%",
       "$c  <!-- A comment -->",
       "  <!-- A comment --$c>",
+      VimStateMachine.Mode.COMMAND,
+      VimStateMachine.SubMode.NONE,
+      HtmlFileType.INSTANCE,
+    )
+  }
+
+  @Test
+  fun `test reverse jump from opening tag to closing tag ignoring inner tag with similar name`() {
+    doTest(
+      "g%",
+      """
+        <${c}Box>
+          <BoxHeading></BoxHeading>
+        </Box>
+      """.trimIndent(),
+      """
+        <Box>
+          <BoxHeading></BoxHeading>
+        <${c}/Box>
+      """.trimIndent(),
+      VimStateMachine.Mode.COMMAND,
+      VimStateMachine.SubMode.NONE,
+      HtmlFileType.INSTANCE,
+    )
+  }
+
+  @Test
+  fun `test reverse jump from closing tag to opening tag ignoring inner tag with similar name`() {
+    doTest(
+      "g%",
+      """
+        <Box>
+          <BoxHeading></BoxHeading>
+        <${c}/Box>
+      """.trimIndent(),
+      """
+        <${c}Box>
+          <BoxHeading></BoxHeading>
+        </Box>
+      """.trimIndent(),
       VimStateMachine.Mode.COMMAND,
       VimStateMachine.SubMode.NONE,
       HtmlFileType.INSTANCE,

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitHtmlTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitHtmlTest.kt
@@ -628,6 +628,18 @@ class MatchitHtmlTest : VimTestCase() {
       HtmlFileType.INSTANCE,
     )
   }
+  
+  @Test
+  fun `test jump from whitespace before comment angle bracket to closing bracket`() {
+    doTest(
+      "%",
+      "$c  <!-- A comment -->",
+      "  <!-- A comment --$c>",
+      VimStateMachine.Mode.COMMAND,
+      VimStateMachine.SubMode.NONE,
+      HtmlFileType.INSTANCE,
+    )
+  }
 
   /*
    *  g% motion tests. For HTML, g% should behave the same as %.
@@ -1145,4 +1157,15 @@ class MatchitHtmlTest : VimTestCase() {
     )
   }
 
+  @Test
+  fun `test reverse jump from whitespace before comment angle bracket to closing bracket`() {
+    doTest(
+      "g%",
+      "$c  <!-- A comment -->",
+      "  <!-- A comment --$c>",
+      VimStateMachine.Mode.COMMAND,
+      VimStateMachine.SubMode.NONE,
+      HtmlFileType.INSTANCE,
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitHtmlTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/matchit/MatchitHtmlTest.kt
@@ -607,6 +607,28 @@ class MatchitHtmlTest : VimTestCase() {
     )
   }
 
+  @Test
+  fun `test jump from multiline opening tag to closing`() {
+    doTest(
+      "%",
+      """
+        <h1 ${c}id="title"
+           class="red right-aligned">
+           Header Content
+        </h1>
+      """.trimIndent(),
+      """
+        <h1 id="title"
+           class="red right-aligned">
+           Header Content
+        <$c/h1>
+      """.trimIndent(),
+      VimStateMachine.Mode.COMMAND,
+      VimStateMachine.SubMode.NONE,
+      HtmlFileType.INSTANCE,
+    )
+  }
+
   /*
    *  g% motion tests. For HTML, g% should behave the same as %.
    */
@@ -1123,25 +1145,4 @@ class MatchitHtmlTest : VimTestCase() {
     )
   }
 
-  @Test
-  fun `test jump from multiline opening tag to closing`() {
-    doTest(
-      "%",
-      """
-        <h1 ${c}id="title"
-           class="red right-aligned">
-           Header Content
-        </h1>
-      """.trimIndent(),
-      """
-        <h1 id="title"
-           class="red right-aligned">
-           Header Content
-        <$c/h1>
-      """.trimIndent(),
-      VimStateMachine.Mode.COMMAND,
-      VimStateMachine.SubMode.NONE,
-      HtmlFileType.INSTANCE,
-    )
-  }
 }


### PR DESCRIPTION
This fixes some Matchit edge cases.

**Missed jumps on comments**
Currently, hitting `%` on the whitespace before a commented pair will not jump. This is a logic bug. When deciding if comments should be included in the search, we need to check the PSI element at the first match offset, not the caret offset.

As a bonus, this fix makes the special `isHtmlAttribute` check unnecessary. If the caret is in an HTML attribute, the first match offset will point to the start of the tag.

**Incorrect jumps on HTML tags sharing a prefix**
The regex for HTML jumps needs a closing `>` else a tag like `<Box>` will match with e.g. `<BoxHeading>`.

**[VIM-2905][link]: Matchit doesnt work with closing JSX tags**

[link]: https://youtrack.jetbrains.com/issue/VIM-2905/Matchit-doesnt-work-with-closing-JSX-tags

In files that mix HTML and JavaScript, like JSX or simple `<script>` tags, the brackets used for arrow functions and comparisons like `x > y` conflict with the brackets on tags.

To fix that, we can ignore the JS brackets using PSI checks like we currently do for some Ruby keywords.

I double checked that those PSI elements are the same anywhere JavaScript or TypeScript syntax highlighting is used e.g. JSX/TSX, Vue.js etc.

Clip showing the fixed jumps on the example in the ticket:

![B8uS1Hgp7d](https://user-images.githubusercontent.com/7775058/231912476-61585c5b-b854-4226-ab2b-c84523635b78.gif)


