### PR TITLE
Add support for ShowHoverInfo action to 2023.1 and 2023.2

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/VimActionConfigurationCustomizer.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimActionConfigurationCustomizer.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2003-2023 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.action
+
+import com.intellij.codeInsight.hint.HintManagerImpl
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.PerformWithDocumentsCommitted
+import com.intellij.openapi.actionSystem.PopupAction
+import com.intellij.openapi.actionSystem.impl.ActionConfigurationCustomizer
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorMouseHoverPopupManager
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseEventArea
+import com.intellij.openapi.project.DumbAware
+import java.awt.event.MouseEvent
+
+// [VERSION UPDATE] 233+ Remove class
+// The ShowHoverInfo action is built into the platform (using a nicer EditorMouseHoverPopupManager API)
+public class VimActionConfigurationCustomizer : ActionConfigurationCustomizer {
+  public override fun customize(actionManager: ActionManager) {
+    // If the ShowHoverInfo action doesn't exist in the platform, add our own implementation
+    if (actionManager.getAction("ShowHoverInfo") == null) {
+      actionManager.registerAction("ShowHoverInfo", VimShowHoverInfoAction())
+    }
+  }
+
+  private class VimShowHoverInfoAction : AnAction(), HintManagerImpl.ActionToIgnore, PopupAction, DumbAware,
+    PerformWithDocumentsCommitted {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+      val dataContext = e.dataContext
+      val editor = CommonDataKeys.EDITOR.getData(dataContext)
+      if (editor == null) {
+        e.presentation.isEnabledAndVisible = false
+      }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+      val editor = CommonDataKeys.EDITOR.getData(e.dataContext) ?: return
+
+      val editorMouseEvent = createFakeEditorMouseEvent(editor)
+      EditorMouseHoverPopupManager.getInstance().showInfoTooltip(editorMouseEvent)
+    }
+
+    private fun createFakeEditorMouseEvent(editor: Editor): EditorMouseEvent {
+      val xy = editor.offsetToXY(editor.caretModel.offset)
+      val mouseEvent =
+        MouseEvent(editor.component, MouseEvent.MOUSE_MOVED, System.currentTimeMillis(), 0, xy.x, xy.y, 0, false)
+      val editorMouseEvent = EditorMouseEvent(
+        editor,
+        mouseEvent,
+        EditorMouseEventArea.EDITING_AREA,
+        editor.caretModel.offset,
+        editor.caretModel.logicalPosition,
+        editor.caretModel.visualPosition,
+        true,
+        null,
+        null,
+        null
+      )
+      return editorMouseEvent
+    }
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -82,6 +82,7 @@
     <editorFloatingToolbarProvider implementation="com.maddyhome.idea.vim.ui.ReloadFloatingToolbar"/>
 
     <actionPromoter implementation="com.maddyhome.idea.vim.key.VimActionsPromoter" order="last"/>
+    <actionConfigurationCustomizer implementation="com.maddyhome.idea.vim.action.VimActionConfigurationCustomizer"/>
 
     <spellchecker.bundledDictionaryProvider implementation="com.maddyhome.idea.vim.VimBundledDictionaryProvider"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,7 @@
   <!-- Please search for "[VERSION UPDATE]" in project in case you update the since-build version -->
   <!-- Check for [Version Update] tag in YouTrack as well -->
   <!-- Also, please update the value in build.gradle.kts file-->
-  <idea-version since-build="231.7515.13"/>
+  <idea-version since-build="231.8109.175"/>
 
   <!-- Mark the plugin as compatible with RubyMine and other products based on the IntelliJ platform (including CWM) -->
   <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
The 2023.3 IntelliJ Platform introduces an action called `ShowHoverInfo` that can be used to show the same tooltip which is displayed when the mouse hovers over a code symbol. This PR adds an extension point that will register an action with the same name for IntelliJ Platform versions that don't support this action. Once the base required version is raised to 2023.3, then this customisation can be removed, and all existing mappings will still work.

The base required version is raised to 2023.1 RTM to allow using the required platform API for the new action. It was on a preview version of 2023.1.

Users can invoke the action from a mapping, such as:

```vimL
nmap gh <Action>(ShowHoverInfo)
```

This PR fixes [VIM-2106](https://youtrack.jetbrains.com/issue/VIM-2106/Go-hover)