### PR TITLE
VIM-2920 fix select block expansion when enclose boundary is line break

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/object/MotionInnerBlockParenActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/object/MotionInnerBlockParenActionTest.kt
@@ -81,6 +81,74 @@ class MotionInnerBlockParenActionTest : VimTestCase() {
   }
 
   @Test
+  fun `test double motion parentheses start end are not line break`() {
+    configureByText(
+      """(outer(b
+        |${c}inner
+        |b)outer)
+      """.trimMargin(),
+    )
+    typeText(injector.parser.parseKeys("vi)i)"))
+    assertSelection(
+      """outer(b
+        |inner
+        |b)outer
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test double motion parentheses start end are line break`() {
+    configureByText(
+      """(outer(
+        |${c}inner
+        |)outer)
+      """.trimMargin(),
+    )
+    typeText(injector.parser.parseKeys("vi)i)"))
+    assertSelection(
+      """outer(
+        |inner
+        |)outer
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test double motion parentheses start is line break end is not`() {
+    configureByText(
+      """(outer(
+        |${c}inner
+        |b)outer)
+      """.trimMargin(),
+    )
+    typeText(injector.parser.parseKeys("vi)i)"))
+    assertSelection(
+      """outer(
+        |inner
+        |b)outer
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test double motion parentheses end is line break start is not`() {
+    configureByText(
+      """(outer(b
+         |${c}inner
+         |)outer)
+      """.trimMargin(),
+    )
+    typeText(injector.parser.parseKeys("vi)i)"))
+    assertSelection(
+      """outer(b
+        |inner
+        |)outer
+      """.trimMargin(),
+    )
+  }
+
+  @Test
   fun `test motion with count`() {
     configureByText(
       """(outer

--- a/src/test/java/org/jetbrains/plugins/ideavim/helper/SearchHelperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/helper/SearchHelperTest.kt
@@ -9,12 +9,16 @@ package org.jetbrains.plugins.ideavim.helper
 
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.VimStateMachine
+import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.helper.checkInString
 import com.maddyhome.idea.vim.newapi.vim
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 @Suppress("SpellCheckingInspection")
 class SearchHelperTest : VimTestCase() {
@@ -235,5 +239,78 @@ class SearchHelperTest : VimTestCase() {
     val text = "abc\"def\"gh\"ij\"k"
     val inString = checkInString(text, 8, true)
     kotlin.test.assertFalse(inString)
+  }
+
+  @ParameterizedTest
+  @MethodSource("findBlockRangeTestCases")
+  fun findBlockRange(testCase: FindBlockRangeTestCase) {
+    val (_, text, type, count, isOuter, expected) = (testCase)
+    configureByText(text)
+    val actual =
+      injector.searchHelper.findBlockRange(fixture.editor.vim, fixture.editor.vim.currentCaret(), type, count, isOuter)
+    kotlin.test.assertEquals(expected, actual)
+  }
+
+  companion object {
+    data class FindBlockRangeTestCase(
+      val description: String,
+      val text: String,
+      val type: Char,
+      val count: Int,
+      val isOuter: Boolean,
+      val expected: TextRange?,
+    )
+
+    @JvmStatic
+    fun findBlockRangeTestCases(): Stream<FindBlockRangeTestCase> {
+      return Stream.of(
+        FindBlockRangeTestCase("no inner match when range selection", "${s}aa${se}", '(', 1, isOuter = false, expected = null),
+        FindBlockRangeTestCase("no inner match when no range selection", "${s}a${se}", '(', 1, isOuter = false, expected = null),
+        FindBlockRangeTestCase("inner match without range selection", "(${c}a)", '(', 1, isOuter = false, expected = TextRange(1, 2)),
+        FindBlockRangeTestCase("outer match without range selection", "(${c}a)", '(', 1, isOuter = true, expected = TextRange(0, 3)),
+        FindBlockRangeTestCase("inner match with range selection", "(${c}${s}a${se})", '(', 1, isOuter = false, expected = TextRange(1, 2)),
+        FindBlockRangeTestCase("outer match with range selection", "(${c}${s}a${se})", '(', 1, isOuter = true, expected = TextRange(0, 3)),
+        FindBlockRangeTestCase("caret at begin inner match forward", "(a)${c}(a)", '(', 1, isOuter = false, expected = TextRange(4, 5)),
+        FindBlockRangeTestCase("caret at begin outer match forward", "(a)${c}(a)", '(', 1, isOuter = true, expected = TextRange(3, 6)),
+        FindBlockRangeTestCase("caret at end inner match backward", "(a${c})(a)", '(', 1, isOuter = false, expected = TextRange(1, 2)),
+        FindBlockRangeTestCase("caret at end outer match backward", "(a${c})(a)", '(', 1, isOuter = true, expected = TextRange(0, 3)),
+        FindBlockRangeTestCase("inner match first paren", "( (${c}a) )", '(', 1, isOuter = false, expected = TextRange(3, 4)),
+        FindBlockRangeTestCase("outer match first paren", "( (${c}a) )", '(', 1, isOuter = true, expected = TextRange(2, 5)),
+        FindBlockRangeTestCase("caret at begin inner match first forward", "${c}( (a) )", '(', 1, isOuter = false, expected = TextRange(1, 6)),
+        FindBlockRangeTestCase("caret at begin outer match first forward", "${c}( (a) )", '(', 1, isOuter = true, expected = TextRange(0, 7)),
+        FindBlockRangeTestCase("inner match multiple occurence", "( (${c}a) )", '(', 2, isOuter = false, expected = TextRange(1, 6)),
+        FindBlockRangeTestCase("outer match multiple occurence", "( (${c}a) )", '(', 2, isOuter = true, expected = TextRange(0, 7)),
+        FindBlockRangeTestCase("expand inner selection to first occurence", "(${c}${s}a${se}a)", '(', 1, isOuter = false, expected = TextRange(1, 3)),
+        FindBlockRangeTestCase("expand outer selection to first occurence", "(${c}${s}a${se}a)", '(', 1, isOuter = true, expected = TextRange(0, 4)),
+        FindBlockRangeTestCase("expand inner selection to next occurence", "( (${c}${s}aa${se}) )", '(', 1, isOuter = false, expected = TextRange(1, 7)),
+        FindBlockRangeTestCase("expand outer selection to next occurence", "( ${c}${s}(aa)${se} )", '(', 1, isOuter = true, expected = TextRange(0, 8)),
+        FindBlockRangeTestCase("paren not in string inner match", "( (\"${c}a\") )", '(', 1, isOuter = false, expected = TextRange(3, 6)),
+        FindBlockRangeTestCase("paren not in string outer match", "( (\"${c}a\") )", '(', 1, isOuter = true, expected = TextRange(2, 7)),
+        FindBlockRangeTestCase("start end paren in string inner match", "( \"(a${c}a)\" )", '(', 1, isOuter = false, expected = TextRange(4, 6)),
+        FindBlockRangeTestCase("start end paren in string outer match", "( \"(a${c}a)\" )", '(', 1, isOuter = true, expected = TextRange(3, 7)),
+        FindBlockRangeTestCase("only start paren in string inner match not match paren outside", "\"(a${c}a\")", '(', 1, isOuter = false, expected = null),
+        FindBlockRangeTestCase("only start paren in string outer match not match paren outside", "(\"a${c}a)\"", '(', 1, isOuter = true, expected = null),
+        FindBlockRangeTestCase("inner match exclude start paren in string when caret at start of quote", "(${c}\"(aa\")", '(', 1, isOuter = false, expected = TextRange(1, 6)),
+        FindBlockRangeTestCase("outer match exclude start paren in string when caret at start of quote", "(${c}\"(aa\")", '(', 1, isOuter = true, expected = TextRange(0, 7)),
+        FindBlockRangeTestCase("inner match exclude start paren in string when caret at end of quote", "(\"(aa${c}\")", '(', 1, isOuter = false, expected = TextRange(1, 6)),
+        FindBlockRangeTestCase("outer match exclude start paren in string when caret at end of quote", "(\"(aa${c}\")", '(', 1, isOuter = true, expected = TextRange(0, 7)),
+        FindBlockRangeTestCase("inner match not exclude start paren in string when caret in between quote", "(\"(a${c}a\")", '(', 1, isOuter = false, expected = null),
+        FindBlockRangeTestCase("outer match not exclude start paren in string when caret in between quote", "(\"(a${c}a\")", '(', 1, isOuter = true, expected = null),
+        FindBlockRangeTestCase("inner match exclude end paren in string when caret at start of quote", "(${c}\"aa)\")", '(', 1, isOuter = false, expected = TextRange(1, 6)),
+        FindBlockRangeTestCase("outer match exclude end paren in string when caret at start of quote", "(${c}\"aa)\")", '(', 1, isOuter = true, expected = TextRange(0, 7)),
+        FindBlockRangeTestCase("inner match exclude end paren in string when caret at end of quote", "(\"aa)${c}\")", '(', 1, isOuter = false, expected = TextRange(1, 6)),
+        FindBlockRangeTestCase("outer match exclude end paren in string when caret at end of quote", "(\"aa)${c}\")", '(', 1, isOuter = true, expected = TextRange(0, 7)),
+        FindBlockRangeTestCase("inner match exclude end paren in string when caret in between quote", "(\"a${c}a)\")", '(', 1, isOuter = false, expected = TextRange(1, 6)),
+        FindBlockRangeTestCase("outer match exclude end paren in string when caret in between quote", "(\"a${c}a)\")", '(', 1, isOuter = true, expected = TextRange(0, 7)),
+        FindBlockRangeTestCase("inner match exclude first line break after start paren", "(\n${c}a)", '(', 1, isOuter = false, expected = TextRange(2, 3)),
+        FindBlockRangeTestCase("inner match exclude only first line break after start paren", "(\n\n${c}a)", '(', 1, isOuter = false, expected = TextRange(2, 4)),
+        FindBlockRangeTestCase("inner match exclude last line break before end paren", "(${c}a\n)", '(', 1, isOuter = false, expected = TextRange(1, 2)),
+        FindBlockRangeTestCase("inner match exclude only last line break before end paren", "(${c}a\n\n)", '(', 1, isOuter = false, expected = TextRange(1, 3)),
+        FindBlockRangeTestCase("inner match exclude last line break and whitespace character before end paren", "(${c}a\n   )", '(', 1, isOuter = false, expected = TextRange(1, 2)),
+        FindBlockRangeTestCase("inner match expand to next occurence when start end paren has line break", "(a(\n${c}${s}a${se}\n)c)", '(', 1, isOuter = false, expected = TextRange(1, 8)),
+        FindBlockRangeTestCase("inner match expand to next occurence when end paren has line break and blank character", "(a(\n${c}${s}a${se}\n )c)", '(', 1, isOuter = false, expected = TextRange(1, 9)),
+        FindBlockRangeTestCase("inner match not expand to next occurence when selection not last line", "(a(\n${c}${s}a${se}\n\n )c)", '(', 1, isOuter = false, expected = TextRange(4, 6)),
+      )
+    }
   }
 }


### PR DESCRIPTION
1. Fix block select expansion when there is line break after open(e.g "(") or before close (e.g. ")") 
2. Add test to cover `findBlockRange` function, so we have more confidence in later refactoring
3. Add Javadoc for easier understanding `findBlockRange`