### PR TITLE
Fix(VIM-2562): Fix hang with multi-width chars in command line

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.java
@@ -371,7 +371,11 @@ public class ExTextField extends JTextField {
   void toggleInsertReplace() {
     ExDocument doc = (ExDocument)getDocument();
     doc.toggleInsertReplace();
+
+    // Hide/show the caret so its new shape is immediately visible
+    caret.setVisible(false);
     resetCaret();
+    caret.setVisible(true);
   }
 
   private void resetCaret() {
@@ -414,20 +418,15 @@ public class ExTextField extends JTextField {
     private boolean hasFocus;
 
     public void setAttributes(GuiCursorAttributes attributes) {
-      final boolean active = isActive();
 
-      // Hide the currently visible caret
-      if (isVisible()) {
-        setVisible(false);
-      }
+      // Note: do not call anything that causes a layout in this method! E.g. setVisible. This method is used as a
+      // callback whenever the caret moves, and causing a layout at this point can cause issues such as an infinite
+      // loop in the layout algorithm with multi-width characters such as emoji or non-Latin characters (I don't know
+      // why the layout algorithm gets stuck, but we can easily avoid it)
+      // See VIM-2562
 
       mode = attributes.getType();
       thickness = mode == GuiCursorType.BLOCK ? 100 : attributes.getThickness();
-
-      // Make sure the caret is visible, but only if we're active, otherwise we'll kick off the flasher timer unnecessarily
-      if (active) {
-        setVisible(true);
-      }
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a hang in the IDE when typing a multi-width character such as an emoji or other non-Latin character in the ex command line or search text field ([VIM-2562[(https://youtrack.jetbrains.com/issue/VIM-2562)). 

The issue was due to the handling of the custom caret in the text field. Like Vim, the caret should change its shape as it moves around the field, and to reflect the insert/replace state - block at the end of the text, bar for insert, underscore for replace. See also [`'guicursor'`](https://vimhelp.org/options.txt.html#%27guicursor%27)). 

When updating the caret, it is first hidden, then updated and then shown again, so any changes in shape are immediately visible. Unfortunately, hiding the caret causes a layout, and when this happens in a callback due to changing the text to add a multi-width character, the layout algorithm gets stuck in an infinite loop.

The fix is to not hide/show the caret on each update - when moving the caret, or editing text, the system makes sure that the caret is correctly updated as part of the flashing. Changing the insert/replace state of the caret is handled explicitly, so hiding/showing the caret to make the changes visible is handled here instead.
