### PR TITLE
Refactor VimOptionGroupBase

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/OptionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/OptionGroup.kt
@@ -40,10 +40,6 @@ internal class OptionGroup : VimOptionGroupBase(), IjVimOptionGroup {
   override fun getGlobalIjOptions() = GlobalIjOptions(OptionAccessScope.GLOBAL(null))
   override fun getEffectiveIjOptions(editor: VimEditor) = EffectiveIjOptions(OptionAccessScope.EFFECTIVE(editor))
 
-  private fun updateFallbackWindow(fallbackWindow: VimEditor, targetEditor: VimEditor) {
-    copyPerWindowGlobalValues(fallbackWindow, targetEditor)
-  }
-
   companion object {
     fun fileEditorManagerSelectionChangedCallback(event: FileEditorManagerEvent) {
       // Vim only has one window, and it's not possible to close it. This means that editing a new file will always
@@ -70,7 +66,7 @@ internal class OptionGroup : VimOptionGroupBase(), IjVimOptionGroup {
 }
 
 internal class IjOptionConstants {
-  @Suppress("SpellCheckingInspection", "MemberVisibilityCanBePrivate")
+  @Suppress("SpellCheckingInspection", "MemberVisibilityCanBePrivate", "ConstPropertyName")
   companion object {
 
     const val idearefactormode_keep = "keep"

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/OptionAccessScopeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/OptionAccessScopeTest.kt
@@ -129,6 +129,23 @@ class OptionAccessScopeTest: VimTestCase() {
     assertEquals(effectiveValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.EFFECTIVE(fixture.editor.vim)))
   }
 
+  @Test
+  fun `test set local-to-buffer option at effective scope to current value changes global value`() {
+    val defaultValue = VimInt(10)
+    val option = NumberOption(OPTION_NAME, OptionDeclaredScope.LOCAL_TO_BUFFER, OPTION_NAME, defaultValue)
+    injector.optionGroup.addOption(option)
+
+    val effectiveValue = VimInt(100)
+    injector.optionGroup.setOptionValue(option, OptionAccessScope.LOCAL(fixture.editor.vim), effectiveValue)
+    assertEquals(defaultValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.GLOBAL(fixture.editor.vim)))
+
+    injector.optionGroup.setOptionValue(option, OptionAccessScope.EFFECTIVE(fixture.editor.vim), effectiveValue)
+
+    assertEquals(effectiveValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.GLOBAL(fixture.editor.vim)))
+    assertEquals(effectiveValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.LOCAL(fixture.editor.vim)))
+    assertEquals(effectiveValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.EFFECTIVE(fixture.editor.vim)))
+  }
+
 
   // LOCAL_TO_WINDOW
   @Test
@@ -166,6 +183,23 @@ class OptionAccessScopeTest: VimTestCase() {
     injector.optionGroup.addOption(option)
 
     val effectiveValue = VimInt(100)
+    injector.optionGroup.setOptionValue(option, OptionAccessScope.EFFECTIVE(fixture.editor.vim), effectiveValue)
+
+    assertEquals(effectiveValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.GLOBAL(fixture.editor.vim)))
+    assertEquals(effectiveValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.LOCAL(fixture.editor.vim)))
+    assertEquals(effectiveValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.EFFECTIVE(fixture.editor.vim)))
+  }
+
+  @Test
+  fun `test set local-to-window option at effective scope to current value changes global value`() {
+    val defaultValue = VimInt(10)
+    val option = NumberOption(OPTION_NAME, OptionDeclaredScope.LOCAL_TO_WINDOW, OPTION_NAME, defaultValue)
+
+    injector.optionGroup.addOption(option)
+    val effectiveValue = VimInt(100)
+    injector.optionGroup.setOptionValue(option, OptionAccessScope.LOCAL(fixture.editor.vim), effectiveValue)
+    assertEquals(defaultValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.GLOBAL(fixture.editor.vim)))
+
     injector.optionGroup.setOptionValue(option, OptionAccessScope.EFFECTIVE(fixture.editor.vim), effectiveValue)
 
     assertEquals(effectiveValue, injector.optionGroup.getOptionValue(option, OptionAccessScope.GLOBAL(fixture.editor.vim)))

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroup.kt
@@ -36,6 +36,10 @@ public interface VimOptionGroup {
    * "global" value or copied directly from the opening window. Global-local options are usually initialised to the
    * option's "unset" marker value.
    *
+   * Note that listeners are not notified. This method is called when a new editor is opened, and also very early in the
+   * process of enabling IdeaVim (to ensure that options are available for the rest of the process). Depending on when a
+   * listener is registered, it might get called or not. To ensure consistency, this method does not call any listeners.
+   *
    * @param editor  The editor to initialise
    * @param sourceEditor  The editor which is opening the new editor. This source editor is used to get the per-window
    * "global" values to initialise the new editor. It can only be null when [scenario] is
@@ -108,6 +112,9 @@ public interface VimOptionGroup {
    *
    * Note that this function accepts a covariant version of [Option] so it can accept derived instances that are
    * specialised by a type derived from [VimDataType].
+   *
+   * This function will initialise the option to default values across all currently open editors, but it does not
+   * notify listeners. This mirrors the behaviour of [initialiseLocalOptions].
    *
    * @param option option
    */

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroup.kt
@@ -21,14 +21,14 @@ import org.jetbrains.annotations.TestOnly
 
 public interface VimOptionGroup {
   /**
-   * Called to initialise the options
+   * Called to initialise the list of available options
    *
    * This function must be idempotent, as it is called each time the plugin is enabled.
    */
   public fun initialiseOptions()
 
   /**
-   * Initialise the local to buffer and local to window options for this editor
+   * Initialise the local to buffer and local to window option values for this editor
    *
    * Depending on the initialisation scenario, the local-to-buffer, local-to-window and/or global-local options are
    * initialised. The scenario dictates where the local options get their values from. Typically, local-to-buffer

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
@@ -207,18 +207,13 @@ public abstract class VimOptionGroupBase : VimOptionGroup {
   }
 
   override fun resetAllOptionsForTesting() {
-    // During testing, this collection is usually empty. Just in case, make sure all editors have default options
-    injector.editorGroup.localEditors().forEach { resetAllOptions(it) }
+    // Resets the global values of all options, including per-window global of the fallback window. Also resets the
+    // local options of the fallback window. When combined with resetting all options for any open editors, this resets
+    // all options everywhere.
     resetAllOptions(injector.fallbackWindow)
 
-    // Make sure we reset global options even if we don't have any editors. This fires listeners and clears caches
-    Options.getAllOptions().filter { it.declaredScope == GLOBAL }.forEach { resetDefaultValue(it, OptionAccessScope.GLOBAL(null)) }
-
-    // Reset global value of other options manually, without firing listeners or clearing caches. This is safe because
-    // we only cache values or listen to changes for the effective values of local options (and not global-local). But
-    // local-to-window options will store global values per-window (which we don't have). So this will have the same
-    // result as resetDefaultValue but without the asserts for setting a local option without a window.
-    Options.getAllOptions().filter { it.declaredScope != GLOBAL }.forEach { globalValues[it.name] = it.defaultValue }
+    // During testing, we do not expect to have any editors, so this collection is usually empty
+    injector.editorGroup.localEditors().forEach { resetAllOptions(it) }
   }
 
   override fun addOption(option: Option<out VimDataType>) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
@@ -408,21 +408,19 @@ public abstract class VimOptionGroupBase : VimOptionGroup {
       GLOBAL -> if (doSetGlobalValue(option, value)) {
         listeners.onGlobalOptionChanged(option.name)
       }
-      LOCAL_TO_BUFFER -> if (doSetBufferLocalValue(option, editor, value)) {
-        // TODO: Update global value even if local value hasn't changed
-        // E.g. :set scroll=5 leaves global and local equal to 5
-        // :setlocal scroll=10 changes local to 10, but leaves global at 5
-        // :set scroll=10 should leave local at 10, but change global to 10
+      LOCAL_TO_BUFFER -> {
+        val changed = doSetBufferLocalValue(option, editor, value)
         doSetGlobalValue(option, value)
-        listeners.onLocalOptionChanged(option, editor)
+        if (changed) {
+          listeners.onLocalOptionChanged(option, editor)
+        }
       }
-      LOCAL_TO_WINDOW -> if (doSetWindowLocalValue(option, editor, value)) {
-        // TODO: Update global value even if local value hasn't changed
-        // E.g. :set scroll=5 leaves global and local equal to 5
-        // :setlocal scroll=10 changes local to 10, but leaves global at 5
-        // :set scroll=10 should leave local at 10, but change global to 10
+      LOCAL_TO_WINDOW -> {
+        val changed = doSetWindowLocalValue(option, editor, value)
         doSetPerWindowGlobalValue(option, editor, value)
-        listeners.onLocalOptionChanged(option, editor)
+        if (changed) {
+          listeners.onLocalOptionChanged(option, editor)
+        }
       }
       GLOBAL_OR_LOCAL_TO_BUFFER -> {
         // Reset the local value if it has previously been set, then set the global value. Number based options

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
@@ -212,8 +212,8 @@ public abstract class VimOptionGroupBase : VimOptionGroup {
  */
 private class OptionStorage {
   private val globalValues = mutableMapOf<String, VimDataType>()
-  private val perWindowGlobalOptionsKey = Key<MutableMap<String, VimDataType>>("perWindowGlobalOptions")
-  private val localOptionsKey = Key<MutableMap<String, VimDataType>>("localOptions")
+  private val perWindowGlobalOptionsKey = Key<MutableMap<String, VimDataType>>("vimPerWindowGlobalOptions")
+  private val localOptionsKey = Key<MutableMap<String, VimDataType>>("vimLocalOptions")
 
   fun <T : VimDataType> getOptionValue(option: Option<T>, scope: OptionAccessScope): T = when (scope) {
     is OptionAccessScope.EFFECTIVE -> getEffectiveValue(option, scope.editor)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/diagnostic/VimLogger.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/diagnostic/VimLogger.kt
@@ -23,13 +23,13 @@ public interface VimLogger {
   public fun info(message: String)
 }
 
-public fun VimLogger.trace(message: () -> String) {
+public inline fun VimLogger.trace(message: () -> String) {
   if (isTrace()) {
     trace(message())
   }
 }
 
-public fun VimLogger.debug(message: () -> String) {
+public inline fun VimLogger.debug(message: () -> String) {
   if (isDebug()) {
     debug(message())
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/listener/ListenerSuppressor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/listener/ListenerSuppressor.kt
@@ -57,7 +57,7 @@ public sealed class VimListenerSuppressor {
 
   public fun lock(): Locked {
     LOG.trace("Suppressor lock")
-    LOG.trace(injector.application.currentStackTrace())
+    LOG.trace { injector.application.currentStackTrace() }
     caretListenerSuppressor++
     return Locked()
   }


### PR DESCRIPTION
The `VimOptionGroupBase` class has become a bit of a god class/kitchen sink class. It has too many responsibilities, and is confusing to reason about. It handles setting/getting option values, initialising options for new windows and buffers, notifying listeners of changes and maintaining a cache of parsed effective values (e.g. parsing the contents of `'guicursor'`).

This PR splits the responsibilities into separate classes that `VimOptionGroupBase` uses. The classes are all implementation details, so remain in the same `VimOptionGroupBase.kt` file, but at least encapsulate responsibilities.

The majority of the changes are renames, extracting classes, and other similar refactoring. There is very little behaviour change, although a couple of minor bugs have been fixed.

This refactoring is the basis for the next PR, which will modify the option storage to allow custom options that are powered by IntelliJ settings (e.g. `'wrap'`, based on IntelliJ's soft wrap settings).