### PR TITLE
Do not enter INSERT mode for read-only editors

### DIFF
--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertExitModeAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertExitModeAction.kt
@@ -14,6 +14,9 @@ import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.VimActionHandler
 
 public class InsertExitModeAction : VimActionHandler.SingleExecution() {
+  // Note that hitting Escape can insert text when exiting insert mode after visual block mode.
+  // If the editor is read-only, we'll get a "This view is read-only" tooltip. However, we should only enter insert
+  // mode if both editor and document are writable.
   override val type: Command.Type = Command.Type.INSERT
 
   override fun execute(editor: VimEditor, context: ExecutionContext, cmd: Command, operatorArguments: OperatorArguments): Boolean {


### PR DESCRIPTION
When initialising a new editor, IdeaVim will automatically start INSERT mode for an editor that is not a primary editor - that is, it's not file-backed, so it's not a main editor in the content area of the IDEA. This provides a more intuitive "just start typing" experience for editors that are more likely to be part of the UI than editing files, e.g. the VCS commit message editor.

IdeaVim would check that the editor was not file-backed, and that the document was writable, and then start INSERT mode. However, it is not enough that the document is writable, the editor needs to be non-read-only, too. Log and console output for run configurations and tests will have a writable document (because the app is updating it while the file is being externally modified), but the editor is in "viewer" mode. This PR will not start INSERT mode if the editor is read-only ("viewer" mode, but also "rendered" mode, which is read-only with hidden caret).

Fixes [VIM-2313](https://youtrack.jetbrains.com/issue/VIM-2313), fixes [VIM-2318](https://youtrack.jetbrains.com/issue/VIM-2318), fixes [VIM-2666](https://youtrack.jetbrains.com/issue/VIM-2666), fixes [VIM-2951](https://youtrack.jetbrains.com/issue/VIM-2951)