### PR TITLE
Fix wording on NERDTree support doc

### DIFF
--- a/doc/NERDTree-support.md
+++ b/doc/NERDTree-support.md
@@ -27,7 +27,7 @@ Plug 'nerdtree'
 ### Preview
 
 <details>
-<summary>Click to the the preview</summary>
+<summary>Click for the preview</summary>
 <img src="images/nerdtree.gif" alt="NERDTree example"/>
 </details>
 


### PR DESCRIPTION
There is one additional `the` before the preview gif, and also, changing the wording from "to" to " for".