### PR TITLE
VIM-1990 fix repeat delete find or till wrong MotionType

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/delete/DeleteMotionActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/delete/DeleteMotionActionTest.kt
@@ -16,6 +16,11 @@ import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 class DeleteMotionActionTest : VimTestCase() {
 
@@ -117,6 +122,29 @@ class DeleteMotionActionTest : VimTestCase() {
       """.trimIndent(),
     )
     assertState("${c}abcde\n${c}")
+  }
+
+  companion object {
+    @JvmStatic
+    fun repeatFindAndTillTestCase(): Stream<Arguments> {
+      return Stream.of(
+        arguments("${c}111b222b333", "dtbd;", "${c}b333"),
+        arguments("111b2${c}22b333", "dtbd,", "111b${c}b333"),
+        arguments("111b222b33${c}3", "dTbd;", "111b${c}3"),
+        arguments("111b2${c}22b333", "dTbd,", "111b${c}b333"),
+        arguments("${c}111b222b333", "dfbd;", "${c}333"),
+        arguments("111b2${c}22b333", "dfbd,", "111${c}333"),
+        arguments("111b222b33${c}3", "dFbd;", "111${c}3"),
+        arguments("111b2${c}22b333", "dFbd,", "111${c}333"),
+      )
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("repeatFindAndTillTestCase")
+  fun `test delete repeat find and till motion`(content: String, keys: String, expected: String) {
+    typeTextInFile(keys, content)
+    assertState(expected)
   }
 
   @Test

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionLastMatchCharAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/leftright/MotionLastMatchCharAction.kt
@@ -17,7 +17,15 @@ import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.MotionActionHandler
 
-public class MotionLastMatchCharAction : MotionActionHandler.ForEachCaret() {
+public class MotionLastMatchCharAction : MotionLastMatchCharActionBase(MotionType.INCLUSIVE, reverse = false)
+public class MotionLastMatchCharReverseAction : MotionLastMatchCharActionBase(MotionType.EXCLUSIVE, reverse = true)
+
+public sealed class MotionLastMatchCharActionBase(defaultMotionType: MotionType, private val reverse: Boolean) :
+  MotionActionHandler.ForEachCaret() {
+
+  // injector.motion.lastFTCmd not up-to-date during construction, need to set during getOffset
+  override var motionType: MotionType = defaultMotionType
+
   override fun getOffset(
     editor: VimEditor,
     caret: ImmutableVimCaret,
@@ -25,24 +33,20 @@ public class MotionLastMatchCharAction : MotionActionHandler.ForEachCaret() {
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Motion {
-    val repeatLastMatchChar = injector.motion.repeatLastMatchChar(editor, caret, operatorArguments.count1)
+    motionType = when (injector.motion.lastFTCmd) {
+      TillCharacterMotionType.LAST_SMALL_F, TillCharacterMotionType.LAST_SMALL_T -> MotionType.INCLUSIVE
+      TillCharacterMotionType.LAST_F, TillCharacterMotionType.LAST_T -> MotionType.EXCLUSIVE
+    }.let { if (reverse) it.reverse() else it }
+    val repeatLastMatchChar =
+      injector.motion.repeatLastMatchChar(editor, caret, operatorArguments.count1.let { if (reverse) -it else it })
     return if (repeatLastMatchChar < 0) Motion.Error else Motion.AbsoluteOffset(repeatLastMatchChar)
   }
 
-  override val motionType: MotionType = MotionType.EXCLUSIVE
-}
-
-public class MotionLastMatchCharReverseAction : MotionActionHandler.ForEachCaret() {
-  override fun getOffset(
-    editor: VimEditor,
-    caret: ImmutableVimCaret,
-    context: ExecutionContext,
-    argument: Argument?,
-    operatorArguments: OperatorArguments,
-  ): Motion {
-    val repeatLastMatchChar = injector.motion.repeatLastMatchChar(editor, caret, -operatorArguments.count1)
-    return if (repeatLastMatchChar < 0) Motion.Error else Motion.AbsoluteOffset(repeatLastMatchChar)
+  public fun MotionType.reverse(): MotionType {
+    return when (this) {
+      MotionType.INCLUSIVE -> MotionType.EXCLUSIVE
+      MotionType.EXCLUSIVE -> MotionType.INCLUSIVE
+      else -> throw IllegalArgumentException("no reverse for $this")
+    }
   }
-
-  override val motionType: MotionType = MotionType.EXCLUSIVE
 }


### PR DESCRIPTION
When doing repeat delete of find/till,
MotionType is determined by actually motion direction
- `t`,`f` -> Forward -> Inclusive
  `T`,`F` -> Backward -> Exclusive
- `,` will reverse direction 
   `;` will not. 