### PR TITLE
Introduce 'operatorfunc' option for custom operators

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/change/OperatorAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/change/OperatorAction.kt
@@ -14,6 +14,7 @@ import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.setChangeMarks
 import com.maddyhome.idea.vim.command.Argument
@@ -21,6 +22,7 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.common.argumentCaptured
+import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.group.MotionGroup
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VimActionHandler
@@ -29,9 +31,62 @@ import com.maddyhome.idea.vim.helper.MessageHelper
 import com.maddyhome.idea.vim.helper.vimStateMachine
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.state.mode.SelectionType
+import com.maddyhome.idea.vim.vimscript.model.CommandLineVimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimFuncref
+import com.maddyhome.idea.vim.vimscript.model.expressions.FunctionCallExpression
+import com.maddyhome.idea.vim.vimscript.model.expressions.SimpleExpression
 
 // todo make it multicaret
 private fun doOperatorAction(editor: VimEditor, context: ExecutionContext, textRange: TextRange, selectionType: SelectionType): Boolean {
+  val func = injector.globalOptions().operatorfunc
+  if (func.isNotEmpty()) {
+    val scriptContext = CommandLineVimLContext
+
+    // The option value is either a function name, which should have a handler, or it might be a lambda expression, or a
+    // `function` or `funcref` call expression, all of which will return a funcref (with a handler)
+    var handler = injector.functionService.getFunctionHandlerOrNull(null, func, scriptContext)
+    if (handler == null) {
+      val expression = injector.vimscriptParser.parseExpression(func)
+      if (expression != null) {
+        try {
+          val value = expression.evaluate(editor, context, scriptContext)
+          if (value is VimFuncref) {
+            handler = value.handler
+          }
+        } catch (ex: ExException) {
+          // Get the argument for function('...') or funcref('...') for the error message
+          val functionName = if (expression is FunctionCallExpression && expression.arguments.size > 0) {
+            expression.arguments[0].evaluate(editor, context, scriptContext).toString()
+          }
+          else {
+            func
+          }
+          VimPlugin.showMessage("E117: Unknown function: $functionName")
+          return false
+        }
+      }
+    }
+
+    if (handler != null) {
+      val arg = when (selectionType) {
+        SelectionType.LINE_WISE -> "line"
+        SelectionType.CHARACTER_WISE -> "char"
+        SelectionType.BLOCK_WISE -> "block"
+      }
+
+      val saveRepeatHandler = VimRepeater.repeatHandler
+      injector.markService.setChangeMarks(editor.primaryCaret(), textRange)
+      KeyHandler.getInstance().reset(editor)
+
+      val arguments = listOf(SimpleExpression(arg))
+      handler.executeFunction(arguments, editor, context, scriptContext)
+
+      VimRepeater.repeatHandler = saveRepeatHandler
+      return true
+    }
+  }
+
+  // TODO: Migrate extensions to use operatorfunc
   val operatorFunction = injector.keyGroup.operatorFunction
   if (operatorFunction == null) {
     VimPlugin.showMessage(MessageHelper.message("E774"))

--- a/src/main/java/com/maddyhome/idea/vim/extension/VimExtensionFacade.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/VimExtensionFacade.kt
@@ -14,21 +14,34 @@ import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.action.change.Extension
+import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.ImmutableVimCaret
 import com.maddyhome.idea.vim.api.VimCaret
+import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.MappingMode
 import com.maddyhome.idea.vim.common.CommandAlias
 import com.maddyhome.idea.vim.common.CommandAliasHandler
+import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.helper.CommandLineHelper
 import com.maddyhome.idea.vim.helper.TestInputModel
+import com.maddyhome.idea.vim.helper.noneOfEnum
 import com.maddyhome.idea.vim.helper.vimStateMachine
 import com.maddyhome.idea.vim.key.MappingOwner
 import com.maddyhome.idea.vim.key.OperatorFunction
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.ui.ModalEntry
+import com.maddyhome.idea.vim.vimscript.model.Executable
+import com.maddyhome.idea.vim.vimscript.model.ExecutionResult
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDataType
+import com.maddyhome.idea.vim.vimscript.model.expressions.Expression
+import com.maddyhome.idea.vim.vimscript.model.expressions.Scope
+import com.maddyhome.idea.vim.vimscript.model.statements.FunctionDeclaration
+import com.maddyhome.idea.vim.vimscript.model.statements.FunctionFlag
 import java.awt.event.KeyEvent
+import java.util.*
 import javax.swing.KeyStroke
 
 /**
@@ -120,12 +133,6 @@ public object VimExtensionFacade {
       .setAlias(name, CommandAlias.Call(minimumNumberOfArguments, maximumNumberOfArguments, name, handler))
   }
 
-  /** Sets the value of 'operatorfunc' to be used as the operator function in 'g@'. */
-  @JvmStatic
-  public fun setOperatorFunction(function: OperatorFunction) {
-    VimPlugin.getKey().operatorFunction = function
-  }
-
   /**
    * Runs normal mode commands similar to ':normal! {commands}'.
    * Mappings doesn't work with this function
@@ -207,4 +214,65 @@ public object VimExtensionFacade {
   public fun setRegister(register: Char, keys: List<KeyStroke?>?, type: SelectionType) {
     VimPlugin.getRegister().setKeys(register, keys?.filterNotNull() ?: emptyList(), type)
   }
+
+  @JvmStatic
+  public fun exportScriptFunction(
+    scope: Scope?,
+    name: String,
+    args: List<String>,
+    defaultArgs: List<Pair<String, Expression>>,
+    hasOptionalArguments: Boolean,
+    flags: EnumSet<FunctionFlag>,
+    function: ScriptFunction
+  ) {
+    var functionDeclaration: FunctionDeclaration? = null
+    val body = listOf(object : Executable {
+      // This context is set to the function declaration during initialisation and then set to the function execution
+      // context during execution
+      override lateinit var vimContext: VimLContext
+      override var rangeInScript: TextRange = TextRange(0, 0)
+
+      override fun execute(editor: VimEditor, context: ExecutionContext): ExecutionResult {
+        return function.execute(editor, context, functionDeclaration!!.functionVariables)
+      }
+    })
+    functionDeclaration = FunctionDeclaration(
+      scope,
+      name,
+      args,
+      defaultArgs,
+      body,
+      replaceExisting = true,
+      flags,
+      hasOptionalArguments
+    )
+    functionDeclaration.rangeInScript = TextRange(0, 0)
+    body.forEach { it.vimContext = functionDeclaration }
+    injector.functionService.storeFunction(functionDeclaration)
+  }
+}
+
+public fun VimExtensionFacade.exportOperatorFunction(name: String, function: OperatorFunction) {
+  exportScriptFunction(null, name, listOf("type"), emptyList(), false, noneOfEnum()) {
+    editor, context, args ->
+
+    val type = args["type"]?.asString()
+    val selectionType = when (type) {
+      "line" -> SelectionType.LINE_WISE
+      "block" -> SelectionType.BLOCK_WISE
+      "char" -> SelectionType.CHARACTER_WISE
+      else -> return@exportScriptFunction ExecutionResult.Error
+    }
+
+    if (function.apply(editor, context, selectionType)) {
+      ExecutionResult.Success
+    }
+    else {
+      ExecutionResult.Error
+    }
+  }
+}
+
+public fun interface ScriptFunction {
+  public fun execute(editor: VimEditor, context: ExecutionContext, args: Map<String, VimDataType>): ExecutionResult
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
@@ -16,6 +16,7 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.endsWithNewLine
 import com.maddyhome.idea.vim.api.getLeadingCharacterOffset
+import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.setChangeMarks
 import com.maddyhome.idea.vim.command.MappingMode
@@ -23,14 +24,16 @@ import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.extension.ExtensionHandler
 import com.maddyhome.idea.vim.extension.VimExtension
+import com.maddyhome.idea.vim.extension.VimExtensionFacade
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.executeNormalWithoutMapping
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.getRegisterForCaret
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.inputKeyStroke
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.inputString
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.putExtensionHandlerMapping
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMappingIfMissing
-import com.maddyhome.idea.vim.extension.VimExtensionFacade.setOperatorFunction
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.setRegisterForCaret
+import com.maddyhome.idea.vim.extension.exportOperatorFunction
+import com.maddyhome.idea.vim.state.mode.mode
 import com.maddyhome.idea.vim.key.OperatorFunction
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.newapi.vim
@@ -74,13 +77,15 @@ internal class VimSurroundExtension : VimExtension {
       putKeyMappingIfMissing(MappingMode.N, injector.parser.parseKeys("ds"), owner, injector.parser.parseKeys("<Plug>DSurround"), true)
       putKeyMappingIfMissing(MappingMode.XO, injector.parser.parseKeys("S"), owner, injector.parser.parseKeys("<Plug>VSurround"), true)
     }
+
+    VimExtensionFacade.exportOperatorFunction(OPERATOR_FUNC, Operator())
   }
 
   private class YSurroundHandler : ExtensionHandler {
     override val isRepeatable = true
 
     override fun execute(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments) {
-      setOperatorFunction(Operator())
+      injector.globalOptions().operatorfunc = OPERATOR_FUNC
       executeNormalWithoutMapping(injector.parser.parseKeys("g@"), editor.ij)
     }
   }
@@ -288,7 +293,9 @@ private val LOG = logger<VimSurroundExtension>()
 
 private const val REGISTER = '"'
 
-private val tagNameAndAttributesCapturePattern = "(\\S+)([^>]*)>".toPattern()
+private const val OPERATOR_FUNC = "SurroundOperatorFunc"
+
+    private val tagNameAndAttributesCapturePattern = "(\\S+)([^>]*)>".toPattern()
 
 private val SURROUND_PAIRS = mapOf(
   'b' to ("(" to ")"),

--- a/src/main/java/com/maddyhome/idea/vim/group/IjOptionProperties.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjOptionProperties.kt
@@ -20,7 +20,6 @@ import com.maddyhome.idea.vim.options.OptionAccessScope
  */
 @Suppress("SpellCheckingInspection")
 public open class GlobalIjOptions(scope: OptionAccessScope) : OptionsPropertiesBase(scope) {
-  public var closenotebooks: Boolean by optionProperty(IjOptions.closenotebooks)
   public var ide: String by optionProperty(IjOptions.ide)
   public var ideamarks: Boolean by optionProperty(IjOptions.ideamarks)
   public var ideastatusicon: String by optionProperty(IjOptions.ideastatusicon)
@@ -29,15 +28,16 @@ public open class GlobalIjOptions(scope: OptionAccessScope) : OptionsPropertiesB
   public val lookupkeys: StringListOptionValue by optionProperty(IjOptions.lookupkeys)
   public var trackactionids: Boolean by optionProperty(IjOptions.trackactionids)
   public var visualdelay: Int by optionProperty(IjOptions.visualdelay)
-  public var showmodewidget: Boolean by optionProperty(IjOptions.showmodewidget)
 
   // Temporary options to control work-in-progress behaviour
-  public var oldundo: Boolean by optionProperty(IjOptions.oldundo)
-  public var unifyjumps: Boolean by optionProperty(IjOptions.unifyjumps)
-  public var exCommandAnnotation: Boolean by optionProperty(IjOptions.exCommandAnnotation)
-  public var vimscriptFunctionAnnotation: Boolean by optionProperty(IjOptions.vimscriptFunctionAnnotation)
+  public var closenotebooks: Boolean by optionProperty(IjOptions.closenotebooks)
   public var commandOrMotionAnnotation: Boolean by optionProperty(IjOptions.commandOrMotionAnnotation)
+  public var exCommandAnnotation: Boolean by optionProperty(IjOptions.exCommandAnnotation)
+  public var oldundo: Boolean by optionProperty(IjOptions.oldundo)
+  public var showmodewidget: Boolean by optionProperty(IjOptions.showmodewidget)
+  public var unifyjumps: Boolean by optionProperty(IjOptions.unifyjumps)
   public var useNewRegex: Boolean by optionProperty(IjOptions.useNewRegex)
+  public var vimscriptFunctionAnnotation: Boolean by optionProperty(IjOptions.vimscriptFunctionAnnotation)
 }
 
 /**

--- a/src/main/java/com/maddyhome/idea/vim/group/IjOptions.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjOptions.kt
@@ -33,8 +33,6 @@ public object IjOptions {
     Options.overrideDefaultValue(Options.clipboard, VimString("ideaput,autoselect,exclude:cons\\|linux"))
   }
 
-  public val closenotebooks: ToggleOption = addOption(ToggleOption("closenotebooks", GLOBAL, "closenotebooks", true))
-  public val exCommandAnnotation: ToggleOption = addOption(ToggleOption("excommandannotation", GLOBAL, "excommandannotation", true))
   public val ide: StringOption = addOption(
     StringOption("ide", GLOBAL, "ide", ApplicationNamesInfo.getInstance().fullProductNameWithEdition)
   )
@@ -81,13 +79,17 @@ public object IjOptions {
       "<Tab>,<Down>,<Up>,<Enter>,<Left>,<Right>,<C-Down>,<C-Up>,<PageUp>,<PageDown>,<C-J>,<C-Q>")
   )
   public val trackactionids: ToggleOption = addOption(ToggleOption("trackactionids", GLOBAL, "tai", false))
-  public val unifyjumps: ToggleOption = addOption(ToggleOption("unifyjumps", GLOBAL, "unifyjumps", true))
   public val visualdelay: UnsignedNumberOption = addOption(UnsignedNumberOption("visualdelay", GLOBAL, "visualdelay", 100))
-  public val oldundo: ToggleOption = addOption(ToggleOption("oldundo", GLOBAL, "oldundo", false, isTemporary = true))
-  public val vimscriptFunctionAnnotation: ToggleOption = addOption(ToggleOption("vimscriptfunctionannotation", GLOBAL, "vimscriptfunctionannotation", true, isTemporary = true))
-  public val commandOrMotionAnnotation: ToggleOption = addOption(ToggleOption("commandormotionannotation", GLOBAL, "commandormotionannotation", true, isTemporary = true))
-  public val showmodewidget: ToggleOption = addOption(ToggleOption("showmodewidget", GLOBAL, "showmodewidget", false, isTemporary = true))
-  public val useNewRegex: ToggleOption = addOption(ToggleOption("usenewregex", GLOBAL, "usenewregex", true, isTemporary = true))
+
+  // Temporary feature flags during development, not really intended for external use
+  public val closenotebooks: ToggleOption = addOption(ToggleOption("closenotebooks", GLOBAL, "closenotebooks", true, isHidden = true))
+  public val commandOrMotionAnnotation: ToggleOption = addOption(ToggleOption("commandormotionannotation", GLOBAL, "commandormotionannotation", true, isHidden = true))
+  public val exCommandAnnotation: ToggleOption = addOption(ToggleOption("excommandannotation", GLOBAL, "excommandannotation", true, isHidden = true))
+  public val oldundo: ToggleOption = addOption(ToggleOption("oldundo", GLOBAL, "oldundo", false, isHidden = true))
+  public val showmodewidget: ToggleOption = addOption(ToggleOption("showmodewidget", GLOBAL, "showmodewidget", false, isHidden = true))
+  public val unifyjumps: ToggleOption = addOption(ToggleOption("unifyjumps", GLOBAL, "unifyjumps", true, isHidden = true))
+  public val useNewRegex: ToggleOption = addOption(ToggleOption("usenewregex", GLOBAL, "usenewregex", true, isHidden = true))
+  public val vimscriptFunctionAnnotation: ToggleOption = addOption(ToggleOption("vimscriptfunctionannotation", GLOBAL, "vimscriptfunctionannotation", true, isHidden = true))
 
   // This needs to be Option<out VimDataType> so that it can work with derived option types, such as NumberOption, which
   // derives from Option<VimInt>

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimApplication.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimApplication.kt
@@ -43,6 +43,10 @@ internal class IjVimApplication : VimApplicationBase() {
     return ApplicationManager.getApplication().isUnitTestMode
   }
 
+  override fun isInternal(): Boolean {
+    return ApplicationManager.getApplication().isInternal
+  }
+
   override fun postKey(stroke: KeyStroke, editor: VimEditor) {
     val component: Component = SwingUtilities.getAncestorOfClass(Window::class.java, editor.ij.component)
     val event = createKeyEvent(stroke, component)

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/OperatorActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/OperatorActionTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2003-2023 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action.change
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class OperatorActionTest : VimTestCase() {
+  @Test
+  fun `test operator action throws error if operatorfunc is empty`() {
+    doTest("g@w", "lorem ipsum", "lorem ipsum")
+    assertPluginErrorMessageContains("E774: 'operatorfunc' is empty")
+  }
+
+  @Test
+  fun `test operator action throws error if operatorfunc is name of unknown function`() {
+    doTest("g@w", "lorem ipsum", "lorem ipsum") {
+      enterCommand("set operatorfunc=Foo")
+    }
+    assertPluginErrorMessageContains("E117: Unknown function: Foo")
+  }
+
+  @Test
+  fun `test operator action with function name`() {
+    doTest("gxe",
+      "lorem ipsum dolor sit amet",
+      "xxxxx ipsum dolor sit amet"
+      ) {
+      executeVimscript("""function! Redact(type)
+        |  execute "normal `[v`]rx"
+        |endfunction
+      """.trimMargin())
+      enterCommand("noremap gx :set opfunc=Redact<CR>g@")
+    }
+  }
+
+  @Test
+  fun `test operator action with character wise motion`() {
+    doTest("gxe",
+      "lorem ipsum dolor sit amet",
+      "charlorem ipsum dolor sit amet"
+    ) {
+      executeVimscript("""function! Redact(type)
+        |  execute "normal i" . a:type
+        |endfunction
+      """.trimMargin())
+      enterCommand("noremap gx :set opfunc=Redact<CR>g@")
+    }
+  }
+
+  @Test
+  fun `test operator action with linewise motion`() {
+    doTest("Vgx",
+      "lorem ipsum dolor sit amet",
+      "linelorem ipsum dolor sit amet"
+    ) {
+      executeVimscript("""function! Redact(type)
+        |  execute "normal i" . a:type
+        |endfunction
+      """.trimMargin())
+      enterCommand("noremap gx <Esc>:set opfunc=Redact<CR>gvg@")
+    }
+  }
+
+  @Test
+  fun `test operator action with blockwise motion`() {
+    doTest("<C-V>gx",
+      "lorem ipsum dolor sit amet",
+      "blocklorem ipsum dolor sit amet"
+    ) {
+      executeVimscript("""function! Redact(type)
+        |  execute "normal i" . a:type
+        |endfunction
+      """.trimMargin())
+      enterCommand("noremap gx <Esc>:set opfunc=Redact<CR>gvg@")
+    }
+  }
+
+  @Test
+  fun `test operator action with function`() {
+    doTest("gxe",
+      "lorem ipsum dolor sit amet",
+      "xxxxx ipsum dolor sit amet"
+    ) {
+      executeVimscript("""function! Redact(type)
+        |  execute "normal `[v`]rx"
+        |endfunction
+      """.trimMargin())
+      enterCommand("noremap gx :set opfunc=function('Redact')<CR>g@")
+    }
+  }
+
+  @Test
+  fun `test operator action throws error with unknown function`() {
+    doTest("gxe",
+      "lorem ipsum dolor sit amet",
+      "lorem ipsum dolor sit amet"
+    ) {
+      enterCommand("noremap gx :set opfunc=function('Foo')<CR>g@")
+    }
+    assertPluginErrorMessageContains("E117: Unknown function: Foo")
+  }
+
+  @Test
+  fun `test operator function with funcref`() {
+    doTest("gxe",
+      "lorem ipsum dolor sit amet",
+      "xxxxx ipsum dolor sit amet"
+    ) {
+      executeVimscript("""function! Redact(type)
+        |  execute "normal `[v`]rx"
+        |endfunction
+      """.trimMargin())
+      enterCommand("noremap gx :set opfunc=funcref('Redact')<CR>g@")
+    }
+  }
+
+  @Test
+  fun `test operator action throws error with unknown function ref`() {
+    doTest("gxe",
+      "lorem ipsum dolor sit amet",
+      "lorem ipsum dolor sit amet"
+    ) {
+      enterCommand("noremap gx :set opfunc=funcref('Foo')<CR>g@")
+    }
+    assertPluginErrorMessageContains("E117: Unknown function: Foo")
+  }
+
+  @Test
+  @Disabled(":set does not correctly parse the quotes in the lambda syntax")
+  // The parser is treating the second double-quote char as a comment. The argument to the command is parsed as:
+  // opfunc={ arg -> execute "`[v`]rx
+  // The map command is properly handled - the `<CR>g@` is correctly understood, and the full lambda is passed to the
+  // parser, but the parser does not fully handle the text
+  fun `test operator function with lambda`() {
+    doTest("gxe",
+      "lorem ipsum dolor sit amet",
+      "lorem ipsum dolor sit amet"
+    ) {
+      enterCommand("noremap gx :set opfunc={ arg -> execute \"`[v`]rx\" }<CR>g@")
+    }
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -153,7 +153,7 @@ class SetCommandTest : VimTestCase() {
     assertCommandOutput("set",
       """
         |--- Options ---
-        |  ideastrictmode      number              relativenumber
+        |  number              relativenumber
         |
       """.trimMargin())
   }
@@ -164,22 +164,20 @@ class SetCommandTest : VimTestCase() {
     assertCommandOutput("set all",
       """
         |--- Options ---
-        |noargtextobj          ideawrite=all       scrolljump=1      notextobj-entire
-        |  closenotebooks    noignorecase          scrolloff=0       notextobj-indent
-        |nocommentary        noincsearch           selectmode=         timeout
-        |nodigraph           nomatchit             shellcmdflag=-x     timeoutlen=1000
-        |noexchange            maxmapdepth=20      shellxescape=@    notrackactionids
-        |nogdefault            more                shellxquote={       undolevels=1000
-        |nohighlightedyank   nomultiple-cursors    showcmd             unifyjumps
-        |  history=50        noNERDTree            showmode            virtualedit=
-        |nohlsearch            nrformats=hex       sidescroll=0      novisualbell
-        |noideaglobalmode    nonumber              sidescrolloff=0     visualdelay=100
-        |noideajoin            octopushandler    nosmartcase           whichwrap=b,s
-        |  ideamarks           operatorfunc=     nosneak               wrapscan
-        |  ideastrictmode    norelativenumber      startofline
-        |noideatracetime       scroll=0          nosurround
+        |noargtextobj        noincsearch           selectmode=       notextobj-indent
+        |nocommentary        nomatchit             shellcmdflag=-x     timeout
+        |nodigraph             maxmapdepth=20      shellxescape=@      timeoutlen=1000
+        |noexchange            more                shellxquote={     notrackactionids
+        |nogdefault          nomultiple-cursors    showcmd             undolevels=1000
+        |nohighlightedyank   noNERDTree            showmode            virtualedit=
+        |  history=50          nrformats=hex       sidescroll=0      novisualbell
+        |nohlsearch          nonumber              sidescrolloff=0     visualdelay=100
+        |noideaglobalmode      operatorfunc=     nosmartcase           whichwrap=b,s
+        |noideajoin          norelativenumber    nosneak               wrapscan
+        |  ideamarks           scroll=0            startofline
+        |  ideawrite=all       scrolljump=1      nosurround
+        |noignorecase          scrolloff=0       notextobj-entire
         |  clipboard=ideaput,autoselect,exclude:cons\|linux
-        |  excommandannotation
         |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
         |  ide=IntelliJ IDEA Community Edition
         |noideacopypreprocess
@@ -213,7 +211,6 @@ class SetCommandTest : VimTestCase() {
     assertCommandOutput("set!",
       """
       |--- Options ---
-      |  ideastrictmode
       |  number
       |  relativenumber
       |""".trimMargin()
@@ -227,11 +224,9 @@ class SetCommandTest : VimTestCase() {
       |--- Options ---
       |noargtextobj
       |  clipboard=ideaput,autoselect,exclude:cons\|linux
-      |  closenotebooks
       |nocommentary
       |nodigraph
       |noexchange
-      |  excommandannotation
       |nogdefault
       |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
       |nohighlightedyank
@@ -244,8 +239,6 @@ class SetCommandTest : VimTestCase() {
       |  ideamarks
       |  idearefactormode=select
       |  ideastatusicon=enabled
-      |  ideastrictmode
-      |noideatracetime
       |  ideavimsupport=dialog
       |  ideawrite=all
       |noignorecase
@@ -261,7 +254,6 @@ class SetCommandTest : VimTestCase() {
       |noNERDTree
       |  nrformats=hex
       |nonumber
-      |  octopushandler
       |  operatorfunc=
       |norelativenumber
       |noReplaceWithRegister
@@ -288,7 +280,6 @@ class SetCommandTest : VimTestCase() {
       |  timeoutlen=1000
       |notrackactionids
       |  undolevels=1000
-      |  unifyjumps
       |novim-paragraph-motion
       |  viminfo='100,<50,s10,h
       |  virtualedit=

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -164,20 +164,20 @@ class SetCommandTest : VimTestCase() {
     assertCommandOutput("set all",
       """
         |--- Options ---
-        |noargtextobj          ideawrite=all       scrolloff=0       notextobj-indent
-        |  closenotebooks    noignorecase          selectmode=         timeout
-        |nocommentary        noincsearch           shellcmdflag=-x     timeoutlen=1000
-        |nodigraph           nomatchit             shellxescape=@    notrackactionids
-        |noexchange            maxmapdepth=20      shellxquote={       undolevels=1000
-        |nogdefault            more                showcmd             unifyjumps
-        |nohighlightedyank   nomultiple-cursors    showmode            virtualedit=
-        |  history=50        noNERDTree            sidescroll=0      novisualbell
-        |nohlsearch            nrformats=hex       sidescrolloff=0     visualdelay=100
-        |noideaglobalmode    nonumber            nosmartcase           whichwrap=b,s
-        |noideajoin            octopushandler    nosneak               wrapscan
-        |  ideamarks         norelativenumber      startofline
-        |  ideastrictmode      scroll=0          nosurround
-        |noideatracetime       scrolljump=1      notextobj-entire
+        |noargtextobj          ideawrite=all       scrolljump=1      notextobj-entire
+        |  closenotebooks    noignorecase          scrolloff=0       notextobj-indent
+        |nocommentary        noincsearch           selectmode=         timeout
+        |nodigraph           nomatchit             shellcmdflag=-x     timeoutlen=1000
+        |noexchange            maxmapdepth=20      shellxescape=@    notrackactionids
+        |nogdefault            more                shellxquote={       undolevels=1000
+        |nohighlightedyank   nomultiple-cursors    showcmd             unifyjumps
+        |  history=50        noNERDTree            showmode            virtualedit=
+        |nohlsearch            nrformats=hex       sidescroll=0      novisualbell
+        |noideaglobalmode    nonumber              sidescrolloff=0     visualdelay=100
+        |noideajoin            octopushandler    nosmartcase           whichwrap=b,s
+        |  ideamarks           operatorfunc=     nosneak               wrapscan
+        |  ideastrictmode    norelativenumber      startofline
+        |noideatracetime       scroll=0          nosurround
         |  clipboard=ideaput,autoselect,exclude:cons\|linux
         |  excommandannotation
         |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
@@ -262,6 +262,7 @@ class SetCommandTest : VimTestCase() {
       |  nrformats=hex
       |nonumber
       |  octopushandler
+      |  operatorfunc=
       |norelativenumber
       |noReplaceWithRegister
       |  scroll=0

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
@@ -328,7 +328,6 @@ class SetglobalCommandTest : VimTestCase() {
   fun `test show all modified global option values`() {
     assertCommandOutput("setglobal", """
       |--- Global option values ---
-      |  ideastrictmode
       |""".trimMargin()
     )
   }
@@ -338,8 +337,7 @@ class SetglobalCommandTest : VimTestCase() {
     enterCommand("setglobal number relativenumber scrolloff=10 nrformats=alpha,hex,octal sidescrolloff=10")
     assertCommandOutput("setglobal", """
       |--- Global option values ---
-      |  ideastrictmode      relativenumber      sidescrolloff=10
-      |  number              scrolloff=10
+      |  number              relativenumber      scrolloff=10        sidescrolloff=10
       |  nrformats=alpha,hex,octal
       |""".trimMargin()
     )
@@ -350,22 +348,20 @@ class SetglobalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     assertCommandOutput("setglobal all", """
       |--- Global option values ---
-      |noargtextobj          ideawrite=all       scrolljump=1      notextobj-entire
-      |  closenotebooks    noignorecase          scrolloff=0       notextobj-indent
-      |nocommentary        noincsearch           selectmode=         timeout
-      |nodigraph           nomatchit             shellcmdflag=-x     timeoutlen=1000
-      |noexchange            maxmapdepth=20      shellxescape=@    notrackactionids
-      |nogdefault            more                shellxquote={       undolevels=1000
-      |nohighlightedyank   nomultiple-cursors    showcmd             unifyjumps
-      |  history=50        noNERDTree            showmode            virtualedit=
-      |nohlsearch            nrformats=hex       sidescroll=0      novisualbell
-      |noideaglobalmode    nonumber              sidescrolloff=0     visualdelay=100
-      |noideajoin            octopushandler    nosmartcase           whichwrap=b,s
-      |  ideamarks           operatorfunc=     nosneak               wrapscan
-      |  ideastrictmode    norelativenumber      startofline
-      |noideatracetime       scroll=0          nosurround
+      |noargtextobj        noincsearch           selectmode=       notextobj-indent
+      |nocommentary        nomatchit             shellcmdflag=-x     timeout
+      |nodigraph             maxmapdepth=20      shellxescape=@      timeoutlen=1000
+      |noexchange            more                shellxquote={     notrackactionids
+      |nogdefault          nomultiple-cursors    showcmd             undolevels=1000
+      |nohighlightedyank   noNERDTree            showmode            virtualedit=
+      |  history=50          nrformats=hex       sidescroll=0      novisualbell
+      |nohlsearch          nonumber              sidescrolloff=0     visualdelay=100
+      |noideaglobalmode      operatorfunc=     nosmartcase           whichwrap=b,s
+      |noideajoin          norelativenumber    nosneak               wrapscan
+      |  ideamarks           scroll=0            startofline
+      |  ideawrite=all       scrolljump=1      nosurround
+      |noignorecase          scrolloff=0       notextobj-entire
       |  clipboard=ideaput,autoselect,exclude:cons\|linux
-      |  excommandannotation
       |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
       |  ide=IntelliJ IDEA Community Edition
       |noideacopypreprocess
@@ -397,7 +393,20 @@ class SetglobalCommandTest : VimTestCase() {
   fun `test show all modified global option values in single column`() {
     assertCommandOutput("setglobal!", """
       |--- Global option values ---
-      |  ideastrictmode
+      |""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `test show all modified global option values in single column 2`() {
+    enterCommand("setglobal number relativenumber scrolloff=10 nrformats=alpha,hex,octal sidescrolloff=10")
+    assertCommandOutput("setglobal!", """
+      |--- Global option values ---
+      |  nrformats=alpha,hex,octal
+      |  number
+      |  relativenumber
+      |  scrolloff=10
+      |  sidescrolloff=10
       |""".trimMargin()
     )
   }
@@ -409,11 +418,9 @@ class SetglobalCommandTest : VimTestCase() {
       |--- Global option values ---
       |noargtextobj
       |  clipboard=ideaput,autoselect,exclude:cons\|linux
-      |  closenotebooks
       |nocommentary
       |nodigraph
       |noexchange
-      |  excommandannotation
       |nogdefault
       |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
       |nohighlightedyank
@@ -426,8 +433,6 @@ class SetglobalCommandTest : VimTestCase() {
       |  ideamarks
       |  idearefactormode=select
       |  ideastatusicon=enabled
-      |  ideastrictmode
-      |noideatracetime
       |  ideavimsupport=dialog
       |  ideawrite=all
       |noignorecase
@@ -443,7 +448,6 @@ class SetglobalCommandTest : VimTestCase() {
       |noNERDTree
       |  nrformats=hex
       |nonumber
-      |  octopushandler
       |  operatorfunc=
       |norelativenumber
       |noReplaceWithRegister
@@ -470,7 +474,6 @@ class SetglobalCommandTest : VimTestCase() {
       |  timeoutlen=1000
       |notrackactionids
       |  undolevels=1000
-      |  unifyjumps
       |novim-paragraph-motion
       |  viminfo='100,<50,s10,h
       |  virtualedit=

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
@@ -350,20 +350,20 @@ class SetglobalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     assertCommandOutput("setglobal all", """
       |--- Global option values ---
-      |noargtextobj          ideawrite=all       scrolloff=0       notextobj-indent
-      |  closenotebooks    noignorecase          selectmode=         timeout
-      |nocommentary        noincsearch           shellcmdflag=-x     timeoutlen=1000
-      |nodigraph           nomatchit             shellxescape=@    notrackactionids
-      |noexchange            maxmapdepth=20      shellxquote={       undolevels=1000
-      |nogdefault            more                showcmd             unifyjumps
-      |nohighlightedyank   nomultiple-cursors    showmode            virtualedit=
-      |  history=50        noNERDTree            sidescroll=0      novisualbell
-      |nohlsearch            nrformats=hex       sidescrolloff=0     visualdelay=100
-      |noideaglobalmode    nonumber            nosmartcase           whichwrap=b,s
-      |noideajoin            octopushandler    nosneak               wrapscan
-      |  ideamarks         norelativenumber      startofline
-      |  ideastrictmode      scroll=0          nosurround
-      |noideatracetime       scrolljump=1      notextobj-entire
+      |noargtextobj          ideawrite=all       scrolljump=1      notextobj-entire
+      |  closenotebooks    noignorecase          scrolloff=0       notextobj-indent
+      |nocommentary        noincsearch           selectmode=         timeout
+      |nodigraph           nomatchit             shellcmdflag=-x     timeoutlen=1000
+      |noexchange            maxmapdepth=20      shellxescape=@    notrackactionids
+      |nogdefault            more                shellxquote={       undolevels=1000
+      |nohighlightedyank   nomultiple-cursors    showcmd             unifyjumps
+      |  history=50        noNERDTree            showmode            virtualedit=
+      |nohlsearch            nrformats=hex       sidescroll=0      novisualbell
+      |noideaglobalmode    nonumber              sidescrolloff=0     visualdelay=100
+      |noideajoin            octopushandler    nosmartcase           whichwrap=b,s
+      |  ideamarks           operatorfunc=     nosneak               wrapscan
+      |  ideastrictmode    norelativenumber      startofline
+      |noideatracetime       scroll=0          nosurround
       |  clipboard=ideaput,autoselect,exclude:cons\|linux
       |  excommandannotation
       |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
@@ -444,6 +444,7 @@ class SetglobalCommandTest : VimTestCase() {
       |  nrformats=hex
       |nonumber
       |  octopushandler
+      |  operatorfunc=
       |norelativenumber
       |noReplaceWithRegister
       |  scroll=0

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
@@ -382,20 +382,20 @@ class SetlocalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     assertCommandOutput("setlocal all", """
       |--- Local option values ---
-      |noargtextobj        noideatracetime       scrolljump=1      notextobj-entire
-      |  closenotebooks      ideawrite=all       scrolloff=-1      notextobj-indent
-      |nocommentary        noignorecase          selectmode=         timeout
-      |nodigraph           noincsearch           shellcmdflag=-x     timeoutlen=1000
-      |noexchange          nomatchit             shellxescape=@    notrackactionids
-      |nogdefault            maxmapdepth=20      shellxquote={       unifyjumps
-      |nohighlightedyank     more                showcmd             virtualedit=
-      |  history=50        nomultiple-cursors    showmode          novisualbell
-      |nohlsearch          noNERDTree            sidescroll=0        visualdelay=100
-      |noideaglobalmode      nrformats=hex       sidescrolloff=-1    whichwrap=b,s
-      |--ideajoin          nonumber            nosmartcase           wrapscan
-      |  ideamarks           octopushandler    nosneak
-      |  idearefactormode= norelativenumber      startofline
-      |  ideastrictmode      scroll=0          nosurround
+      |noargtextobj        noideatracetime       scroll=0          nosurround
+      |  closenotebooks      ideawrite=all       scrolljump=1      notextobj-entire
+      |nocommentary        noignorecase          scrolloff=-1      notextobj-indent
+      |nodigraph           noincsearch           selectmode=         timeout
+      |noexchange          nomatchit             shellcmdflag=-x     timeoutlen=1000
+      |nogdefault            maxmapdepth=20      shellxescape=@    notrackactionids
+      |nohighlightedyank     more                shellxquote={       unifyjumps
+      |  history=50        nomultiple-cursors    showcmd             virtualedit=
+      |nohlsearch          noNERDTree            showmode          novisualbell
+      |noideaglobalmode      nrformats=hex       sidescroll=0        visualdelay=100
+      |--ideajoin          nonumber              sidescrolloff=-1    whichwrap=b,s
+      |  ideamarks           octopushandler    nosmartcase           wrapscan
+      |  idearefactormode=   operatorfunc=     nosneak
+      |  ideastrictmode    norelativenumber      startofline
       |  clipboard=ideaput,autoselect,exclude:cons\|linux
       |  excommandannotation
       |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
@@ -482,6 +482,7 @@ class SetlocalCommandTest : VimTestCase() {
       |  nrformats=hex
       |nonumber
       |  octopushandler
+      |  operatorfunc=
       |norelativenumber
       |noReplaceWithRegister
       |  scroll=0

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
@@ -355,8 +355,7 @@ class SetlocalCommandTest : VimTestCase() {
   fun `test show all modified local option and unset global-local values`() {
     assertCommandOutput("setlocal", """
       |--- Local option values ---
-      |--ideajoin            ideastrictmode      sidescrolloff=-1
-      |  idearefactormode=   scrolloff=-1
+      |--ideajoin            idearefactormode=   scrolloff=-1        sidescrolloff=-1
       |--ideacopypreprocess
       |  undolevels=-123456
       |""".trimMargin()
@@ -368,8 +367,8 @@ class SetlocalCommandTest : VimTestCase() {
     enterCommand("setlocal number relativenumber scrolloff=10 nrformats=alpha,hex,octal sidescrolloff=10")
     assertCommandOutput("setlocal", """
       |--- Local option values ---
-      |--ideajoin            ideastrictmode      relativenumber      sidescrolloff=10
-      |  idearefactormode=   number              scrolloff=10
+      |--ideajoin            number              scrolloff=10
+      |  idearefactormode=   relativenumber      sidescrolloff=10
       |--ideacopypreprocess
       |  nrformats=alpha,hex,octal
       |  undolevels=-123456
@@ -382,22 +381,20 @@ class SetlocalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     assertCommandOutput("setlocal all", """
       |--- Local option values ---
-      |noargtextobj        noideatracetime       scroll=0          nosurround
-      |  closenotebooks      ideawrite=all       scrolljump=1      notextobj-entire
-      |nocommentary        noignorecase          scrolloff=-1      notextobj-indent
-      |nodigraph           noincsearch           selectmode=         timeout
-      |noexchange          nomatchit             shellcmdflag=-x     timeoutlen=1000
-      |nogdefault            maxmapdepth=20      shellxescape=@    notrackactionids
-      |nohighlightedyank     more                shellxquote={       unifyjumps
-      |  history=50        nomultiple-cursors    showcmd             virtualedit=
-      |nohlsearch          noNERDTree            showmode          novisualbell
-      |noideaglobalmode      nrformats=hex       sidescroll=0        visualdelay=100
-      |--ideajoin          nonumber              sidescrolloff=-1    whichwrap=b,s
-      |  ideamarks           octopushandler    nosmartcase           wrapscan
-      |  idearefactormode=   operatorfunc=     nosneak
-      |  ideastrictmode    norelativenumber      startofline
+      |noargtextobj        noignorecase          scrolloff=-1      notextobj-entire
+      |nocommentary        noincsearch           selectmode=       notextobj-indent
+      |nodigraph           nomatchit             shellcmdflag=-x     timeout
+      |noexchange            maxmapdepth=20      shellxescape=@      timeoutlen=1000
+      |nogdefault            more                shellxquote={     notrackactionids
+      |nohighlightedyank   nomultiple-cursors    showcmd             virtualedit=
+      |  history=50        noNERDTree            showmode          novisualbell
+      |nohlsearch            nrformats=hex       sidescroll=0        visualdelay=100
+      |noideaglobalmode    nonumber              sidescrolloff=-1    whichwrap=b,s
+      |--ideajoin            operatorfunc=     nosmartcase           wrapscan
+      |  ideamarks         norelativenumber    nosneak
+      |  idearefactormode=   scroll=0            startofline
+      |  ideawrite=all       scrolljump=1      nosurround
       |  clipboard=ideaput,autoselect,exclude:cons\|linux
-      |  excommandannotation
       |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
       |  ide=IntelliJ IDEA Community Edition
       |--ideacopypreprocess
@@ -432,7 +429,6 @@ class SetlocalCommandTest : VimTestCase() {
       |--ideacopypreprocess
       |--ideajoin
       |  idearefactormode=
-      |  ideastrictmode
       |  scrolloff=-1
       |  sidescrolloff=-1
       |  undolevels=-123456
@@ -447,11 +443,9 @@ class SetlocalCommandTest : VimTestCase() {
       |--- Local option values ---
       |noargtextobj
       |  clipboard=ideaput,autoselect,exclude:cons\|linux
-      |  closenotebooks
       |nocommentary
       |nodigraph
       |noexchange
-      |  excommandannotation
       |nogdefault
       |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
       |nohighlightedyank
@@ -464,8 +458,6 @@ class SetlocalCommandTest : VimTestCase() {
       |  ideamarks
       |  idearefactormode=
       |  ideastatusicon=enabled
-      |  ideastrictmode
-      |noideatracetime
       |  ideavimsupport=dialog
       |  ideawrite=all
       |noignorecase
@@ -481,7 +473,6 @@ class SetlocalCommandTest : VimTestCase() {
       |noNERDTree
       |  nrformats=hex
       |nonumber
-      |  octopushandler
       |  operatorfunc=
       |norelativenumber
       |noReplaceWithRegister
@@ -508,7 +499,6 @@ class SetlocalCommandTest : VimTestCase() {
       |  timeoutlen=1000
       |notrackactionids
       |  undolevels=-123456
-      |  unifyjumps
       |novim-paragraph-motion
       |  viminfo='100,<50,s10,h
       |  virtualedit=

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
@@ -29,6 +29,7 @@ public open class GlobalOptions(scope: OptionAccessScope): OptionsPropertiesBase
   public val keymodel: StringListOptionValue by optionProperty(Options.keymodel)
   public var maxmapdepth: Int by optionProperty(Options.maxmapdepth)
   public var more: Boolean by optionProperty(Options.more)
+  public var operatorfunc: String by optionProperty(Options.operatorfunc)
   public var scrolljump: Int by optionProperty(Options.scrolljump)
   public var selection: String by optionProperty(Options.selection)
   public val selectmode: StringListOptionValue by optionProperty(Options.selectmode)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
@@ -54,6 +54,8 @@ public open class GlobalOptions(scope: OptionAccessScope): OptionsPropertiesBase
   // This is an experimental option that enables global mode for the editor. However,
   //   for the moment it has issues and there is no quality garantee if this option is enabled
   public var ideaglobalmode: Boolean by optionProperty(Options.ideaglobalmode)
+
+  // Temporary flags for work-in-progress behaviour. Hidden from the output of `:set all`
   public var ideastrictmode: Boolean by optionProperty(Options.ideastrictmode)
   public var ideatracetime: Boolean by optionProperty(Options.ideatracetime)
   public var octopushandler: Boolean by optionProperty(Options.octopushandler)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -318,9 +318,11 @@ public object Options {
 
   // IdeaVim specific options. Put any editor or IDE specific options in IjOptionProperties
   public val ideaglobalmode: ToggleOption = addOption(ToggleOption("ideaglobalmode", GLOBAL, "ideaglobalmode", false))
-  public val ideastrictmode: ToggleOption = addOption(ToggleOption("ideastrictmode", GLOBAL, "ideastrictmode", false))
-  public val ideatracetime: ToggleOption = addOption(ToggleOption("ideatracetime", GLOBAL, "ideatracetime", false))
-  public val octopushandler: ToggleOption = addOption(ToggleOption("octopushandler", GLOBAL, "octopushandler", true))
+
+  // Temporary feature flags for work-in-progress behaviour, diagnostic switches, etc. Hidden from the output of `:set all`
+  public val ideastrictmode: ToggleOption = addOption(ToggleOption("ideastrictmode", GLOBAL, "ideastrictmode", false, isHidden = true))
+  public val ideatracetime: ToggleOption = addOption(ToggleOption("ideatracetime", GLOBAL, "ideatracetime", false, isHidden = true))
+  public val octopushandler: ToggleOption = addOption(ToggleOption("octopushandler", GLOBAL, "octopushandler", true, isHidden = true))
 }
 
 private class MultikeyMap(vararg entries: Option<VimDataType>) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -253,6 +253,24 @@ public object Options {
       }
     })
 
+  public val operatorfunc: StringOption = addOption(object : StringOption("operatorfunc", GLOBAL, "opfunc", VimString.EMPTY) {
+    override fun parseValue(value: String, token: String): VimString {
+      // TODO: Support script local functions
+      // If this value is a function name, it should be a global function. It's possible to use a local function by
+      // adding the correct `<SNR>#_` prefix for the script context. Setting the option should automatically expand the
+      // `<SID>` prefix to `<SNR>#_`.
+      // If using the `funcref('...')` or `function('...')` expressions, `<SID>` is also expanded, but it's not clear if
+      // setting the option does a simple find/replace inside the string option value, or if the expression is parsed
+      // and the string literal is expanded (this might not affect the end result, but it does have implications for
+      // IdeaVim's implementation).
+      // The `s:` prefix is not supported, and using it will result in all of the following errors:
+      // * E81: Using <SID> not in a script context
+      // * E475: Invalid argument: s:MyFunc
+      // * E474: Invalid argument: opfunc=funcref('s:MyFunc')
+      return super.parseValue(value, token)
+    }
+  })
+
   public val scrolljump: NumberOption = addOption(object : NumberOption("scrolljump", GLOBAL, "sj", 1) {
     override fun checkIfValueValid(value: VimDataType, token: String) {
       super.checkIfValueValid(value, token)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimApplication.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimApplication.kt
@@ -15,6 +15,7 @@ public interface VimApplication {
   public fun invokeLater(action: () -> Unit, editor: VimEditor)
   public fun invokeLater(action: () -> Unit)
   public fun isUnitTest(): Boolean
+  public fun isInternal(): Boolean
   public fun postKey(stroke: KeyStroke, editor: VimEditor)
 
   public fun localEditors(): List<VimEditor>

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimKeyGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimKeyGroup.kt
@@ -15,7 +15,6 @@ import com.maddyhome.idea.vim.key.KeyMapping
 import com.maddyhome.idea.vim.key.KeyMappingLayer
 import com.maddyhome.idea.vim.key.MappingInfo
 import com.maddyhome.idea.vim.key.MappingOwner
-import com.maddyhome.idea.vim.key.OperatorFunction
 import com.maddyhome.idea.vim.key.ShortcutOwnerInfo
 import com.maddyhome.idea.vim.vimscript.model.expressions.Expression
 import javax.swing.KeyStroke
@@ -66,5 +65,4 @@ public interface VimKeyGroup {
 
   public val shortcutConflicts: MutableMap<KeyStroke, ShortcutOwnerInfo>
   public val savedShortcutConflicts: MutableMap<KeyStroke, ShortcutOwnerInfo>
-  public var operatorFunction: OperatorFunction?
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimKeyGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimKeyGroupBase.kt
@@ -17,7 +17,6 @@ import com.maddyhome.idea.vim.key.KeyMapping
 import com.maddyhome.idea.vim.key.KeyMappingLayer
 import com.maddyhome.idea.vim.key.MappingInfo
 import com.maddyhome.idea.vim.key.MappingOwner
-import com.maddyhome.idea.vim.key.OperatorFunction
 import com.maddyhome.idea.vim.key.RequiredShortcut
 import com.maddyhome.idea.vim.key.RootNode
 import com.maddyhome.idea.vim.key.ShortcutOwnerInfo
@@ -33,8 +32,6 @@ public abstract class VimKeyGroupBase : VimKeyGroup {
   public val requiredShortcutKeys: MutableSet<RequiredShortcut> = HashSet(300)
   public val keyRoots: MutableMap<MappingMode, CommandPartNode<LazyVimCommand>> = EnumMap(MappingMode::class.java)
   public val keyMappings: MutableMap<MappingMode, KeyMapping> = EnumMap(MappingMode::class.java)
-
-  override var operatorFunction: OperatorFunction? = null
 
   override fun removeKeyMapping(modes: Set<MappingMode>, keys: List<KeyStroke>) {
     modes.map { getKeyMapping(it) }.forEach { it.delete(keys) }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimApplicationStub.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimApplicationStub.kt
@@ -34,6 +34,10 @@ public class VimApplicationStub : VimApplicationBase() {
     TODO("Not yet implemented")
   }
 
+  override fun isInternal(): Boolean {
+    TODO("Not yet implemented")
+  }
+
   override fun postKey(stroke: KeyStroke, editor: VimEditor) {
     TODO("Not yet implemented")
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/Option.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/Option.kt
@@ -36,15 +36,15 @@ import java.util.*
  * @param abbrev  An abbreviated name for the option, recognised by `:set`
  * @param defaultValue  The default value of the option, if not set by the user
  * @param unsetValue    The value of the local part of a global-local option, if the local part has not been set
- * @param isTemporary   True for feature-toggle options that will be reviewed in future releases.
- *                      Such options won't be printed in option list.
+ * @param isHidden   True for feature-toggle options that will be reviewed in future releases.
+ *                      Such options won't be printed in the output to `:set`
  */
 public abstract class Option<T : VimDataType>(public val name: String,
                                               public val declaredScope: OptionDeclaredScope,
                                               public val abbrev: String,
                                               defaultValue: T,
                                               public val unsetValue: T,
-                                              public val isTemporary: Boolean = false) {
+                                              public val isHidden: Boolean = false) {
   private var defaultValueField = defaultValue
 
   public open val defaultValue: T
@@ -294,16 +294,24 @@ public open class UnsignedNumberOption(
  * @param declaredScope The declared scope of the option - global, global-local, local-to-buffer, local-to-window
  * @param abbrev  An abbreviated name for the option, recognised by `:set`
  * @param defaultValue The option's default value of the option
+ * @param isHidden   True for feature-toggle options that will be reviewed in future releases.
+ *                   Such options won't be printed in the output to `:set`
  */
-public class ToggleOption(name: String, declaredScope: OptionDeclaredScope, abbrev: String, defaultValue: VimInt, isTemporary: Boolean = false) :
-  Option<VimInt>(name, declaredScope, abbrev, defaultValue, VimInt.MINUS_ONE, isTemporary) {
-  public constructor(name: String, declaredScope: OptionDeclaredScope, abbrev: String, defaultValue: Boolean, isTemporary: Boolean = false) : this(
-    name,
-    declaredScope,
-    abbrev,
-    if (defaultValue) VimInt.ONE else VimInt.ZERO,
-    isTemporary
-  )
+public class ToggleOption(
+  name: String,
+  declaredScope: OptionDeclaredScope,
+  abbrev: String,
+  defaultValue: VimInt,
+  isHidden: Boolean = false,
+) : Option<VimInt>(name, declaredScope, abbrev, defaultValue, VimInt.MINUS_ONE, isHidden) {
+
+  public constructor(
+    name: String,
+    declaredScope: OptionDeclaredScope,
+    abbrev: String,
+    defaultValue: Boolean,
+    isHidden: Boolean = false,
+  ) : this(name, declaredScope, abbrev, if (defaultValue) VimInt.ONE else VimInt.ZERO, isHidden)
 
   override fun checkIfValueValid(value: VimDataType, token: String) {
     if (value !is VimInt) throw exExceptionMessage("E474", token)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/SetCommand.kt
@@ -104,12 +104,17 @@ public fun parseOptionLine(editor: VimEditor, args: String, scope: OptionAccessS
   when {
     argument.isEmpty() -> {
       // No arguments mean we show only changed values
-      val changedOptions = optionGroup.getAllOptions().filter { !optionGroup.isDefaultValue(it, scope) && !it.isTemporary }
-      showOptions(editor, changedOptions.map { Pair(it.name, it.name) }, scope, true, columnFormat)
+      val changedOptions = optionGroup.getAllOptions()
+        .filter { !optionGroup.isDefaultValue(it, scope) && (!it.isHidden || (injector.application.isInternal() && !injector.application.isUnitTest())) }
+        .map { Pair(it.name, it.name) }
+      showOptions(editor, changedOptions, scope, true, columnFormat)
       return
     }
     argument == "all" -> {
-      showOptions(editor, optionGroup.getAllOptions().filter { !it.isTemporary }.map { Pair(it.name, it.name) }, scope, true, columnFormat)
+      val options = optionGroup.getAllOptions()
+        .filter { !it.isHidden || (injector.application.isInternal() && !injector.application.isUnitTest()) }
+        .map { Pair(it.name, it.name) }
+      showOptions(editor, options, scope, true, columnFormat)
       return
     }
     argument == "all&" -> {


### PR DESCRIPTION
This PR introduces the `'operatorfunc'` option. This option contains the name of a function that can act like a custom operator, and is called by the `g@` command, such as in this example from the #702 discussion:

```vimL
nnoremap gx :set opfunc=Redact<cr>g@
function! Redact(type)
    execute "normal `[v`]rx"
endfunction
```

Using a command such as `gxiw`, this map will invoke the custom operator function on a given word, and replace it with `x` characters.

The `'opfunc'` option can be the name of a function, a reference from `function('…')` or `funcref('…')` or a lambda.

This PR also allows an extension to export a script function that can be called from the VimScript executor, which is a simple wrapper function that invokes extension code. A helper function has been added to create a script function with the right signature for operator functions. All extensions have been updated to export a function, and to use the `'operatorfunc'` option.