### PR TITLE
Fix indent size calculation in "vin indent object" extention

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/textobjindent/VimIndentObject.java
+++ b/src/main/java/com/maddyhome/idea/vim/extension/textobjindent/VimIndentObject.java
@@ -131,10 +131,11 @@ public class VimIndentObject implements VimExtension {
         // This is done as a separate step so that it works even when the caret is inside the indentation.
         int offset = caretLineStartOffset;
         int indentSize = 0;
-        while (++offset < charSequence.length()) {
+        while (offset < charSequence.length()) {
           final char ch = charSequence.charAt(offset);
           if (ch == ' ' || ch == '\t') {
             ++indentSize;
+            ++offset;
           } else {
             break;
           }


### PR DESCRIPTION
Previously it ignored the first indent character, which caused errors with tabs. You wouldn't get any errors in behavior with spaces as you'd typically have 4 spaces at each indent level, so 1 in calculation doesn't make a difference.

Can be tested on following text. Easier with vii
```
first level selects all
{
	second level with tab. will still select all before fix
	{
		third level with tab. Will select also the second level before fix
	}
}

first level selects all
{
    second level with spaces. Will work before fix
    {
        third level with spaces. will only select that line
    }
}
```