### PR TITLE
Enforce LF line separator in project code style

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,6 +6,7 @@
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </value>
     </option>
+    <option name="LINE_SEPARATOR" value="&#10;" />
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="my" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="our" />


### PR DESCRIPTION
The project code style defaults to "System-dependent" line separator, and as I develop on Windows it means IDEA is giving me this warning and wants me to convert every file to CRLF, which imo doesn't make any sense. So this PR sets the code style to LF to make developing on Windows less annoying.

![image](https://github.com/JetBrains/ideavim/assets/3685160/d0502b6a-fab2-4c81-806a-006de329a044)
