### PR TITLE
Improve formatting of `:set` command output

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
@@ -68,7 +68,9 @@ public class ExOutputPanel extends JPanel {
     add(myScrollPane, BorderLayout.CENTER);
     add(myLabel, BorderLayout.SOUTH);
 
+    // Set the text area read only, and support wrap
     myText.setEditable(false);
+    myText.setLineWrap(true);
 
     myAdapter = new ComponentAdapter() {
       @Override

--- a/src/test/java/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -531,9 +531,14 @@ abstract class VimTestCase {
     assertEquals(expected, selected)
   }
 
+  fun assertCommandOutput(command: String, expected: String) {
+    enterCommand(command)
+    assertExOutput(expected)
+  }
+
   fun assertExOutput(expected: String) {
     val actual = getInstance(fixture.editor).text
-    assertNotNull("No Ex output", actual)
+    assertNotNull(actual, "No Ex output")
     assertEquals(expected, actual)
     NeovimTesting.typeCommand("<esc>", testInfo, fixture.editor)
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -11,14 +11,13 @@ package org.jetbrains.plugins.ideavim.ex.implementation.commands
 import com.maddyhome.idea.vim.api.Options
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.options.OptionScope
-import org.jetbrains.plugins.ideavim.SkipNeovimReason
-import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@Suppress("SpellCheckingInspection")
 class SetCommandTest : VimTestCase() {
 
   @Test
@@ -38,36 +37,32 @@ class SetCommandTest : VimTestCase() {
     assertFalse(options().relativenumber)
   }
 
-  // todo we have spaces in assertExOutput because of pad(20) in the com.maddyhome.idea.vim.vimscript.model.commands.SetCommandKt#showOptions method
-  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
   @Test
   fun `test number option`() {
     configureByText("\n")
     enterCommand("set scrolloff&")
     assertEquals(0, options().scrolloff)
     enterCommand("set scrolloff?")
-    assertExOutput("scrolloff=0         \n")
+    assertExOutput("scrolloff=0\n")
     enterCommand("set scrolloff=5")
     assertEquals(5, options().scrolloff)
     enterCommand("set scrolloff?")
-    assertExOutput("scrolloff=5         \n")
+    assertExOutput("scrolloff=5\n")
   }
 
-  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
   @Test
   fun `test toggle option as a number`() {
     configureByText("\n")
     enterCommand("set number&")
     assertEquals(0, injector.optionGroup.getOptionValue(Options.number, OptionScope.GLOBAL).asDouble().toInt())
     enterCommand("set number?")
-    assertExOutput("nonumber            \n")
+    assertExOutput("nonumber\n")
     enterCommand("let &nu=1000")
     assertEquals(1000, injector.optionGroup.getOptionValue(Options.number, OptionScope.GLOBAL).asDouble().toInt())
     enterCommand("set number?")
-    assertExOutput("  number            \n")
+    assertExOutput("  number\n")
   }
 
-  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN_ERROR)
   @Test
   fun `test toggle option exceptions`() {
     configureByText("\n")
@@ -93,7 +88,6 @@ class SetCommandTest : VimTestCase() {
     assertPluginErrorMessageContains("E474: Invalid argument: number-=test")
   }
 
-  @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN_ERROR)
   @Test
   fun `test number option exceptions`() {
     configureByText("\n")
@@ -116,33 +110,30 @@ class SetCommandTest : VimTestCase() {
     assertPluginErrorMessageContains("E521: Number required after =: scrolloff-=test")
   }
 
-  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
   @Test
   fun `test string option`() {
     configureByText("\n")
     enterCommand("set selection&")
     assertEquals("inclusive", options().selection)
     enterCommand("set selection?")
-    assertExOutput("selection=inclusive \n")
+    assertExOutput("selection=inclusive\n")
     enterCommand("set selection=exclusive")
     assertEquals("exclusive", options().selection)
     enterCommand("set selection?")
-    assertExOutput("selection=exclusive \n")
+    assertExOutput("selection=exclusive\n")
   }
 
-  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
   @Test
   fun `test show numbered value`() {
     configureByText("\n")
     enterCommand("set so")
-    assertExOutput("scrolloff=0         \n")
+    assertExOutput("scrolloff=0\n")
   }
 
-  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
   @Test
   fun `test show numbered value with question mark`() {
     configureByText("\n")
     enterCommand("set so?")
-    assertExOutput("scrolloff=0         \n")
+    assertExOutput("scrolloff=0\n")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -42,12 +42,10 @@ class SetCommandTest : VimTestCase() {
     configureByText("\n")
     enterCommand("set scrolloff&")
     assertEquals(0, options().scrolloff)
-    enterCommand("set scrolloff?")
-    assertExOutput("scrolloff=0\n")
+    assertCommandOutput("set scrolloff?", "scrolloff=0\n")
     enterCommand("set scrolloff=5")
     assertEquals(5, options().scrolloff)
-    enterCommand("set scrolloff?")
-    assertExOutput("scrolloff=5\n")
+    assertCommandOutput("set scrolloff?", "scrolloff=5\n")
   }
 
   @Test
@@ -55,12 +53,10 @@ class SetCommandTest : VimTestCase() {
     configureByText("\n")
     enterCommand("set number&")
     assertEquals(0, injector.optionGroup.getOptionValue(Options.number, OptionScope.GLOBAL).asDouble().toInt())
-    enterCommand("set number?")
-    assertExOutput("nonumber\n")
+    assertCommandOutput("set number?", "nonumber\n")
     enterCommand("let &nu=1000")
     assertEquals(1000, injector.optionGroup.getOptionValue(Options.number, OptionScope.GLOBAL).asDouble().toInt())
-    enterCommand("set number?")
-    assertExOutput("  number\n")
+    assertCommandOutput("set number?", "  number\n")
   }
 
   @Test
@@ -115,25 +111,21 @@ class SetCommandTest : VimTestCase() {
     configureByText("\n")
     enterCommand("set selection&")
     assertEquals("inclusive", options().selection)
-    enterCommand("set selection?")
-    assertExOutput("selection=inclusive\n")
+    assertCommandOutput("set selection?", "selection=inclusive\n")
     enterCommand("set selection=exclusive")
     assertEquals("exclusive", options().selection)
-    enterCommand("set selection?")
-    assertExOutput("selection=exclusive\n")
+    assertCommandOutput("set selection?", "selection=exclusive\n")
   }
 
   @Test
   fun `test show numbered value`() {
     configureByText("\n")
-    enterCommand("set so")
-    assertExOutput("scrolloff=0\n")
+    assertCommandOutput("set so", "scrolloff=0\n")
   }
 
   @Test
   fun `test show numbered value with question mark`() {
     configureByText("\n")
-    enterCommand("set so?")
-    assertExOutput("scrolloff=0\n")
+    assertCommandOutput("set so?", "scrolloff=0\n")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -42,10 +42,10 @@ class SetCommandTest : VimTestCase() {
     configureByText("\n")
     enterCommand("set scrolloff&")
     assertEquals(0, options().scrolloff)
-    assertCommandOutput("set scrolloff?", "scrolloff=0\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=0\n")
     enterCommand("set scrolloff=5")
     assertEquals(5, options().scrolloff)
-    assertCommandOutput("set scrolloff?", "scrolloff=5\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=5\n")
   }
 
   @Test
@@ -111,21 +111,21 @@ class SetCommandTest : VimTestCase() {
     configureByText("\n")
     enterCommand("set selection&")
     assertEquals("inclusive", options().selection)
-    assertCommandOutput("set selection?", "selection=inclusive\n")
+    assertCommandOutput("set selection?", "  selection=inclusive\n")
     enterCommand("set selection=exclusive")
     assertEquals("exclusive", options().selection)
-    assertCommandOutput("set selection?", "selection=exclusive\n")
+    assertCommandOutput("set selection?", "  selection=exclusive\n")
   }
 
   @Test
   fun `test show numbered value`() {
     configureByText("\n")
-    assertCommandOutput("set so", "scrolloff=0\n")
+    assertCommandOutput("set so", "  scrolloff=0\n")
   }
 
   @Test
   fun `test show numbered value with question mark`() {
     configureByText("\n")
-    assertCommandOutput("set so?", "scrolloff=0\n")
+    assertCommandOutput("set so?", "  scrolloff=0\n")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -28,6 +28,13 @@ class SetCommandTest : VimTestCase() {
     configureByText("\n")
   }
 
+  private fun setOsSpecificOptionsToSafeValues() {
+    enterCommand("set shell=/dummy/path/to/bash")
+    enterCommand("set shellcmdflag=-x")
+    enterCommand("set shellxescape=@")
+    enterCommand("set shellxquote={")
+  }
+
   @Test
   fun `test unknown option`() {
     enterCommand("set unknownOption")
@@ -141,15 +148,16 @@ class SetCommandTest : VimTestCase() {
 
   @Test
   fun `test show all effective option values`() {
+    setOsSpecificOptionsToSafeValues()
     assertCommandOutput("set all",
       """
         |--- Options ---
         |noargtextobj          ideawrite=all       scrolljump=1      notextobj-indent
         |  closenotebooks    noignorecase          scrolloff=0         timeout
         |nocommentary        noincsearch           selectmode=         timeoutlen=1000
-        |nodigraph           nomatchit             shellcmdflag=-c   notrackactionids
-        |noexchange            maxmapdepth=20      shellxescape=       undolevels=1000
-        |nogdefault            more                shellxquote=        unifyjumps
+        |nodigraph           nomatchit             shellcmdflag=-x   notrackactionids
+        |noexchange            maxmapdepth=20      shellxescape=@      undolevels=1000
+        |nogdefault            more                shellxquote={       unifyjumps
         |nohighlightedyank   nomultiple-cursors    showcmd             virtualedit=
         |  history=50        noNERDTree            showmode          novisualbell
         |nohlsearch            nrformats=hex       sidescroll=0        visualdelay=100
@@ -172,7 +180,7 @@ class SetCommandTest : VimTestCase() {
         |  matchpairs=(:),{:},[:]
         |noReplaceWithRegister
         |  selection=inclusive
-        |  shell=/usr/local/bin/bash
+        |  shell=/dummy/path/to/bash
         |novim-paragraph-motion
         |  viminfo='100,<50,s10,h
         |  vimscriptfunctionannotation
@@ -203,6 +211,7 @@ class SetCommandTest : VimTestCase() {
 
   @Test
   fun `test show all option values in single column`() {
+    setOsSpecificOptionsToSafeValues()
     assertCommandOutput("set! all", """
       |--- Options ---
       |noargtextobj
@@ -250,10 +259,10 @@ class SetCommandTest : VimTestCase() {
       |  scrolloff=0
       |  selection=inclusive
       |  selectmode=
-      |  shell=/usr/local/bin/bash
-      |  shellcmdflag=-c
-      |  shellxescape=
-      |  shellxquote=
+      |  shell=/dummy/path/to/bash
+      |  shellcmdflag=-x
+      |  shellxescape=@
+      |  shellxquote={
       |  showcmd
       |  showmode
       |  sidescroll=0

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -12,7 +12,9 @@ import com.maddyhome.idea.vim.api.Options
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.options.OptionScope
 import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -20,9 +22,14 @@ import kotlin.test.assertTrue
 @Suppress("SpellCheckingInspection")
 class SetCommandTest : VimTestCase() {
 
+  @BeforeEach
+  override fun setUp(testInfo: TestInfo) {
+    super.setUp(testInfo)
+    configureByText("\n")
+  }
+
   @Test
   fun `test unknown option`() {
-    configureByText("\n")
     enterCommand("set unknownOption")
     assertPluginError(true)
     assertPluginErrorMessageContains("Unknown option: unknownOption")
@@ -30,7 +37,6 @@ class SetCommandTest : VimTestCase() {
 
   @Test
   fun `test toggle option`() {
-    configureByText("\n")
     enterCommand("set rnu")
     assertTrue(options().relativenumber)
     enterCommand("set rnu!")
@@ -39,7 +45,6 @@ class SetCommandTest : VimTestCase() {
 
   @Test
   fun `test number option`() {
-    configureByText("\n")
     enterCommand("set scrolloff&")
     assertEquals(0, options().scrolloff)
     assertCommandOutput("set scrolloff?", "  scrolloff=0\n")
@@ -50,7 +55,6 @@ class SetCommandTest : VimTestCase() {
 
   @Test
   fun `test toggle option as a number`() {
-    configureByText("\n")
     enterCommand("set number&")
     assertEquals(0, injector.optionGroup.getOptionValue(Options.number, OptionScope.GLOBAL).asDouble().toInt())
     assertCommandOutput("set number?", "nonumber\n")
@@ -61,7 +65,6 @@ class SetCommandTest : VimTestCase() {
 
   @Test
   fun `test toggle option exceptions`() {
-    configureByText("\n")
     enterCommand("set number+=10")
     assertPluginError(true)
     assertPluginErrorMessageContains("E474: Invalid argument: number+=10")
@@ -86,7 +89,6 @@ class SetCommandTest : VimTestCase() {
 
   @Test
   fun `test number option exceptions`() {
-    configureByText("\n")
     enterCommand("set scrolloff+=10")
     assertPluginError(false)
     enterCommand("set scrolloff+=test")
@@ -108,7 +110,6 @@ class SetCommandTest : VimTestCase() {
 
   @Test
   fun `test string option`() {
-    configureByText("\n")
     enterCommand("set selection&")
     assertEquals("inclusive", options().selection)
     assertCommandOutput("set selection?", "  selection=inclusive\n")
@@ -119,13 +120,174 @@ class SetCommandTest : VimTestCase() {
 
   @Test
   fun `test show numbered value`() {
-    configureByText("\n")
     assertCommandOutput("set so", "  scrolloff=0\n")
   }
 
   @Test
   fun `test show numbered value with question mark`() {
-    configureByText("\n")
     assertCommandOutput("set so?", "  scrolloff=0\n")
+  }
+
+  @Test
+  fun `test show all modified effective option values`() {
+    enterCommand("set number relativenumber scrolloff nrformats")
+    assertCommandOutput("set",
+      """
+        |--- Options ---
+        |  ideastrictmode      number              relativenumber
+        |
+      """.trimMargin())
+  }
+
+  @Test
+  fun `test show all effective option values`() {
+    assertCommandOutput("set all",
+      """
+        |--- Options ---
+        |noargtextobj          ideawrite=all       scrolljump=1      notextobj-indent
+        |  closenotebooks    noignorecase          scrolloff=0         timeout
+        |nocommentary        noincsearch           selectmode=         timeoutlen=1000
+        |nodigraph           nomatchit             shellcmdflag=-c   notrackactionids
+        |noexchange            maxmapdepth=20      shellxescape=       undolevels=1000
+        |nogdefault            more                shellxquote=        unifyjumps
+        |nohighlightedyank   nomultiple-cursors    showcmd             virtualedit=
+        |  history=50        noNERDTree            showmode          novisualbell
+        |nohlsearch            nrformats=hex       sidescroll=0        visualdelay=100
+        |noideaglobalmode    nonumber              sidescrolloff=0     whichwrap=b,s
+        |noideajoin          nooctopushandler    nosmartcase           wrapscan
+        |  ideamarks           oldundo             startofline
+        |  ideastrictmode    norelativenumber    nosurround
+        |noideatracetime       scroll=0          notextobj-entire
+        |  clipboard=ideaput,autoselect,exclude:cons\|linux
+        |  excommandannotation
+        |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
+        |  ide=IntelliJ IDEA Community Edition
+        |noideacopypreprocess
+        |  idearefactormode=select
+        |  ideastatusicon=enabled
+        |  ideavimsupport=dialog
+        |  iskeyword=@,48-57,_
+        |  keymodel=continueselect,stopselect
+        |  lookupkeys=<Tab>,<Down>,<Up>,<Enter>,<Left>,<Right>,<C-Down>,<C-Up>,<PageUp>,<PageDown>,<C-J>,<C-Q>
+        |  matchpairs=(:),{:},[:]
+        |noReplaceWithRegister
+        |  selection=inclusive
+        |  shell=/usr/local/bin/bash
+        |novim-paragraph-motion
+        |  viminfo='100,<50,s10,h
+        |  vimscriptfunctionannotation
+        |
+      """.trimMargin())
+  }
+
+  @Test
+  fun `test show named options`() {
+    assertCommandOutput("set number? relativenumber? scrolloff? nrformats?", """
+      |  nrformats=hex     nonumber            norelativenumber      scrolloff=0
+      |""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `test show all modified option values in single column`() {
+    enterCommand("set number relativenumber scrolloff nrformats")
+    assertCommandOutput("set!",
+      """
+      |--- Options ---
+      |  ideastrictmode
+      |  number
+      |  relativenumber
+      |""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `test show all option values in single column`() {
+    assertCommandOutput("set! all", """
+      |--- Options ---
+      |noargtextobj
+      |  clipboard=ideaput,autoselect,exclude:cons\|linux
+      |  closenotebooks
+      |nocommentary
+      |nodigraph
+      |noexchange
+      |  excommandannotation
+      |nogdefault
+      |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
+      |nohighlightedyank
+      |  history=50
+      |nohlsearch
+      |  ide=IntelliJ IDEA Community Edition
+      |noideacopypreprocess
+      |noideaglobalmode
+      |noideajoin
+      |  ideamarks
+      |  idearefactormode=select
+      |  ideastatusicon=enabled
+      |  ideastrictmode
+      |noideatracetime
+      |  ideavimsupport=dialog
+      |  ideawrite=all
+      |noignorecase
+      |noincsearch
+      |  iskeyword=@,48-57,_
+      |  keymodel=continueselect,stopselect
+      |  lookupkeys=<Tab>,<Down>,<Up>,<Enter>,<Left>,<Right>,<C-Down>,<C-Up>,<PageUp>,<PageDown>,<C-J>,<C-Q>
+      |nomatchit
+      |  matchpairs=(:),{:},[:]
+      |  maxmapdepth=20
+      |  more
+      |nomultiple-cursors
+      |noNERDTree
+      |  nrformats=hex
+      |nonumber
+      |nooctopushandler
+      |  oldundo
+      |norelativenumber
+      |noReplaceWithRegister
+      |  scroll=0
+      |  scrolljump=1
+      |  scrolloff=0
+      |  selection=inclusive
+      |  selectmode=
+      |  shell=/usr/local/bin/bash
+      |  shellcmdflag=-c
+      |  shellxescape=
+      |  shellxquote=
+      |  showcmd
+      |  showmode
+      |  sidescroll=0
+      |  sidescrolloff=0
+      |nosmartcase
+      |  startofline
+      |nosurround
+      |notextobj-entire
+      |notextobj-indent
+      |  timeout
+      |  timeoutlen=1000
+      |notrackactionids
+      |  undolevels=1000
+      |  unifyjumps
+      |novim-paragraph-motion
+      |  viminfo='100,<50,s10,h
+      |  vimscriptfunctionannotation
+      |  virtualedit=
+      |novisualbell
+      |  visualdelay=100
+      |  whichwrap=b,s
+      |  wrapscan
+      |""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `test show named options in single column`() {
+    assertCommandOutput("set! number? relativenumber? scrolloff? nrformats?", """
+      |  nrformats=hex
+      |nonumber
+      |norelativenumber
+      |  scrolloff=0
+      |""".trimMargin()
+    )
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
@@ -203,7 +203,8 @@ private fun showOptions(editor: VimEditor, nameAndToken: Collection<Pair<String,
   val optionService = injector.optionGroup
   val optionsToShow = mutableListOf<Option<VimDataType>>()
   var unknownOption: Pair<String, String>? = null
-  for (pair in nameAndToken) {
+
+  for (pair in nameAndToken.sortedWith { o1, o2 -> String.CASE_INSENSITIVE_ORDER.compare(o1.first, o2.first) }) {
     val myOption = optionService.getOption(pair.first)
     if (myOption != null) {
       optionsToShow.add(myOption)
@@ -220,9 +221,6 @@ private fun showOptions(editor: VimEditor, nameAndToken: Collection<Pair<String,
     val optionAsString = formatKnownOptionValue(option, scope)
     if (optionAsString.length >= colWidth) extra.add(optionAsString) else cols.add(optionAsString)
   }
-
-  cols.sort()
-  extra.sort()
 
   val width = injector.engineEditorHelper.getApproximateScreenWidth(editor).let { if (it < 20) 80 else it }
   val colCount = width / colWidth

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
@@ -214,20 +214,18 @@ private fun showOptions(editor: VimEditor, nameAndToken: Collection<Pair<String,
   }
 
   val colWidth = 20
-  val cols = mutableListOf<String>()
+  val cells = mutableListOf<String>()
   val extra = mutableListOf<String>()
   for (option in optionsToShow) {
     val optionAsString = formatKnownOptionValue(option, scope)
-    if (optionAsString.length >= colWidth) extra.add(optionAsString) else cols.add(optionAsString)
+    if (optionAsString.length >= colWidth) extra.add(optionAsString) else cells.add(optionAsString)
   }
 
   // Note that this is the approximate width of the associated editor, not the ex output panel!
   // It excludes gutter width, for example
   val width = injector.engineEditorHelper.getApproximateScreenWidth(editor).let { if (it < 20) 80 else it }
   val colCount = width / colWidth
-  val height = ceil(cols.size.toDouble() / colCount.toDouble()).toInt()
-  var empty = cols.size % colCount
-  empty = if (empty == 0) colCount else empty
+  val height = ceil(cells.size.toDouble() / colCount.toDouble()).toInt()
 
   val output = buildString {
     if (showIntro) {
@@ -237,21 +235,15 @@ private fun showOptions(editor: VimEditor, nameAndToken: Collection<Pair<String,
     for (h in 0 until height) {
       val lengthAtStartOfLine = length
       for (c in 0 until colCount) {
-        if (h == height - 1 && c >= empty) {
-          break
-        }
+        val index = c * height + h
+        if (index < cells.size) {
+          val padLength = lengthAtStartOfLine + (c * colWidth) - length
+          for (i in 1..padLength) {
+            append(' ')
+          }
 
-        var pos = c * height + h
-        if (c > empty) {
-          pos -= c - empty
+          append(cells[index])
         }
-
-        val padLength = lengthAtStartOfLine + (c * colWidth) - length
-        for (i in 1 .. padLength) {
-          append(' ')
-        }
-
-        append(cols[pos])
       }
       appendLine()
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
@@ -34,7 +34,6 @@ import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 import java.util.*
 import kotlin.math.ceil
-import kotlin.math.min
 
 /**
  * see "h :set"
@@ -222,6 +221,8 @@ private fun showOptions(editor: VimEditor, nameAndToken: Collection<Pair<String,
     if (optionAsString.length >= colWidth) extra.add(optionAsString) else cols.add(optionAsString)
   }
 
+  // Note that this is the approximate width of the associated editor, not the ex output panel!
+  // It excludes gutter width, for example
   val width = injector.engineEditorHelper.getApproximateScreenWidth(editor).let { if (it < 20) 80 else it }
   val colCount = width / colWidth
   val height = ceil(cols.size.toDouble() / colCount.toDouble()).toInt()
@@ -255,13 +256,9 @@ private fun showOptions(editor: VimEditor, nameAndToken: Collection<Pair<String,
       appendLine()
     }
 
-    // Add any extra, long options and hard wrap to the screen width
-    for (opt in extra) {
-      val seg = (opt.length - 1) / width
-      for (j in 0..seg) {
-        append(opt, j * width, min(j * width + width, opt.length))
-        appendLine()
-      }
+    // Add any lines that are too long to fit into columns. The panel will soft wrap text
+    for (option in extra) {
+      appendLine(option)
     }
   }
   injector.exOutputPanel.getPanel(editor).output(output)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
@@ -276,7 +276,7 @@ private fun formatKnownOptionValue(option: Option<out VimDataType>, scope: Optio
   return if (option is ToggleOption) {
     if (value.asBoolean()) "  ${option.name}" else "no${option.name}"
   } else {
-    "${option.name}=$value"
+    "  ${option.name}=$value"
   }
 }
 


### PR DESCRIPTION
This PR fixes a few minor formatting issues with the output of the `:set` command:

* It removes the trailing spaces added to the end of the line for column padding
* It sorts option names before formatting, so the `no` prefix for boolean options isn't included
* Options with values (`scrolloff=5`) are formatted with a 2 char indent to line up with the boolean options
* Long options are not wrapped by the formatter, but expected to be wrapped by the output pane. The formatter doesn't have the actual width of the output pane, only the character width of the editor, which doesn't include line numbers and gutter width. The output pane can enable soft wraps to provide better wrapping
* Output in the same order as Vim, filling each column in turn, rather than filling multiple columns horizontally
* Support `:set!` to output options in a single column