### PR TITLE
Add operating system type to `has()` function

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/HasFunctionHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/HasFunctionHandler.kt
@@ -8,6 +8,8 @@
 
 package com.maddyhome.idea.vim.vimscript.model.functions.handlers
 
+import com.intellij.openapi.util.SystemInfoRt
+import com.intellij.util.system.CpuArch
 import com.intellij.vim.annotations.VimscriptFunction
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
@@ -23,7 +25,7 @@ internal class HasFunctionHandler : FunctionHandler() {
   override val minimumNumberOfArguments = 1
   override val maximumNumberOfArguments = 2
 
-  private val supportedFeatures = setOf("ide")
+  private val supportedFeatures = Features.discover()
 
   override fun doFunction(
     argumentValues: List<Expression>,
@@ -39,6 +41,40 @@ internal class HasFunctionHandler : FunctionHandler() {
       VimInt.ONE
     } else {
       VimInt.ZERO
+    }
+  }
+
+  private object Features {
+    fun discover(): Set<String> {
+      val result = mutableSetOf("ide")
+
+      collectOperatingSystemType(result)
+
+      return result
+    }
+
+    private fun collectOperatingSystemType(result: MutableSet<String>) {
+      if (SystemInfoRt.isWindows) {
+        result.add("win32")
+        if (CpuArch.CURRENT.width == 64) {
+          result.add("win64")
+        }
+      } else if (SystemInfoRt.isLinux) {
+        result.add("linux")
+      } else if (SystemInfoRt.isMac) {
+        result.add("mac")
+        result.add("macunix")
+        result.add("osx")
+        result.add("osxdarwin")
+      } else if (SystemInfoRt.isFreeBSD) {
+        result.add("bsd")
+      } else if (SystemInfoRt.isSolaris) {
+        result.add("sun")
+      }
+
+      if (SystemInfoRt.isUnix) {
+        result.add("unix")
+      }
     }
   }
 }


### PR DESCRIPTION
I tried to replicate the logic from https://github.com/vim/vim/blob/0f058d13206665bad37c7d42834cfa0075f50239/src/evalfunc.c#L5511, not 100% sure if I got it right (and some special cases like `win32unix` are missing) but hopefully it's ok.