### PR TITLE
Only notify option change to initialised editors

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/PluginStartup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/PluginStartup.kt
@@ -38,7 +38,7 @@ internal class PyNotebooksCloseWorkaround : ProjectManagerListener {
   override fun projectClosingBeforeSave(project: Project) {
     // TODO: Confirm context in CWM scenario
     if (injector.globalIjOptions().closenotebooks) {
-      injector.editorGroup.localEditors().forEach { vimEditor ->
+      injector.editorGroup.getEditors().forEach { vimEditor ->
         val editor = (vimEditor as IjVimEditor).editor
         val virtualFile = EditorHelper.getVirtualFile(editor)
         if (virtualFile?.extension == "ipynb") {

--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -208,6 +208,8 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
   }
 
   public void editorCreated(@NotNull Editor editor) {
+    UserDataManager.setVimInitialised(editor, true);
+
     VimPlugin.getKey().registerRequiredShortcutKeys(new IjVimEditor(editor));
 
     initLineNumbers(editor);
@@ -326,10 +328,18 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
     }
   }
 
+  @Override
+  public @NotNull Collection<VimEditor> getEditorsRaw() {
+    return getLocalEditors()
+      .map(IjVimEditor::new)
+      .collect(Collectors.toList());
+  }
+
   @NotNull
   @Override
   public Collection<VimEditor> localEditors() {
     return getLocalEditors()
+      .filter(UserDataManager::getVimInitialised)
       .map(IjVimEditor::new)
       .collect(Collectors.toList());
   }
@@ -339,7 +349,7 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
   public Collection<VimEditor> localEditors(@NotNull VimDocument buffer) {
     final Document document = ((IjVimDocument)buffer).getDocument();
     return getLocalEditors()
-      .filter(editor -> editor.getDocument().equals(document))
+      .filter(editor -> UserDataManager.getVimInitialised(editor) && editor.getDocument().equals(document))
       .map(IjVimEditor::new)
       .collect(Collectors.toList());
   }

--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -337,7 +337,7 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
 
   @NotNull
   @Override
-  public Collection<VimEditor> localEditors() {
+  public Collection<VimEditor> getEditors() {
     return getLocalEditors()
       .filter(UserDataManager::getVimInitialised)
       .map(IjVimEditor::new)
@@ -346,7 +346,7 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
 
   @NotNull
   @Override
-  public Collection<VimEditor> localEditors(@NotNull VimDocument buffer) {
+  public Collection<VimEditor> getEditors(@NotNull VimDocument buffer) {
     final Document document = ((IjVimDocument)buffer).getDocument();
     return getLocalEditors()
       .filter(editor -> UserDataManager.getVimInitialised(editor) && editor.getDocument().equals(document))

--- a/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -98,7 +98,7 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
 
   @Override
   public void updateShortcutKeysRegistration() {
-    for (VimEditor editor : injector.getEditorGroup().localEditors()) {
+    for (VimEditor editor : injector.getEditorGroup().getEditors()) {
       unregisterShortcutKeys(editor);
       registerRequiredShortcutKeys(editor);
     }

--- a/src/main/java/com/maddyhome/idea/vim/group/SearchGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/SearchGroup.java
@@ -1208,7 +1208,7 @@ public class SearchGroup extends IjVimSearchGroup implements PersistentStateComp
       // ClientId.current will be a guest ID), but we don't care - we still need to add/remove highlights for the
       // changed text. Make sure we only update local editors, though.
       final Document document = event.getDocument();
-      for (VimEditor vimEditor : injector.getEditorGroup().localEditors(new IjVimDocument(document))) {
+      for (VimEditor vimEditor : injector.getEditorGroup().getEditors(new IjVimDocument(document))) {
         final Editor editor = ((IjVimEditor)vimEditor).getEditor();
         Collection<RangeHighlighter> hls = UserDataManager.getVimLastHighlighters(editor);
         if (hls == null) {

--- a/src/main/java/com/maddyhome/idea/vim/group/VimJumpServiceImpl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/VimJumpServiceImpl.kt
@@ -111,7 +111,7 @@ internal class JumpsListener(val project: Project) : RecentPlacesListener {
   }
 
   private fun buildJump(place: PlaceInfo): Jump? {
-    val editor = injector.editorGroup.localEditors().firstOrNull { it.ij.virtualFile == place.file } ?: return null
+    val editor = injector.editorGroup.getEditors().firstOrNull { it.ij.virtualFile == place.file } ?: return null
     val offset = place.caretPosition?.startOffset ?: return null
 
     val bufferPosition = editor.offsetToBufferPosition(offset)

--- a/src/main/java/com/maddyhome/idea/vim/group/VimMarkServiceImpl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/VimMarkServiceImpl.kt
@@ -232,7 +232,7 @@ internal class VimMarkServiceImpl : VimMarkServiceBase(), PersistentStateCompone
      * Get any editor for the given document
      *
      * We need an editor to help calculate offsets for marks, and it doesn't matter which one we use, because they would
-     * all return the same results. However, we cannot use [VimEditorGroup.localEditors] because the change might have
+     * all return the same results. However, we cannot use [VimEditorGroup.getEditors] because the change might have
      * come from a remote guest and there might not be an open local editor.
      */
     private fun getAnyEditorForDocument(doc: Document) =

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -208,7 +208,7 @@ public class EditorHelper {
     if (doc == null) {
       return null;
     }
-    return injector.getEditorGroup().localEditors(new IjVimDocument(doc)).stream().findFirst().orElse(null);
+    return injector.getEditorGroup().getEditors(new IjVimDocument(doc)).stream().findFirst().orElse(null);
   }
 
   public static @NotNull String pad(final @NotNull Editor editor,

--- a/src/main/java/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
@@ -98,7 +98,7 @@ private fun updateSearchHighlights(
 
   for (project in projectManager.openProjects) {
     val current = FileEditorManager.getInstance(project).selectedTextEditor ?: continue
-    val editors = injector.editorGroup.localEditors(IjVimDocument(current.document))
+    val editors = injector.editorGroup.getEditors(IjVimDocument(current.document))
     for (vimEditor in editors) {
       val editor = (vimEditor as IjVimEditor).editor
       if (editor.project != project) {

--- a/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
@@ -99,6 +99,8 @@ internal var Caret.registerStorage: CaretRegisterStorageBase? by userDataCaretTo
 internal var Caret.markStorage: LocalMarkStorage? by userDataCaretToEditor()
 internal var Caret.lastSelectionInfo: SelectionInfo? by userDataCaretToEditor()
 
+internal var Editor.vimInitialised: Boolean by userDataOr { false }
+
 // ------------------ Editor
 internal fun unInitializeEditor(editor: Editor) {
   editor.vimLastSelectionType = null
@@ -106,6 +108,7 @@ internal fun unInitializeEditor(editor: Editor) {
   editor.vimMorePanel = null
   editor.vimExOutput = null
   editor.vimLastHighlighters = null
+  editor.vimInitialised = false
 }
 
 internal var Editor.vimLastSearch: String? by userData()

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -232,7 +232,7 @@ internal object VimListenerManager {
     }
 
     fun removeAll() {
-      injector.editorGroup.localEditors().forEach { editor ->
+      injector.editorGroup.getEditors().forEach { editor ->
         remove(editor.ij)
       }
     }

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -222,7 +222,8 @@ internal object VimListenerManager {
 
       // We could have a split window in this list, but since they're all being initialised from the same opening editor
       // there's no need to use the SPLIT scenario
-      injector.editorGroup.localEditors().forEach { vimEditor ->
+      // Make sure we get all editors, including uninitialised
+      injector.editorGroup.getEditorsRaw().forEach { vimEditor ->
         val editor = vimEditor.ij
         if (!initialisedEditors.contains(editor)) {
           add(editor, getOpeningEditor(editor)?.vim ?: injector.fallbackWindow, LocalOptionInitialisationScenario.NEW)
@@ -273,7 +274,6 @@ internal object VimListenerManager {
       eventFacade.addCaretListener(editor, EditorCaretHandler, listenersDisposable)
 
       VimPlugin.getEditor().editorCreated(editor)
-
       VimPlugin.getChange().editorCreated(editor, listenersDisposable)
 
       injector.listenersNotifier.notifyEditorCreated(vimEditor)

--- a/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
@@ -369,7 +369,7 @@ public class ExOutputPanel extends JPanel {
 
       // This listener is only invoked for local scenarios, and we only need to update local editor UI. This will invoke
       // updateUI on the output pane and it's child components
-      for (VimEditor vimEditor : injector.getEditorGroup().localEditors()) {
+      for (VimEditor vimEditor : injector.getEditorGroup().getEditors()) {
         Editor editor = ((IjVimEditor)vimEditor).getEditor();
         if (!ExOutputPanel.isPanelActive(editor)) continue;
         IJSwingUtilities.updateComponentTreeUI(ExOutputPanel.getInstance(editor));

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditorGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditorGroup.kt
@@ -14,7 +14,7 @@ public interface VimEditorGroup {
   /**
    * Get a collection of all editors, including those that have not yet been initialised.
    *
-   * You probably don't want to use this - use [localEditors]!
+   * You probably don't want to use this - use [getEditors]!
    *
    * This function is only useful during plugin initialisation. It will return all currently open editors, including
    * those that have not yet been initialised, so the plugin can correctly initialise them. When the plugin starts, the
@@ -40,7 +40,7 @@ public interface VimEditorGroup {
    *
    * Also note that it is possible for multiple editors in different projects to open the same file (document/buffer).
    */
-  public fun localEditors(): Collection<VimEditor>
+  public fun getEditors(): Collection<VimEditor>
 
   /**
    * Get a collection of all initialised editors for the given buffer
@@ -54,5 +54,5 @@ public interface VimEditorGroup {
    * Implementors should take care to only return "local" editors. I.e. for IntelliJ, this function will not include
    * hidden editors that are used to handle requests from Code With Me guests.
    */
-  public fun localEditors(buffer: VimDocument): Collection<VimEditor>
+  public fun getEditors(buffer: VimDocument): Collection<VimEditor>
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditorGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditorGroup.kt
@@ -12,14 +12,30 @@ public interface VimEditorGroup {
   public fun notifyIdeaJoin(editor: VimEditor)
 
   /**
-   * Get a collection of all editors
+   * Get a collection of all editors, including those that have not yet been initialised.
+   *
+   * You probably don't want to use this - use [localEditors]!
+   *
+   * This function is only useful during plugin initialisation. It will return all currently open editors, including
+   * those that have not yet been initialised, so the plugin can correctly initialise them. When the plugin starts, the
+   * IDE might already have editors open, either because the plugin is initialised after the IDE starts, or because the
+   * IDE has reopened editors at startup.
+   */
+  public fun getEditorsRaw(): Collection<VimEditor>
+
+  /**
+   * Get a collection of all initialised editors
    *
    * This will return all editors, including both main file editors and other editors in the UI such as the commit
-   * message editor. Implementors should take care to only return "local" editors. I.e. for IntelliJ, this function will
-   * not include hidden editors that are used to handle requests from Code With Me guests.
+   * message editor. Editors will have been initialised by IdeaVim - any listeners installed, all options set, etc. This
+   * is important to prevent using editors in listener callbacks (such as option change notifications) before they've
+   * been initialised.
+   *
+   * Implementors should take care to only return "local" editors. I.e., for IntelliJ, this function will not include
+   * hidden editors that are used to handle requests from Code With Me guests.
    *
    * Note that this function returns editors for all projects, which is necessary because IdeaVim does not maintain
-   * per-project state. This can have surprising consequences, such as search highlights updating across all open
+   * state per-project. This can have surprising consequences, such as search highlights updating across all open
    * top-level project frames, which is at odds with the behaviour of separate top-level windows in GVim/MacVim.
    *
    * Also note that it is possible for multiple editors in different projects to open the same file (document/buffer).
@@ -27,11 +43,13 @@ public interface VimEditorGroup {
   public fun localEditors(): Collection<VimEditor>
 
   /**
-   * Get a collection of all editors for the given buffer
-   * editor
+   * Get a collection of all initialised editors for the given buffer
+   *
    * This will return all editors that are currently displaying the given buffer. These are most likely to be main file
    * editors, but given the right buffer could return editors from the UI. Note that a document's file might be open in
-   * multiple projects at the same time, and this function will return all such editors across all projects.
+   * multiple projects at the same time, and this function will return all such editors across all projects. Editors
+   * will have been initialised by IdeaVim - any listeners installed, all options set, etc. This is important to prevent
+   * using editors in listener callbacks (such as option change notifications) before they've been initialised.
    *
    * Implementors should take care to only return "local" editors. I.e. for IntelliJ, this function will not include
    * hidden editors that are used to handle requests from Code With Me guests.

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMarkServiceBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMarkServiceBase.kt
@@ -136,7 +136,7 @@ public abstract class VimMarkServiceBase : VimMarkService {
   }
 
   override fun getAllMarksForFile(editor: VimEditor): List<Pair<ImmutableVimCaret?, Set<Mark>>> {
-    val localMarks = injector.editorGroup.localEditors()
+    val localMarks = injector.editorGroup.getEditors()
       .filter { it.getPath() == editor.getPath() }
       .flatMap { it.carets() }
       .map { Pair(it, getAllLocalMarks(it)) }
@@ -413,7 +413,7 @@ public abstract class VimMarkServiceBase : VimMarkService {
   }
 
   override fun resetAllMarks() {
-    for (editor in injector.editorGroup.localEditors()) {
+    for (editor in injector.editorGroup.getEditors()) {
       editor.carets().forEach {
         resetAllMarksForCaret(it)
       }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
@@ -666,6 +666,7 @@ private class OptionListenersImpl(private val optionStorage: OptionStorage, priv
       if (!optionStorage.isUnsetValue(option, editor)) affectedEditors.add(editor)
     }
     else if (option.declaredScope == GLOBAL_OR_LOCAL_TO_BUFFER) {
+      // TODO: Should this be localEditors(doc)?
       affectedEditors.addAll(editorGroup.localEditors().filter { !optionStorage.isUnsetValue(option, it) })
     }
 
@@ -744,4 +745,3 @@ private class ParsedValuesCache(
     getStorage(option, editor).remove(option.name)
   }
 }
-

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/impl/state/VimStateMachineImpl.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/impl/state/VimStateMachineImpl.kt
@@ -121,7 +121,7 @@ public class VimStateMachineImpl(private val editor: VimEditor?) : VimStateMachi
       editor.updateCaretsVisualAttributes()
       editor.updateCaretsVisualPosition()
     } else {
-      injector.editorGroup.localEditors().forEach { editor ->
+      injector.editorGroup.getEditors().forEach { editor ->
         editor.updateCaretsVisualAttributes()
         editor.updateCaretsVisualPosition()
       }


### PR DESCRIPTION
This PR ensures that IdeaVim only works with editors that have been initialised. This is important for various callbacks, such as notifications when setting editor options. 

For example, the `~/.ideavimrc` file is evaluated during startup, before other editors are initialised. It can set various option values which in turn notify all affected editors. If the IDE opens editors at startup, these editors would be notified of changes before they've been initialised. [VIM-3256](https://youtrack.jetbrains.com/issue/VIM-3256) is an example of an issue caused by this - the uninitialised editors are notified, and try to check local-to-buffer options. These local-to-buffer options haven't yet been initialised, but trying to get a value will create the storage map for them, without setting any values. Subsequent attempts to use local-to-buffer options (such as `'keyword'`) can result in an assert.