### PR TITLE
Fix md links in doc

### DIFF
--- a/doc/Home.md
+++ b/doc/Home.md
@@ -1,6 +1,6 @@
 Welcome to the IdeaVim wiki!
 
-- List of IdeaVim plugins: [[plugins|IdeaVim Plugins]]
-- Examples of `ideajoin` option (also known as "smart join"): [["ideajoin" examples|ideajoin-examples]]
-- List of "set" commands: [["set" commands|set-commands]]
-- Docs about "select" mode in vim: [[select mode|Select-mode]]
+- List of IdeaVim plugins: [plugins](IdeaVim%20Plugins.md)
+- Examples of `ideajoin` option (also known as "smart join"): ["ideajoin" examples](ideajoin-examples.md)
+- List of "set" commands: ["set" commands](set-commands.md)
+- Docs about "select" mode in vim: [select mode](Select-mode.md)

--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -77,7 +77,7 @@ Original plugin: [NERDTree](https://github.com/preservim/nerdtree).
    
 ### Instructions
    
-[[See here|NERDTree-support]].
+[See here](NERDTree-support.md).
 
 </details>
 


### PR DESCRIPTION
Hi 
I've been browsing through the doc and come across some broken markdown links:

https://github.com/JetBrains/ideavim/blob/master/doc/Home.md

so I've decided to grab my chance to become an open source contributor :) 
It ain't much just some boy scout rule applied