### PR TITLE
Add NERDTree action to toggle excluded files

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTree.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTree.kt
@@ -477,6 +477,7 @@ internal class NerdTree : VimExtension {
       "r",
       NerdAction.ToIj("SynchronizeCurrentFile"),
     )
+    registerCommand("NERDTreeMapToggleHidden", "I", NerdAction.ToIj("ProjectView.ShowExcludedFiles"))
     registerCommand("NERDTreeMapRefreshRoot", "R", NerdAction.ToIj("Synchronize"))
     registerCommand("NERDTreeMapMenu", "m", NerdAction.ToIj("ShowPopupMenu"))
     registerCommand("NERDTreeMapQuit", "q", NerdAction.ToIj("HideActiveWindow"))


### PR DESCRIPTION
NERDTree uses 'I' to toggle hidden files ([source](https://github.com/preservim/nerdtree/blob/6acfc48d80f83b7c23c4e6f9faa93c3defdb150b/doc/NERDTree.txt#L286)), which I think maps nicely to excluded files in IntelliJ, so I added support for it.