### PR TITLE
Fix(VIM-2933): Reloading/sourcing .ideavimrc does not initialize new plugins

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/ui/ReloadVimRc.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ReloadVimRc.kt
@@ -18,12 +18,12 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.toolbar.floating.AbstractFloatingToolbarProvider
 import com.intellij.openapi.editor.toolbar.floating.FloatingToolbarComponent
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.io.FileUtil
 import com.maddyhome.idea.vim.api.VimrcFileState
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.extension.VimExtensionRegistrar
 import com.maddyhome.idea.vim.helper.MessageHelper
 import com.maddyhome.idea.vim.icons.VimIcons
 import com.maddyhome.idea.vim.key.MappingOwner
@@ -149,12 +149,14 @@ internal class ReloadVimRc : DumbAwareAction() {
 
   override fun actionPerformed(e: AnActionEvent) {
     val editor = e.getData(PlatformDataKeys.EDITOR) ?: return
-    FileDocumentManager.getInstance().saveDocumentAsIs(editor.document)
     injector.keyGroup.removeKeyMapping(MappingOwner.IdeaVim.InitScript)
     Troubleshooter.instance.removeByType("old-action-notation-in-mappings")
 
     // Reload the ideavimrc in the context of the current window, as though we had called `:source ~/.ideavimrc`
     executeIdeaVimRc(editor.vim)
+
+    // Ensure newly added extensions are initialized
+    VimExtensionRegistrar.enableDelayedExtensions()
   }
 }
 


### PR DESCRIPTION
Found two issues related to [VIM-2933](https://youtrack.jetbrains.com/issue/VIM-2933):

1. Clicking the Reload button did not call `VimExtensionRegistrar.enableDelayedExtensions()`, so new extensions were not getting initialized.

   At this point, there are 3 places in the code that follow the pattern of setting the `vimscriptExecutor.executingVimscript` flag, executing a script, and then initializing new extensions. On the other hand, the `:source` command does not appear to do this at all, it just executes the script and initializes extensions immediately.

   I don't know why extensions have to be delayed, but it seems like the inconsistency and duplication of this behavior should be refactored. If this behavior exists at all, isn't it always necessary? - In which case the delayed initialization + setting of the flag should perhaps be done directly in `Executor.execute`, rather than having to remember to do it manually anywhere scripts are being executed.

2. It was possible to edit `.ideavimrc` and run `:source ~/.ideavimrc` before the file was actually saved. The Reload button ensures the file is saved first, but `:source` does not.

   This PR ensures that, before executing any script file, if the script file is currently opened in an editor and dirty, it will be saved first. This also means the Reload button itself doesn't need to save the file anymore.

   As I said earlier, `:source` does (eagerly) initialize new extensions, so this is a slightly different issue. I'm guessing the author of VIM-2933 edited the file, tried sourcing it, and it did not initialize new extensions just because IntelliJ hadn't saved the file yet, so they assumed the initialization was broken entirely; that's what happened to me while I was trying to reproduce the issue.

   Since this fix affects all script file executions, let me know if you'd like me to separate it into 2 commits and/or PRs.