### PR TITLE
Remove CommandFlags.FLAG_EXIT_VISUAL and FLAG_MULTIKEY_UNDO

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/change/OperatorAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/change/OperatorAction.kt
@@ -18,9 +18,7 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.setChangeMarks
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
-import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.common.argumentCaptured
 import com.maddyhome.idea.vim.group.MotionGroup
@@ -28,10 +26,9 @@ import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
 import com.maddyhome.idea.vim.helper.MessageHelper
-import com.maddyhome.idea.vim.helper.enumSetOf
 import com.maddyhome.idea.vim.helper.vimStateMachine
 import com.maddyhome.idea.vim.newapi.ij
-import java.util.*
+import com.maddyhome.idea.vim.state.mode.SelectionType
 
 // todo make it multicaret
 private fun doOperatorAction(editor: VimEditor, context: ExecutionContext, textRange: TextRange, selectionType: SelectionType): Boolean {
@@ -103,8 +100,6 @@ internal class OperatorAction : VimActionHandler.SingleExecution() {
 @CommandOrMotion(keys = ["g@"], modes = [Mode.VISUAL])
 internal class VisualOperatorAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.OTHER_SELF_SYNCHRONIZED
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeAction(
     editor: VimEditor,

--- a/src/main/java/com/maddyhome/idea/vim/action/change/delete/DeleteJoinVisualLinesAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/change/delete/DeleteJoinVisualLinesAction.kt
@@ -14,13 +14,10 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
 import com.maddyhome.idea.vim.newapi.ijOptions
-import java.util.*
 
 /**
  * @author vlan
@@ -28,8 +25,6 @@ import java.util.*
 @CommandOrMotion(keys = ["gJ"], modes = [Mode.VISUAL])
 public class DeleteJoinVisualLinesAction : VisualOperatorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.DELETE
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeForAllCarets(
     editor: VimEditor,

--- a/src/main/java/com/maddyhome/idea/vim/action/change/delete/DeleteJoinVisualLinesSpacesAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/change/delete/DeleteJoinVisualLinesSpacesAction.kt
@@ -14,13 +14,10 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
 import com.maddyhome.idea.vim.newapi.ijOptions
-import java.util.*
 
 /**
  * @author vlan
@@ -28,8 +25,6 @@ import java.util.*
 @CommandOrMotion(keys = ["J"], modes = [Mode.VISUAL])
 public class DeleteJoinVisualLinesSpacesAction : VisualOperatorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.DELETE
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeForAllCarets(
     editor: VimEditor,

--- a/src/main/java/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/commentary/CommentaryExtension.kt
@@ -156,11 +156,6 @@ internal class CommentaryExtension : VimExtension {
   private class CommentaryOperatorHandler : OperatorFunction, ExtensionHandler {
     override val isRepeatable = true
 
-    // In this operator we process selection by ourselves. This is necessary for rider, VIM-1758
-    override fun postProcessSelection(): Boolean {
-      return false
-    }
-
     override fun execute(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments) {
       setOperatorFunction(this)
       executeNormalWithoutMapping(injector.parser.parseKeys("g@"), editor.ij)

--- a/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
@@ -124,10 +124,6 @@ internal var Editor.vimMorePanel: ExOutputPanel? by userData()
 internal var Editor.vimExOutput: ExOutputModel? by userData()
 internal var Editor.vimTestInputModel: TestInputModel? by userData()
 
-/**
- * Checks whether a keeping visual mode visual operator action is performed on editor.
- */
-internal var Editor.vimKeepingVisualOperatorAction: Boolean by userDataOr { false }
 internal var Editor.vimChangeActionSwitchMode: Mode? by userData()
 
 /**

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
@@ -54,7 +54,6 @@ import com.maddyhome.idea.vim.helper.isTemplateActive
 import com.maddyhome.idea.vim.helper.updateCaretsVisualAttributes
 import com.maddyhome.idea.vim.helper.updateCaretsVisualPosition
 import com.maddyhome.idea.vim.helper.vimChangeActionSwitchMode
-import com.maddyhome.idea.vim.helper.vimKeepingVisualOperatorAction
 import com.maddyhome.idea.vim.helper.vimLastSelectionType
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
@@ -67,7 +66,7 @@ internal class IjVimEditor(editor: Editor) : MutableLinearEditor() {
   companion object {
     // For cases where Editor does not have a project (for some reason)
     // It's something IJ Platform related and stored here because of this reason
-    const val DEFAULT_PROJECT_ID = "no project" 
+    const val DEFAULT_PROJECT_ID = "no project"
   }
 
   // All the editor actions should be performed with top level editor!!!
@@ -81,11 +80,6 @@ internal class IjVimEditor(editor: Editor) : MutableLinearEditor() {
     get() = editor.vimChangeActionSwitchMode
     set(value) {
       editor.vimChangeActionSwitchMode = value
-    }
-  override var vimKeepingVisualOperatorAction: Boolean
-    get() = editor.vimKeepingVisualOperatorAction
-    set(value) {
-      editor.vimKeepingVisualOperatorAction = value
     }
 
   override fun fileSize(): Long = editor.fileSize.toLong()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/AutoIndentLinesVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/AutoIndentLinesVisualAction.kt
@@ -28,7 +28,7 @@ import java.util.*
 public class AutoIndentLinesVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE, CommandFlags.FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseLowerVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseLowerVisualAction.kt
@@ -14,13 +14,10 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
 import com.maddyhome.idea.vim.helper.CharacterHelper
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 /**
  * @author vlan
@@ -28,8 +25,6 @@ import java.util.*
 @CommandOrMotion(keys = ["u"], modes = [Mode.VISUAL])
 public class ChangeCaseLowerVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseToggleVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseToggleVisualAction.kt
@@ -14,13 +14,10 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
 import com.maddyhome.idea.vim.helper.CharacterHelper
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 /**
  * @author vlan
@@ -28,8 +25,6 @@ import java.util.*
 @CommandOrMotion(keys = ["~"], modes = [Mode.VISUAL])
 public class ChangeCaseToggleVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseUpperVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseUpperVisualAction.kt
@@ -14,13 +14,10 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
 import com.maddyhome.idea.vim.helper.CharacterHelper
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 /**
  * @author vlan
@@ -28,8 +25,6 @@ import java.util.*
 @CommandOrMotion(keys = ["U"], modes = [Mode.VISUAL])
 public class ChangeCaseUpperVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCharactersAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCharactersAction.kt
@@ -16,7 +16,6 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
-import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MULTIKEY_UNDO
 import com.maddyhome.idea.vim.command.CommandFlags.FLAG_NO_REPEAT_INSERT
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
@@ -27,7 +26,7 @@ import java.util.*
 public class ChangeCharactersAction : ChangeEditorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_NO_REPEAT_INSERT, FLAG_MULTIKEY_UNDO)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_NO_REPEAT_INSERT)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeEndOfLineAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeEndOfLineAction.kt
@@ -16,7 +16,6 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
-import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MULTIKEY_UNDO
 import com.maddyhome.idea.vim.command.CommandFlags.FLAG_NO_REPEAT_INSERT
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
@@ -27,7 +26,7 @@ import java.util.*
 public class ChangeEndOfLineAction : ChangeEditorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_NO_REPEAT_INSERT, FLAG_MULTIKEY_UNDO)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_NO_REPEAT_INSERT)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeLineAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeLineAction.kt
@@ -17,7 +17,6 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
-import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MULTIKEY_UNDO
 import com.maddyhome.idea.vim.command.CommandFlags.FLAG_NO_REPEAT_INSERT
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
@@ -28,7 +27,7 @@ import java.util.*
 public class ChangeLineAction : ChangeEditorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_NO_REPEAT_INSERT, FLAG_MULTIKEY_UNDO)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_NO_REPEAT_INSERT)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeReplaceAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeReplaceAction.kt
@@ -14,17 +14,12 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 @CommandOrMotion(keys = ["R"], modes = [Mode.NORMAL])
 public class ChangeReplaceAction : ChangeEditorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.CHANGE
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualAction.kt
@@ -28,7 +28,7 @@ import java.util.*
 public class ChangeVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO, CommandFlags.FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualAction.kt
@@ -14,12 +14,9 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 /**
  * @author vlan
@@ -27,8 +24,6 @@ import java.util.*
 @CommandOrMotion(keys = ["c", "s"], modes = [Mode.VISUAL])
 public class ChangeVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualCharacterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualCharacterAction.kt
@@ -34,7 +34,7 @@ public class ChangeVisualCharacterAction : VisualOperatorActionHandler.ForEachCa
 
   override val argumentType: Argument.Type = Argument.Type.DIGRAPH
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_ALLOW_DIGRAPH, CommandFlags.FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_ALLOW_DIGRAPH)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualLinesAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualLinesAction.kt
@@ -17,7 +17,6 @@ import com.maddyhome.idea.vim.api.getLineStartForOffset
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
-import com.maddyhome.idea.vim.command.CommandFlags.FLAG_EXIT_VISUAL
 import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MOT_LINEWISE
 import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MULTIKEY_UNDO
 import com.maddyhome.idea.vim.command.OperatorArguments
@@ -35,7 +34,7 @@ import java.util.*
 public class ChangeVisualLinesAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_MOT_LINEWISE, FLAG_MULTIKEY_UNDO, FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_MOT_LINEWISE, FLAG_MULTIKEY_UNDO)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualLinesAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualLinesAction.kt
@@ -18,7 +18,6 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MOT_LINEWISE
-import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MULTIKEY_UNDO
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.common.TextRange
@@ -34,7 +33,7 @@ import java.util.*
 public class ChangeVisualLinesAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_MOT_LINEWISE, FLAG_MULTIKEY_UNDO)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_MOT_LINEWISE)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualLinesEndAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualLinesEndAction.kt
@@ -18,7 +18,6 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MOT_LINEWISE
-import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MULTIKEY_UNDO
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.common.TextRange
@@ -34,7 +33,7 @@ import java.util.*
 public class ChangeVisualLinesEndAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_MOT_LINEWISE, FLAG_MULTIKEY_UNDO)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_MOT_LINEWISE)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualLinesEndAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualLinesEndAction.kt
@@ -17,7 +17,6 @@ import com.maddyhome.idea.vim.api.getLineStartForOffset
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
-import com.maddyhome.idea.vim.command.CommandFlags.FLAG_EXIT_VISUAL
 import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MOT_LINEWISE
 import com.maddyhome.idea.vim.command.CommandFlags.FLAG_MULTIKEY_UNDO
 import com.maddyhome.idea.vim.command.OperatorArguments
@@ -35,7 +34,7 @@ import java.util.*
 public class ChangeVisualLinesEndAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_MOT_LINEWISE, FLAG_MULTIKEY_UNDO, FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_MOT_LINEWISE, FLAG_MULTIKEY_UNDO)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ReformatCodeVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ReformatCodeVisualAction.kt
@@ -28,7 +28,7 @@ import java.util.*
 public class ReformatCodeVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE, CommandFlags.FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/number/ChangeVisualNumberIncAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/number/ChangeVisualNumberIncAction.kt
@@ -14,16 +14,12 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 public sealed class IncNumber(public val inc: Int, private val avalanche: Boolean) : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/delete/DeleteVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/delete/DeleteVisualAction.kt
@@ -14,12 +14,9 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 /**
  * @author vlan
@@ -27,8 +24,6 @@ import java.util.*
 @CommandOrMotion(keys = ["d", "x", "<Del>"], modes = [Mode.VISUAL])
 public class DeleteVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.DELETE
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/delete/DeleteVisualLinesAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/delete/DeleteVisualLinesAction.kt
@@ -32,7 +32,7 @@ import java.util.*
 public class DeleteVisualLinesAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.DELETE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE, CommandFlags.FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/delete/DeleteVisualLinesEndAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/delete/DeleteVisualLinesEndAction.kt
@@ -32,7 +32,7 @@ import java.util.*
 public class DeleteVisualLinesEndAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.DELETE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE, CommandFlags.FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE)
 
   override fun executeAction(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAfterCursorAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAfterCursorAction.kt
@@ -14,17 +14,12 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 @CommandOrMotion(keys = ["a"], modes = [Mode.NORMAL])
 public class InsertAfterCursorAction : ChangeEditorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAfterLineEndAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAfterLineEndAction.kt
@@ -14,17 +14,12 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 @CommandOrMotion(keys = ["A"], modes = [Mode.NORMAL])
 public class InsertAfterLineEndAction : ChangeEditorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAtPreviousInsertAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAtPreviousInsertAction.kt
@@ -15,18 +15,13 @@ import com.maddyhome.idea.vim.api.VimMarkService
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
 import com.maddyhome.idea.vim.handler.Motion
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 @CommandOrMotion(keys = ["gi"], modes = [Mode.NORMAL])
 public class InsertAtPreviousInsertAction : ChangeEditorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBeforeCursorAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBeforeCursorAction.kt
@@ -14,19 +14,14 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
 import org.jetbrains.annotations.Contract
-import java.util.*
 
 @CommandOrMotion(keys = ["i", "<Insert>"], modes = [Mode.NORMAL])
 public class InsertBeforeCursorAction : ChangeEditorActionHandler.SingleExecution() {
   @get:Contract(pure = true)
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBeforeFirstNonBlankAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBeforeFirstNonBlankAction.kt
@@ -14,17 +14,12 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 @CommandOrMotion(keys = ["I"], modes = [Mode.NORMAL])
 public class InsertBeforeFirstNonBlankAction : ChangeEditorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertLineStartAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertLineStartAction.kt
@@ -14,17 +14,12 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 @CommandOrMotion(keys = ["gI"], modes = [Mode.NORMAL])
 public class InsertLineStartAction : ChangeEditorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertNewLineBelowAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertNewLineBelowAction.kt
@@ -14,19 +14,14 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
-import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.common.Offset
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
+import com.maddyhome.idea.vim.state.mode.Mode
 
 @CommandOrMotion(keys = ["o"], modes = [com.intellij.vim.annotations.Mode.NORMAL])
 public class InsertNewLineBelowAction : ChangeEditorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun execute(
     editor: VimEditor,
@@ -43,8 +38,6 @@ public class InsertNewLineBelowAction : ChangeEditorActionHandler.SingleExecutio
 @CommandOrMotion(keys = ["O"], modes = [com.intellij.vim.annotations.Mode.NORMAL])
 public class InsertNewLineAboveAction : ChangeEditorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun execute(
     editor: VimEditor,
@@ -67,7 +60,7 @@ private fun insertNewLineAbove(editor: VimEditor, context: ExecutionContext) {
   // However, we'll use EditorStartNewLineBefore in PyCharm notebooks where the last character of the previous line
   //   may be locked with a guard
 
-  // Note that we're deliberately bypassing MotionGroup.moveCaret to avoid side effects, most notably unncessary
+  // Note that we're deliberately bypassing MotionGroup.moveCaret to avoid side effects, most notably unnecessary
   // scrolling
   val firstLiners: MutableSet<VimCaret> = HashSet()
   val moves: MutableSet<Pair<VimCaret, Int>> = HashSet()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/VisualBlockAppendAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/VisualBlockAppendAction.kt
@@ -14,13 +14,10 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
-import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
+import com.maddyhome.idea.vim.state.mode.SelectionType
 
 /**
  * @author vlan
@@ -28,8 +25,6 @@ import java.util.*
 @CommandOrMotion(keys = ["A"], modes = [Mode.VISUAL])
 public class VisualBlockAppendAction : VisualOperatorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun executeForAllCarets(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/VisualBlockAppendAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/VisualBlockAppendAction.kt
@@ -29,7 +29,7 @@ import java.util.*
 public class VisualBlockAppendAction : VisualOperatorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO, CommandFlags.FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun executeForAllCarets(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/VisualBlockInsertAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/VisualBlockInsertAction.kt
@@ -29,7 +29,7 @@ import java.util.*
 public class VisualBlockInsertAction : VisualOperatorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO, CommandFlags.FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun executeForAllCarets(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/VisualBlockInsertAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/VisualBlockInsertAction.kt
@@ -14,13 +14,10 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
-import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
+import com.maddyhome.idea.vim.state.mode.SelectionType
 
 /**
  * @author vlan
@@ -28,8 +25,6 @@ import java.util.*
 @CommandOrMotion(keys = ["I"], modes = [Mode.VISUAL])
 public class VisualBlockInsertAction : VisualOperatorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MULTIKEY_UNDO)
 
   override fun executeForAllCarets(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/shift/ShiftLeft.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/shift/ShiftLeft.kt
@@ -71,8 +71,6 @@ public class ShiftLeftMotionAction : ChangeEditorActionHandler.ForEachCaret(), D
 public class ShiftLeftVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
-
   override fun executeAction(
     editor: VimEditor,
     caret: VimCaret,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/shift/ShiftRight.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/shift/ShiftRight.kt
@@ -71,8 +71,6 @@ public class ShiftRightMotionAction : ChangeEditorActionHandler.ForEachCaret(), 
 public class ShiftRightVisualAction : VisualOperatorActionHandler.ForEachCaret() {
   override val type: Command.Type = Command.Type.CHANGE
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
-
   override fun executeAction(
     editor: VimEditor,
     caret: VimCaret,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/copy/PutVisualTextAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/copy/PutVisualTextAction.kt
@@ -15,13 +15,10 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
 import com.maddyhome.idea.vim.put.PutData
-import java.util.*
 
 /**
  * @author vlan
@@ -34,8 +31,6 @@ public sealed class PutVisualTextBaseAction(
 ) : VisualOperatorActionHandler.SingleExecution() {
 
   override val type: Command.Type = Command.Type.OTHER_SELF_SYNCHRONIZED
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeForAllCarets(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/copy/YankVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/copy/YankVisualAction.kt
@@ -14,13 +14,10 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.enumSetOf
-import java.util.*
 
 /**
  * @author vlan
@@ -28,8 +25,6 @@ import java.util.*
 @CommandOrMotion(keys = ["y"], modes = [Mode.VISUAL])
 public class YankVisualAction : VisualOperatorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.COPY
-
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_EXIT_VISUAL)
 
   override fun executeForAllCarets(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/copy/YankVisualLinesAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/copy/YankVisualLinesAction.kt
@@ -30,7 +30,7 @@ import java.util.*
 public class YankVisualLinesAction : VisualOperatorActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.COPY
 
-  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE, CommandFlags.FLAG_EXIT_VISUAL)
+  override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_MOT_LINEWISE)
 
   override fun executeForAllCarets(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
@@ -127,7 +127,6 @@ public interface VimEditor {
 
   public val lfMakesNewLine: Boolean
   public var vimChangeActionSwitchMode: Mode?
-  public var vimKeepingVisualOperatorAction: Boolean
 
   public fun fileSize(): Long
 
@@ -242,7 +241,7 @@ public interface VimEditor {
 
   public fun getPath(): String?
   public fun extractProtocol(): String?
-  
+
   // Can be used as a key to store something for specific project
   public val projectId: String
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandFlags.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandFlags.kt
@@ -64,11 +64,6 @@ public enum class CommandFlags {
   FLAG_IGNORE_SIDE_SCROLL_JUMP,
 
   /**
-   * Command exits the visual mode, so caret movement shouldn't update visual selection
-   */
-  FLAG_EXIT_VISUAL,
-
-  /**
    * This command starts a multi-command undo transaction
    */
   FLAG_MULTIKEY_UNDO,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandFlags.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandFlags.kt
@@ -64,11 +64,6 @@ public enum class CommandFlags {
   FLAG_IGNORE_SIDE_SCROLL_JUMP,
 
   /**
-   * This command starts a multi-command undo transaction
-   */
-  FLAG_MULTIKEY_UNDO,
-
-  /**
    * This command should be followed by another command
    */
   FLAG_EXPECT_MORE,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
@@ -232,7 +232,6 @@ public sealed class VisualOperatorActionHandler : EditorActionHandlerBase(false)
 
     fun start() {
       logger.debug("Preparing visual command")
-      editor.vimKeepingVisualOperatorAction = false //CommandFlags.FLAG_EXIT_VISUAL !in cmd.flags
 
       editor.forEachCaret {
         val change =
@@ -268,8 +267,6 @@ public sealed class VisualOperatorActionHandler : EditorActionHandlerBase(false)
           }
         }
       }
-
-      editor.vimKeepingVisualOperatorAction = false
     }
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
@@ -238,16 +238,16 @@ public sealed class VisualOperatorActionHandler : EditorActionHandlerBase(false)
 
       editor.forEachCaret {
         val change =
-          if (this@VisualStartFinishWrapper.editor.inVisualMode && !this@VisualStartFinishWrapper.editor.inRepeatMode) {
-            VisualOperation.getRange(this@VisualStartFinishWrapper.editor, it, this@VisualStartFinishWrapper.cmd.flags)
+          if (editor.inVisualMode && !editor.inRepeatMode) {
+            VisualOperation.getRange(editor, it, cmd.flags)
           } else {
             null
           }
-        this@VisualStartFinishWrapper.visualChanges[it] = change
+        visualChanges[it] = change
       }
       logger.debug { visualChanges.values.joinToString("\n") { "Caret: $visualChanges" } }
 
-      // If this is a mutli key change then exit visual now
+      // If this is a multi key change then exit visual now
       if (CommandFlags.FLAG_MULTIKEY_UNDO in cmd.flags || CommandFlags.FLAG_EXIT_VISUAL in cmd.flags) {
         logger.debug("Exit visual before command executing")
         editor.exitVisualMode()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
@@ -247,11 +247,8 @@ public sealed class VisualOperatorActionHandler : EditorActionHandlerBase(false)
       }
       logger.debug { visualChanges.values.joinToString("\n") { "Caret: $visualChanges" } }
 
-      // If this is a multi key change then exit visual now
-      if (CommandFlags.FLAG_MULTIKEY_UNDO in cmd.flags || true /* CommandFlags.FLAG_EXIT_VISUAL in cmd.flags */) {
-        logger.debug("Exit visual before command executing")
-        editor.exitVisualMode()
-      }
+      logger.debug("Exit visual before command executing")
+      editor.exitVisualMode()
     }
 
     fun finish(res: Boolean) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/VisualOperatorActionHandler.kt
@@ -234,7 +234,7 @@ public sealed class VisualOperatorActionHandler : EditorActionHandlerBase(false)
 
     fun start() {
       logger.debug("Preparing visual command")
-      editor.vimKeepingVisualOperatorAction = CommandFlags.FLAG_EXIT_VISUAL !in cmd.flags
+      editor.vimKeepingVisualOperatorAction = false //CommandFlags.FLAG_EXIT_VISUAL !in cmd.flags
 
       editor.forEachCaret {
         val change =
@@ -248,7 +248,7 @@ public sealed class VisualOperatorActionHandler : EditorActionHandlerBase(false)
       logger.debug { visualChanges.values.joinToString("\n") { "Caret: $visualChanges" } }
 
       // If this is a multi key change then exit visual now
-      if (CommandFlags.FLAG_MULTIKEY_UNDO in cmd.flags || CommandFlags.FLAG_EXIT_VISUAL in cmd.flags) {
+      if (CommandFlags.FLAG_MULTIKEY_UNDO in cmd.flags || true /* CommandFlags.FLAG_EXIT_VISUAL in cmd.flags */) {
         logger.debug("Exit visual before command executing")
         editor.exitVisualMode()
       }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineModeExtensions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineModeExtensions.kt
@@ -27,9 +27,7 @@ public fun VimEditor.exitVisualMode() {
     if (inBlockSelection) {
       this.removeSecondaryCarets()
     }
-    if (!this.vimKeepingVisualOperatorAction) {
-      this.nativeCarets().forEach(VimCaret::removeSelection)
-    }
+    this.nativeCarets().forEach(VimCaret::removeSelection)
   }
   if (this.inVisualMode) {
     this.vimLastSelectionType = selectionType

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/OperatorFunction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/OperatorFunction.kt
@@ -22,6 +22,4 @@ public interface OperatorFunction {
    * Make sure to synchronize your function properly using read/write actions.
    */
   public fun apply(editor: VimEditor, context: ExecutionContext, selectionType: SelectionType?): Boolean
-
-  public fun postProcessSelection(): Boolean = true
 }


### PR DESCRIPTION
This PR removes the `CommandFlags.FLAG_EXIT_VISUAL` and `CommandFlags.FLAG_MULTIKEY_UNDO` enum values.

The `FLAG_EXIT_VISUAL` enum value was used to decide if a visual operator should exit visual mode. All visual operators derive from `VisualOperatorActionHandler` and all had `FLAG_EXIT_VISUAL`, so the conditional behaviour can be made default, and the flag removed. Note that visual motions (such as `v_w`) are not visual operators, don't use the same codepath, and don't require the flag.

The visual operator handler also included logic to exit visual mode _after_ executing the operator, as well as before. This second mode reset is not required - we are no longer in visual mode at this time, unless the operator puts us there. By making it the responsibility of the visual operator implementation to ensure the correct mode, we can remove this check.

This simplifies `OperatorFunction`, which no longer needs `postProcessSelection` to help decide if we should exit visual mode. (This was required for the Commentary extension to allow keeping the selection while waiting for Rider's async line/block comment actions to complete).

Removing the check also removes the only usage of `FLAG_MULTIKEY_UNDO` outside of command declarations. It is unclear what this flag was intended for, but since it is no longer checked anywhere, it can be removed.

Finally, because all visual operators had `FLAG_EXIT_VISUAL`, the `editor.vimKeepingVisualOperatorAction` flag set as part of the visual operator execution would always be `false`. Since the flag is not set anywhere else, it can be removed too.