### PR TITLE
Prevent code completion popup from appearing after running a macro

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/MacroGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/MacroGroup.kt
@@ -7,6 +7,8 @@
  */
 package com.maddyhome.idea.vim.group
 
+import com.intellij.codeInsight.completion.CompletionPhase
+import com.intellij.codeInsight.completion.impl.CompletionServiceImpl
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProcessCanceledException
@@ -71,7 +73,10 @@ internal class MacroGroup : VimMacroBase() {
             } catch (e: ProcessCanceledException) {
               return@runnable
             }
-            ProgressManager.getInstance().executeNonCancelableSection { getInstance().handleKey(editor, key, context) }
+            ProgressManager.getInstance().executeNonCancelableSection {
+              CompletionServiceImpl.setCompletionPhase(CompletionPhase.NoCompletion)
+              getInstance().handleKey(editor, key, context)
+            }
             if (injector.messages.isError()) return@runnable
           }
           keyStack.resetFirst()


### PR DESCRIPTION
When running a macro with "Code Completion - Show suggestions as you type" enabled, it queues up the code completion popup to appear which causes a few issues:
 - It happens even when the macro ends in normal mode, preventing keys such as Enter from executing their usual normal mode mapping because the popup steals them
 - It prevents "Add unambiguous imports on the fly" from running, so as long as macros don't support imports ([VIM-2712](https://youtrack.jetbrains.com/issue/VIM-2712/Macros-dont-work-well-with-autocompletion-and-import)) it makes using macros across many files really slow, because after every macro run I have to press Escape and then wait

The PR stops code completion popup from being scheduled during a macro. The completion phase seems to get reinstated after every key, so I reset it before every key in the macro.

Not 100% sure if it's the best way to do it, but it seems IDEA uses this to temporarily prevent completion popups in a few places, and I didn't see anything more sensible in the guard checks in `AutoPopupControllerImpl#scheduleAutoPopup` that could be toggled.