### PR TITLE
Add VimShowHoverInfo action

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/VimShowHoverInfoAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShowHoverInfoAction.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2003-2023 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.action
+
+import com.intellij.codeInsight.hint.HintManagerImpl.ActionToIgnore
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.PerformWithDocumentsCommitted
+import com.intellij.openapi.actionSystem.PopupAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorMouseHoverPopupManager
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseEventArea
+import com.intellij.openapi.project.DumbAware
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.newapi.vim
+import java.awt.event.MouseEvent
+
+public class VimShowHoverInfoAction: AnAction(), ActionToIgnore, PopupAction, DumbAware, PerformWithDocumentsCommitted {
+  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+  override fun update(e: AnActionEvent) {
+    val dataContext = e.dataContext
+    val editor = CommonDataKeys.EDITOR.getData(dataContext)
+    if (editor == null) {
+      e.presentation.isEnabledAndVisible = false
+    }
+  }
+
+  override fun actionPerformed(e: AnActionEvent) {
+    val dataContext = e.dataContext
+    val editor = CommonDataKeys.EDITOR.getData(dataContext) ?: return
+
+    // Use the ShowHoverInfo action from the platform if it exists (added in 233). Before that, there wasn't an
+    // overload of showInfoTooltip that would show both highlighting info and documentation - the API was hardcoded to
+    // only show highlighting info (for ShowErrorDescription and the tooltips in GotoNextError). We can fake the hover
+    // action by asking the popup manager to show the tooltip for a fake mouse event at the current caret location
+    val nativeAction = injector.actionExecutor.getAction("ShowHoverInfo")
+    if (nativeAction != null) {
+      injector.actionExecutor.executeAction(editor.vim, nativeAction, dataContext.vim)
+    }
+    else {
+      val editorMouseEvent = createFakeEditorMouseEvent(editor)
+      EditorMouseHoverPopupManager.getInstance().showInfoTooltip(editorMouseEvent)
+    }
+  }
+
+  private fun createFakeEditorMouseEvent(editor: Editor): EditorMouseEvent {
+    val xy = editor.offsetToXY(editor.caretModel.offset)
+    val mouseEvent =
+      MouseEvent(editor.component, MouseEvent.MOUSE_MOVED, System.currentTimeMillis(), 0, xy.x, xy.y, 0, false)
+    val editorMouseEvent = EditorMouseEvent(
+      editor,
+      mouseEvent,
+      EditorMouseEventArea.EDITING_AREA,
+      editor.caretModel.offset,
+      editor.caretModel.logicalPosition,
+      editor.caretModel.visualPosition,
+      true,
+      null,
+      null,
+      null
+    )
+    return editorMouseEvent
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,7 @@
   <!-- Please search for "[VERSION UPDATE]" in project in case you update the since-build version -->
   <!-- Check for [Version Update] tag in YouTrack as well -->
   <!-- Also, please update the value in build.gradle.kts file-->
-  <idea-version since-build="231.7515.13"/>
+  <idea-version since-build="231.8109.175"/>
 
   <!-- Mark the plugin as compatible with RubyMine and other products based on the IntelliJ platform (including CWM) -->
   <depends>com.intellij.modules.platform</depends>
@@ -142,5 +142,7 @@
     </group>
 
     <action id="VimFindActionIdAction" class="com.maddyhome.idea.vim.listener.FindActionIdAction"/>
+
+    <action id="VimShowHoverInfo" class="com.maddyhome.idea.vim.action.VimShowHoverInfoAction"/>
   </actions>
 </idea-plugin>


### PR DESCRIPTION
The `ShowHoverInfo` action has just been added to the 2023.3 wave of releases (233.8745 and above). This action will show a combined tooltip of highlighting info and quick documentation, exactly the same as shown when hovering over a code element. This can be mapped to keys, such as `nmap gh <Action>(ShowHoverInfo)`.

This PR adds a safe workaround for 2023.1 and 2023.2. It adds a `VimShowHoverInfo` action that will defer to `ShowHoverInfo` if it exists, and calls an appropriate platform API if not. This API is intended to show the tooltip in response to an `EditorMouseEvent`, so this action simply creates a fake instance for the location of the text caret.

It also bumps the `since-build` value in `plugin.xml` to match 2023.1 RTM, to allow using this platform API (it was previously on an earlier 231 build).

Fixes [VIM-2106](https://youtrack.jetbrains.com/issue/VIM-2106/Go-hover)