### PR TITLE
Fix various options and ex text field issues

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
@@ -28,14 +28,18 @@ public class ExOutputModel private constructor(private val myEditor: Editor) : V
     get() = if (!ApplicationManager.getApplication().isUnitTestMode) {
       ExOutputPanel.getInstance(myEditor).text
     } else {
-      field
+      // ExOutputPanel always returns a non-null string
+      field ?: ""
     }
     set(value) {
+      // ExOutputPanel will strip a trailing newline. We'll do it now so that tests have the same behaviour. We also
+      // never pass null to ExOutputPanel, but we do store it for tests, so we know if we're active or not
+      val newValue = value?.removeSuffix("\n")
       if (!ApplicationManager.getApplication().isUnitTestMode) {
-        ExOutputPanel.getInstance(myEditor).setText(value ?: "")
+        ExOutputPanel.getInstance(myEditor).setText(newValue ?: "")
       } else {
-        field = value
-        isActiveInTestMode = !value.isNullOrEmpty()
+        field = newValue
+        isActiveInTestMode = !newValue.isNullOrEmpty()
       }
     }
 

--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -217,22 +217,23 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
       editorEx.addPropertyChangeListener(FontSizeChangeListener.INSTANCE);
     }
 
-    // We add Vim bindings to all opened editors, even read-only editors. We also add bindings to editors that are used
-    // elsewhere in the IDE, rather than just for editing project files. This includes editors used as part of the UI,
-    // such as the VCS commit message, or used as read-only viewers for text output, such as log files in run
-    // configurations or the Git Console tab. And editors are used for interactive stdin/stdout for console-based run
-    // configurations.
+    // We add Vim bindings to all opened editors, including editors used as UI controls rather than just project file
+    // editors. This includes editors used as part of the UI, such as the VCS commit message, or used as read-only
+    // viewers for text output, such as log files in run configurations or the Git Console tab. And editors are used for
+    // interactive stdin/stdout for console-based run configurations.
     // We want to provide an intuitive experience for working with these additional editors, so we automatically switch
-    // to INSERT mode for interactive editors. Recognising these can be a bit tricky.
+    // to INSERT mode if they are interactive editors. Recognising these can be a bit tricky.
     // These additional interactive editors are not file-based, but must have a writable document. However, log output
     // documents are also writable (the IDE is writing new content as it becomes available) just not user-editable. So
     // we must also check that the editor is not in read-only "viewer" mode (this includes "rendered" mode, which is
     // read-only and also hides the caret).
-    // Furthermore, the interactive stdin/stdout console output is hosted in a read-only editor, but it can still be
-    // edited. The `ConsoleViewImpl` class installs a typing handler that ignores the editor's `isViewer` property and
-    // allows typing if the associated process (if any) is still running. We can get the editor's console view and check
-    // this ourselves, but we have to wait until the editor has finished initialising before it's available in user
-    // data.
+    // Furthermore, interactive stdin/stdout console output in run configurations is hosted in a read-only editor, but
+    // it can still be edited. The `ConsoleViewImpl` class installs a typing handler that ignores the editor's
+    // `isViewer` property and allows typing if the associated process (if any) is still running. We can get the
+    // editor's console view and check this ourselves, but we have to wait until the editor has finished initialising
+    // before it's available in user data.
+    // Finally, we have a special check for diff windows. If we compare against clipboard, we get a diff editor that is
+    // not file based, is writable, and not a viewer, but we don't want to treat this as an interactive editor.
     // Note that we need a similar check in `VimEditor.isWritable` to allow Escape to work to exit insert mode. We need
     // to know that a read-only editor that is hosting a console view with a running process can be treated as writable.
     Runnable switchToInsertMode = () -> {
@@ -243,7 +244,8 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
     if (!editor.isViewer() &&
         !EditorHelper.isFileEditor(editor) &&
         editor.getDocument().isWritable() &&
-        !CommandStateHelper.inInsertMode(editor)) {
+        !CommandStateHelper.inInsertMode(editor) &&
+        editor.getEditorKind() != EditorKind.DIFF) {
       switchToInsertMode.run();
     }
     ApplicationManager.getApplication().invokeLater(

--- a/src/main/java/com/maddyhome/idea/vim/group/IjOptions.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjOptions.kt
@@ -63,7 +63,7 @@ public object IjOptions {
   public val wrap: ToggleOption = addOption(ToggleOption("wrap", LOCAL_TO_WINDOW, "wrap", true))
 
   // These options are not explicitly listed as local-noglobal in Vim's help, but are set when a new buffer is edited,
-  // based on the value of 'fileformats' or 'fileencodings'. To prevent unexpected file cnversion, we treat them as
+  // based on the value of 'fileformats' or 'fileencodings'. To prevent unexpected file conversion, we treat them as
   // local-noglobal. See `:help local-noglobal`, `:help 'fileformats'` and `:help 'fileencodings'`
   public val bomb: ToggleOption =
     addOption(ToggleOption("bomb", LOCAL_TO_BUFFER, "bomb", false, isLocalNoGlobal = true))

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
@@ -314,7 +314,7 @@ internal class MotionGroup : VimMotionGroupBase() {
               }
               is Mode.CMD_LINE -> {
                 injector.processGroup.cancelExEntry(vimEditor, false)
-                ExOutputModel.getInstance(editor).clear()
+                ExOutputModel.getInstance(editor).close()
               }
               else -> {}
             }

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -726,7 +726,7 @@ internal object VimListenerManager {
           injector.processGroup.cancelExEntry(editor.vim, false)
         }
 
-        ExOutputModel.getInstance(editor).clear()
+        ExOutputModel.getInstance(editor).close()
 
         val caretModel = editor.caretModel
         if (editor.vim.mode.selectionType != null) {
@@ -757,7 +757,7 @@ internal object VimListenerManager {
           injector.processGroup.cancelExEntry(event.editor.vim, false)
         }
 
-        ExOutputModel.getInstance(event.editor).clear()
+        ExOutputModel.getInstance(event.editor).close()
       }
     }
   }

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -128,8 +128,23 @@ import javax.swing.SwingUtilities
  * Make sure the selected editor isn't the new editor, which can happen if there are no other editors open.
  */
 private fun getOpeningEditor(newEditor: Editor) = newEditor.project?.let { project ->
-  FileEditorManager.getInstance(project).selectedTextEditor?.takeUnless { it == newEditor }
+  // Some TextEditor implementations create a dummy Editor instance on demand, e.g., while downloading a file to edit
+  // (see BaseRemoteFileEditor). This can cause recursion if the newly opened/created TextEditor is also the currently
+  // selected TextEditor, because we will be notified of the new dummy Editor before it has finished initialisation, and
+  // try to get its opening editor, causing a new dummy Editor to be created and notifications sent, and so on.
+  // This was reported for 232 and 233 (see VIM-3066), but I can't recreate in 241. The callstack looks different, now
+  // using coroutines, so it's possible the deadlock has been broken. However, it's sensible to leave the recursion
+  // guard in.
+  if (openingEditorRecursionGuard) return null
+  openingEditorRecursionGuard = true
+  try {
+    FileEditorManager.getInstance(project).selectedTextEditor?.takeUnless { it == newEditor }
+  }
+  finally {
+    openingEditorRecursionGuard = false
+  }
 }
+private var openingEditorRecursionGuard = false
 
 internal object VimListenerManager {
 

--- a/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
@@ -135,6 +135,9 @@ public class ExOutputPanel extends JPanel {
       myText.setBorder(null);
       myScrollPane.setBorder(null);
       myLabel.setForeground(myText.getForeground());
+
+      // Make sure the panel is positioned correctly in case we're changing font size
+      positionPanel();
     }
   }
 
@@ -144,7 +147,7 @@ public class ExOutputPanel extends JPanel {
     }
 
     myText.setText(data);
-    myText.setFont(UiHelper.selectFont(data));
+    myText.setFont(UiHelper.selectEditorFont(myEditor, data));
     myText.setCaretPosition(0);
     if (!data.isEmpty()) {
       activate();
@@ -213,8 +216,8 @@ public class ExOutputPanel extends JPanel {
   }
 
   private void setFontForElements() {
-    myText.setFont(UiHelper.selectFont(myText.getText()));
-    myLabel.setFont(UiHelper.selectFont(myLabel.getText()));
+    myText.setFont(UiHelper.selectEditorFont(myEditor, myText.getText()));
+    myLabel.setFont(UiHelper.selectEditorFont(myEditor, myLabel.getText()));
   }
 
   private void scrollLine() {
@@ -242,7 +245,7 @@ public class ExOutputPanel extends JPanel {
 
   private void badKey() {
     myLabel.setText(MessageHelper.message("more.ret.line.space.page.d.half.page.q.quit"));
-    myLabel.setFont(UiHelper.selectFont(myLabel.getText()));
+    myLabel.setFont(UiHelper.selectEditorFont(myEditor, myLabel.getText()));
   }
 
   private void scrollOffset(int more) {
@@ -258,7 +261,7 @@ public class ExOutputPanel extends JPanel {
     else {
       myLabel.setText(MessageHelper.message("ex.output.panel.more"));
     }
-    myLabel.setFont(UiHelper.selectFont(myLabel.getText()));
+    myLabel.setFont(UiHelper.selectEditorFont(myEditor, myLabel.getText()));
   }
 
   private void positionPanel() {

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
@@ -130,7 +130,7 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
   }
 
   public @Nullable Editor getEditor() {
-    return weakEditor.get();
+    return weakEditor != null ? weakEditor.get() : null;
   }
 
   public void setEditor(@Nullable Editor editor) {
@@ -152,11 +152,11 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
   public void activate(@NotNull Editor editor, DataContext context, @NotNull String label, String initText) {
     logger.info("Activate ex entry panel");
     this.label.setText(label);
-    this.label.setFont(UiHelper.selectFont(label));
+    this.label.setFont(UiHelper.selectEditorFont(editor, label));
     entry.reset();
     entry.setEditor(editor, context);
     entry.setText(initText);
-    entry.setFont(UiHelper.selectFont(initText));
+    entry.setFont(UiHelper.selectEditorFont(editor, initText));
     entry.setType(label);
     parent = editor.getContentComponent();
 
@@ -275,7 +275,7 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
     @Override
     protected void textChanged(@NotNull DocumentEvent e) {
       String text = entry.getText();
-      Font newFont = UiHelper.selectFont(text);
+      Font newFont = UiHelper.selectEditorFont(getEditor(), text);
       if (newFont != entry.getFont()) {
         entry.setFont(newFont);
       }
@@ -430,6 +430,9 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
 
       // Label background is automatically picked up
       label.setForeground(entry.getForeground());
+
+      // Make sure the panel is positioned correctly if we're changing font size
+      positionPanel();
     }
   }
 
@@ -447,8 +450,8 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
   }
 
   private void setFontForElements() {
-    label.setFont(UiHelper.selectFont(label.getText()));
-    entry.setFont(UiHelper.selectFont(getVisibleText()));
+    label.setFont(UiHelper.selectEditorFont(getEditor(), label.getText()));
+    entry.setFont(UiHelper.selectEditorFont(getEditor(), getVisibleText()));
   }
 
   private void positionPanel() {

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/CommandParserTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/CommandParserTest.kt
@@ -432,7 +432,7 @@ class CommandParserTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo x"))
-    assertExOutput("3\n")
+    assertExOutput("3")
   }
 
   @Test
@@ -449,7 +449,7 @@ class CommandParserTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo x"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/LongerScriptTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/LongerScriptTest.kt
@@ -63,7 +63,7 @@ class LongerScriptTest : VimTestCase() {
     println(parsingTime)
     executeVimscript(function)
     typeText(commandToKeys("echo F('s[ubstitute]')"))
-    assertExOutput("'s' | 'su' | 'sub' | 'subs' | 'subst' | 'substi' | 'substit' | 'substitu' | 'substitut' | 'substitute';\n")
+    assertExOutput("'s' | 'su' | 'sub' | 'subs' | 'subst' | 'substi' | 'substit' | 'substitu' | 'substitut' | 'substitute';")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/ClearJumpsCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/ClearJumpsCommandTest.kt
@@ -15,15 +15,16 @@ class ClearJumpsCommandTest : VimTestCase() {
   @Test
   fun `test clear jumps`() {
     configureByText(
-      """I found ${c}it in a legendary land
-                      |all rocks and lavender and tufted grass,
-                      |where it was settled on some sodden sand
-                      |hard by the torrent of a mountain pass.
-                      |
-                      |The features it combines mark it as new
-                      |to science: shape and shade -- the special tinge,
-                      |akin to moonlight, tempering its blue,
-                      |the dingy underside, the checquered fringe.
+      """
+        |I found ${c}it in a legendary land
+        |all rocks and lavender and tufted grass,
+        |where it was settled on some sodden sand
+        |hard by the torrent of a mountain pass.
+        |
+        |The features it combines mark it as new
+        |to science: shape and shade -- the special tinge,
+        |akin to moonlight, tempering its blue,
+        |the dingy underside, the checquered fringe.
       """.trimMargin(),
     )
 
@@ -34,34 +35,40 @@ class ClearJumpsCommandTest : VimTestCase() {
 
     enterCommand("jumps")
     assertExOutput(
-      """ jump line  col file/text
-                     |   4     1    8 I found it in a legendary land
-                     |   3     3   29 where it was settled on some sodden sand
-                     |   2     7   12 to science: shape and shade -- the special tinge,
-                     |   1     2    4 all rocks and lavender and tufted grass,
-                     |>
-                     |
+      """
+        | jump line  col file/text
+        |   4     1    8 I found it in a legendary land
+        |   3     3   29 where it was settled on some sodden sand
+        |   2     7   12 to science: shape and shade -- the special tinge,
+        |   1     2    4 all rocks and lavender and tufted grass,
+        |>
       """.trimMargin(),
     )
 
     enterCommand("clearjumps")
 
     enterCommand("jumps")
-    assertExOutput(" jump line  col file/text\n>\n")
+    assertExOutput(
+      """
+        | jump line  col file/text
+        |>
+      """.trimMargin()
+    )
   }
 
   @Test
-  fun `test clear jumps abbreviate`() {
+  fun `test clear jumps abbreviation`() {
     configureByText(
-      """I found ${c}it in a legendary land
-                      |all rocks and lavender and tufted grass,
-                      |where it was settled on some sodden sand
-                      |hard by the torrent of a mountain pass.
-                      |
-                      |The features it combines mark it as new
-                      |to science: shape and shade -- the special tinge,
-                      |akin to moonlight, tempering its blue,
-                      |the dingy underside, the checquered fringe.
+      """
+        |I found ${c}it in a legendary land
+        |all rocks and lavender and tufted grass,
+        |where it was settled on some sodden sand
+        |hard by the torrent of a mountain pass.
+        |
+        |The features it combines mark it as new
+        |to science: shape and shade -- the special tinge,
+        |akin to moonlight, tempering its blue,
+        |the dingy underside, the checquered fringe.
       """.trimMargin(),
     )
 
@@ -72,19 +79,22 @@ class ClearJumpsCommandTest : VimTestCase() {
 
     enterCommand("jumps")
     assertExOutput(
-      """ jump line  col file/text
-                     |   4     1    8 I found it in a legendary land
-                     |   3     3   29 where it was settled on some sodden sand
-                     |   2     7   12 to science: shape and shade -- the special tinge,
-                     |   1     2    4 all rocks and lavender and tufted grass,
-                     |>
-                     |
+      """
+        | jump line  col file/text
+        |   4     1    8 I found it in a legendary land
+        |   3     3   29 where it was settled on some sodden sand
+        |   2     7   12 to science: shape and shade -- the special tinge,
+        |   1     2    4 all rocks and lavender and tufted grass,
+        |>
       """.trimMargin(),
     )
 
     enterCommand("clearju")
 
     enterCommand("jumps")
-    assertExOutput(" jump line  col file/text\n>\n")
+    assertExOutput("""
+      | jump line  col file/text
+      |>
+    """.trimMargin())
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/CmdClearCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/CmdClearCommandTest.kt
@@ -22,7 +22,7 @@ class CmdClearCommandTest : VimTestCase() {
     configureByText("\n")
     typeText(commandToKeys("command"))
     assertPluginError(false)
-    assertExOutput("Name        Args       Definition\n") // There should not be any aliases.
+    assertExOutput("Name        Args       Definition") // There should not be any aliases.
 
     typeText(commandToKeys("command Vs vs"))
     assertPluginError(false)
@@ -46,6 +46,6 @@ class CmdClearCommandTest : VimTestCase() {
     assertPluginError(false)
     typeText(commandToKeys("command"))
     assertPluginError(false)
-    assertExOutput("Name        Args       Definition\n") // There should not be any aliases.
+    assertExOutput("Name        Args       Definition") // There should not be any aliases.
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/CmdCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/CmdCommandTest.kt
@@ -35,7 +35,7 @@ class CmdCommandTest : VimTestCase() {
     configureByText("\n")
     typeText(commandToKeys("command"))
     assertPluginError(false)
-    assertExOutput("Name        Args       Definition\n") // There should not be any aliases.
+    assertExOutput("Name        Args       Definition") // There should not be any aliases.
 
     typeText(commandToKeys("command Vs vs"))
     assertPluginError(false)
@@ -201,13 +201,13 @@ class CmdCommandTest : VimTestCase() {
     assertPluginError(false)
     typeText(commandToKeys("Error test"))
     assertPluginError(false)
-    assertExOutput("Hello!\n")
+    assertExOutput("Hello!")
 
     typeText(commandToKeys("command! -nargs=1 Error echo <q-args>"))
     assertPluginError(false)
     typeText(commandToKeys("Error test message"))
     assertPluginError(false)
-    assertExOutput("test message\n")
+    assertExOutput("test message")
   }
 
   @Test
@@ -220,7 +220,7 @@ class CmdCommandTest : VimTestCase() {
     assertPluginError(false)
     typeText(commandToKeys("Show test"))
     assertPluginError(false)
-    assertExOutput("test\n")
+    assertExOutput("test")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/DelCmdCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/DelCmdCommandTest.kt
@@ -22,7 +22,7 @@ class DelCmdCommandTest : VimTestCase() {
     configureByText("\n")
     typeText(commandToKeys("command"))
     assertPluginError(false)
-    assertExOutput("Name        Args       Definition\n") // There should not be any aliases.
+    assertExOutput("Name        Args       Definition") // There should not be any aliases.
 
     typeText(commandToKeys("command Vs vs"))
     assertPluginError(false)

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/EchoCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/EchoCommandTest.kt
@@ -17,34 +17,34 @@ class EchoCommandTest : VimTestCase() {
   fun `test echo with a string`() {
     configureByText("\n")
     typeText(commandToKeys("echo \"Hello, World!\""))
-    assertExOutput("Hello, World!\n")
+    assertExOutput("Hello, World!")
   }
 
   @Test
   fun `test echo with an expression`() {
     configureByText("\n")
     typeText(commandToKeys("echo 3 + 7"))
-    assertExOutput("10\n")
+    assertExOutput("10")
   }
 
   @Test
   fun `test echo with multiple expressions`() {
     configureByText("\n")
     typeText(commandToKeys("echo 3 + 7 'Hello ' . 'world'"))
-    assertExOutput("10 Hello world\n")
+    assertExOutput("10 Hello world")
   }
 
   @Test
   fun `test ec`() {
     configureByText("\n")
     typeText(commandToKeys("ec 3"))
-    assertExOutput("3\n")
+    assertExOutput("3")
   }
 
   @Test
   fun `test echo without spaces`() {
     configureByText("\n")
     typeText(commandToKeys("echo(42)(999)"))
-    assertExOutput("42 999\n")
+    assertExOutput("42 999")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/ExecuteCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/ExecuteCommandTest.kt
@@ -17,7 +17,7 @@ class ExecuteCommandTest : VimTestCase() {
   fun `test execute with one expression`() {
     configureByText("\n")
     typeText(commandToKeys("execute 'echo 42'"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 
   @Test
@@ -32,20 +32,20 @@ class ExecuteCommandTest : VimTestCase() {
   fun `test execute multiple expressions`() {
     configureByText("\n")
     typeText(commandToKeys("execute 'echo' 4 + 2 * 3"))
-    assertExOutput("10\n")
+    assertExOutput("10")
   }
 
   @Test
   fun `test execute adds space between expressions if missing`() {
     configureByText("\n")
     typeText(commandToKeys("execute 'echo ' . \"'result =\"4+2*3.\"'\""))
-    assertExOutput("result = 10\n")
+    assertExOutput("result = 10")
   }
 
   @Test
   fun `test execute without spaces`() {
     configureByText("\n")
     typeText(commandToKeys("execute('echo '.42)"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/GlobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/GlobalCommandTest.kt
@@ -255,7 +255,7 @@ class GlobalCommandTest : VimTestCase() {
       initialText,
       initialText,
     )
-    assertExOutput("I found it in a legendary land\n")
+    assertExOutput("I found it in a legendary land")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.DIFFERENT)
@@ -269,7 +269,7 @@ class GlobalCommandTest : VimTestCase() {
     assertExOutput("""
       |I found it in a legendary land
       |where it was settled on some sodden sand
-      |""".trimMargin())
+      """.trimMargin())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.DIFFERENT)
@@ -280,7 +280,7 @@ class GlobalCommandTest : VimTestCase() {
       initialText,
       initialText,
     )
-    assertExOutput("I found it in a legendary land\n")
+    assertExOutput("I found it in a legendary land")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/GlobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/GlobalCommandTest.kt
@@ -11,7 +11,6 @@ package org.jetbrains.plugins.ideavim.ex.implementation.commands
 import com.intellij.idea.TestFor
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.history.HistoryConstants
-import com.maddyhome.idea.vim.state.mode.Mode
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -205,6 +204,36 @@ class GlobalCommandTest : VimTestCase() {
   }
 
   @Test
+  fun `test match ignores case`() {
+    doTest(
+      exCommand("g/test/p"),
+      """
+        |one test
+        |two
+        |three Test
+        |four
+        |five TEST
+      """.trimMargin(),
+      """
+        |one test
+        |two
+        |three Test
+        |four
+        |five TEST
+      """.trimMargin()
+    ) {
+      enterCommand("set ignorecase")
+    }
+    assertExOutput(
+      """
+        |one test
+        |three Test
+        |five TEST
+      """.trimMargin()
+    )
+  }
+
+  @Test
   fun `test check history`() {
     VimPlugin.getHistory().clear()
     val initialEntries = VimPlugin.getHistory().getEntries(HistoryConstants.COMMAND, 0, 0)
@@ -335,6 +364,6 @@ end
   }
 
   private fun doTest(command: String, before: String, after: String) {
-    doTest(listOf(exCommand(command)), before, after, Mode.NORMAL())
+    doTest(listOf(exCommand(command)), before, after)
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/JumpsCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/JumpsCommandTest.kt
@@ -17,7 +17,7 @@ class JumpsCommandTest : VimTestCase() {
   fun `test shows empty list`() {
     configureByText("")
     enterCommand("jumps")
-    assertExOutput(" jump line  col file/text\n>\n")
+    assertExOutput(" jump line  col file/text\n>")
   }
 
   @Test
@@ -48,7 +48,6 @@ class JumpsCommandTest : VimTestCase() {
                      |   2     7   12 to science: shape and shade -- the special tinge,
                      |   1     2    4 all rocks and lavender and tufted grass,
                      |>
-                     |
       """.trimMargin(),
     )
   }
@@ -83,7 +82,6 @@ class JumpsCommandTest : VimTestCase() {
                      |>  0     7   12 to science: shape and shade -- the special tinge,
                      |   1     2    4 all rocks and lavender and tufted grass,
                      |   2     9   10 the dingy underside, the checquered fringe.
-                     |
       """.trimMargin(),
     )
   }
@@ -101,7 +99,6 @@ class JumpsCommandTest : VimTestCase() {
       """ jump line  col file/text
                      |   1     1    0 ${text.substring(0, 200)}
                      |>
-                     |
       """.trimMargin(),
     )
   }
@@ -114,10 +111,10 @@ class JumpsCommandTest : VimTestCase() {
 
     enterCommand("jumps")
     assertExOutput(
-      """ jump line  col file/text
-                     |   1     1    0 Hello^FWorld^?
-                     |>
-                     |
+      """
+        | jump line  col file/text
+        |   1     1    0 Hello^FWorld^?
+        |>
       """.trimMargin(),
     )
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/LetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/LetCommandTest.kt
@@ -36,47 +36,47 @@ class LetCommandTest : VimTestCase() {
   @Test
   fun `test assignment to string`() {
     enterCommand("let s = \"foo\"")
-    assertCommandOutput("echo s", "foo\n")
+    assertCommandOutput("echo s", "foo")
   }
 
   @Test
   fun `test assignment to number`() {
     enterCommand("let s = 100")
-    assertCommandOutput("echo s", "100\n")
+    assertCommandOutput("echo s", "100")
   }
 
   @Test
   fun `test assignment to expression`() {
     enterCommand("let s = 10 + 20 * 4")
-    assertCommandOutput("echo s", "90\n")
+    assertCommandOutput("echo s", "90")
   }
 
   @Test
   fun `test adding new pair to dictionary`() {
     enterCommand("let s = {'key1' : 1}")
     enterCommand("let s['key2'] = 2")
-    assertCommandOutput("echo s", "{'key1': 1, 'key2': 2}\n")
+    assertCommandOutput("echo s", "{'key1': 1, 'key2': 2}")
   }
 
   @Test
   fun `test editing existing pair in dictionary`() {
     enterCommand("let s = {'key1' : 1}")
     enterCommand("let s['key1'] = 2")
-    assertCommandOutput("echo s", "{'key1': 2}\n")
+    assertCommandOutput("echo s", "{'key1': 2}")
   }
 
   @Test
   fun `test assignment plus operator`() {
     enterCommand("let s = 10")
     enterCommand("let s += 5")
-    assertCommandOutput("echo s", "15\n")
+    assertCommandOutput("echo s", "15")
   }
 
   @Test
   fun `test changing list item`() {
     enterCommand("let s = [1, 1]")
     enterCommand("let s[1] = 2")
-    assertCommandOutput("echo s", "[1, 2]\n")
+    assertCommandOutput("echo s", "[1, 2]")
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN_ERROR)
@@ -92,7 +92,7 @@ class LetCommandTest : VimTestCase() {
   fun `test changing list with sublist expression`() {
     enterCommand("let s = [1, 2, 3]")
     enterCommand("let s[0:1] = [5, 4]")
-    assertCommandOutput("echo s", "[5, 4, 3]\n")
+    assertCommandOutput("echo s", "[5, 4, 3]")
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN_ERROR)
@@ -117,7 +117,7 @@ class LetCommandTest : VimTestCase() {
   fun `test changing list with sublist expression and undefined end`() {
     enterCommand("let s = [1, 2, 3]")
     enterCommand("let s[1:] = [5, 5, 5, 5]")
-    assertCommandOutput("echo s", "[1, 5, 5, 5, 5]\n")
+    assertCommandOutput("echo s", "[1, 5, 5, 5, 5]")
   }
 
   @Test
@@ -227,13 +227,13 @@ class LetCommandTest : VimTestCase() {
   @Test
   fun `test comment`() {
     enterCommand("let s = [1, 2, 3] \" my list for storing numbers")
-    assertCommandOutput("echo s", "[1, 2, 3]\n")
+    assertCommandOutput("echo s", "[1, 2, 3]")
   }
 
   @Test
   fun `test vimScriptGlobalEnvironment`() {
     enterCommand("let g:WhichKey_ShowVimActions = \"true\"")
-    assertCommandOutput("echo g:WhichKey_ShowVimActions", "true\n")
+    assertCommandOutput("echo g:WhichKey_ShowVimActions", "true")
     assertEquals("true", VimScriptGlobalEnvironment.getInstance().variables["g:WhichKey_ShowVimActions"])
   }
 
@@ -242,7 +242,7 @@ class LetCommandTest : VimTestCase() {
     enterCommand("let list = [1, 2, 3]")
     enterCommand("let l2 = list")
     enterCommand("let list += [4]")
-    assertCommandOutput("echo l2", "[1, 2, 3, 4]\n")
+    assertCommandOutput("echo l2", "[1, 2, 3, 4]")
   }
 
   @Test
@@ -250,7 +250,7 @@ class LetCommandTest : VimTestCase() {
     enterCommand("let list = [1, 2, 3, []]")
     enterCommand("let l2 = list")
     enterCommand("let list[3] += [4]")
-    assertCommandOutput("echo l2", "[1, 2, 3, [4]]\n")
+    assertCommandOutput("echo l2", "[1, 2, 3, [4]]")
   }
 
   @Test
@@ -259,7 +259,7 @@ class LetCommandTest : VimTestCase() {
     enterCommand("let dict = {}")
     enterCommand("let dict.l2 = list")
     enterCommand("let list[3] += [4]")
-    assertCommandOutput("echo dict.l2", "[1, 2, 3, [4]]\n")
+    assertCommandOutput("echo dict.l2", "[1, 2, 3, [4]]")
   }
 
   @Test
@@ -268,7 +268,7 @@ class LetCommandTest : VimTestCase() {
     enterCommand("let dict = {}")
     enterCommand("let dict.l2 = list")
     enterCommand("let dict.l2 += [4]")
-    assertCommandOutput("echo dict.l2", "[1, 2, 3, 4]\n")
+    assertCommandOutput("echo dict.l2", "[1, 2, 3, 4]")
   }
 
   @Test
@@ -276,7 +276,7 @@ class LetCommandTest : VimTestCase() {
     enterCommand("let number = 10")
     enterCommand("let n2 = number")
     enterCommand("let number += 2")
-    assertCommandOutput("echo n2", "10\n")
+    assertCommandOutput("echo n2", "10")
   }
 
   @Test
@@ -284,7 +284,7 @@ class LetCommandTest : VimTestCase() {
     enterCommand("let string = 'abc'")
     enterCommand("let str2 = string")
     enterCommand("let string .= 'd'")
-    assertCommandOutput("echo str2", "abc\n")
+    assertCommandOutput("echo str2", "abc")
   }
 
   @Test
@@ -293,7 +293,7 @@ class LetCommandTest : VimTestCase() {
     enterCommand("let dict2 = dictionary")
     enterCommand("let dictionary.one = 1")
     enterCommand("let dictionary['two'] = 2")
-    assertCommandOutput("echo dict2", "{'one': 1, 'two': 2}\n")
+    assertCommandOutput("echo dict2", "{'one': 1, 'two': 2}")
   }
 
   @Test
@@ -301,13 +301,13 @@ class LetCommandTest : VimTestCase() {
     enterCommand("let list = [1, 2, 3, {'a': 'b'}]")
     enterCommand("let dict = list[3]")
     enterCommand("let list[3].key = 'value'")
-    assertCommandOutput("echo dict", "{'a': 'b', 'key': 'value'}\n")
+    assertCommandOutput("echo dict", "{'a': 'b', 'key': 'value'}")
   }
 
   @Test
   fun `test numbered register`() {
     enterCommand("let @4 = 'inumber register works'")
-    assertCommandOutput("echo @4", "inumber register works\n")
+    assertCommandOutput("echo @4", "inumber register works")
 
     typeText("@4")
     assertState("number register works\n")
@@ -316,7 +316,7 @@ class LetCommandTest : VimTestCase() {
   @Test
   fun `test lowercase letter register`() {
     enterCommand("let @o = 'ilowercase letter register works'")
-    assertCommandOutput("echo @o", "ilowercase letter register works\n")
+    assertCommandOutput("echo @o", "ilowercase letter register works")
 
     typeText("@o")
     assertState("lowercase letter register works\n")
@@ -325,20 +325,20 @@ class LetCommandTest : VimTestCase() {
   @Test
   fun `test uppercase letter register`() {
     enterCommand("let @O = 'iuppercase letter register works'")
-    assertCommandOutput("echo @O", "iuppercase letter register works\n")
+    assertCommandOutput("echo @O", "iuppercase letter register works")
 
     typeText("@O")
     assertState("uppercase letter register works\n")
     typeText("<Esc>")
 
     enterCommand("let @O = '!'")
-    assertCommandOutput("echo @O", "iuppercase letter register works!\n")
+    assertCommandOutput("echo @O", "iuppercase letter register works!")
   }
 
   @Test
   fun `test unnamed register`() {
     enterCommand("let @\" = 'iunnamed register works'")
-    assertCommandOutput("echo @\"", "iunnamed register works\n")
+    assertCommandOutput("echo @\"", "iunnamed register works")
 
     typeText("@\"")
     assertState("unnamed register works\n")

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/LockVarCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/LockVarCommandTest.kt
@@ -35,7 +35,7 @@ class LockVarCommandTest : VimTestCase() {
     typeText(commandToKeys("let x = 15"))
     assertPluginError(false)
     typeText(commandToKeys("echo x"))
-    assertExOutput("15\n")
+    assertExOutput("15")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)
@@ -67,10 +67,10 @@ class LockVarCommandTest : VimTestCase() {
     typeText(commandToKeys("lockvar x"))
     typeText(commandToKeys("let y = x"))
     typeText(commandToKeys("echo y"))
-    assertExOutput("10\n")
+    assertExOutput("10")
     typeText(commandToKeys("let y = 15"))
     typeText(commandToKeys("echo y"))
-    assertExOutput("15\n")
+    assertExOutput("15")
     assertPluginError(false)
   }
 
@@ -84,7 +84,7 @@ class LockVarCommandTest : VimTestCase() {
     assertPluginError(true)
     assertPluginErrorMessageContains("E741: Value is locked")
     typeText(commandToKeys("echo x"))
-    assertExOutput("[1, 2]\n")
+    assertExOutput("[1, 2]")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)
@@ -97,7 +97,7 @@ class LockVarCommandTest : VimTestCase() {
     assertPluginError(true)
     assertPluginErrorMessageContains("E741: Value is locked")
     typeText(commandToKeys("echo x"))
-    assertExOutput("{'one': 1}\n")
+    assertExOutput("{'one': 1}")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)
@@ -109,12 +109,12 @@ class LockVarCommandTest : VimTestCase() {
     typeText(commandToKeys("let x.one = 42"))
     assertPluginError(false)
     typeText(commandToKeys("echo x"))
-    assertExOutput("{'one': 42}\n")
+    assertExOutput("{'one': 42}")
     typeText(commandToKeys("let x.two = 2"))
     assertPluginError(true)
     assertPluginErrorMessageContains("E741: Value is locked")
     typeText(commandToKeys("echo x"))
-    assertExOutput("{'one': 42}\n")
+    assertExOutput("{'one': 42}")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)
@@ -127,7 +127,7 @@ class LockVarCommandTest : VimTestCase() {
     assertPluginError(true)
     assertPluginErrorMessageContains("E741: Value is locked")
     typeText(commandToKeys("echo x"))
-    assertExOutput("{'one': 1}\n")
+    assertExOutput("{'one': 1}")
   }
 
   @Test
@@ -137,7 +137,7 @@ class LockVarCommandTest : VimTestCase() {
     typeText(commandToKeys("lockvar x"))
     typeText(commandToKeys("let x.list[0] = 42"))
     typeText(commandToKeys("echo x"))
-    assertExOutput("{'list': [42]}\n")
+    assertExOutput("{'list': [42]}")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)
@@ -150,6 +150,6 @@ class LockVarCommandTest : VimTestCase() {
     assertPluginError(true)
     assertPluginErrorMessageContains("E741: Value is locked")
     typeText(commandToKeys("echo x"))
-    assertExOutput("{'list': [1]}\n")
+    assertExOutput("{'list': [1]}")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MapCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MapCommandTest.kt
@@ -107,18 +107,18 @@ class MapCommandTest : VimTestCase() {
     typeText(commandToKeys("imap"))
     assertExOutput(
       """
-  i  <C-Down>      <C-O>gt
-  i  bar           <Esc>
-  i  foo           bar
-  
-      """.trimIndent(),
+        |i  <C-Down>      <C-O>gt
+        |i  bar           <Esc>
+        |i  foo           bar
+      """.trimMargin(),
     )
     typeText(commandToKeys("map"))
     assertExOutput(
-      """   <C-Down>      gt
-n  <Plug>Foo     iHello<Esc>
-n  ,f            <Plug>Foo
-""",
+      """
+        |   <C-Down>      gt
+        |n  <Plug>Foo     iHello<Esc>
+        |n  ,f            <Plug>Foo
+        """.trimMargin(),
     )
   }
 
@@ -167,10 +167,9 @@ n  ,f            <Plug>Foo
     typeText(commandToKeys("imap"))
     assertExOutput(
       """
-  i  foo           bar
-  i  jj          * <Esc>
-  
-      """.trimIndent(),
+        |i  foo           bar
+        |i  jj          * <Esc>
+      """.trimMargin(),
     )
   }
 
@@ -197,7 +196,7 @@ n  ,f            <Plug>Foo
     )
     assertOffset(1)
     typeText(commandToKeys("nmap"))
-    assertExOutput("n  <Right>     * <Nop>\n")
+    assertExOutput("n  <Right>     * <Nop>")
   }
 
   @Test
@@ -213,14 +212,13 @@ n  ,f            <Plug>Foo
     typeText(commandToKeys("nmap"))
     assertExOutput(
       """
-  n  ,a            /a<CR>
-  n  ,b            /b<CR>
-  n  ,c            /c<CR>
-  n  ,d            /d<CR>
-  n  ,f            '/f<CR>'
-  n  ,g            /g<CR>
-  
-      """.trimIndent(),
+        |n  ,a            /a<CR>
+        |n  ,b            /b<CR>
+        |n  ,c            /c<CR>
+        |n  ,d            /d<CR>
+        |n  ,f            '/f<CR>'
+        |n  ,g            /g<CR>
+      """.trimMargin(),
     )
   }
 
@@ -311,7 +309,7 @@ n  ,f            <Plug>Foo
     assertState("#\n")
     assertMode(Mode.NORMAL())
     typeText(commandToKeys("imap"))
-    assertExOutput("i  #           * X<C-H>#\n")
+    assertExOutput("i  #           * X<C-H>#")
   }
 
   // VIM-679 |:map|
@@ -336,7 +334,7 @@ n  ,f            <Plug>Foo
     )
     assertMode(Mode.NORMAL())
     typeText(commandToKeys("map"))
-    assertExOutput("   <C-X>i        dd\n")
+    assertExOutput("   <C-X>i        dd")
     typeText(injector.parser.parseKeys("<C-X>i"))
     assertState("bar\n")
   }
@@ -642,17 +640,16 @@ n  ,f            <Plug>Foo
     typeText(commandToKeys("nmap"))
     assertExOutput(
       """
-n  ,a            <Action>(Back)
-n  ,b            <Action>(Back)
-n  ,c            <Action>(Back)
-n  ,d            <Action>(Back)
-n  ,e            <Action>(Back)
-n  ,f            <Action>(Back)
-n  ,g            <Action>(Back)
-n  ,h            <Action>(Back)
-n  ,i            <Action>(Back)
-
-      """.trimIndent(),
+        |n  ,a            <Action>(Back)
+        |n  ,b            <Action>(Back)
+        |n  ,c            <Action>(Back)
+        |n  ,d            <Action>(Back)
+        |n  ,e            <Action>(Back)
+        |n  ,f            <Action>(Back)
+        |n  ,g            <Action>(Back)
+        |n  ,h            <Action>(Back)
+        |n  ,i            <Action>(Back)
+      """.trimMargin(),
     )
   }
 
@@ -671,17 +668,16 @@ n  ,i            <Action>(Back)
     typeText(commandToKeys("nnoremap"))
     assertExOutput(
       """
-n  ,a            <Action>(Back)
-n  ,b            <Action>(Back)
-n  ,c            <Action>(Back)
-n  ,d            <Action>(Back)
-n  ,e            <Action>(Back)
-n  ,f            <Action>(Back)
-n  ,g            <Action>(Back)
-n  ,h            <Action>(Back)
-n  ,i            <Action>(Back)
-
-      """.trimIndent(),
+        |n  ,a            <Action>(Back)
+        |n  ,b            <Action>(Back)
+        |n  ,c            <Action>(Back)
+        |n  ,d            <Action>(Back)
+        |n  ,e            <Action>(Back)
+        |n  ,f            <Action>(Back)
+        |n  ,g            <Action>(Back)
+        |n  ,h            <Action>(Back)
+        |n  ,i            <Action>(Back)
+      """.trimMargin(),
     )
   }
 
@@ -690,7 +686,7 @@ n  ,i            <Action>(Back)
     configureByText("\n")
     typeText(commandToKeys("map A :echo 42<CR>"))
     typeText(injector.parser.parseKeys("A"))
-    assertExOutput("42\n")
+    assertExOutput("42")
     kotlin.test.assertEquals(
       "map A :echo 42<CR>",
       injector.historyGroup.getEntries(HistoryConstants.COMMAND, 0, 0).last().entry,

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MarksCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MarksCommandTest.kt
@@ -156,7 +156,7 @@ class MarksCommandTest : VimTestCase() {
   fun `test list empty marks`() {
     configureByText("")
     enterCommand("marks")
-    assertExOutput("mark line  col file/text\n")
+    assertExOutput("mark line  col file/text")
   }
 
   @Test
@@ -172,8 +172,9 @@ class MarksCommandTest : VimTestCase() {
 
     enterCommand("marks")
     assertExOutput(
-      """mark line  col file/text
-                     | a      3    8 where it was settled on some sodden sand
+      """
+        |mark line  col file/text
+        | a      3    8 where it was settled on some sodden sand
       """.trimMargin(),
     )
   }
@@ -191,8 +192,9 @@ class MarksCommandTest : VimTestCase() {
 
     enterCommand("marks")
     assertExOutput(
-      """mark line  col file/text
-                     | a      1    0 Lorem ipsum dolor sit amet,
+      """
+        |mark line  col file/text
+        | a      1    0 Lorem ipsum dolor sit amet,
       """.trimMargin(),
     )
   }
@@ -213,11 +215,12 @@ class MarksCommandTest : VimTestCase() {
 
     enterCommand("marks")
     assertExOutput(
-      """mark line  col file/text
-                     | a      1    8 I found it in a legendary land
-                     | b      2    9 all rocks and lavender and tufted grass,
-                     | c      3   10 where it was settled on some sodden sand
-                     | d      4   11 hard by the torrent of a mountain pass.
+      """
+        |mark line  col file/text
+        | a      1    8 I found it in a legendary land
+        | b      2    9 all rocks and lavender and tufted grass,
+        | c      3   10 where it was settled on some sodden sand
+        | d      4   11 hard by the torrent of a mountain pass.
       """.trimMargin(),
     )
   }
@@ -236,9 +239,10 @@ class MarksCommandTest : VimTestCase() {
 
     enterCommand("marks")
     assertExOutput(
-      """mark line  col file/text
-                     | A      1    8 I found it in a legendary land
-                     | B      2   10 all rocks and lavender and tufted grass,
+      """
+        |mark line  col file/text
+        | A      1    8 I found it in a legendary land
+        | B      2   10 all rocks and lavender and tufted grass,
       """.trimMargin(),
     )
   }
@@ -259,9 +263,10 @@ class MarksCommandTest : VimTestCase() {
 
     enterCommand("marks bdD")
     assertExOutput(
-      """mark line  col file/text
-                     | b      2    9 consectetur adipiscing elit
-                     | D      4   11 Cras id tellus in ex imperdiet egestas.
+      """
+        |mark line  col file/text
+        | b      2    9 consectetur adipiscing elit
+        | D      4   11 Cras id tellus in ex imperdiet egestas.
       """.trimMargin(),
     )
   }
@@ -277,7 +282,7 @@ class MarksCommandTest : VimTestCase() {
     )
     typeText(injector.parser.parseKeys("ma" + "jl"))
     enterCommand("marks b")
-    assertExOutput("mark line  col file/text\n")
+    assertExOutput("mark line  col file/text")
   }
 
   @Test
@@ -293,8 +298,9 @@ class MarksCommandTest : VimTestCase() {
     injector.markService.setMark(vimEditor.primaryCaret(), 'a', 100000)
     enterCommand("marks")
     assertExOutput(
-      """mark line  col file/text
-                     | a      4   39 Cras id tellus in ex imperdiet egestas.
+      """
+        |mark line  col file/text
+        | a      4   39 Cras id tellus in ex imperdiet egestas.
       """.trimMargin(),
     )
   }
@@ -305,10 +311,11 @@ class MarksCommandTest : VimTestCase() {
     typeText(injector.parser.parseKeys("ma" + "j" + "mb" + "j" + "mc"))
     enterCommand("marks abc")
     assertExOutput(
-      """mark line  col file/text
-                     | a      1    0 Hello world
-                     | b      2    0 ^F
-                     | c      3    0 ^?
+      """
+        |mark line  col file/text
+        | a      1    0 Hello world
+        | b      2    0 ^F
+        | c      3    0 ^?
       """.trimMargin(),
     )
   }
@@ -321,8 +328,9 @@ class MarksCommandTest : VimTestCase() {
     typeText(injector.parser.parseKeys("ma"))
     enterCommand("marks a")
     assertExOutput(
-      """mark line  col file/text
-                     | a      1  100 ${text.substring(0, 200)}
+      """
+        |mark line  col file/text
+        | a      1  100 ${text.substring(0, 200)}
       """.trimMargin(),
     )
   }
@@ -359,18 +367,19 @@ class MarksCommandTest : VimTestCase() {
     // Can't easily test 0-9 or " (locations of previously closed files from vim-info)
     enterCommand("marks")
     assertExOutput(
-      """mark line  col file/text
-                     | '      8   20 akin replaced content its blue,
-                     | a      1    8 I found it in a legendary land
-                     | b      1   11 I found it in a legendary land
-                     | A      4    6 hard by the torrent of a mountain pass.
-                     | B      3    6 where it was settled on some sodden sand
-                     | [      8    5 akin replaced content its blue,
-                     | ]      8   21 akin replaced content its blue,
-                     | ^      8   21 akin replaced content its blue,
-                     | .      8   20 akin replaced content its blue,
-                     | <      2   10 all rocks and lavender and tufted grass,
-                     | >      2   16 all rocks and lavender and tufted grass,
+      """
+        |mark line  col file/text
+        | '      8   20 akin replaced content its blue,
+        | a      1    8 I found it in a legendary land
+        | b      1   11 I found it in a legendary land
+        | A      4    6 hard by the torrent of a mountain pass.
+        | B      3    6 where it was settled on some sodden sand
+        | [      8    5 akin replaced content its blue,
+        | ]      8   21 akin replaced content its blue,
+        | ^      8   21 akin replaced content its blue,
+        | .      8   20 akin replaced content its blue,
+        | <      2   10 all rocks and lavender and tufted grass,
+        | >      2   16 all rocks and lavender and tufted grass,
       """.trimMargin(),
     )
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/PrintCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/PrintCommandTest.kt
@@ -17,28 +17,28 @@ class PrintCommandTest : VimTestCase() {
   fun `test default range`() {
     configureByText(initialText)
     typeText(commandToKeys("p"))
-    assertExOutput("    Lorem Ipsum\n")
+    assertExOutput("    Lorem Ipsum")
   }
 
   @Test
   fun `test clears output between execution`() {
     configureByText(initialText)
     typeText(commandToKeys("p"))
-    assertExOutput("    Lorem Ipsum\n", clear = false)
+    assertExOutput("    Lorem Ipsum", clear = false)
     // TODO: We need a better way to handle output
     // We should be waiting for a keypress now, such as <Enter> or <Esc> to close the output panel. But that's handled
     // by a separate key event loop which doesn't operate in tests.
     // Simulate closing the output panel in the same way as if we'd entered the right key
     ExOutputModel.getInstance(fixture.editor).close()
     typeText(commandToKeys("p"))
-    assertExOutput("    Lorem Ipsum\n")
+    assertExOutput("    Lorem Ipsum")
   }
 
   @Test
   fun `test default range with P`() {
     configureByText(initialText)
     typeText(commandToKeys("P"))
-    assertExOutput("    Lorem Ipsum\n")
+    assertExOutput("    Lorem Ipsum")
   }
 
   @Test
@@ -67,7 +67,7 @@ class PrintCommandTest : VimTestCase() {
       |    Lorem ipsum dolor sit amet,
       |    consectetur adipiscing elit
       |    Sed in orci mauris.
-      |""".trimMargin(),
+      """.trimMargin(),
     )
   }
 
@@ -89,7 +89,7 @@ class PrintCommandTest : VimTestCase() {
       |    Lorem Ipsum
       |
       |    Lorem ipsum dolor sit amet,
-      |""".trimMargin(),
+      """.trimMargin(),
     )
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/RegistersCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/RegistersCommandTest.kt
@@ -22,7 +22,7 @@ class RegistersCommandTest : VimTestCase() {
   fun `test list empty registers`() {
     configureByText("")
     enterCommand("registers")
-    assertExOutput("Type Name Content\n")
+    assertExOutput("Type Name Content")
   }
 
   @Test
@@ -77,7 +77,7 @@ class RegistersCommandTest : VimTestCase() {
     }
 
     enterCommand("registers Z")
-    assertExOutput("Type Name Content\n")
+    assertExOutput("Type Name Content")
   }
 
   @Test
@@ -92,8 +92,9 @@ class RegistersCommandTest : VimTestCase() {
     // Does not trim whitespace
     enterCommand("registers a")
     assertExOutput(
-      """Type Name Content
-                     |  c  "a   ${(indent + text).take(200)}
+      """
+        |Type Name Content
+        |  c  "a   ${(indent + text).take(200)}
       """.trimMargin(),
     )
   }
@@ -106,8 +107,9 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-                     |  c  "a   ^IHello World^J^[
+      """
+        |Type Name Content
+        |  c  "a   ^IHello World^J^[
       """.trimMargin(),
     )
   }
@@ -123,10 +125,11 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("display abc")
     assertExOutput(
-      """Type Name Content
-      |  c  "a   Content for register a
-      |  c  "b   Content for register b
-      |  c  "c   Content for register c
+      """
+        |Type Name Content
+        |  c  "a   Content for register a
+        |  c  "b   Content for register b
+        |  c  "c   Content for register c
       """.trimMargin(),
     )
   }
@@ -181,48 +184,49 @@ class RegistersCommandTest : VimTestCase() {
     // "= expression register
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-      |  c  ""   s
-      |  c  "0   last yank 
-      |  l  "1   line 9^J
-      |  l  "2   line 8^J
-      |  l  "3   line 7^J
-      |  l  "4   line 6^J
-      |  l  "5   line 5^J
-      |  l  "6   line 4^J
-      |  l  "7   line 3^J
-      |  l  "8   line 2^J
-      |  l  "9   line 1^J
-      |  c  "a   Hello world a
-      |  c  "b   Hello world b
-      |  c  "c   Hello world c
-      |  c  "d   Hello world d
-      |  c  "e   Hello world e
-      |  c  "f   Hello world f
-      |  c  "g   Hello world g
-      |  c  "h   Hello world h
-      |  c  "i   Hello world i
-      |  c  "j   Hello world j
-      |  c  "k   Hello world k
-      |  c  "l   Hello world l
-      |  c  "m   Hello world m
-      |  c  "n   Hello world n
-      |  c  "o   Hello world o
-      |  c  "p   Hello world p
-      |  c  "q   Hello world q
-      |  c  "r   Hello world r
-      |  c  "s   Hello world s
-      |  c  "t   Hello world t
-      |  c  "u   Hello world u
-      |  c  "v   Hello world v
-      |  c  "w   Hello world w
-      |  c  "x   Hello world x
-      |  c  "y   Hello world y
-      |  c  "z   Hello world z
-      |  c  "-   s
-      |  c  "*   clipboard content
-      |  c  ":   ascii
-      |  c  "/   search pattern
+      """
+        |Type Name Content
+        |  c  ""   s
+        |  c  "0   last yank 
+        |  l  "1   line 9^J
+        |  l  "2   line 8^J
+        |  l  "3   line 7^J
+        |  l  "4   line 6^J
+        |  l  "5   line 5^J
+        |  l  "6   line 4^J
+        |  l  "7   line 3^J
+        |  l  "8   line 2^J
+        |  l  "9   line 1^J
+        |  c  "a   Hello world a
+        |  c  "b   Hello world b
+        |  c  "c   Hello world c
+        |  c  "d   Hello world d
+        |  c  "e   Hello world e
+        |  c  "f   Hello world f
+        |  c  "g   Hello world g
+        |  c  "h   Hello world h
+        |  c  "i   Hello world i
+        |  c  "j   Hello world j
+        |  c  "k   Hello world k
+        |  c  "l   Hello world l
+        |  c  "m   Hello world m
+        |  c  "n   Hello world n
+        |  c  "o   Hello world o
+        |  c  "p   Hello world p
+        |  c  "q   Hello world q
+        |  c  "r   Hello world r
+        |  c  "s   Hello world s
+        |  c  "t   Hello world t
+        |  c  "u   Hello world u
+        |  c  "v   Hello world v
+        |  c  "w   Hello world w
+        |  c  "x   Hello world x
+        |  c  "y   Hello world y
+        |  c  "z   Hello world z
+        |  c  "-   s
+        |  c  "*   clipboard content
+        |  c  ":   ascii
+        |  c  "/   search pattern
       """.trimMargin(),
     )
   }
@@ -237,8 +241,9 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-      |  c  "*   clipboard content
+      """
+        |Type Name Content
+        |  c  "*   clipboard content
       """.trimMargin(),
     )
   }
@@ -252,11 +257,12 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-      |  c  ""   line
-      |  c  "0   line
-      |  c  "*   line
-      |  c  ":   set clipboard=unnamed,unnamedplus
+      """
+        |Type Name Content
+        |  c  ""   line
+        |  c  "0   line
+        |  c  "*   line
+        |  c  ":   set clipboard=unnamed,unnamedplus
       """.trimMargin(),
     )
     enterCommand("set clipboard&")
@@ -271,11 +277,12 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-      |  c  ""   line
-      |  c  "-   line
-      |  c  "*   line
-      |  c  ":   set clipboard=unnamed,unnamedplus
+      """
+        |Type Name Content
+        |  c  ""   line
+        |  c  "-   line
+        |  c  "*   line
+        |  c  ":   set clipboard=unnamed,unnamedplus
       """.trimMargin(),
     )
     enterCommand("set clipboard&")
@@ -290,11 +297,12 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-      |  c  ""   line
-      |  c  "-   line
-      |  c  "*   line
-      |  c  ":   set clipboard=unnamedplus
+      """
+        |Type Name Content
+        |  c  ""   line
+        |  c  "-   line
+        |  c  "*   line
+        |  c  ":   set clipboard=unnamedplus
       """.trimMargin(),
     )
     enterCommand("set clipboard&")
@@ -316,9 +324,10 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-                     |  c  "a   ^IHello World^J^[
-                     |  c  "*   
+      """
+        |Type Name Content
+        |  c  "a   ^IHello World^J^[
+        |  c  "*   
       """.trimMargin(),
     )
   }
@@ -374,49 +383,50 @@ class RegistersCommandTest : VimTestCase() {
     // "= expression register
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-      |  c  ""   s
-      |  c  "0   last yank 
-      |  l  "1   line 9^J
-      |  l  "2   line 8^J
-      |  l  "3   line 7^J
-      |  l  "4   line 6^J
-      |  l  "5   line 5^J
-      |  l  "6   line 4^J
-      |  l  "7   line 3^J
-      |  l  "8   line 2^J
-      |  l  "9   line 1^J
-      |  c  "a   Hello world a
-      |  c  "b   Hello world b
-      |  c  "c   Hello world c
-      |  c  "d   Hello world d
-      |  c  "e   Hello world e
-      |  c  "f   Hello world f
-      |  c  "g   Hello world g
-      |  c  "h   Hello world h
-      |  c  "i   Hello world i
-      |  c  "j   Hello world j
-      |  c  "k   Hello world k
-      |  c  "l   Hello world l
-      |  c  "m   Hello world m
-      |  c  "n   Hello world n
-      |  c  "o   Hello world o
-      |  c  "p   Hello world p
-      |  c  "q   Hello world q
-      |  c  "r   Hello world r
-      |  c  "s   Hello world s
-      |  c  "t   Hello world t
-      |  c  "u   Hello world u
-      |  c  "v   Hello world v
-      |  c  "w   Hello world w
-      |  c  "x   Hello world x
-      |  c  "y   Hello world y
-      |  c  "z   Hello world z
-      |  c  "-   s
-      |  c  "*   mall delete register
-      |  c  "+   clipboard content
-      |  c  ":   ascii
-      |  c  "/   search pattern
+      """
+        |Type Name Content
+        |  c  ""   s
+        |  c  "0   last yank 
+        |  l  "1   line 9^J
+        |  l  "2   line 8^J
+        |  l  "3   line 7^J
+        |  l  "4   line 6^J
+        |  l  "5   line 5^J
+        |  l  "6   line 4^J
+        |  l  "7   line 3^J
+        |  l  "8   line 2^J
+        |  l  "9   line 1^J
+        |  c  "a   Hello world a
+        |  c  "b   Hello world b
+        |  c  "c   Hello world c
+        |  c  "d   Hello world d
+        |  c  "e   Hello world e
+        |  c  "f   Hello world f
+        |  c  "g   Hello world g
+        |  c  "h   Hello world h
+        |  c  "i   Hello world i
+        |  c  "j   Hello world j
+        |  c  "k   Hello world k
+        |  c  "l   Hello world l
+        |  c  "m   Hello world m
+        |  c  "n   Hello world n
+        |  c  "o   Hello world o
+        |  c  "p   Hello world p
+        |  c  "q   Hello world q
+        |  c  "r   Hello world r
+        |  c  "s   Hello world s
+        |  c  "t   Hello world t
+        |  c  "u   Hello world u
+        |  c  "v   Hello world v
+        |  c  "w   Hello world w
+        |  c  "x   Hello world x
+        |  c  "y   Hello world y
+        |  c  "z   Hello world z
+        |  c  "-   s
+        |  c  "*   mall delete register
+        |  c  "+   clipboard content
+        |  c  ":   ascii
+        |  c  "/   search pattern
       """.trimMargin(),
     )
   }
@@ -431,9 +441,10 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-      |  c  "*   line 0 
-      |  c  "+   clipboard content
+      """
+        |Type Name Content
+        |  c  "*   line 0 
+        |  c  "+   clipboard content
       """.trimMargin(),
     )
   }
@@ -447,12 +458,13 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-      |  c  ""   line
-      |  c  "0   line
-      |  c  "*   line
-      |  c  "+   line
-      |  c  ":   set clipboard=unnamed,unnamedplus
+      """
+        |Type Name Content
+        |  c  ""   line
+        |  c  "0   line
+        |  c  "*   line
+        |  c  "+   line
+        |  c  ":   set clipboard=unnamed,unnamedplus
       """.trimMargin(),
     )
     enterCommand("set clipboard&")
@@ -467,12 +479,13 @@ class RegistersCommandTest : VimTestCase() {
 
     enterCommand("registers")
     assertExOutput(
-      """Type Name Content
-      |  c  ""   line
-      |  c  "-   line
-      |  c  "*   
-      |  c  "+   line
-      |  c  ":   set clipboard=unnamed,unnamedplus
+      """
+        |Type Name Content
+        |  c  ""   line
+        |  c  "-   line
+        |  c  "*   
+        |  c  "+   line
+        |  c  ":   set clipboard=unnamed,unnamedplus
       """.trimMargin(),
     )
     enterCommand("set clipboard&")

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -61,24 +61,24 @@ class SetCommandTest : VimTestCase() {
   fun `test number option`() {
     enterCommand("set scrolloff&")
     assertEquals(0, options().scrolloff)
-    assertCommandOutput("set scrolloff?", "  scrolloff=0\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=0")
     enterCommand("set scrolloff=5")
     assertEquals(5, options().scrolloff)
-    assertCommandOutput("set scrolloff?", "  scrolloff=5\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=5")
   }
 
   @Test
   fun `test toggle option as a number`() {
     enterCommand("set digraph&")   // Local to window. Reset local + per-window "global" value to default: nodigraph
     assertEquals(0, injector.optionGroup.getOptionValue(Options.digraph, OptionAccessScope.LOCAL(fixture.editor.vim)).asDouble().toInt())
-    assertCommandOutput("set digraph?", "nodigraph\n")
+    assertCommandOutput("set digraph?", "nodigraph")
 
     // Should have the same effect as `:set` (although `:set` doesn't allow assigning a number to a boolean)
     // I.e. this sets the local value and the per-window "global" value
     enterCommand("let &dg=1000")
     assertEquals(1000, injector.optionGroup.getOptionValue(Options.digraph, OptionAccessScope.GLOBAL(fixture.editor.vim)).asDouble().toInt())
     assertEquals(1000, injector.optionGroup.getOptionValue(Options.digraph, OptionAccessScope.LOCAL(fixture.editor.vim)).asDouble().toInt())
-    assertCommandOutput("set digraph?", "  digraph\n")
+    assertCommandOutput("set digraph?", "  digraph")
   }
 
   @Test
@@ -130,20 +130,20 @@ class SetCommandTest : VimTestCase() {
   fun `test string option`() {
     enterCommand("set selection&")
     assertEquals("inclusive", options().selection)
-    assertCommandOutput("set selection?", "  selection=inclusive\n")
+    assertCommandOutput("set selection?", "  selection=inclusive")
     enterCommand("set selection=exclusive")
     assertEquals("exclusive", options().selection)
-    assertCommandOutput("set selection?", "  selection=exclusive\n")
+    assertCommandOutput("set selection?", "  selection=exclusive")
   }
 
   @Test
   fun `test show numbered value`() {
-    assertCommandOutput("set so", "  scrolloff=0\n")
+    assertCommandOutput("set so", "  scrolloff=0")
   }
 
   @Test
   fun `test show numbered value with question mark`() {
-    assertCommandOutput("set so?", "  scrolloff=0\n")
+    assertCommandOutput("set so?", "  scrolloff=0")
   }
 
   @Test
@@ -159,7 +159,6 @@ class SetCommandTest : VimTestCase() {
         |--- Options ---
         |  number              relativenumber
         |  fileencoding=utf-8
-        |
       """.trimMargin())
   }
 
@@ -202,7 +201,6 @@ class SetCommandTest : VimTestCase() {
         |  shell=/dummy/path/to/bash
         |novim-paragraph-motion
         |  viminfo='100,<50,s10,h
-        |
       """.trimMargin())
   }
 
@@ -210,7 +208,7 @@ class SetCommandTest : VimTestCase() {
   fun `test show named options`() {
     assertCommandOutput("set number? relativenumber? scrolloff? nrformats?", """
       |  nrformats=hex     nonumber            norelativenumber      scrolloff=0
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -228,7 +226,7 @@ class SetCommandTest : VimTestCase() {
       |  fileencoding=utf-8
       |  number
       |  relativenumber
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -312,7 +310,7 @@ class SetCommandTest : VimTestCase() {
       |  whichwrap=b,s
       |  wrap
       |  wrapscan
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -323,7 +321,7 @@ class SetCommandTest : VimTestCase() {
       |nonumber
       |norelativenumber
       |  scrolloff=0
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -333,21 +331,21 @@ class SetCommandTest : VimTestCase() {
 
     enterCommand("set nrformats&")
 
-    assertCommandOutput("set nrformats?", "  nrformats=hex\n")
+    assertCommandOutput("set nrformats?", "  nrformats=hex")
   }
 
   @Test
   fun `test reset local value for global-local option`() {
     enterCommand("set virtualedit=block") // Sets the global + effective values. Local is unset
     enterCommand("setlocal virtualedit=onemore")  // Sets the local + effective values
-    assertCommandOutput("set virtualedit?", "  virtualedit=onemore\n")
-    assertCommandOutput("setlocal virtualedit?", "  virtualedit=onemore\n")
+    assertCommandOutput("set virtualedit?", "  virtualedit=onemore")
+    assertCommandOutput("setlocal virtualedit?", "  virtualedit=onemore")
 
     // This is like setting the global-local value to its own global value. :set with a global-local option will set the
     // global value and unset the local value
     enterCommand("set virtualedit<")
 
-    assertCommandOutput("set virtualedit?", "  virtualedit=block\n")
-    assertCommandOutput("setlocal virtualedit?", "  virtualedit=\n")
+    assertCommandOutput("set virtualedit?", "  virtualedit=block")
+    assertCommandOutput("setlocal virtualedit?", "  virtualedit=")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
@@ -57,20 +57,20 @@ class SetglobalCommandTest : VimTestCase() {
   @Test
   fun `test set toggle option global value`() {
     enterCommand("setglobal rnu")
-    assertCommandOutput("setglobal rnu?", "  relativenumber\n")
-    assertCommandOutput("setlocal rnu?", "norelativenumber\n")
+    assertCommandOutput("setglobal rnu?", "  relativenumber")
+    assertCommandOutput("setlocal rnu?", "norelativenumber")
 
     enterCommand("setglobal nornu")
-    assertCommandOutput("setglobal rnu?", "norelativenumber\n")
-    assertCommandOutput("setlocal rnu?", "norelativenumber\n")
+    assertCommandOutput("setglobal rnu?", "norelativenumber")
+    assertCommandOutput("setlocal rnu?", "norelativenumber")
 
     enterCommand("setglobal rnu!")
-    assertCommandOutput("setglobal rnu?", "  relativenumber\n")
-    assertCommandOutput("setlocal rnu?", "norelativenumber\n")
+    assertCommandOutput("setglobal rnu?", "  relativenumber")
+    assertCommandOutput("setlocal rnu?", "norelativenumber")
 
     enterCommand("setglobal invrnu")
-    assertCommandOutput("setglobal rnu?", "norelativenumber\n")
-    assertCommandOutput("setlocal rnu?", "norelativenumber\n")
+    assertCommandOutput("setglobal rnu?", "norelativenumber")
+    assertCommandOutput("setlocal rnu?", "norelativenumber")
   }
 
   @Test
@@ -110,29 +110,29 @@ class SetglobalCommandTest : VimTestCase() {
 
   @Test
   fun `test show toggle option global value`() {
-    assertCommandOutput("setglobal rnu?", "norelativenumber\n")
+    assertCommandOutput("setglobal rnu?", "norelativenumber")
 
     enterCommand("setglobal invrnu")
-    assertCommandOutput("setglobal rnu?", "  relativenumber\n")
+    assertCommandOutput("setglobal rnu?", "  relativenumber")
   }
 
   @Test
   fun `test reset global toggle option value to default value`() {
     enterCommand("setglobal rnu") // Local option, global value
-    assertCommandOutput("setglobal rnu?", "  relativenumber\n")
+    assertCommandOutput("setglobal rnu?", "  relativenumber")
 
     enterCommand("setglobal rnu&")
-    assertCommandOutput("setglobal rnu?", "norelativenumber\n")
+    assertCommandOutput("setglobal rnu?", "norelativenumber")
   }
 
   @Test
   fun `test reset global toggle option value to global value does nothing`() {
     enterCommand("setglobal relativenumber") // Local option, global value
-    assertCommandOutput("setglobal rnu?", "  relativenumber\n")
+    assertCommandOutput("setglobal rnu?", "  relativenumber")
 
     // Copies the global value to itself, doesn't change anything
     enterCommand("setglobal relativenumber<")
-    assertCommandOutput("setglobal rnu?", "  relativenumber\n")
+    assertCommandOutput("setglobal rnu?", "  relativenumber")
   }
 
   @Test
@@ -143,14 +143,14 @@ class SetglobalCommandTest : VimTestCase() {
 
       enterCommand("setglobal test")
       enterCommand("setlocal notest")
-      assertCommandOutput("setglobal test?", "  test\n")
-      assertCommandOutput("setlocal test?", "notest\n")
+      assertCommandOutput("setglobal test?", "  test")
+      assertCommandOutput("setlocal test?", "notest")
 
       // Reset global value to default
       enterCommand("setglobal test&")
 
-      assertCommandOutput("setglobal test?", "notest\n")
-      assertCommandOutput("setlocal test?", "notest\n")
+      assertCommandOutput("setglobal test?", "notest")
+      assertCommandOutput("setlocal test?", "notest")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -165,14 +165,14 @@ class SetglobalCommandTest : VimTestCase() {
 
       enterCommand("setglobal test")
       enterCommand("setlocal notest")
-      assertCommandOutput("setglobal test?", "  test\n")
-      assertCommandOutput("setlocal test?", "notest\n")
+      assertCommandOutput("setglobal test?", "  test")
+      assertCommandOutput("setlocal test?", "notest")
 
       // Copies the global value to the target scope (i.e. global, this is a no-op)
       enterCommand("setglobal test<")
 
-      assertCommandOutput("setglobal test?", "  test\n")
-      assertCommandOutput("setlocal test?", "notest\n")
+      assertCommandOutput("setglobal test?", "  test")
+      assertCommandOutput("setlocal test?", "notest")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -182,28 +182,28 @@ class SetglobalCommandTest : VimTestCase() {
   @Test
   fun `test set number option global value`() {
     enterCommand("setglobal scroll&")
-    assertCommandOutput("setglobal scroll?", "  scroll=0\n")
-    assertCommandOutput("setlocal scroll?", "  scroll=0\n")
+    assertCommandOutput("setglobal scroll?", "  scroll=0")
+    assertCommandOutput("setlocal scroll?", "  scroll=0")
 
     enterCommand("setglobal scroll=5")
-    assertCommandOutput("setglobal scroll?", "  scroll=5\n")
-    assertCommandOutput("setlocal scroll?", "  scroll=0\n")
+    assertCommandOutput("setglobal scroll?", "  scroll=5")
+    assertCommandOutput("setlocal scroll?", "  scroll=0")
 
     enterCommand("setglobal scroll:10")
-    assertCommandOutput("setglobal scroll?", "  scroll=10\n")
-    assertCommandOutput("setlocal scroll?", "  scroll=0\n")
+    assertCommandOutput("setglobal scroll?", "  scroll=10")
+    assertCommandOutput("setlocal scroll?", "  scroll=0")
 
     enterCommand("setglobal scroll+=5")
-    assertCommandOutput("setglobal scroll?", "  scroll=15\n")
-    assertCommandOutput("setlocal scroll?", "  scroll=0\n")
+    assertCommandOutput("setglobal scroll?", "  scroll=15")
+    assertCommandOutput("setlocal scroll?", "  scroll=0")
 
     enterCommand("setglobal scroll-=10")
-    assertCommandOutput("setglobal scroll?", "  scroll=5\n")
-    assertCommandOutput("setlocal scroll?", "  scroll=0\n")
+    assertCommandOutput("setglobal scroll?", "  scroll=5")
+    assertCommandOutput("setlocal scroll?", "  scroll=0")
 
     enterCommand("setglobal scroll^=2")
-    assertCommandOutput("setglobal scroll?", "  scroll=10\n")
-    assertCommandOutput("setlocal scroll?", "  scroll=0\n")
+    assertCommandOutput("setglobal scroll?", "  scroll=10")
+    assertCommandOutput("setlocal scroll?", "  scroll=0")
   }
 
   @Test
@@ -228,13 +228,13 @@ class SetglobalCommandTest : VimTestCase() {
   @Test
   fun `test show number option global value`() {
     enterCommand("setglobal scroll=10")
-    assertCommandOutput("setglobal scroll?", "  scroll=10\n")
+    assertCommandOutput("setglobal scroll?", "  scroll=10")
   }
 
   @Test
   fun `test number option with no arguments shows current global value`() {
     enterCommand("setglobal scroll=10")
-    assertCommandOutput("setglobal scroll", "  scroll=10\n")
+    assertCommandOutput("setglobal scroll", "  scroll=10")
   }
 
   @Test
@@ -242,7 +242,7 @@ class SetglobalCommandTest : VimTestCase() {
     enterCommand("setglobal scroll=10")  // Default global value is 0
 
     enterCommand("setglobal scroll&")
-    assertCommandOutput("setglobal scroll?", "  scroll=0\n")
+    assertCommandOutput("setglobal scroll?", "  scroll=0")
   }
 
   @Test
@@ -250,7 +250,7 @@ class SetglobalCommandTest : VimTestCase() {
     enterCommand("setglobal scroll=10")  // Default global value is 0
 
     enterCommand("setglobal scroll<")
-    assertCommandOutput("setglobal scroll?", "  scroll=10\n")
+    assertCommandOutput("setglobal scroll?", "  scroll=10")
   }
 
   @Test
@@ -261,14 +261,14 @@ class SetglobalCommandTest : VimTestCase() {
 
       enterCommand("setglobal test=20")
       enterCommand("setlocal test=30")
-      assertCommandOutput("setglobal test?", "  test=20\n")
-      assertCommandOutput("setlocal test?", "  test=30\n")
+      assertCommandOutput("setglobal test?", "  test=20")
+      assertCommandOutput("setlocal test?", "  test=30")
 
       // setglobal {option}< copies the global value to the target scope
       enterCommand("setglobal test&")
 
-      assertCommandOutput("setglobal test?", "  test=10\n")
-      assertCommandOutput("setlocal test?", "  test=30\n")
+      assertCommandOutput("setglobal test?", "  test=10")
+      assertCommandOutput("setlocal test?", "  test=30")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -283,14 +283,14 @@ class SetglobalCommandTest : VimTestCase() {
 
       enterCommand("setglobal test=20")
       enterCommand("setlocal test=30")
-      assertCommandOutput("setglobal test?", "  test=20\n")
-      assertCommandOutput("setlocal test?", "  test=30\n")
+      assertCommandOutput("setglobal test?", "  test=20")
+      assertCommandOutput("setlocal test?", "  test=30")
 
       // setglobal {option}< copies the global value to the target scope
       enterCommand("setglobal test<")
 
-      assertCommandOutput("setglobal test?", "  test=20\n")
-      assertCommandOutput("setlocal test?", "  test=30\n")
+      assertCommandOutput("setglobal test?", "  test=20")
+      assertCommandOutput("setlocal test?", "  test=30")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -300,24 +300,24 @@ class SetglobalCommandTest : VimTestCase() {
   @Test
   fun `test set string option global value`() {
     enterCommand("setglobal nrformats=octal")
-    assertCommandOutput("setglobal nrformats", "  nrformats=octal\n")
-    assertCommandOutput("setlocal nrformats", "  nrformats=hex\n")
+    assertCommandOutput("setglobal nrformats", "  nrformats=octal")
+    assertCommandOutput("setlocal nrformats", "  nrformats=hex")
 
     enterCommand("setglobal nrformats:alpha")
-    assertCommandOutput("setglobal nrformats", "  nrformats=alpha\n")
-    assertCommandOutput("setlocal nrformats", "  nrformats=hex\n")
+    assertCommandOutput("setglobal nrformats", "  nrformats=alpha")
+    assertCommandOutput("setlocal nrformats", "  nrformats=hex")
 
     enterCommand("setglobal nrformats+=hex")
-    assertCommandOutput("setglobal nrformats", "  nrformats=alpha,hex\n")
-    assertCommandOutput("setlocal nrformats", "  nrformats=hex\n")
+    assertCommandOutput("setglobal nrformats", "  nrformats=alpha,hex")
+    assertCommandOutput("setlocal nrformats", "  nrformats=hex")
 
     enterCommand("setglobal nrformats-=hex")
-    assertCommandOutput("setglobal nrformats", "  nrformats=alpha\n")
-    assertCommandOutput("setlocal nrformats", "  nrformats=hex\n")
+    assertCommandOutput("setglobal nrformats", "  nrformats=alpha")
+    assertCommandOutput("setlocal nrformats", "  nrformats=hex")
 
     enterCommand("setglobal nrformats^=hex")
-    assertCommandOutput("setglobal nrformats", "  nrformats=hex,alpha\n")
-    assertCommandOutput("setlocal nrformats", "  nrformats=hex\n")
+    assertCommandOutput("setglobal nrformats", "  nrformats=hex,alpha")
+    assertCommandOutput("setlocal nrformats", "  nrformats=hex")
   }
 
   @Test
@@ -341,29 +341,29 @@ class SetglobalCommandTest : VimTestCase() {
 
   @Test
   fun `test show string option global value`() {
-    assertCommandOutput("setglobal nrformats?", "  nrformats=hex\n")
+    assertCommandOutput("setglobal nrformats?", "  nrformats=hex")
 
     enterCommand("setglobal nrformats+=alpha")
-    assertCommandOutput("setglobal nrformats?", "  nrformats=hex,alpha\n")
+    assertCommandOutput("setglobal nrformats?", "  nrformats=hex,alpha")
   }
 
   @Test
   fun `test string option with no arguments shows current global value`() {
-    assertCommandOutput("setglobal nrformats", "  nrformats=hex\n")
+    assertCommandOutput("setglobal nrformats", "  nrformats=hex")
   }
 
   @Test
   fun `test reset string global option value to default value`() {
     enterCommand("setglobal nrformats=alpha")
     enterCommand("setglobal nrformats&")
-    assertCommandOutput("setglobal nrformats?", "  nrformats=hex\n")
+    assertCommandOutput("setglobal nrformats?", "  nrformats=hex")
   }
 
   @Test
   fun `test reset string global option value to global value does nothing`() {
     enterCommand("setglobal nrformats=alpha")
     enterCommand("setglobal nrformats<")
-    assertCommandOutput("setglobal nrformats?", "  nrformats=alpha\n")
+    assertCommandOutput("setglobal nrformats?", "  nrformats=alpha")
   }
 
   @Test
@@ -378,7 +378,7 @@ class SetglobalCommandTest : VimTestCase() {
       // Copies the default value to the target scope
       enterCommand("setglobal test&")
 
-      assertCommandOutput("setglobal test?", "  test=testValue\n")
+      assertCommandOutput("setglobal test?", "  test=testValue")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -397,7 +397,7 @@ class SetglobalCommandTest : VimTestCase() {
       // Copies the global value to the target scope (i.e. global, this is a no-op)
       enterCommand("setglobal test<")
 
-      assertCommandOutput("setglobal test?", "  test=globalValue\n")
+      assertCommandOutput("setglobal test?", "  test=globalValue")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -408,14 +408,14 @@ class SetglobalCommandTest : VimTestCase() {
   fun `test reset string option to default value`() {
     enterCommand("setglobal nrformats=alpha")
     enterCommand("setglobal nrformats&")
-    assertCommandOutput("setglobal nrformats?", "  nrformats=hex\n")
+    assertCommandOutput("setglobal nrformats?", "  nrformats=hex")
   }
 
   @Test
   fun `test show all modified global option values`() {
     assertCommandOutput("setglobal", """
       |--- Global option values ---
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -426,7 +426,7 @@ class SetglobalCommandTest : VimTestCase() {
       |--- Global option values ---
       |  number              relativenumber      scrolloff=10        sidescrolloff=10
       |  nrformats=alpha,hex,octal
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -466,7 +466,7 @@ class SetglobalCommandTest : VimTestCase() {
       |  shell=/dummy/path/to/bash
       |novim-paragraph-motion
       |  viminfo='100,<50,s10,h
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -474,7 +474,7 @@ class SetglobalCommandTest : VimTestCase() {
   fun `test show named options`() {
     assertCommandOutput("setglobal number? relativenumber? scrolloff? nrformats?", """
       |  nrformats=hex     nonumber            norelativenumber      scrolloff=0
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -482,7 +482,7 @@ class SetglobalCommandTest : VimTestCase() {
   fun `test show all modified global option values in single column`() {
     assertCommandOutput("setglobal!", """
       |--- Global option values ---
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -496,7 +496,7 @@ class SetglobalCommandTest : VimTestCase() {
       |  relativenumber
       |  scrolloff=10
       |  sidescrolloff=10
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -579,7 +579,7 @@ class SetglobalCommandTest : VimTestCase() {
       |  whichwrap=b,s
       |  wrap
       |  wrapscan
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -590,7 +590,7 @@ class SetglobalCommandTest : VimTestCase() {
       |nonumber
       |norelativenumber
       |  scrolloff=0
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
@@ -106,11 +106,11 @@ class SetlocalCommandTest : VimTestCase() {
 
   @Test
   fun `test show toggle option local value`() {
-    assertCommandOutput("setlocal rnu?", "norelativenumber\n")
+    assertCommandOutput("setlocal rnu?", "norelativenumber")
 
     enterCommand("setlocal invrnu")
 
-    assertCommandOutput("setlocal rnu?", "  relativenumber\n")
+    assertCommandOutput("setlocal rnu?", "  relativenumber")
   }
 
   @Test
@@ -119,7 +119,7 @@ class SetlocalCommandTest : VimTestCase() {
     try {
       injector.optionGroup.addOption(option)
 
-      assertCommandOutput("setlocal test?", "--test\n")
+      assertCommandOutput("setlocal test?", "--test")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -129,23 +129,23 @@ class SetlocalCommandTest : VimTestCase() {
   @Test
   fun `test reset local toggle option value to default value`() {
     enterCommand("setlocal relativenumber") // Default global value is off
-    assertCommandOutput("setglobal rnu?", "norelativenumber\n")
-    assertCommandOutput("setlocal rnu?", "  relativenumber\n")
+    assertCommandOutput("setglobal rnu?", "norelativenumber")
+    assertCommandOutput("setlocal rnu?", "  relativenumber")
 
     enterCommand("setlocal relativenumber&")
-    assertCommandOutput("setglobal rnu?", "norelativenumber\n")
-    assertCommandOutput("setlocal rnu?", "norelativenumber\n")
+    assertCommandOutput("setglobal rnu?", "norelativenumber")
+    assertCommandOutput("setlocal rnu?", "norelativenumber")
   }
 
   @Test
   fun `test reset local toggle option value to global value`() {
     enterCommand("setlocal relativenumber")
-    assertCommandOutput("setglobal rnu?", "norelativenumber\n")
-    assertCommandOutput("setlocal rnu?", "  relativenumber\n")
+    assertCommandOutput("setglobal rnu?", "norelativenumber")
+    assertCommandOutput("setlocal rnu?", "  relativenumber")
 
     enterCommand("setlocal relativenumber<")
-    assertCommandOutput("setglobal rnu?", "norelativenumber\n")
-    assertCommandOutput("setlocal rnu?", "norelativenumber\n")
+    assertCommandOutput("setglobal rnu?", "norelativenumber")
+    assertCommandOutput("setlocal rnu?", "norelativenumber")
   }
 
   @Test
@@ -155,14 +155,14 @@ class SetlocalCommandTest : VimTestCase() {
       injector.optionGroup.addOption(option)
 
       enterCommand("setlocal test")
-      assertCommandOutput("setglobal test?", "notest\n")
-      assertCommandOutput("setlocal test?", "  test\n")
+      assertCommandOutput("setglobal test?", "notest")
+      assertCommandOutput("setlocal test?", "  test")
 
       // Reset local value to default
       enterCommand("setlocal test&")
 
-      assertCommandOutput("setglobal test?", "notest\n")
-      assertCommandOutput("setlocal test?", "notest\n")
+      assertCommandOutput("setglobal test?", "notest")
+      assertCommandOutput("setlocal test?", "notest")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -176,8 +176,8 @@ class SetlocalCommandTest : VimTestCase() {
       injector.optionGroup.addOption(option)
 
       enterCommand("setlocal test")
-      assertCommandOutput("setglobal test?", "notest\n")
-      assertCommandOutput("setlocal test?", "  test\n")
+      assertCommandOutput("setglobal test?", "notest")
+      assertCommandOutput("setlocal test?", "  test")
 
       // Vim's docs state this should copy global value to local scope, but it actually unsets the value instead. Use
       // `:set {option}<` to copy global value to local
@@ -185,8 +185,8 @@ class SetlocalCommandTest : VimTestCase() {
       // https://github.com/vim/vim/issues/14062
       enterCommand("setlocal test<")
 
-      assertCommandOutput("setglobal test?", "notest\n")
-      assertCommandOutput("setlocal test?", "--test\n")
+      assertCommandOutput("setglobal test?", "notest")
+      assertCommandOutput("setlocal test?", "--test")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -235,16 +235,16 @@ class SetlocalCommandTest : VimTestCase() {
 
   @Test
   fun `test show number option local value`() {
-    assertCommandOutput("setlocal scroll?", "  scroll=0\n")
+    assertCommandOutput("setlocal scroll?", "  scroll=0")
 
     enterCommand("setlocal scroll=10")
 
-    assertCommandOutput("setlocal scroll?", "  scroll=10\n")
+    assertCommandOutput("setlocal scroll?", "  scroll=10")
   }
 
   @Test
   fun `test number option with no arguments shows current local value`() {
-    assertCommandOutput("setlocal scroll", "  scroll=0\n")
+    assertCommandOutput("setlocal scroll", "  scroll=0")
   }
 
   @Test
@@ -253,7 +253,7 @@ class SetlocalCommandTest : VimTestCase() {
     try {
       injector.optionGroup.addOption(option)
 
-      assertCommandOutput("setlocal test?", "  test=-1\n")
+      assertCommandOutput("setlocal test?", "  test=-1")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -265,7 +265,7 @@ class SetlocalCommandTest : VimTestCase() {
     enterCommand("setlocal scroll=10")
 
     enterCommand("setlocal scroll&")
-    assertCommandOutput("setlocal scroll?", "  scroll=0\n")
+    assertCommandOutput("setlocal scroll?", "  scroll=0")
   }
 
   @Test
@@ -273,7 +273,7 @@ class SetlocalCommandTest : VimTestCase() {
     enterCommand("setlocal scroll=10")  // Default global value is 0
 
     enterCommand("setlocal scroll<")
-    assertCommandOutput("setlocal scroll?", "  scroll=0\n")
+    assertCommandOutput("setlocal scroll?", "  scroll=0")
   }
 
   @Test
@@ -285,14 +285,14 @@ class SetlocalCommandTest : VimTestCase() {
       enterCommand("setglobal test=15")
       enterCommand("setlocal test=20")
 
-      assertCommandOutput("setglobal test?", "  test=15\n")
-      assertCommandOutput("setlocal test?", "  test=20\n")
+      assertCommandOutput("setglobal test?", "  test=15")
+      assertCommandOutput("setlocal test?", "  test=20")
 
       // Reset local value to default
       enterCommand("setlocal test&")
 
-      assertCommandOutput("setglobal test?", "  test=15\n")
-      assertCommandOutput("setlocal test?", "  test=10\n")
+      assertCommandOutput("setglobal test?", "  test=15")
+      assertCommandOutput("setlocal test?", "  test=10")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -308,8 +308,8 @@ class SetlocalCommandTest : VimTestCase() {
       enterCommand("setglobal test=15")
       enterCommand("setlocal test=20")
 
-      assertCommandOutput("setglobal test?", "  test=15\n")
-      assertCommandOutput("setlocal test?", "  test=20\n")
+      assertCommandOutput("setglobal test?", "  test=15")
+      assertCommandOutput("setlocal test?", "  test=20")
 
       // Vim's docs state this should copy global value to local scope, but it actually unsets the value instead. Use
       // `:set {option}<` to copy global value to local
@@ -317,8 +317,8 @@ class SetlocalCommandTest : VimTestCase() {
       // https://github.com/vim/vim/issues/14062
       enterCommand("setlocal test<")
 
-      assertCommandOutput("setglobal test?", "  test=15\n")
-      assertCommandOutput("setlocal test?", "  test=-1\n")
+      assertCommandOutput("setglobal test?", "  test=15")
+      assertCommandOutput("setlocal test?", "  test=-1")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -364,16 +364,16 @@ class SetlocalCommandTest : VimTestCase() {
 
   @Test
   fun `test show string option local value`() {
-    assertCommandOutput("setlocal nrformats?", "  nrformats=hex\n")
+    assertCommandOutput("setlocal nrformats?", "  nrformats=hex")
 
     enterCommand("setlocal nrformats+=alpha")
 
-    assertCommandOutput("setlocal nrformats?", "  nrformats=hex,alpha\n")
+    assertCommandOutput("setlocal nrformats?", "  nrformats=hex,alpha")
   }
 
   @Test
   fun `test string option with no arguments shows current local value`() {
-    assertCommandOutput("setlocal nrformats", "  nrformats=hex\n")
+    assertCommandOutput("setlocal nrformats", "  nrformats=hex")
   }
 
   @Test
@@ -382,7 +382,7 @@ class SetlocalCommandTest : VimTestCase() {
     try {
       injector.optionGroup.addOption(option)
 
-      assertCommandOutput("setlocal test?", "  test=\n")
+      assertCommandOutput("setlocal test?", "  test=")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -393,14 +393,14 @@ class SetlocalCommandTest : VimTestCase() {
   fun `test reset string local option value to default value`() {
     enterCommand("setlocal nrformats=alpha")
     enterCommand("setlocal nrformats&")
-    assertCommandOutput("setlocal nrformats?", "  nrformats=hex\n")
+    assertCommandOutput("setlocal nrformats?", "  nrformats=hex")
   }
 
   @Test
   fun `test reset string local option value to global value`() {
     enterCommand("setlocal nrformats=alpha")
     enterCommand("setlocal nrformats<")
-    assertCommandOutput("setlocal nrformats?", "  nrformats=hex\n")
+    assertCommandOutput("setlocal nrformats?", "  nrformats=hex")
   }
 
   @Test
@@ -415,8 +415,8 @@ class SetlocalCommandTest : VimTestCase() {
       // Copies the default value to target scope
       enterCommand("setlocal test&")
 
-      assertCommandOutput("setglobal test?", "  test=globalValue\n")
-      assertCommandOutput("setlocal test?", "  test=testValue\n")
+      assertCommandOutput("setglobal test?", "  test=globalValue")
+      assertCommandOutput("setlocal test?", "  test=testValue")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -438,8 +438,8 @@ class SetlocalCommandTest : VimTestCase() {
       // https://github.com/vim/vim/issues/14062
       enterCommand("setlocal test<")
 
-      assertCommandOutput("setglobal test?", "  test=globalValue\n")
-      assertCommandOutput("setlocal test?", "  test=globalValue\n")
+      assertCommandOutput("setglobal test?", "  test=globalValue")
+      assertCommandOutput("setlocal test?", "  test=globalValue")
     }
     finally {
       injector.optionGroup.removeOption(option.name)
@@ -459,7 +459,7 @@ class SetlocalCommandTest : VimTestCase() {
       |  fileencoding=utf-8
       |--ideacopypreprocess
       |  undolevels=-123456
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -479,7 +479,7 @@ class SetlocalCommandTest : VimTestCase() {
       |--ideacopypreprocess
       |  nrformats=alpha,hex,octal
       |  undolevels=-123456
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -521,7 +521,7 @@ class SetlocalCommandTest : VimTestCase() {
       |  undolevels=-123456
       |novim-paragraph-motion
       |  viminfo='100,<50,s10,h
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -529,7 +529,7 @@ class SetlocalCommandTest : VimTestCase() {
   fun `test show named options`() {
     assertCommandOutput("setlocal number? relativenumber? scrolloff? nrformats?", """
       |  nrformats=hex     nonumber            norelativenumber      scrolloff=-1
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -549,7 +549,7 @@ class SetlocalCommandTest : VimTestCase() {
       |  scrolloff=-1
       |  sidescrolloff=-1
       |  undolevels=-123456
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -633,7 +633,7 @@ class SetlocalCommandTest : VimTestCase() {
       |  whichwrap=b,s
       |  wrap
       |  wrapscan
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 
@@ -644,7 +644,7 @@ class SetlocalCommandTest : VimTestCase() {
       |nonumber
       |norelativenumber
       |  scrolloff=-1
-      |""".trimMargin()
+      """.trimMargin()
     )
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/CurlyBracesNameTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/CurlyBracesNameTest.kt
@@ -18,7 +18,7 @@ class CurlyBracesNameTest : VimTestCase() {
     configureByText("\n")
     typeText(commandToKeys("let x1 = 10"))
     typeText(commandToKeys("echo x{0 + 1}"))
-    assertExOutput("10\n")
+    assertExOutput("10")
   }
 
   @Test
@@ -28,7 +28,7 @@ class CurlyBracesNameTest : VimTestCase() {
     typeText(commandToKeys("let z = 1"))
     typeText(commandToKeys("let y1 = 'leven'"))
     typeText(commandToKeys("echo e{y{z}}"))
-    assertExOutput("11\n")
+    assertExOutput("11")
   }
 
   @Test
@@ -41,9 +41,9 @@ class CurlyBracesNameTest : VimTestCase() {
     typeText(commandToKeys("let twelve = 42"))
 
     typeText(commandToKeys("echo {x1}{x2}{x3}"))
-    assertExOutput("twelve\n")
+    assertExOutput("twelve")
 
     typeText(commandToKeys("echo {{x1}{x2}{x3}}"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/DictionaryElementByKeyTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/DictionaryElementByKeyTest.kt
@@ -17,28 +17,28 @@ class DictionaryElementByKeyTest : VimTestCase() {
   fun `test get element by key`() {
     configureByText("\n")
     typeText(commandToKeys("let dict = {'a': 42} | echo dict.a"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 
   @Test
   fun `test get element from inner dictionary`() {
     configureByText("\n")
     typeText(commandToKeys("let dict = {'a': 42, 'b' : {'c': 'oh, hi Mark'}} | echo dict.b.c"))
-    assertExOutput("oh, hi Mark\n")
+    assertExOutput("oh, hi Mark")
   }
 
   @Test
   fun `test get element by key with minus`() {
     configureByText("\n")
     typeText(commandToKeys("let dict = {'first-key': 42, 'second-key' : {'third-key': 'oh, hi Mark'}} | echo dict.first-key"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 
   @Test
   fun `test get element from inner dictionary by keys with minuses`() {
     configureByText("\n")
     typeText(commandToKeys("let dict = {'first-key': 42, 'second-key' : {'third-key': 'oh, hi Mark'}} | echo dict.second-key.third-key"))
-    assertExOutput("oh, hi Mark\n")
+    assertExOutput("oh, hi Mark")
   }
 
   @Test
@@ -46,7 +46,7 @@ class DictionaryElementByKeyTest : VimTestCase() {
     configureByText("\n")
     typeText(commandToKeys("let dict = {'list': [42]}"))
     typeText(commandToKeys("echo dict.list[0]"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 
   @Test
@@ -54,6 +54,6 @@ class DictionaryElementByKeyTest : VimTestCase() {
     configureByText("\n")
     typeText(commandToKeys("let dict = {'list': [{'key': [42]}]}"))
     typeText(commandToKeys("echo dict.list[0].key[0]"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/FunctionCallTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/FunctionCallTest.kt
@@ -19,7 +19,7 @@ class FunctionCallTest : VimTestCase() {
   fun `test function as method call`() {
     configureByText("\n")
     typeText(commandToKeys("echo -4->abs()"))
-    assertExOutput("4\n")
+    assertExOutput("4")
   }
 
   @Test
@@ -35,7 +35,7 @@ class FunctionCallTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("81\n")
+    assertExOutput("81")
 
     typeText(commandToKeys("delfunction! Power2"))
   }
@@ -53,7 +53,7 @@ class FunctionCallTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("42\n")
+    assertExOutput("42")
 
     typeText(commandToKeys("delfunction! Subtraction"))
   }
@@ -62,7 +62,7 @@ class FunctionCallTest : VimTestCase() {
   fun `test function as method call with lambda`() {
     configureByText("\n")
     typeText(commandToKeys("echo 52->{x,y -> x-y}(10)"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)
@@ -99,7 +99,7 @@ class FunctionCallTest : VimTestCase() {
     )
     typeText(commandToKeys("let dict = {'power': function('Power2')}"))
     typeText(commandToKeys("echo dict.power(9)"))
-    assertExOutput("81\n")
+    assertExOutput("81")
 
     typeText(commandToKeys("delfunction! Power2"))
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/LambdaTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/LambdaTest.kt
@@ -26,7 +26,7 @@ class LambdaTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("hello from an empty function\n")
+    assertExOutput("hello from an empty function")
   }
 
   @Test
@@ -40,7 +40,7 @@ class LambdaTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 
   @Test
@@ -54,7 +54,7 @@ class LambdaTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 
   @Test
@@ -69,10 +69,10 @@ class LambdaTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("function('<lambda>0')\n")
+    assertExOutput("function('<lambda>0')")
 
     typeText(commandToKeys("echo Subtraction"))
-    assertExOutput("function('<lambda>1')\n")
+    assertExOutput("function('<lambda>1')")
   }
 
   @Test
@@ -90,7 +90,7 @@ class LambdaTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("5 - 2 = 3\n")
+    assertExOutput("5 - 2 = 3")
   }
 
   @Test
@@ -105,7 +105,7 @@ class LambdaTest : VimTestCase() {
       ),
     )
     assertPluginError(false)
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)
@@ -128,13 +128,13 @@ class LambdaTest : VimTestCase() {
   fun `test lambda function call with no args`() {
     configureByText("\n")
     typeText(commandToKeys("echo {-> 'hello from an empty function'}()"))
-    assertExOutput("hello from an empty function\n")
+    assertExOutput("hello from an empty function")
   }
 
   @Test
   fun `test lambda function call with args`() {
     configureByText("\n")
     typeText(commandToKeys("echo {x, y -> x*y}(6, 7)"))
-    assertExOutput("42\n")
+    assertExOutput("42")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/OptionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/OptionTest.kt
@@ -21,7 +21,7 @@ class OptionTest : VimTestCase() {
     configureByText("\n")
     enterCommand("set ignorecase") // Default is off
     typeText(commandToKeys("if &ic | echo 'ignore case is on' | else | echo 'ignore case is off' | endif"))
-    assertExOutput("ignore case is on\n")
+    assertExOutput("ignore case is on")
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
@@ -31,7 +31,7 @@ class OptionTest : VimTestCase() {
     enterCommand("set ignorecase") // Default is off
     enterCommand("set noignorecase")
     typeText(commandToKeys("if &ic | echo 'ignore case is on' | else | echo 'ignore case is off' | endif"))
-    assertExOutput("ignore case is off\n")
+    assertExOutput("ignore case is off")
   }
 
   @Test
@@ -39,8 +39,8 @@ class OptionTest : VimTestCase() {
     configureByText("\n")
     enterCommand("set ignorecase digraph") // Both off by default
     typeText(commandToKeys("if &ic | echo 'ignore case is on' | else | echo 'ignore case is off' | endif"))
-    assertExOutput("ignore case is on\n")
+    assertExOutput("ignore case is on")
     typeText(commandToKeys("if &dg | echo 'digraph is on' | else | echo 'digraph is off' | endif"))
-    assertExOutput("digraph is on\n")
+    assertExOutput("digraph is on")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/SublistExpressionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/SublistExpressionTest.kt
@@ -17,21 +17,21 @@ class SublistExpressionTest : VimTestCase() {
   fun `test strung sublist`() {
     configureByText("\n")
     typeText(commandToKeys("echo 'abc'[0:1]"))
-    assertExOutput("ab\n")
+    assertExOutput("ab")
   }
 
   @Test
   fun `test negative index with sting`() {
     configureByText("\n")
     typeText(commandToKeys("echo 'abc'[-1]"))
-    assertExOutput("\n")
+    assertExOutput("")
   }
 
   @Test
   fun `test index greater than size with string`() {
     configureByText("\n")
     typeText(commandToKeys("echo 'abc'[1000]"))
-    assertExOutput("\n")
+    assertExOutput("")
   }
 
   @Test
@@ -52,48 +52,48 @@ class SublistExpressionTest : VimTestCase() {
   fun `test list with correct index`() {
     configureByText("\n")
     typeText(commandToKeys("echo [1, 2][1]"))
-    assertExOutput("2\n")
+    assertExOutput("2")
   }
 
   @Test
   fun `test negative first index`() {
     configureByText("\n")
     typeText(commandToKeys("echo 'abc'[-1:]"))
-    assertExOutput("c\n")
+    assertExOutput("c")
   }
 
   @Test
   fun `test negative last index`() {
     configureByText("\n")
     typeText(commandToKeys("echo 'abc'[0:-2]"))
-    assertExOutput("ab\n")
+    assertExOutput("ab")
   }
 
   @Test
   fun `test negative last index2`() {
     configureByText("\n")
     typeText(commandToKeys("echo 'abc'[0:-1]"))
-    assertExOutput("abc\n")
+    assertExOutput("abc")
   }
 
   @Test
   fun `test last index bigger sting size`() {
     configureByText("\n")
     typeText(commandToKeys("echo 'abc'[1:10000]"))
-    assertExOutput("bc\n")
+    assertExOutput("bc")
   }
 
   @Test
   fun `test both indexes bigger sting size`() {
     configureByText("\n")
     typeText(commandToKeys("echo 'abc'[100:10000]"))
-    assertExOutput("\n")
+    assertExOutput("")
   }
 
   @Test
   fun `test first index is bigger than second`() {
     configureByText("\n")
     typeText(commandToKeys("echo 'abc'[100:10]"))
-    assertExOutput("\n")
+    assertExOutput("")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/AnonymousFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/AnonymousFunctionTest.kt
@@ -30,7 +30,7 @@ class AnonymousFunctionTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo dict.pi()"))
-    assertExOutput("3.1415\n")
+    assertExOutput("3.1415")
   }
 
   // todo. `commandToKeys` is executed as if it would from the command line. so no script - no scope ¯\_(ツ)_/¯
@@ -49,7 +49,7 @@ class AnonymousFunctionTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo s:dict.pi()"))
-    assertExOutput("3.1415\n")
+    assertExOutput("3.1415")
   }
 
   @Test
@@ -66,7 +66,7 @@ class AnonymousFunctionTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo dict.getName()"))
-    assertExOutput("dict\n")
+    assertExOutput("dict")
   }
 
   @Test
@@ -83,7 +83,7 @@ class AnonymousFunctionTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("call dict.dict2.dict3.sayHi()"))
-    assertExOutput("hi\n")
+    assertExOutput("hi")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)
@@ -144,7 +144,7 @@ class AnonymousFunctionTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo dict.abs(-10)"))
-    assertExOutput("10\n")
+    assertExOutput("10")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN)

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/BasicStringFunctions.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/BasicStringFunctions.kt
@@ -17,28 +17,28 @@ class BasicStringFunctions : VimTestCase() {
   fun `test toupper`() {
     configureByText("\n")
     typeText(commandToKeys("echo toupper('Vim is awesome')"))
-    assertExOutput("VIM IS AWESOME\n")
+    assertExOutput("VIM IS AWESOME")
   }
 
   @Test
   fun `test tolower`() {
     configureByText("\n")
     typeText(commandToKeys("echo tolower('Vim is awesome')"))
-    assertExOutput("vim is awesome\n")
+    assertExOutput("vim is awesome")
   }
 
   @Test
   fun `test join`() {
     configureByText("\n")
     typeText(commandToKeys("echo join(['Vim', 'is', 'awesome'], '_')"))
-    assertExOutput("Vim_is_awesome\n")
+    assertExOutput("Vim_is_awesome")
   }
 
   @Test
   fun `test join without second argument`() {
     configureByText("\n")
     typeText(commandToKeys("echo join(['Vim', 'is', 'awesome'])"))
-    assertExOutput("Vim is awesome\n")
+    assertExOutput("Vim is awesome")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/BuiltInFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/BuiltInFunctionTest.kt
@@ -18,71 +18,71 @@ class BuiltInFunctionTest : VimTestCase() {
   fun `test abs`() {
     configureByText("\n")
     typeText(commandToKeys("echo abs(-123) abs(2)"))
-    assertExOutput("123 2\n")
+    assertExOutput("123 2")
   }
 
   @Test
   fun `test sin`() {
     configureByText("\n")
     typeText(commandToKeys("echo sin(0) sin(1)"))
-    assertExOutput("0.0 0.841471\n")
+    assertExOutput("0.0 0.841471")
   }
 
   @Test
   fun `test empty`() {
     configureByText("\n")
     typeText(commandToKeys("echo empty(0) empty(1)"))
-    assertExOutput("1 0\n")
+    assertExOutput("1 0")
     typeText(commandToKeys("echo empty(\"123\") empty(\"\")"))
-    assertExOutput("0 1\n")
+    assertExOutput("0 1")
     typeText(commandToKeys("echo empty([1, 2]) empty([])"))
-    assertExOutput("0 1\n")
+    assertExOutput("0 1")
     typeText(commandToKeys("echo empty({1:2}) empty({})"))
-    assertExOutput("0 1\n")
+    assertExOutput("0 1")
   }
 
   @Test
   fun `test line`() {
     configureByText("1\n2\n${c}3\n4\n5")
     typeText(commandToKeys("echo line('.')"))
-    assertExOutput("3\n")
+    assertExOutput("3")
 
     typeText(commandToKeys("echo line('$')"))
-    assertExOutput("5\n")
+    assertExOutput("5")
 
     typeText(injector.parser.parseKeys("ma"))
     typeText(commandToKeys("""echo line("'a") line("'x")"""))
-    assertExOutput("3 0\n")
+    assertExOutput("3 0")
 
     setEditorVisibleSize(screenWidth, 3)
     setPositionAndScroll(2, 2)
     typeText(commandToKeys("""echo line("w0") line("w$")"""))
-    assertExOutput("3 5\n")
+    assertExOutput("3 5")
 
     // Without selection - current line
     typeText(commandToKeys("""echo line("v")"""))
-    assertExOutput("3\n")
+    assertExOutput("3")
 
     // With selection - make sure to delete the '<,'> that is automatically prepended when entering Command-line mode
     // with a selection
     typeText(injector.parser.parseKeys("vj"))
     typeText(injector.parser.parseKeys(""":<BS><BS><BS><BS><BS>echo line("v")<CR>"""))
-    assertExOutput("3\n")
+    assertExOutput("3")
 
     // Remove selection and check again - note that exiting Command-line mode removes selection and switches back to
     // Normal. This <esc> does nothing
     typeText(injector.parser.parseKeys("<esc>"))
     typeText(commandToKeys("""echo line("v")"""))
-    assertExOutput("3\n")
+    assertExOutput("3")
 
     typeText(commandToKeys("""echo line("abs") line(1) line([])"""))
-    assertExOutput("0 0 0\n")
+    assertExOutput("0 0 0")
 
     typeText(commandToKeys("""echo line([1, 1]) line(['.', '$']) line(['$', '$'])"""))
-    assertExOutput("1 0 0\n")
+    assertExOutput("1 0 0")
 
     typeText(commandToKeys("""echo line([0, 1]) line([1, 1]) line([5, 1]) line([6, 1]) line([5, 2]) line([5, 3])"""))
-    assertExOutput("0 1 5 0 5 0\n")
+    assertExOutput("0 1 5 0 5 0")
   }
 
   // XXX virtualedit is not tested
@@ -98,81 +98,81 @@ class BuiltInFunctionTest : VimTestCase() {
       """.trimIndent(),
     )
     typeText(commandToKeys("echo col('.')"))
-    assertExOutput("5\n")
+    assertExOutput("5")
 
     typeText(commandToKeys("echo col('$')"))
-    assertExOutput("10\n")
+    assertExOutput("10")
 
     typeText(injector.parser.parseKeys("ma"))
     typeText(commandToKeys("""echo col("'a") col("'z")"""))
-    assertExOutput("5 0\n")
+    assertExOutput("5 0")
 
     // Without selection - current line
     typeText(commandToKeys("""echo col("v")"""))
-    assertExOutput("5\n")
+    assertExOutput("5")
 
     // With selection - make sure to delete the '<,'> that is automatically prepended when entering Command-line mode
     // with a selection
     typeText(injector.parser.parseKeys("vll"))
     typeText(injector.parser.parseKeys(""":<BS><BS><BS><BS><BS>echo col("v")<CR>"""))
-    assertExOutput("5\n")
+    assertExOutput("5")
 
     // Remove selection and check again - note that exiting Command-line mode removes selection and switches back to
     // Normal. This <esc> does nothing
     typeText(injector.parser.parseKeys("<esc>"))
     typeText(commandToKeys("""echo col("v")"""))
-    assertExOutput("5\n")
+    assertExOutput("5")
 
     typeText(commandToKeys("echo col('$')"))
-    assertExOutput("10\n")
+    assertExOutput("10")
 
     typeText(commandToKeys("""echo col("abs") col(1) col([])"""))
-    assertExOutput("0 0 0\n")
+    assertExOutput("0 0 0")
 
     typeText(commandToKeys("""echo col([1, 1]) col([3, '$'])  col(['.', '$']) col(['$', '$'])"""))
-    assertExOutput("1 11 0 0\n")
+    assertExOutput("1 11 0 0")
 
     typeText(commandToKeys("""echo col([0, 1]) col([1, 1]) col([5, 1]) col([6, 1]) col([5, 2])"""))
-    assertExOutput("0 1 1 0 2\n")
+    assertExOutput("0 1 1 0 2")
   }
 
   @Test
   fun `test exists`() {
     configureByText("\n")
     typeText(commandToKeys("echo exists(\"&nu\")"))
-    assertExOutput("1\n")
+    assertExOutput("1")
 
     typeText(commandToKeys("echo exists(\"&unknownOptionName\")"))
-    assertExOutput("0\n")
+    assertExOutput("0")
 
     typeText(commandToKeys("echo exists(\"g:myVar\")"))
-    assertExOutput("0\n")
+    assertExOutput("0")
 
     enterCommand("let myVar = 42")
     typeText(commandToKeys("echo exists(\"g:myVar\")"))
-    assertExOutput("1\n")
+    assertExOutput("1")
   }
 
   @Test
   fun `test len`() {
     configureByText("\n")
     typeText(commandToKeys("echo len(123)"))
-    assertExOutput("3\n")
+    assertExOutput("3")
 
     typeText(commandToKeys("echo len('abcd')"))
-    assertExOutput("4\n")
+    assertExOutput("4")
 
     typeText(commandToKeys("echo len([1])"))
-    assertExOutput("1\n")
+    assertExOutput("1")
 
     typeText(commandToKeys("echo len({})"))
-    assertExOutput("0\n")
+    assertExOutput("0")
 
     typeText(commandToKeys("echo len(#{1: 'one'})"))
-    assertExOutput("1\n")
+    assertExOutput("1")
 
     typeText(commandToKeys("echo len(12 . 4)"))
-    assertExOutput("3\n")
+    assertExOutput("3")
 
     typeText(commandToKeys("echo len(4.2)"))
     assertPluginErrorMessageContains("E701: Invalid type for len()")

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/DictionaryFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/DictionaryFunctionTest.kt
@@ -30,7 +30,7 @@ class DictionaryFunctionTest : VimTestCase() {
     )
     typeText(commandToKeys("let dict = {'data': [], 'print': function('Print')}"))
     typeText(commandToKeys("call dict.print()"))
-    assertExOutput("[]\n")
+    assertExOutput("[]")
 
     typeText(commandToKeys("delfunction! Print"))
   }
@@ -51,7 +51,7 @@ class DictionaryFunctionTest : VimTestCase() {
     typeText(commandToKeys("let PrintFr = function('Print')"))
     typeText(commandToKeys("let dict.print = PrintFr"))
     typeText(commandToKeys("call dict.print()"))
-    assertExOutput("dict_name\n")
+    assertExOutput("dict_name")
 
     typeText(commandToKeys("delfunction! Print"))
   }
@@ -96,7 +96,7 @@ class DictionaryFunctionTest : VimTestCase() {
     typeText(commandToKeys("echo dict"))
     assertExOutput("{'name': 'dict', 'print': function('Print')}")
     typeText(commandToKeys("call dict.print()"))
-    assertExOutput("dict\n")
+    assertExOutput("dict")
 
     typeText(commandToKeys("let dict2 = {'name': 'dict2', 'print': dict.print}"))
     typeText(commandToKeys("echo dict2.print"))
@@ -104,7 +104,7 @@ class DictionaryFunctionTest : VimTestCase() {
     typeText(commandToKeys("echo dict2"))
     assertExOutput("{'name': 'dict2', 'print': function('Print', {name: 'dict', 'print': function('Print')})}")
     typeText(commandToKeys("call dict2.print()"))
-    assertExOutput("dict2\n")
+    assertExOutput("dict2")
 
     typeText(commandToKeys("delfunction! Print"))
   }
@@ -126,10 +126,10 @@ class DictionaryFunctionTest : VimTestCase() {
     typeText(commandToKeys("let dict2.print = dict.print"))
 
     typeText(commandToKeys("call dict2.print()"))
-    assertExOutput("dict2\n")
+    assertExOutput("dict2")
 
     typeText(commandToKeys("call dict.print()"))
-    assertExOutput("dict\n")
+    assertExOutput("dict")
 
     typeText(commandToKeys("delfunction! Print"))
   }
@@ -150,10 +150,10 @@ class DictionaryFunctionTest : VimTestCase() {
     typeText(commandToKeys("let dict2 = {'name': 'dict2', 'print': dict.print}"))
 
     typeText(commandToKeys("call dict2.print()"))
-    assertExOutput("dict2\n")
+    assertExOutput("dict2")
 
     typeText(commandToKeys("call dict.print()"))
-    assertExOutput("dict\n")
+    assertExOutput("dict")
 
     typeText(commandToKeys("delfunction! Print"))
   }
@@ -173,11 +173,11 @@ class DictionaryFunctionTest : VimTestCase() {
     typeText(commandToKeys("let dict = {'name': 'dict'}"))
     typeText(commandToKeys("let dict.print = function('Print', dict)"))
     typeText(commandToKeys("call dict.print()"))
-    assertExOutput("dict\n")
+    assertExOutput("dict")
 
     typeText(commandToKeys("let dict2 = {'name': 'dict2', 'print': dict.print}"))
     typeText(commandToKeys("call dict2.print()"))
-    assertExOutput("dict\n")
+    assertExOutput("dict")
 
     typeText(commandToKeys("delfunction! Print"))
   }
@@ -217,7 +217,7 @@ class DictionaryFunctionTest : VimTestCase() {
     )
     typeText(commandToKeys("let dict = {'name': 'dict', 'innerDict': {'name': 'innerDict', 'print': function('Print')}}"))
     typeText(commandToKeys("call dict.innerDict.print()"))
-    assertExOutput("innerDict\n")
+    assertExOutput("innerDict")
 
     typeText(commandToKeys("delfunction! Print"))
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/FuncrefTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/FuncrefTest.kt
@@ -38,10 +38,10 @@ class FuncrefTest : VimTestCase() {
     )
     typeText(commandToKeys("let Ff = funcref('Abs', [-10])"))
     typeText(commandToKeys("echo Ff()"))
-    assertExOutput("10\n")
+    assertExOutput("10")
 
     typeText(commandToKeys("echo Ff"))
-    assertExOutput("function('Abs', [-10])\n")
+    assertExOutput("function('Abs', [-10])")
 
     typeText(commandToKeys("delfunction! Abs"))
   }
@@ -118,7 +118,7 @@ class FuncrefTest : VimTestCase() {
     )
     typeText(commandToKeys("let Ff = funcref('SayHi')"))
     typeText(commandToKeys("call Ff()"))
-    assertExOutput("hello\n")
+    assertExOutput("hello")
 
     typeText(
       commandToKeys(
@@ -130,7 +130,7 @@ class FuncrefTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("call Ff()"))
-    assertExOutput("hello\n")
+    assertExOutput("hello")
 
     typeText(commandToKeys("delfunction! SayHi"))
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/FunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/FunctionTest.kt
@@ -20,10 +20,10 @@ class FunctionTest : VimTestCase() {
     configureByText("\n")
     typeText(commandToKeys("let Ff = function('abs')"))
     typeText(commandToKeys("echo Ff(-10)"))
-    assertExOutput("10\n")
+    assertExOutput("10")
 
     typeText(commandToKeys("echo Ff"))
-    assertExOutput("abs\n")
+    assertExOutput("abs")
   }
 
   @Test
@@ -31,10 +31,10 @@ class FunctionTest : VimTestCase() {
     configureByText("\n")
     typeText(commandToKeys("let Ff = function('abs', [-10])"))
     typeText(commandToKeys("echo Ff()"))
-    assertExOutput("10\n")
+    assertExOutput("10")
 
     typeText(commandToKeys("echo Ff"))
-    assertExOutput("function('abs', [-10])\n")
+    assertExOutput("function('abs', [-10])")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)
@@ -88,7 +88,7 @@ class FunctionTest : VimTestCase() {
     )
     typeText(commandToKeys("let Ff = function('SayHi')"))
     typeText(commandToKeys("call Ff()"))
-    assertExOutput("hello\n")
+    assertExOutput("hello")
 
     typeText(
       commandToKeys(
@@ -100,7 +100,7 @@ class FunctionTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("call Ff()"))
-    assertExOutput("hi\n")
+    assertExOutput("hi")
 
     typeText(commandToKeys("delfunction! SayHi"))
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/GetFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/GetFunctionTest.kt
@@ -16,41 +16,41 @@ class GetFunctionTest : VimTestCase() {
   fun `test get with dictionary`() {
     configureByText("\n")
     typeText(commandToKeys("echo get({1: 'one', 2: 'two', 3: 'three'}, '2')"))
-    assertExOutput("two\n")
+    assertExOutput("two")
   }
 
   @Test
   fun `test get by nonexistent key in dictionary`() {
     configureByText("\n")
     typeText(commandToKeys("echo get({1: 'one', 2: 'two', 3: 'three'}, '10')"))
-    assertExOutput("0\n")
+    assertExOutput("0")
   }
 
   @Test
   fun `test get by nonexistent key in dictionary with default value`() {
     configureByText("\n")
     typeText(commandToKeys("echo get({1: 'one', 2: 'two', 3: 'three'}, '10', 'null')"))
-    assertExOutput("null\n")
+    assertExOutput("null")
   }
 
   @Test
   fun `test get with list`() {
     configureByText("\n")
     typeText(commandToKeys("echo get(['one', 'two', 'three'], 1)"))
-    assertExOutput("two\n")
+    assertExOutput("two")
   }
 
   @Test
   fun `test get by nonexistent index in list`() {
     configureByText("\n")
     typeText(commandToKeys("echo get(['one', 'two', 'three'], 10)"))
-    assertExOutput("-1\n")
+    assertExOutput("-1")
   }
 
   @Test
   fun `test get by nonexistent index in list with default value`() {
     configureByText("\n")
     typeText(commandToKeys("echo get(['one', 'two', 'three'], 10, 'null')"))
-    assertExOutput("null\n")
+    assertExOutput("null")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/HasFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/HasFunctionTest.kt
@@ -19,21 +19,21 @@ class HasFunctionTest : VimTestCase() {
   fun `test has for supported feature`() {
     configureByText("\n")
     typeText(commandToKeys("echo has('ide')"))
-    assertExOutput("1\n")
+    assertExOutput("1")
   }
 
   @Test
   fun `test has for unsupported feature`() {
     configureByText("\n")
     typeText(commandToKeys("echo has('autocmd')"))
-    assertExOutput("0\n")
+    assertExOutput("0")
   }
 
   @Test
   fun `test has for int as an argument`() {
     configureByText("\n")
     typeText(commandToKeys("echo has(42)"))
-    assertExOutput("0\n")
+    assertExOutput("0")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/SplitFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/SplitFunctionTest.kt
@@ -16,27 +16,27 @@ class SplitFunctionTest : VimTestCase() {
   fun `test split with default delimiter`() {
     configureByText("\n")
     typeText(commandToKeys("echo split('Hello world')"))
-    assertExOutput("['Hello', 'world']\n")
+    assertExOutput("['Hello', 'world']")
   }
 
   @Test
   fun `test split comma separated text`() {
     configureByText("\n")
     typeText(commandToKeys("echo split('a,b,c,d', ',')"))
-    assertExOutput("['a', 'b', 'c', 'd']\n")
+    assertExOutput("['a', 'b', 'c', 'd']")
   }
 
   @Test
   fun `test split comma separated text 2`() {
     configureByText("\n")
     typeText(commandToKeys("echo split(',a,b,c,d,', ',')"))
-    assertExOutput("['a', 'b', 'c', 'd']\n")
+    assertExOutput("['a', 'b', 'c', 'd']")
   }
 
   @Test
   fun `test split comma separated text with keepempty flag`() {
     configureByText("\n")
     typeText(commandToKeys("echo split(',a,b,c,,d,', ',', 1)"))
-    assertExOutput("['', 'a', 'b', 'c', '', 'd', '']\n")
+    assertExOutput("['', 'a', 'b', 'c', '', 'd', '']")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/services/VimVariableServiceTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/services/VimVariableServiceTest.kt
@@ -17,7 +17,7 @@ class VimVariableServiceTest : VimTestCase() {
     configureByText("\n")
     enterCommand("nnoremap <expr> n ':echo ' .. v:count .. \"\\<CR>\"")
     typeText("n")
-    assertExOutput("0\n")
+    assertExOutput("0")
   }
 
   @Test
@@ -25,7 +25,7 @@ class VimVariableServiceTest : VimTestCase() {
     configureByText("\n")
     enterCommand("nnoremap <expr> n ':' .. \"\\<C-u>\" .. 'echo ' .. v:count .. \"\\<CR>\"")
     typeText("5n")
-    assertExOutput("5\n")
+    assertExOutput("5")
   }
 
   @Test
@@ -33,7 +33,7 @@ class VimVariableServiceTest : VimTestCase() {
     configureByText("\n")
     enterCommand("nnoremap <expr> n ':echo ' .. v:count1 .. \"\\<CR>\"")
     typeText("n")
-    assertExOutput("1\n")
+    assertExOutput("1")
   }
 
   @Test
@@ -41,7 +41,7 @@ class VimVariableServiceTest : VimTestCase() {
     configureByText("\n")
     enterCommand("nnoremap <expr> n ':' .. \"\\<C-u>\" .. 'echo ' .. v:count1 .. \"\\<CR>\"")
     typeText("5n")
-    assertExOutput("5\n")
+    assertExOutput("5")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/ForTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/ForTest.kt
@@ -30,7 +30,7 @@ class ForTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("aabbccddeeff\n")
+    assertExOutput("aabbccddeeff")
   }
 
   @Test
@@ -47,7 +47,7 @@ class ForTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("hello\n")
+    assertExOutput("hello")
   }
 
   @Test
@@ -68,7 +68,7 @@ class ForTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("hello!!\n")
+    assertExOutput("hello!!")
   }
 
   @Test
@@ -88,7 +88,7 @@ class ForTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("123\n")
+    assertExOutput("123")
   }
 
   @Test
@@ -110,7 +110,7 @@ class ForTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("3\n")
+    assertExOutput("3")
   }
 
   @Test
@@ -129,7 +129,7 @@ class ForTest : VimTestCase() {
         """.trimIndent(),
       ),
     )
-    assertExOutput("123 abc\n")
+    assertExOutput("123 abc")
   }
 
   @TestWithoutNeovim(SkipNeovimReason.PLUGIN_ERROR)

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/FunctionDeclarationTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/FunctionDeclarationTest.kt
@@ -27,7 +27,7 @@ class FunctionDeclarationTest : VimTestCase() {
           "echo GetHiString('Mark')",
       ),
     )
-    assertExOutput("Oh hi Mark\n")
+    assertExOutput("Oh hi Mark")
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN_ERROR)
@@ -54,9 +54,9 @@ class FunctionDeclarationTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo F1()"))
-    assertExOutput("5550\n")
+    assertExOutput("5550")
     typeText(commandToKeys("echo F2()"))
-    assertExOutput("555\n")
+    assertExOutput("555")
 
     typeText(commandToKeys("delf! F1"))
     typeText(commandToKeys("delf! F2"))
@@ -109,7 +109,7 @@ class FunctionDeclarationTest : VimTestCase() {
     assertPluginErrorMessageContains("E122: Function F1 already exists, add ! to replace it")
 
     typeText(commandToKeys("echo F1()"))
-    assertExOutput("10\n")
+    assertExOutput("10")
 
     typeText(commandToKeys("delf! F1"))
   }
@@ -135,7 +135,7 @@ class FunctionDeclarationTest : VimTestCase() {
     )
     assertPluginError(false)
     typeText(commandToKeys("echo F1()"))
-    assertExOutput("100\n")
+    assertExOutput("100")
 
     typeText(commandToKeys("delf! F1"))
   }
@@ -156,7 +156,7 @@ class FunctionDeclarationTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo F1()"))
-    assertExOutput("50\n")
+    assertExOutput("50")
 
     typeText(commandToKeys("delf! F1"))
     typeText(commandToKeys("delf! F2"))
@@ -181,7 +181,7 @@ class FunctionDeclarationTest : VimTestCase() {
     typeText(commandToKeys("echo F1()"))
     assertPluginError(true)
     assertPluginErrorMessageContains("E121: Undefined variable: x")
-    assertExOutput("0\n")
+    assertExOutput("0")
 
     typeText(commandToKeys("delf! F1"))
     typeText(commandToKeys("delf! F2"))
@@ -204,11 +204,11 @@ class FunctionDeclarationTest : VimTestCase() {
     )
     typeText(commandToKeys("echo F1()"))
     typeText(commandToKeys("echo F2()"))
-    assertExOutput("1\n")
+    assertExOutput("1")
     typeText(commandToKeys("echo F2()"))
-    assertExOutput("2\n")
+    assertExOutput("2")
     typeText(commandToKeys("echo F2()"))
-    assertExOutput("3\n")
+    assertExOutput("3")
 
     typeText(commandToKeys("delf! F1"))
     typeText(commandToKeys("delf! F2"))
@@ -231,10 +231,10 @@ class FunctionDeclarationTest : VimTestCase() {
     )
     typeText(commandToKeys("echo F1()"))
     typeText(commandToKeys("echo F2()"))
-    assertExOutput("1\n")
+    assertExOutput("1")
     typeText(commandToKeys("delf! F1"))
     typeText(commandToKeys("echo F2()"))
-    assertExOutput("2\n")
+    assertExOutput("2")
 
     typeText(commandToKeys("delf! F1"))
     typeText(commandToKeys("delf! F2"))
@@ -261,7 +261,7 @@ class FunctionDeclarationTest : VimTestCase() {
     assertPluginErrorMessageContains("E121: Undefined variable: x")
 
     typeText(commandToKeys("echo F2()"))
-    assertExOutput("10\n")
+    assertExOutput("10")
     assertPluginError(false)
 
     typeText(commandToKeys("echo F1()"))
@@ -290,7 +290,7 @@ class FunctionDeclarationTest : VimTestCase() {
     assertPluginErrorMessageContains("E121: Undefined variable: unknownVar")
 
     typeText(commandToKeys("echo x"))
-    assertExOutput("10\n")
+    assertExOutput("10")
     assertPluginError(false)
 
     typeText(commandToKeys("delf! F1"))
@@ -342,7 +342,7 @@ class FunctionDeclarationTest : VimTestCase() {
     typeText(commandToKeys("1,3call F1()"))
     typeText(commandToKeys("echo rangesConcatenation"))
     assertPluginError(false)
-    assertExOutput("123\n")
+    assertExOutput("123")
 
     assertState(
       """
@@ -377,7 +377,7 @@ class FunctionDeclarationTest : VimTestCase() {
     typeText(commandToKeys("1,3call F1()"))
     typeText(commandToKeys("echo rangesConcatenation"))
     assertPluginError(false)
-    assertExOutput("1\n")
+    assertExOutput("1")
 
     assertState(
       """
@@ -442,7 +442,7 @@ class FunctionDeclarationTest : VimTestCase() {
     )
     typeText(commandToKeys("call F1()"))
     assertPluginError(false)
-    assertExOutput("2:2\n")
+    assertExOutput("2:2")
     assertState(
       """
         -----
@@ -474,7 +474,7 @@ class FunctionDeclarationTest : VimTestCase() {
     )
     typeText(commandToKeys("1,4call F1()"))
     assertPluginError(false)
-    assertExOutput("1:4\n")
+    assertExOutput("1:4")
     assertState(
       """
         -----
@@ -508,13 +508,13 @@ class FunctionDeclarationTest : VimTestCase() {
     typeText(commandToKeys("call F1()"))
     typeText(commandToKeys("echo columns"))
     assertPluginError(false)
-    assertExOutput("4,\n")
+    assertExOutput("4,")
 
     typeText(commandToKeys("let columns = ''"))
     typeText(commandToKeys("1,3call F1()"))
     typeText(commandToKeys("echo columns"))
     assertPluginError(false)
-    assertExOutput("1,1,1,\n")
+    assertExOutput("1,1,1,")
 
     typeText(commandToKeys("delf! F1"))
   }
@@ -541,13 +541,13 @@ class FunctionDeclarationTest : VimTestCase() {
     typeText(commandToKeys("call F1()"))
     typeText(commandToKeys("echo columns"))
     assertPluginError(false)
-    assertExOutput("4,\n")
+    assertExOutput("4,")
 
     typeText(commandToKeys("let columns = ''"))
     typeText(commandToKeys("1,3call F1()"))
     typeText(commandToKeys("echo columns"))
     assertPluginError(false)
-    assertExOutput("1,\n")
+    assertExOutput("1,")
 
     typeText(commandToKeys("delf! F1"))
   }
@@ -564,13 +564,13 @@ class FunctionDeclarationTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo GetOptionalArgs()"))
-    assertExOutput("[]\n")
+    assertExOutput("[]")
     typeText(
       commandToKeys(
         "echo GetOptionalArgs(42, 'optional arg')",
       ),
     )
-    assertExOutput("[42, 'optional arg']\n")
+    assertExOutput("[42, 'optional arg']")
 
     typeText(commandToKeys("delfunction! GetOptionalArgs"))
   }
@@ -587,9 +587,9 @@ class FunctionDeclarationTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo GetDefaultArgs()"))
-    assertExOutput("[10, 20]\n")
+    assertExOutput("[10, 20]")
     typeText(commandToKeys("echo GetDefaultArgs(42, 'optional arg')"))
-    assertExOutput("[42, 'optional arg']\n")
+    assertExOutput("[42, 'optional arg']")
 
     typeText(commandToKeys("delfunction! GetDefaultArgs"))
   }
@@ -606,13 +606,13 @@ class FunctionDeclarationTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo GetOptionalArgs('this arg is not optional')"))
-    assertExOutput("[]\n")
+    assertExOutput("[]")
     typeText(
       commandToKeys(
         "echo GetOptionalArgs('this arg is not optional', 42, 'optional arg')",
       ),
     )
-    assertExOutput("[42, 'optional arg']\n")
+    assertExOutput("[42, 'optional arg']")
 
     typeText(commandToKeys("delfunction! GetOptionalArgs"))
   }
@@ -629,13 +629,13 @@ class FunctionDeclarationTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo GetOptionalArgs('this arg is not optional')"))
-    assertExOutput("a = 10, b = 20\n")
+    assertExOutput("a = 10, b = 20")
 
     typeText(commandToKeys("echo GetOptionalArgs('this arg is not optional', 42)"))
-    assertExOutput("a = 42, b = 20\n")
+    assertExOutput("a = 42, b = 20")
 
     typeText(commandToKeys("echo GetOptionalArgs('this arg is not optional', 100, 200)"))
-    assertExOutput("a = 100, b = 200\n")
+    assertExOutput("a = 100, b = 200")
 
     typeText(commandToKeys("delfunction! GetOptionalArgs"))
   }
@@ -652,16 +652,16 @@ class FunctionDeclarationTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo GetOptionalArgs('this arg is not optional')"))
-    assertExOutput("{'a': 10, 'b': 20, '000': []}\n")
+    assertExOutput("{'a': 10, 'b': 20, '000': []}")
 
     typeText(commandToKeys("echo GetOptionalArgs('this arg is not optional', 42)"))
-    assertExOutput("{'a': 42, 'b': 20, '000': []}\n")
+    assertExOutput("{'a': 42, 'b': 20, '000': []}")
 
     typeText(commandToKeys("echo GetOptionalArgs('this arg is not optional', 100, 200)"))
-    assertExOutput("{'a': 100, 'b': 200, '000': []}\n")
+    assertExOutput("{'a': 100, 'b': 200, '000': []}")
 
     typeText(commandToKeys("echo GetOptionalArgs('this arg is not optional', 100, 200, 300)"))
-    assertExOutput("{'a': 100, 'b': 200, '000': [300]}\n")
+    assertExOutput("{'a': 100, 'b': 200, '000': [300]}")
 
     typeText(commandToKeys("delfunction! GetOptionalArgs"))
   }
@@ -682,7 +682,7 @@ class FunctionDeclarationTest : VimTestCase() {
     )
     typeText(commandToKeys("call F()"))
     typeText(commandToKeys("echo x"))
-    assertExOutput("3\n")
+    assertExOutput("3")
 
     typeText(commandToKeys("delfunction! F"))
   }
@@ -704,7 +704,7 @@ class FunctionDeclarationTest : VimTestCase() {
     typeText(commandToKeys("call AddNumbers(d)"))
     typeText(commandToKeys("echo d"))
     assertPluginError(false)
-    assertExOutput("{'one': 1, 'two': 2}\n")
+    assertExOutput("{'one': 1, 'two': 2}")
 
     typeText(commandToKeys("delfunction! AddNumbers"))
   }
@@ -758,6 +758,6 @@ class FunctionDeclarationTest : VimTestCase() {
     )
     assertPluginError(false)
     typeText(commandToKeys("echo ZeroGenerator()"))
-    assertExOutput("0\n")
+    assertExOutput("0")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/IfStatementTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/IfStatementTest.kt
@@ -24,7 +24,7 @@ class IfStatementTest : VimTestCase() {
           "endif",
       ),
     )
-    assertExOutput("success\n")
+    assertExOutput("success")
   }
 
   @Test
@@ -54,7 +54,7 @@ class IfStatementTest : VimTestCase() {
           "endif",
       ),
     )
-    assertExOutput("success\n")
+    assertExOutput("success")
   }
 
   @Test
@@ -70,7 +70,7 @@ class IfStatementTest : VimTestCase() {
           "endif",
       ),
     )
-    assertExOutput("success\n")
+    assertExOutput("success")
   }
 
   @Test
@@ -88,7 +88,7 @@ class IfStatementTest : VimTestCase() {
           "endif",
       ),
     )
-    assertExOutput("success\n")
+    assertExOutput("success")
   }
 
   @Test
@@ -106,7 +106,7 @@ class IfStatementTest : VimTestCase() {
           "endif",
       ),
     )
-    assertExOutput("success\n")
+    assertExOutput("success")
   }
 
   @Test
@@ -126,6 +126,6 @@ class IfStatementTest : VimTestCase() {
           "endif",
       ),
     )
-    assertExOutput("success\n")
+    assertExOutput("success")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/TryCatchTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/TryCatchTest.kt
@@ -29,7 +29,7 @@ class TryCatchTest : VimTestCase() {
       ),
     )
     assertPluginError(false)
-    assertExOutput("caught\n")
+    assertExOutput("caught")
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN_ERROR)
@@ -134,7 +134,7 @@ class TryCatchTest : VimTestCase() {
       ),
     )
     assertPluginError(false)
-    assertExOutput("finally block\n")
+    assertExOutput("finally block")
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN_ERROR)
@@ -155,7 +155,7 @@ class TryCatchTest : VimTestCase() {
     )
     assertPluginError(true)
     assertPluginErrorMessageContains("my exception")
-    assertExOutput("finally block\n")
+    assertExOutput("finally block")
   }
 
   @Test
@@ -176,6 +176,6 @@ class TryCatchTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo x .. ' ' .. y"))
-    assertExOutput("0 1\n")
+    assertExOutput("0 1")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/WhileTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/statements/WhileTest.kt
@@ -26,7 +26,7 @@ class WhileTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo x"))
-    assertExOutput("103\n")
+    assertExOutput("103")
   }
 
   @Test
@@ -46,7 +46,7 @@ class WhileTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo x"))
-    assertExOutput("13\n")
+    assertExOutput("13")
   }
 
   @Test
@@ -67,6 +67,6 @@ class WhileTest : VimTestCase() {
       ),
     )
     typeText(commandToKeys("echo evenNumbers"))
-    assertExOutput("50\n")
+    assertExOutput("50")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/BreakIndentOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/BreakIndentOptionMapperTest.kt
@@ -61,39 +61,39 @@ class BreakIndentOptionMapperTest : VimTestCase() {
   @Test
   fun `test 'breakindent' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = false
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("set breakindent?", "nobreakindent")
 
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = true
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("set breakindent?", "  breakindent")
   }
 
   @Test
   fun `test local 'breakindent' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = false
-    assertCommandOutput("setlocal breakindent?", "nobreakindent\n")
+    assertCommandOutput("setlocal breakindent?", "nobreakindent")
 
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = true
-    assertCommandOutput("setlocal breakindent?", "  breakindent\n")
+    assertCommandOutput("setlocal breakindent?", "  breakindent")
   }
 
   @Test
   fun `test 'breakindent' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isUseCustomSoftWrapIndent = false
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("set breakindent?", "nobreakindent")
 
     // Note that there is no actual UI in the IDE to set this
     fixture.editor.settings.isUseCustomSoftWrapIndent = true
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("set breakindent?", "  breakindent")
   }
 
   @Test
   fun `test local 'breakindent' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isUseCustomSoftWrapIndent = false
-    assertCommandOutput("setlocal breakindent?", "nobreakindent\n")
+    assertCommandOutput("setlocal breakindent?", "nobreakindent")
 
     // Note that there is no actual UI in the IDE to set this
     fixture.editor.settings.isUseCustomSoftWrapIndent = true
-    assertCommandOutput("setlocal breakindent?", "  breakindent\n")
+    assertCommandOutput("setlocal breakindent?", "  breakindent")
   }
 
   @Test
@@ -127,17 +127,17 @@ class BreakIndentOptionMapperTest : VimTestCase() {
   @Test
   fun `test setglobal 'breakindent' option affects IdeaVim global value only`() {
     assertFalse(IjOptions.breakindent.defaultValue.asBoolean()) // Vim default
-    assertCommandOutput("setglobal breakindent?", "nobreakindent\n")
+    assertCommandOutput("setglobal breakindent?", "nobreakindent")
 
     enterCommand("setglobal breakindent")
-    assertCommandOutput("setglobal breakindent?", "  breakindent\n")
+    assertCommandOutput("setglobal breakindent?", "  breakindent")
     assertFalse(EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent)
   }
 
   @Test
   fun `test set updates IdeaVim global value as well as local`() {
     enterCommand("set breakindent")
-    assertCommandOutput("setglobal breakindent?", "  breakindent\n")
+    assertCommandOutput("setglobal breakindent?", "  breakindent")
   }
 
   @Test
@@ -146,9 +146,9 @@ class BreakIndentOptionMapperTest : VimTestCase() {
     // affects the local value
     // Note that there is no actual UI in the IDE to set this
     fixture.editor.settings.isUseCustomSoftWrapIndent = true
-    assertCommandOutput("setlocal breakindent?", "  breakindent\n")
-    assertCommandOutput("set breakindent?", "  breakindent\n")
-    assertCommandOutput("setglobal breakindent?", "nobreakindent\n")
+    assertCommandOutput("setlocal breakindent?", "  breakindent")
+    assertCommandOutput("set breakindent?", "  breakindent")
+    assertCommandOutput("setglobal breakindent?", "nobreakindent")
   }
 
   @Test
@@ -156,16 +156,16 @@ class BreakIndentOptionMapperTest : VimTestCase() {
     enterCommand("set breakindent")
 
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = false
-    assertCommandOutput("setlocal breakindent?", "  breakindent\n")
-    assertCommandOutput("set breakindent?", "  breakindent\n")
-    assertCommandOutput("setglobal breakindent?", "  breakindent\n")
+    assertCommandOutput("setlocal breakindent?", "  breakindent")
+    assertCommandOutput("set breakindent?", "  breakindent")
+    assertCommandOutput("setglobal breakindent?", "  breakindent")
 
     enterCommand("set nobreakindent")
 
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = true
-    assertCommandOutput("setlocal breakindent?", "nobreakindent\n")
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
-    assertCommandOutput("setglobal breakindent?", "nobreakindent\n")
+    assertCommandOutput("setlocal breakindent?", "nobreakindent")
+    assertCommandOutput("set breakindent?", "nobreakindent")
+    assertCommandOutput("setglobal breakindent?", "nobreakindent")
   }
 
   @Test
@@ -185,9 +185,9 @@ class BreakIndentOptionMapperTest : VimTestCase() {
     }
 
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = false
-    assertCommandOutput("setlocal breakindent?", "nobreakindent\n")
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
-    assertCommandOutput("setglobal breakindent?", "nobreakindent\n")
+    assertCommandOutput("setlocal breakindent?", "nobreakindent")
+    assertCommandOutput("set breakindent?", "nobreakindent")
+    assertCommandOutput("setglobal breakindent?", "nobreakindent")
   }
 
   @Test
@@ -206,7 +206,7 @@ class BreakIndentOptionMapperTest : VimTestCase() {
   fun `test reset 'breakindent' to default copies current global intellij setting`() {
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = true
     fixture.editor.settings.isUseCustomSoftWrapIndent = false
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("set breakindent?", "nobreakindent")
 
     enterCommand("set breakindent&")
     assertTrue(fixture.editor.settings.isUseCustomSoftWrapIndent)
@@ -221,7 +221,7 @@ class BreakIndentOptionMapperTest : VimTestCase() {
   fun `test reset local 'breakindent' to default copies current global intellij setting`() {
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = true
     fixture.editor.settings.isUseCustomSoftWrapIndent = false
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("set breakindent?", "nobreakindent")
 
     enterCommand("setlocal breakindent&")
     assertTrue(fixture.editor.settings.isUseCustomSoftWrapIndent)
@@ -236,58 +236,58 @@ class BreakIndentOptionMapperTest : VimTestCase() {
   fun `test open new window without setting the option copies value as not-explicitly set`() {
     // New window will clone local and global local-to-window options, then apply global to local. This tests that our
     // handling of per-window "global" values is correct.
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("set breakindent?", "nobreakindent")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("set breakindent?", "nobreakindent")
 
     // Changing the global setting should update the new editor
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = true
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("set breakindent?", "  breakindent")
   }
 
   @Test
   fun `test open new window after setting option copies value as explicitly set`() {
     enterCommand("set breakindent")
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("set breakindent?", "  breakindent")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("set breakindent?", "  breakindent")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = false
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("set breakindent?", "  breakindent")
   }
 
   @Test
   fun `test setglobal 'breakindent' used when opening new window`() {
     enterCommand("setglobal breakindent")
-    assertCommandOutput("setglobal breakindent?", "  breakindent\n")
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("setglobal breakindent?", "  breakindent")
+    assertCommandOutput("set breakindent?", "nobreakindent")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("set breakindent?", "  breakindent")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = false
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("set breakindent?", "  breakindent")
   }
 
   @Test
   fun `test setlocal 'breakindent' then open new window uses value from setglobal`() {
     enterCommand("setlocal breakindent")
-    assertCommandOutput("setglobal breakindent?", "nobreakindent\n")
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("setglobal breakindent?", "nobreakindent")
+    assertCommandOutput("set breakindent?", "  breakindent")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("set breakindent?", "nobreakindent")
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = true
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("set breakindent?", "nobreakindent")
   }
 
   @Test
@@ -308,10 +308,10 @@ class BreakIndentOptionMapperTest : VimTestCase() {
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set breakindent?", "  breakindent\n")
+    assertCommandOutput("set breakindent?", "  breakindent")
 
     // Changing the global setting should update the editor, because it was initially set during plugin startup
     EditorSettingsExternalizable.getInstance().isUseCustomSoftWrapIndent = false
-    assertCommandOutput("set breakindent?", "nobreakindent\n")
+    assertCommandOutput("set breakindent?", "nobreakindent")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/ColorColumnOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/ColorColumnOptionMapperTest.kt
@@ -101,92 +101,92 @@ class ColorColumnOptionMapperTest : VimTestCase() {
     // IntelliJ only has one setting for visual guides and hard-wrap typing margin, so we have to report a special value
     // of "+0", which makes Vim show a highlight column at 'textwidth' (IntelliJ shows it even if 'textwidth' is 0)
     fixture.editor.settings.isRightMarginShown = true
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=+0")
   }
 
   @Test
   fun `test 'colorcolumn' reports '+0' at end of visual guide list`() {
     fixture.editor.settings.isRightMarginShown = true
     fixture.editor.settings.setSoftMargins(listOf(10,20,30))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0")
   }
 
   @Test
   fun `test 'colorcolumn' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isRightMarginShown = true
     setGlobalSoftMargins(listOf(10, 20, 30))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0")
 
     setGlobalSoftMargins(listOf(90, 80, 70))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=70,80,90,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=70,80,90,+0")
 
     setGlobalSoftMargins(emptyList())
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=+0")
 
     EditorSettingsExternalizable.getInstance().isRightMarginShown = false
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=")
   }
 
   @Test
   fun `test local 'colorcolumn' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isRightMarginShown = true
     setGlobalSoftMargins(listOf(10, 20, 30))
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=10,20,30,+0")
 
     setGlobalSoftMargins(listOf(90, 80, 70))
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=70,80,90,+0\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=70,80,90,+0")
 
     setGlobalSoftMargins(emptyList())
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=+0\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=+0")
 
     EditorSettingsExternalizable.getInstance().isRightMarginShown = false
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=")
   }
 
   @Test
   fun `test 'colorcolumn' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isRightMarginShown = true
     fixture.editor.settings.setSoftMargins(listOf(10, 20, 30))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0")
 
     fixture.editor.settings.setSoftMargins(listOf(70, 80, 90))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=70,80,90,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=70,80,90,+0")
 
     fixture.editor.settings.setSoftMargins(emptyList())
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=+0")
 
     fixture.editor.settings.isRightMarginShown = false
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=")
   }
 
   @Test
   fun `test local 'colorcolumn' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isRightMarginShown = true
     fixture.editor.settings.setSoftMargins(listOf(10, 20, 30))
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=10,20,30,+0")
 
     fixture.editor.settings.setSoftMargins(listOf(70, 80, 90))
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=70,80,90,+0\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=70,80,90,+0")
 
     fixture.editor.settings.setSoftMargins(emptyList())
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=+0\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=+0")
 
     fixture.editor.settings.isRightMarginShown = false
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=")
   }
 
   @Test
   fun `test 'colorcolumn' does not report current visual guides if global right margin option is disabled`() {
     EditorSettingsExternalizable.getInstance().isRightMarginShown = false
     fixture.editor.settings.setSoftMargins(listOf(10,20,30))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=")
   }
 
   @Test
   fun `test 'colorcolumn' does not report current visual guides if local right margin option is disabled`() {
     fixture.editor.settings.isRightMarginShown = false
     fixture.editor.settings.setSoftMargins(listOf(10,20,30))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=")
   }
 
   @Test
@@ -241,10 +241,10 @@ class ColorColumnOptionMapperTest : VimTestCase() {
   fun `test setglobal 'colorcolumn' option affects IdeaVim global value only`() {
     assertFalse(EditorSettingsExternalizable.getInstance().isRightMarginShown)
     assertEmpty(getGlobalSoftMargins())
-    assertCommandOutput("setglobal colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("setglobal colorcolumn?", "  colorcolumn=")
 
     enterCommand("setglobal colorcolumn=10,20,30")
-    assertCommandOutput("setglobal colorcolumn?", "  colorcolumn=10,20,30\n")
+    assertCommandOutput("setglobal colorcolumn?", "  colorcolumn=10,20,30")
     assertFalse(EditorSettingsExternalizable.getInstance().isRightMarginShown)
     assertEmpty(getGlobalSoftMargins())
   }
@@ -252,8 +252,8 @@ class ColorColumnOptionMapperTest : VimTestCase() {
   @Test
   fun `test set 'colorcolumn' updates IdeaVim global value as well as local`() {
     enterCommand("set colorcolumn=10,20,30")
-    assertCommandOutput("setglobal colorcolumn?", "  colorcolumn=10,20,30\n")
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("setglobal colorcolumn?", "  colorcolumn=10,20,30")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0")
   }
 
   @Test
@@ -262,9 +262,9 @@ class ColorColumnOptionMapperTest : VimTestCase() {
     // affects the local value
     fixture.editor.settings.isRightMarginShown = true
     fixture.editor.settings.setSoftMargins(listOf(70, 80, 90))
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=70,80,90,+0\n")
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=70,80,90,+0\n")
-    assertCommandOutput("setglobal colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=70,80,90,+0")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=70,80,90,+0")
+    assertCommandOutput("setglobal colorcolumn?", "  colorcolumn=")
   }
 
   @Test
@@ -286,7 +286,7 @@ class ColorColumnOptionMapperTest : VimTestCase() {
     fixture.editor.settings.setSoftMargins(listOf(10, 20, 30))
 
     enterCommand("set colorcolumn&")
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=")
     assertFalse(fixture.editor.settings.isRightMarginShown)
     assertEmpty(fixture.editor.settings.softMargins)
 
@@ -301,7 +301,7 @@ class ColorColumnOptionMapperTest : VimTestCase() {
     fixture.editor.settings.setSoftMargins(listOf(10, 20, 30))
 
     enterCommand("setlocal colorcolumn&")
-    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("setlocal colorcolumn?", "  colorcolumn=")
     assertFalse(fixture.editor.settings.isRightMarginShown)
     assertEmpty(fixture.editor.settings.softMargins)
 
@@ -314,18 +314,18 @@ class ColorColumnOptionMapperTest : VimTestCase() {
   fun `test open new window without setting ideavim option will initialise 'colorcolumn' to defaults`() {
     EditorSettingsExternalizable.getInstance().isRightMarginShown = true
     setGlobalSoftMargins(listOf(10, 20, 30))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0")
 
     openNewBufferWindow("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0")
 
     // Changing the global value should update the editor
     setGlobalSoftMargins(listOf(40, 50, 60, 70))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=40,50,60,70,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=40,50,60,70,+0")
 
     EditorSettingsExternalizable.getInstance().isRightMarginShown = false
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=")
   }
 
   @Test
@@ -333,15 +333,15 @@ class ColorColumnOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().isRightMarginShown = true
     setGlobalSoftMargins(listOf(10, 20, 30))
     enterCommand("set colorcolumn=40,50,60")
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=40,50,60,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=40,50,60,+0")
 
     openNewBufferWindow("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=40,50,60,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=40,50,60,+0")
 
     // Changing the global value should NOT update the editor
     setGlobalSoftMargins(listOf(10, 20, 30))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=40,50,60,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=40,50,60,+0")
   }
 
   @Test
@@ -350,11 +350,11 @@ class ColorColumnOptionMapperTest : VimTestCase() {
 
     openNewBufferWindow("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0")
 
     // Changing the global value should NOT update the editor
     setGlobalSoftMargins(listOf(40, 50, 60))
-    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0\n")
+    assertCommandOutput("set colorcolumn?", "  colorcolumn=10,20,30,+0")
   }
 
   private fun getGlobalSoftMargins(): List<Int> {

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/CursorLineOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/CursorLineOptionMapperTest.kt
@@ -57,32 +57,32 @@ class CursorLineOptionMapperTest : VimTestCase() {
   fun `test 'cursorline' option reports global intellij setting if not explicitly set`() {
     (fixture.editor.settings as SettingsImpl).getState().apply { clearOverriding(this::myCaretRowShown) }
     assertTrue(EditorSettingsExternalizable.getInstance().isCaretRowShown)
-    assertCommandOutput("set cursorline?", "  cursorline\n")
+    assertCommandOutput("set cursorline?", "  cursorline")
   }
 
   @Test
   fun `test local 'cursorline' option reports global intellij setting if not explicitly set`() {
     (fixture.editor.settings as SettingsImpl).getState().apply { clearOverriding(this::myCaretRowShown) }
     assertTrue(EditorSettingsExternalizable.getInstance().isCaretRowShown)
-    assertCommandOutput("setlocal cursorline?", "  cursorline\n")
+    assertCommandOutput("setlocal cursorline?", "  cursorline")
   }
 
   @Test
   fun `test 'cursorline' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isCaretRowShown = false
-    assertCommandOutput("set cursorline?", "nocursorline\n")
+    assertCommandOutput("set cursorline?", "nocursorline")
 
     fixture.editor.settings.isCaretRowShown = true
-    assertCommandOutput("set cursorline?", "  cursorline\n")
+    assertCommandOutput("set cursorline?", "  cursorline")
   }
 
   @Test
   fun `test local 'cursorline' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isCaretRowShown = false
-    assertCommandOutput("setlocal cursorline?", "nocursorline\n")
+    assertCommandOutput("setlocal cursorline?", "nocursorline")
 
     fixture.editor.settings.isCaretRowShown = true
-    assertCommandOutput("setlocal cursorline?", "  cursorline\n")
+    assertCommandOutput("setlocal cursorline?", "  cursorline")
   }
 
   @Test
@@ -116,20 +116,20 @@ class CursorLineOptionMapperTest : VimTestCase() {
   @Test
   fun `test setglobal 'cursorline' option affects IdeaVim global value only`() {
     assertFalse(IjOptions.cursorline.defaultValue.asBoolean())
-    assertCommandOutput("setglobal cursorline?", "nocursorline\n")
+    assertCommandOutput("setglobal cursorline?", "nocursorline")
 
     enterCommand("setglobal cursorline")
-    assertCommandOutput("setglobal cursorline?", "  cursorline\n")
+    assertCommandOutput("setglobal cursorline?", "  cursorline")
 
     enterCommand("setglobal nocursorline")
-    assertCommandOutput("setglobal cursorline?", "nocursorline\n")
+    assertCommandOutput("setglobal cursorline?", "nocursorline")
     assertTrue(EditorSettingsExternalizable.getInstance().isCaretRowShown)
   }
 
   @Test
   fun `test set updateds IdeaVim global value as well as local`() {
     enterCommand("set cursorline")
-    assertCommandOutput("setglobal cursorline?", "  cursorline\n")
+    assertCommandOutput("setglobal cursorline?", "  cursorline")
   }
 
   @Test
@@ -138,9 +138,9 @@ class CursorLineOptionMapperTest : VimTestCase() {
     // affects the local value
     enterCommand("setglobal cursorline")
     fixture.editor.settings.isCaretRowShown = false
-    assertCommandOutput("setlocal cursorline?", "nocursorline\n")
-    assertCommandOutput("set cursorline?", "nocursorline\n")
-    assertCommandOutput("setglobal cursorline?", "  cursorline\n")
+    assertCommandOutput("setlocal cursorline?", "nocursorline")
+    assertCommandOutput("set cursorline?", "nocursorline")
+    assertCommandOutput("setglobal cursorline?", "  cursorline")
   }
 
   @Test
@@ -159,7 +159,7 @@ class CursorLineOptionMapperTest : VimTestCase() {
   @Test
   fun `test rest 'cursorline' to default copies current global intellij setting`() {
     fixture.editor.settings.isCaretRowShown = false
-    assertCommandOutput("set cursorline?", "nocursorline\n")
+    assertCommandOutput("set cursorline?", "nocursorline")
 
     enterCommand("set cursorline&")
     assertTrue(fixture.editor.settings.isCaretRowShown)
@@ -171,7 +171,7 @@ class CursorLineOptionMapperTest : VimTestCase() {
   @Test
   fun `test reset local 'cursorline' to default copies current global intellij setting`() {
     fixture.editor.settings.isCaretRowShown = false
-    assertCommandOutput("set cursorline?", "nocursorline\n")
+    assertCommandOutput("set cursorline?", "nocursorline")
 
     enterCommand("setlocal cursorline&")
     assertTrue(fixture.editor.settings.isCaretRowShown)
@@ -185,11 +185,11 @@ class CursorLineOptionMapperTest : VimTestCase() {
     // New window will clone local and global local-to-window options, then apply global to local. This tests that our
     // handling of per-window "global" values is correct.
     (fixture.editor.settings as SettingsImpl).getState().apply { clearOverriding(this::myCaretRowShown) }
-    assertCommandOutput("set cursorline?", "  cursorline\n")
+    assertCommandOutput("set cursorline?", "  cursorline")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set cursorline?", "  cursorline\n")
+    assertCommandOutput("set cursorline?", "  cursorline")
 
     // Can't prove that it was copied as a default value because we can't change the global value
   }
@@ -197,11 +197,11 @@ class CursorLineOptionMapperTest : VimTestCase() {
   @Test
   fun `test open new window after setting option copies value as explicitly set`() {
     enterCommand("set nocursorline")
-    assertCommandOutput("set cursorline?", "nocursorline\n")
+    assertCommandOutput("set cursorline?", "nocursorline")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set cursorline?", "nocursorline\n")
+    assertCommandOutput("set cursorline?", "nocursorline")
 
     // Can't prove that it was copied as a default value because we can't change the global value and see it update
   }
@@ -209,12 +209,12 @@ class CursorLineOptionMapperTest : VimTestCase() {
   @Test
   fun `test setglobal 'cursorline' used when opening new window`() {
     enterCommand("setglobal cursorline")
-    assertCommandOutput("setglobal cursorline?", "  cursorline\n")
-    assertCommandOutput("set cursorline?", "nocursorline\n")
+    assertCommandOutput("setglobal cursorline?", "  cursorline")
+    assertCommandOutput("set cursorline?", "nocursorline")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set cursorline?", "  cursorline\n")
+    assertCommandOutput("set cursorline?", "  cursorline")
 
     // Can't prove that it was copied as a locally set value because we can't change the global value
   }
@@ -222,12 +222,12 @@ class CursorLineOptionMapperTest : VimTestCase() {
   @Test
   fun `test setlocal 'cursorline' then open new window uses value from setglobal`() {
     enterCommand("setlocal nocursorline")
-    assertCommandOutput("setglobal cursorline?", "nocursorline\n")
-    assertCommandOutput("set cursorline?", "nocursorline\n")
+    assertCommandOutput("setglobal cursorline?", "nocursorline")
+    assertCommandOutput("set cursorline?", "nocursorline")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set cursorline?", "  cursorline\n")
+    assertCommandOutput("set cursorline?", "  cursorline")
 
     // Can't prove that it was copied as a locally set value because we can't change the global value
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/LineNumberOptionsMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/LineNumberOptionsMapperTest.kt
@@ -65,67 +65,67 @@ class LineNumberOptionsMapperTest : VimTestCase() {
   @Test
   fun `test 'number' and 'relativenumber' options reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = false
-    assertCommandOutput("set number?", "nonumber\n")
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("set number?", "nonumber")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
 
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = true
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.HYBRID
-    assertCommandOutput("set number?", "  number\n")
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set number?", "  number")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
   }
 
   @Test
   fun `test local 'number' and 'relativenumber' options reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = false
-    assertCommandOutput("setlocal number?", "nonumber\n")
-    assertCommandOutput("setlocal relativenumber?", "norelativenumber\n")
+    assertCommandOutput("setlocal number?", "nonumber")
+    assertCommandOutput("setlocal relativenumber?", "norelativenumber")
 
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = true
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.HYBRID
-    assertCommandOutput("setlocal number?", "  number\n")
-    assertCommandOutput("setlocal relativenumber?", "  relativenumber\n")
+    assertCommandOutput("setlocal number?", "  number")
+    assertCommandOutput("setlocal relativenumber?", "  relativenumber")
   }
 
   @Test
   fun `test 'number' and 'relativenumber' options report local intellij settings if set via IDE`() {
     fixture.editor.settings.isLineNumbersShown = false
-    assertCommandOutput("set number?", "nonumber\n")
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("set number?", "nonumber")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
 
     // View | Active Editor | Show Line Numbers. There is no UI for line numeration type
     fixture.editor.settings.isLineNumbersShown = true
     fixture.editor.settings.lineNumerationType = LineNumerationType.HYBRID
-    assertCommandOutput("set number?", "  number\n")
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set number?", "  number")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
 
     fixture.editor.settings.lineNumerationType = LineNumerationType.ABSOLUTE
-    assertCommandOutput("set number?", "  number\n")
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("set number?", "  number")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
 
     fixture.editor.settings.lineNumerationType = LineNumerationType.RELATIVE
-    assertCommandOutput("set number?", "nonumber\n")
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set number?", "nonumber")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
   }
 
   @Test
   fun `test local 'number' and 'relativenumber' options report local intellij settings if set via IDE`() {
     fixture.editor.settings.isLineNumbersShown = false
-    assertCommandOutput("setlocal number?", "nonumber\n")
-    assertCommandOutput("setlocal relativenumber?", "norelativenumber\n")
+    assertCommandOutput("setlocal number?", "nonumber")
+    assertCommandOutput("setlocal relativenumber?", "norelativenumber")
 
     // View | Active Editor | Show Line Numbers. There is no UI for line numeration type
     fixture.editor.settings.isLineNumbersShown = true
     fixture.editor.settings.lineNumerationType = LineNumerationType.HYBRID
-    assertCommandOutput("setlocal number?", "  number\n")
-    assertCommandOutput("setlocal relativenumber?", "  relativenumber\n")
+    assertCommandOutput("setlocal number?", "  number")
+    assertCommandOutput("setlocal relativenumber?", "  relativenumber")
 
     fixture.editor.settings.lineNumerationType = LineNumerationType.ABSOLUTE
-    assertCommandOutput("setlocal number?", "  number\n")
-    assertCommandOutput("setlocal relativenumber?", "norelativenumber\n")
+    assertCommandOutput("setlocal number?", "  number")
+    assertCommandOutput("setlocal relativenumber?", "norelativenumber")
 
     fixture.editor.settings.lineNumerationType = LineNumerationType.RELATIVE
-    assertCommandOutput("setlocal number?", "nonumber\n")
-    assertCommandOutput("setlocal relativenumber?", "  relativenumber\n")
+    assertCommandOutput("setlocal number?", "nonumber")
+    assertCommandOutput("setlocal relativenumber?", "  relativenumber")
   }
 
   @Test
@@ -199,10 +199,10 @@ class LineNumberOptionsMapperTest : VimTestCase() {
   @Test
   fun `test set global 'number' option affects IdeaVim global value only`() {
     assertFalse(IjOptions.number.defaultValue.asBoolean())
-    assertCommandOutput("setglobal number?", "nonumber\n")
+    assertCommandOutput("setglobal number?", "nonumber")
 
     enterCommand("setglobal number")
-    assertCommandOutput("setglobal number?", "  number\n")
+    assertCommandOutput("setglobal number?", "  number")
     assertFalse(EditorSettingsExternalizable.getInstance().isLineNumbersShown)
     assertFalse(fixture.editor.settings.isLineNumbersShown)
   }
@@ -210,10 +210,10 @@ class LineNumberOptionsMapperTest : VimTestCase() {
   @Test
   fun `test set global 'relativenumber' option affects IdeaVim global value only`() {
     assertFalse(IjOptions.number.defaultValue.asBoolean())
-    assertCommandOutput("setglobal relativenumber?", "norelativenumber\n")
+    assertCommandOutput("setglobal relativenumber?", "norelativenumber")
 
     enterCommand("setglobal relativenumber")
-    assertCommandOutput("setglobal relativenumber?", "  relativenumber\n")
+    assertCommandOutput("setglobal relativenumber?", "  relativenumber")
     assertFalse(EditorSettingsExternalizable.getInstance().isLineNumbersShown)
     assertFalse(fixture.editor.settings.isLineNumbersShown)
   }
@@ -221,13 +221,13 @@ class LineNumberOptionsMapperTest : VimTestCase() {
   @Test
   fun `test set 'number' updates IdeaVim global value as well as local`() {
     enterCommand("set number")
-    assertCommandOutput("setglobal number?", "  number\n")
+    assertCommandOutput("setglobal number?", "  number")
   }
 
   @Test
   fun `test set 'relativenumber' updates IdeaVim global value as well as local`() {
     enterCommand("set relativenumber")
-    assertCommandOutput("setglobal relativenumber?", "  relativenumber\n")
+    assertCommandOutput("setglobal relativenumber?", "  relativenumber")
   }
 
   @Test
@@ -237,13 +237,13 @@ class LineNumberOptionsMapperTest : VimTestCase() {
     fixture.editor.settings.isLineNumbersShown = true
     fixture.editor.settings.lineNumerationType = LineNumerationType.HYBRID
 
-    assertCommandOutput("setlocal number?", "  number\n")
-    assertCommandOutput("set number?", "  number\n")
-    assertCommandOutput("setglobal number?", "nonumber\n")
+    assertCommandOutput("setlocal number?", "  number")
+    assertCommandOutput("set number?", "  number")
+    assertCommandOutput("setglobal number?", "nonumber")
 
-    assertCommandOutput("setlocal relativenumber?", "  relativenumber\n")
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
-    assertCommandOutput("setglobal relativenumber?", "norelativenumber\n")
+    assertCommandOutput("setlocal relativenumber?", "  relativenumber")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
+    assertCommandOutput("setglobal relativenumber?", "norelativenumber")
   }
 
   @Test
@@ -251,16 +251,16 @@ class LineNumberOptionsMapperTest : VimTestCase() {
     enterCommand("set number relativenumber")
 
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = false
-    assertCommandOutput("setlocal number?", "  number\n")
-    assertCommandOutput("set number?", "  number\n")
-    assertCommandOutput("setglobal number?", "  number\n")
+    assertCommandOutput("setlocal number?", "  number")
+    assertCommandOutput("set number?", "  number")
+    assertCommandOutput("setglobal number?", "  number")
 
     enterCommand("set nonumber")
 
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = true
-    assertCommandOutput("setlocal number?", "nonumber\n")
-    assertCommandOutput("set number?", "nonumber\n")
-    assertCommandOutput("setglobal number?", "nonumber\n")
+    assertCommandOutput("setlocal number?", "nonumber")
+    assertCommandOutput("set number?", "nonumber")
+    assertCommandOutput("setglobal number?", "nonumber")
   }
 
   @Test
@@ -268,16 +268,16 @@ class LineNumberOptionsMapperTest : VimTestCase() {
     enterCommand("set number relativenumber")
 
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.ABSOLUTE
-    assertCommandOutput("setlocal relativenumber?", "  relativenumber\n")
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
-    assertCommandOutput("setglobal relativenumber?", "  relativenumber\n")
+    assertCommandOutput("setlocal relativenumber?", "  relativenumber")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
+    assertCommandOutput("setglobal relativenumber?", "  relativenumber")
 
     enterCommand("set norelativenumber")
 
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.HYBRID
-    assertCommandOutput("setlocal relativenumber?", "norelativenumber\n")
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
-    assertCommandOutput("setglobal relativenumber?", "norelativenumber\n")
+    assertCommandOutput("setlocal relativenumber?", "norelativenumber")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
+    assertCommandOutput("setglobal relativenumber?", "norelativenumber")
   }
 
   @Test
@@ -297,9 +297,9 @@ class LineNumberOptionsMapperTest : VimTestCase() {
     }
 
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = false
-    assertCommandOutput("setlocal number?", "nonumber\n")
-    assertCommandOutput("set number?", "nonumber\n")
-    assertCommandOutput("setglobal number?", "nonumber\n")
+    assertCommandOutput("setlocal number?", "nonumber")
+    assertCommandOutput("set number?", "nonumber")
+    assertCommandOutput("setglobal number?", "nonumber")
   }
 
   @Test
@@ -317,9 +317,9 @@ class LineNumberOptionsMapperTest : VimTestCase() {
     }
 
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.ABSOLUTE
-    assertCommandOutput("setlocal relativenumber?", "norelativenumber\n")
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
-    assertCommandOutput("setglobal relativenumber?", "norelativenumber\n")
+    assertCommandOutput("setlocal relativenumber?", "norelativenumber")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
+    assertCommandOutput("setglobal relativenumber?", "norelativenumber")
   }
 
   @Test
@@ -327,7 +327,7 @@ class LineNumberOptionsMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = true
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.ABSOLUTE
     fixture.editor.settings.isLineNumbersShown = false
-    assertCommandOutput("set number?", "nonumber\n")
+    assertCommandOutput("set number?", "nonumber")
 
     enterCommand("set number&")
     assertTrue(fixture.editor.settings.isLineNumbersShown)
@@ -347,7 +347,7 @@ class LineNumberOptionsMapperTest : VimTestCase() {
 
     // Value becomes External(true) because the user is explicitly setting it
     fixture.editor.settings.isLineNumbersShown = false
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
 
     enterCommand("set relativenumber&")
     assertTrue(fixture.editor.settings.isLineNumbersShown)
@@ -364,7 +364,7 @@ class LineNumberOptionsMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = true
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.ABSOLUTE
     fixture.editor.settings.isLineNumbersShown = false
-    assertCommandOutput("set number?", "nonumber\n")
+    assertCommandOutput("set number?", "nonumber")
 
     enterCommand("setlocal number&")
     assertTrue(fixture.editor.settings.isLineNumbersShown)
@@ -384,7 +384,7 @@ class LineNumberOptionsMapperTest : VimTestCase() {
 
     // Value becomes External(true) because the user is explicitly setting it
     fixture.editor.settings.isLineNumbersShown = false
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
 
     enterCommand("setlocal relativenumber&")
     assertTrue(fixture.editor.settings.isLineNumbersShown)
@@ -400,120 +400,120 @@ class LineNumberOptionsMapperTest : VimTestCase() {
   fun `test open new window without setting 'number' copies value as not-explicitly set`() {
     // New window will clone local and global local-to-window options, then apply global to local. This tests that our
     // handling of per-window "global" values is correct.
-    assertCommandOutput("set number?", "nonumber\n")
+    assertCommandOutput("set number?", "nonumber")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set number?", "nonumber\n")
+    assertCommandOutput("set number?", "nonumber")
 
     // Changing the global setting should update the new editor
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = true
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.ABSOLUTE
-    assertCommandOutput("set number?", "  number\n")
+    assertCommandOutput("set number?", "  number")
   }
 
   @Test
   fun `test open new window without setting 'relativenumber' copies value as not-explicitly set`() {
     // New window will clone local and global local-to-window options, then apply global to local. This tests that our
     // handling of per-window "global" values is correct.
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
 
     // Changing the global setting should update the new editor
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = true
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.RELATIVE
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
   }
 
   @Test
   fun `test open new window after setting 'number' copies value as explicitly set`() {
     enterCommand("set number")
-    assertCommandOutput("set number?", "  number\n")
+    assertCommandOutput("set number?", "  number")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set number?", "  number\n")
+    assertCommandOutput("set number?", "  number")
 
     // Changing the global setting should NOT update the new editor
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = false
-    assertCommandOutput("set number?", "  number\n")
+    assertCommandOutput("set number?", "  number")
   }
 
   @Test
   fun `test open new window after setting 'relativenumber' copies value as explicitly set`() {
     enterCommand("set relativenumber")
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
 
     // Changing the global setting should NOT update the new editor
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = false
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
   }
 
   @Test
   fun `test setglobal 'number' used when opening new window`() {
     enterCommand("setglobal number")
-    assertCommandOutput("setglobal number?", "  number\n")
-    assertCommandOutput("set number?", "nonumber\n")
+    assertCommandOutput("setglobal number?", "  number")
+    assertCommandOutput("set number?", "nonumber")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set number?", "  number\n")
+    assertCommandOutput("set number?", "  number")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = false
-    assertCommandOutput("set number?", "  number\n")
+    assertCommandOutput("set number?", "  number")
   }
 
   @Test
   fun `test setglobal 'relativenumber' used when opening new window`() {
     enterCommand("setglobal relativenumber")
-    assertCommandOutput("setglobal relativenumber?", "  relativenumber\n")
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("setglobal relativenumber?", "  relativenumber")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = false
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
   }
 
   @Test
   fun `test setlocal 'number' then open new window uses value from setglobal`() {
     enterCommand("setlocal number")
-    assertCommandOutput("setglobal number?", "nonumber\n")
-    assertCommandOutput("set number?", "  number\n")
+    assertCommandOutput("setglobal number?", "nonumber")
+    assertCommandOutput("set number?", "  number")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set number?", "nonumber\n")
+    assertCommandOutput("set number?", "nonumber")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = true
-    assertCommandOutput("set number?", "nonumber\n")
+    assertCommandOutput("set number?", "nonumber")
   }
 
   @Test
   fun `test setlocal 'relativenumber' then open new window uses value from setglobal`() {
     enterCommand("setlocal relativenumber")
-    assertCommandOutput("setglobal relativenumber?", "norelativenumber\n")
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("setglobal relativenumber?", "norelativenumber")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = true
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
   }
 
   @Test
@@ -531,12 +531,12 @@ class LineNumberOptionsMapperTest : VimTestCase() {
     }
 
     switchToNewFile("bbb.txt", "lorem ipsum")
-    assertCommandOutput("set number?", "  number\n")
+    assertCommandOutput("set number?", "  number")
 
     EditorSettingsExternalizable.getInstance().isLineNumbersShown = false
-    assertCommandOutput("setlocal number?", "nonumber\n")
-    assertCommandOutput("set number?", "nonumber\n")
-    assertCommandOutput("setglobal number?", "nonumber\n")
+    assertCommandOutput("setlocal number?", "nonumber")
+    assertCommandOutput("set number?", "nonumber")
+    assertCommandOutput("setglobal number?", "nonumber")
   }
 
   @Test
@@ -554,11 +554,11 @@ class LineNumberOptionsMapperTest : VimTestCase() {
     }
 
     switchToNewFile("bbb.txt", "lorem ipsum")
-    assertCommandOutput("set relativenumber?", "  relativenumber\n")
+    assertCommandOutput("set relativenumber?", "  relativenumber")
 
     EditorSettingsExternalizable.getInstance().lineNumeration = LineNumerationType.ABSOLUTE
-    assertCommandOutput("setlocal relativenumber?", "norelativenumber\n")
-    assertCommandOutput("set relativenumber?", "norelativenumber\n")
-    assertCommandOutput("setglobal relativenumber?", "norelativenumber\n")
+    assertCommandOutput("setlocal relativenumber?", "norelativenumber")
+    assertCommandOutput("set relativenumber?", "norelativenumber")
+    assertCommandOutput("setglobal relativenumber?", "norelativenumber")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/ListOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/ListOptionMapperTest.kt
@@ -54,39 +54,39 @@ class ListOptionMapperTest : VimTestCase() {
   @Test
   fun `test 'list' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = true
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
 
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = false
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
   }
 
   @Test
   fun `test local 'list' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = true
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
 
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = false
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
   }
 
   @Test
   fun `test 'list' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isWhitespacesShown = true
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
 
     // View | Active Editor | Show Whitespaces
     fixture.editor.settings.isWhitespacesShown = false
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
   }
 
   @Test
   fun `test local 'list' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isWhitespacesShown = true
-    assertCommandOutput("setlocal list?", "  list\n")
+    assertCommandOutput("setlocal list?", "  list")
 
     // View | Active Editor | Show Whitespaces
     fixture.editor.settings.isWhitespacesShown = false
-    assertCommandOutput("setlocal list?", "nolist\n")
+    assertCommandOutput("setlocal list?", "nolist")
   }
 
   @Test
@@ -122,17 +122,17 @@ class ListOptionMapperTest : VimTestCase() {
   @Test
   fun `test setglobal 'list' option affects IdeaVim global value only`() {
     assertFalse(IjOptions.list.defaultValue.asBoolean())  // Vim default
-    assertCommandOutput("setglobal list?", "nolist\n")
+    assertCommandOutput("setglobal list?", "nolist")
 
     enterCommand("setglobal list")
-    assertCommandOutput("setglobal list?", "  list\n")
+    assertCommandOutput("setglobal list?", "  list")
     assertFalse(EditorSettingsExternalizable.getInstance().isWhitespacesShown)
   }
 
   @Test
   fun `test set 'list' updates IdeaVim global value as well as local`() {
     enterCommand("set list")
-    assertCommandOutput("setglobal list?", "  list\n")
+    assertCommandOutput("setglobal list?", "  list")
   }
 
   @Test
@@ -141,9 +141,9 @@ class ListOptionMapperTest : VimTestCase() {
     // affects the local value
     // View | Active Editor | Show Whitespaces
     fixture.editor.settings.isWhitespacesShown = true
-    assertCommandOutput("setlocal list?", "  list\n")
-    assertCommandOutput("set list?", "  list\n")
-    assertCommandOutput("setglobal list?", "nolist\n")
+    assertCommandOutput("setlocal list?", "  list")
+    assertCommandOutput("set list?", "  list")
+    assertCommandOutput("setglobal list?", "nolist")
   }
 
   @Test
@@ -151,16 +151,16 @@ class ListOptionMapperTest : VimTestCase() {
     enterCommand("set list")
 
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = false
-    assertCommandOutput("setlocal list?", "  list\n")
-    assertCommandOutput("set list?", "  list\n")
-    assertCommandOutput("setglobal list?", "  list\n")
+    assertCommandOutput("setlocal list?", "  list")
+    assertCommandOutput("set list?", "  list")
+    assertCommandOutput("setglobal list?", "  list")
 
     enterCommand("set nolist")
 
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = true
-    assertCommandOutput("setlocal list?", "nolist\n")
-    assertCommandOutput("set list?", "nolist\n")
-    assertCommandOutput("setglobal list?", "nolist\n")
+    assertCommandOutput("setlocal list?", "nolist")
+    assertCommandOutput("set list?", "nolist")
+    assertCommandOutput("setglobal list?", "nolist")
   }
 
   @Test
@@ -178,9 +178,9 @@ class ListOptionMapperTest : VimTestCase() {
     }
 
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = false
-    assertCommandOutput("setlocal list?", "nolist\n")
-    assertCommandOutput("set list?", "nolist\n")
-    assertCommandOutput("setglobal list?", "nolist\n")
+    assertCommandOutput("setlocal list?", "nolist")
+    assertCommandOutput("set list?", "nolist")
+    assertCommandOutput("setglobal list?", "nolist")
   }
 
   @Test
@@ -199,7 +199,7 @@ class ListOptionMapperTest : VimTestCase() {
   fun `test reset 'list' to default copies current global intellij setting`() {
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = true
     fixture.editor.settings.isWhitespacesShown = false
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
 
     enterCommand("set list&")
     assertTrue(fixture.editor.settings.isWhitespacesShown)
@@ -214,7 +214,7 @@ class ListOptionMapperTest : VimTestCase() {
   fun `test reset local 'list' to default copies current global intellij setting`() {
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = true
     fixture.editor.settings.isWhitespacesShown = false
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
 
     enterCommand("setlocal list&")
     assertTrue(fixture.editor.settings.isWhitespacesShown)
@@ -229,60 +229,60 @@ class ListOptionMapperTest : VimTestCase() {
   fun `test open new window without setting the option copies value as not-explicitly set`() {
     // New window will clone local and global local-to-window options, then apply global to local. This tests that our
     // handling of per-window "global" values is correct.
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
 
     // Changing the global setting should update the new editor
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = true
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
   }
 
 
   @Test
   fun `test open new window after setting option copies value as explicitly set`() {
     enterCommand("set list")
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = false
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
   }
 
   @Test
   fun `test setglobal 'list' used when opening new window`() {
     enterCommand("setglobal list")
-    assertCommandOutput("setglobal list?", "  list\n")
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("setglobal list?", "  list")
+    assertCommandOutput("set list?", "nolist")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = false
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
   }
 
   @Test
   fun `test setlocal 'list' then open new window uses value from setglobal`() {
     enterCommand("setlocal list")
-    assertCommandOutput("setglobal list?", "nolist\n")
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("setglobal list?", "nolist")
+    assertCommandOutput("set list?", "  list")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = true
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
   }
 
   @Test
@@ -301,10 +301,10 @@ class ListOptionMapperTest : VimTestCase() {
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set list?", "  list\n")
+    assertCommandOutput("set list?", "  list")
 
     // Changing the global setting should update the editor, because it was initially set during plugin startup
     EditorSettingsExternalizable.getInstance().isWhitespacesShown = false
-    assertCommandOutput("set list?", "nolist\n")
+    assertCommandOutput("set list?", "nolist")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/ScrollJumpOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/ScrollJumpOptionMapperTest.kt
@@ -62,11 +62,11 @@ class ScrollJumpOptionMapperTest : VimTestCase() {
   @Test
   fun `test 'scrolljump' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().verticalScrollJump = 7
-    assertCommandOutput("set scrolljump?", "  scrolljump=7\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=7")
 
     // Also tests the value being modified in the IDE's settings
     EditorSettingsExternalizable.getInstance().verticalScrollJump = 3
-    assertCommandOutput("set scrolljump?", "  scrolljump=3\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=3")
   }
 
   // 'scrolljump' is a global option, so we don't need to test `:setlocal` or `:setglobal`
@@ -77,11 +77,11 @@ class ScrollJumpOptionMapperTest : VimTestCase() {
     // values for scrolling during typing (when IdeaVim's scroll implementation isn't called early enough), we set the
     // local value for all editors
     fixture.editor.settings.verticalScrollJump = 7
-    assertCommandOutput("set scrolljump?", "  scrolljump=7\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=7")
 
     // Also tests the value being modified in the IDE's settings
     fixture.editor.settings.verticalScrollJump = 3
-    assertCommandOutput("set scrolljump?", "  scrolljump=3\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=3")
   }
 
   @Test
@@ -102,25 +102,25 @@ class ScrollJumpOptionMapperTest : VimTestCase() {
     enterCommand("set scrolljump=-25")
     assertEquals(0, fixture.editor.settings.verticalScrollJump)
     assertEquals(10, EditorSettingsExternalizable.getInstance().verticalScrollJump)
-    assertCommandOutput("setlocal scrolljump?", "  scrolljump=-25\n")
-    assertCommandOutput("set scrolljump?", "  scrolljump=-25\n")
-    assertCommandOutput("setglobal scrolljump?", "  scrolljump=-25\n")
+    assertCommandOutput("setlocal scrolljump?", "  scrolljump=-25")
+    assertCommandOutput("set scrolljump?", "  scrolljump=-25")
+    assertCommandOutput("setglobal scrolljump?", "  scrolljump=-25")
   }
 
   @Test
   fun `test setting global IDE value will update IdeaVim value`() {
     enterCommand("set scrolljump=7")
     EditorSettingsExternalizable.getInstance().verticalScrollJump = 3
-    assertCommandOutput("setlocal scrolljump?", "  scrolljump=3\n")
-    assertCommandOutput("set scrolljump?", "  scrolljump=3\n")
-    assertCommandOutput("setglobal scrolljump?", "  scrolljump=3\n")
+    assertCommandOutput("setlocal scrolljump?", "  scrolljump=3")
+    assertCommandOutput("set scrolljump?", "  scrolljump=3")
+    assertCommandOutput("setglobal scrolljump?", "  scrolljump=3")
   }
 
   @Test
   fun `test reset 'scrolljump' to default resets to global intellij setting`() {
     EditorSettingsExternalizable.getInstance().verticalScrollJump = 20
     fixture.editor.settings.verticalScrollJump = 10
-    assertCommandOutput("set scrolljump?", "  scrolljump=10\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=10")
 
     enterCommand("set scrolljump&")
     assertEquals(20, fixture.editor.settings.verticalScrollJump)
@@ -129,21 +129,21 @@ class ScrollJumpOptionMapperTest : VimTestCase() {
     // Unlike many other overridden options, this one allows us to reset it back to global-local, so it will correctly
     // pick up the global value
     EditorSettingsExternalizable.getInstance().verticalScrollJump = 30
-    assertCommandOutput("set scrolljump?", "  scrolljump=30\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=30")
   }
 
   @Test
   fun `test open new window without setting the option correctly keeps global intellij setting`() {
     EditorSettingsExternalizable.getInstance().verticalScrollJump = 20
-    assertCommandOutput("set scrolljump?", "  scrolljump=20\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=20")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set scrolljump?", "  scrolljump=20\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=20")
 
     // Changing the global intellij setting should update the new editor
     EditorSettingsExternalizable.getInstance().verticalScrollJump = 30
-    assertCommandOutput("set scrolljump?", "  scrolljump=30\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=30")
   }
 
   @Test
@@ -153,7 +153,7 @@ class ScrollJumpOptionMapperTest : VimTestCase() {
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set scrolljump?", "  scrolljump=20\n")
+    assertCommandOutput("set scrolljump?", "  scrolljump=20")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/ScrollOffOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/ScrollOffOptionMapperTest.kt
@@ -55,24 +55,24 @@ class ScrollOffOptionMapperTest : VimTestCase() {
   @Test
   fun `test 'scrolloff' option reports global intellij setting if not set`() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
 
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 20
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
   }
 
   @Test
   fun `test local 'scrolloff' option reports unset value if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
   }
 
   @Test
   fun `test global 'scrolloff' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
   }
 
   @Test
@@ -81,8 +81,8 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     enterCommand("set scrolloff=20")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
     assertEquals(10, EditorSettingsExternalizable.getInstance().verticalScrollOffset)
   }
 
@@ -92,8 +92,8 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     enterCommand("set scrolloff=20")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
     assertEquals(10, EditorSettingsExternalizable.getInstance().verticalScrollOffset)
   }
@@ -104,8 +104,8 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     enterCommand("setlocal scrolloff=20")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20")
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
     assertEquals(10, EditorSettingsExternalizable.getInstance().verticalScrollOffset)
   }
@@ -116,9 +116,9 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     enterCommand("setglobal scrolloff=20")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
     assertEquals(10, EditorSettingsExternalizable.getInstance().verticalScrollOffset)
   }
@@ -161,9 +161,9 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     enterCommand("set scrolloff=10")
 
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 20
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
   }
 
   @Test
@@ -171,9 +171,9 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     enterCommand("setlocal scrolloff=10")
 
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 20
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
   }
 
   @Test
@@ -182,31 +182,31 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
 
     // Changing the global setting should update the new editor
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
   }
 
   @Test
   fun `test open new window after setting the global option correctly updates local intellij value for new window`() {
     enterCommand("set scrolloff=20")
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
 
     // Changing the global IntelliJ setting syncs with the global Vim value
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
 
     // We don't support externally changing the local editor setting
     enterCommand("setlocal scrolloff=30")
-    assertCommandOutput("set scrolloff?", "  scrolloff=30\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=30\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=30")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=30")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
     assertEquals(10, EditorSettingsExternalizable.getInstance().verticalScrollOffset)
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
   }
@@ -218,7 +218,7 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
   }
 
   // :set[local|global] {option}& - reset to default value
@@ -228,20 +228,20 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 20
 
     enterCommand("set scrolloff=10")
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     // Vim: global=10, local=-1 => global=default, local=unset
     enterCommand("set scrolloff&")
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 15
-    assertCommandOutput("set scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
   }
 
   @Test
@@ -253,9 +253,9 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     // Vim: global=10, local=20 => global=default, local=default
     enterCommand("set scrolloff&")
-    assertCommandOutput("set scrolloff?", "  scrolloff=5\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=5\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=5\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=5")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=5")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=5")
 
     // Note that global=default, local=default is the same as global=default, local=unset
     // Changing the IDE value is reflected in the global Vim value, and also the local value
@@ -263,9 +263,9 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     // would also change the local value, so it's reasonable that changing the default value (by changing the IDE value)
     // is reflected in the local Vim value.
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 15
-    assertCommandOutput("set scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=15\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=15")
   }
 
   @Test
@@ -277,21 +277,21 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     switchToNewFile("bbb.txt", "lorem ipsum")
 
     enterCommand("set scrolloff=10")
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
     assertEquals(10, injector.options(firstEditor.vim).scrolloff) // Equivalent to `set scrolloff?`
 
     enterCommand("set scrolloff&")
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
     assertEquals(20, injector.options(firstEditor.vim).scrolloff) // Equivalent to `set scrolloff?`
 
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 15
-    assertCommandOutput("set scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
     assertEquals(15, injector.options(firstEditor.vim).scrolloff) // Equivalent to `set scrolloff?`
   }
 
@@ -306,23 +306,23 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     enterCommand("set scrolloff=10")
     enterCommand("setlocal scrolloff=5")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=5\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=5\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=5")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=5")
     assertEquals(7, injector.options(firstEditor.vim).scrolloff) // Equivalent to `set scrolloff?`
 
     // Vim: global=10, local=5 => global=default, local=default
     // local=default behaves like local=unset
     enterCommand("set scrolloff&")
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20")
     assertEquals(7, injector.options(firstEditor.vim).scrolloff) // Equivalent to `set scrolloff?`
 
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 15
-    assertCommandOutput("set scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=15\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=15")
     assertEquals(7, injector.options(firstEditor.vim).scrolloff) // Equivalent to `set scrolloff?`
   }
 
@@ -335,22 +335,22 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     switchToNewFile("bbb.txt", "lorem ipsum")
 
     enterCommand("set scrolloff=10")
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
     assertEquals(7, injector.options(firstEditor.vim).scrolloff) // `set scrolloff?` for first editor
 
     // Vim: global=10, local=-1 => global=default, local=unset
     enterCommand("set scrolloff&")
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
     assertEquals(7, injector.options(firstEditor.vim).scrolloff) // `set scrolloff?` for first editor
 
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 15
-    assertCommandOutput("set scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
     assertEquals(7, injector.options(firstEditor.vim).scrolloff) // `set scrolloff?` for first editor
   }
 
@@ -365,24 +365,24 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     enterCommand("set scrolloff=10")
     enterCommand("setlocal scrolloff=5")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=5\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=5\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=5")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=5")
     assertEquals(7, injector.options(firstEditor.vim).scrolloff) // Equivalent to `set scrolloff?`
 
     // Vim: global=10, local=5 => global=default, local=default
     // Note that global=default, local=default behaves the same as global=default, local=unset
     enterCommand("set scrolloff&")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20")
     assertEquals(7, injector.options(firstEditor.vim).scrolloff) // Equivalent to `set scrolloff?`
 
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 15
-    assertCommandOutput("set scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=15\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=15")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=15")
     assertEquals(7, injector.options(firstEditor.vim).scrolloff) // Equivalent to `set scrolloff?`
   }
 
@@ -396,15 +396,15 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     // This resets global to default + local to unset, but doesn't modify the local intellij value
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     // Changing the intellij default value is reflected in IdeaVim
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 30
-    assertCommandOutput("set scrolloff?", "  scrolloff=30\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=30\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=30")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=30")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
   }
 
   @Test
@@ -417,16 +417,16 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     // set global value to default, but not resetting the local intellij value...
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n") // Vim is default of 0, but we want to use global intellij value
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20") // Vim is default of 0, but we want to use global intellij value
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10")
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
 
     // Changing the intellij default value is reflected in IdeaVim global, but not local
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 30
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=30\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=30")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10")
   }
 
   @Test
@@ -434,22 +434,22 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 20
     enterCommand("setglobal scrolloff=10")
     enterCommand("setlocal scrolloff=15")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=15\n")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=15")
 
     // Vim: global=10, local=15 => global=10, local=default
     // IdeaVim's defaults are transparent, so this should come from the IDE default value
     enterCommand("setlocal scrolloff&")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20")
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
 
     // Changing the intellij default value is reflected in IdeaVim
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 30
-    assertCommandOutput("set scrolloff?", "  scrolloff=30\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=30\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=30\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=30")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=30")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=30")
   }
 
   @Test
@@ -461,15 +461,15 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     // local=default behaves like local=unset
     enterCommand("setlocal scrolloff&")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n") // Was originally default
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20") // Was originally default
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20")
 
     // Changing the intellij default value is reflected in IdeaVim
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 30
-    assertCommandOutput("set scrolloff?", "  scrolloff=30\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=30\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=30\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=30")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=30")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=30")
   }
 
   // :set[local|global] {option}< - reset effective/local/global value to global value
@@ -481,26 +481,26 @@ class ScrollOffOptionMapperTest : VimTestCase() {
   fun `test reset effective 'scrolloff' to global default value does not modify unset local value`() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 20
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     // The local value is unset, so "set {option}<" does not modify it (effective value is still global)
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("set scrolloff<")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
 
     // Global is default and local is unset, so this should affect values
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
   }
@@ -510,27 +510,27 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 20
 
     enterCommand("setlocal scrolloff=10")
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10")
 
     // The local value has been set, so "set {option}<" copies the global value (effective value is still global)
     // Global was default, so now local is default too
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("set scrolloff<")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=20")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
 
     // Both global and local values should be defaults, so this should affect both
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
   }
@@ -540,26 +540,26 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
 
     enterCommand("set scrolloff=20")  // No longer default
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     // The local value has been set, so "set {option}<" copies the global value (effective value is still global)
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("set scrolloff<")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
 
     // Global is explicitly set, and local is unset. Global changes should not affect values
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
   }
@@ -569,26 +569,26 @@ class ScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 20
 
     enterCommand("setlocal scrolloff=10")
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10")
 
     // "setlocal {option}<" always unsets number-based global-local options
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("setlocal scrolloff<")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
 
     // Global is default, so this should affect global only
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
   }
@@ -599,26 +599,26 @@ class ScrollOffOptionMapperTest : VimTestCase() {
 
     enterCommand("set scrolloff=20")  // No longer default
     enterCommand("setlocal scrolloff=10")
-    assertCommandOutput("set scrolloff?", "  scrolloff=10\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=10")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=10")
 
     // "setlocal {option}<" always unsets number-based global-local options
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("setlocal scrolloff<")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
 
     // Global is not default, so should not be affected by this change
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 10
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.verticalScrollOffset)
   }
@@ -627,15 +627,15 @@ class ScrollOffOptionMapperTest : VimTestCase() {
   fun `test reset global 'scrolloff' to global value does nothing`() {
     EditorSettingsExternalizable.getInstance().verticalScrollOffset = 20
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
 
     // This copies the global value to the global value. It's a no-op
     enterCommand("setglobal scrolloff<")
 
-    assertCommandOutput("set scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20\n")
-    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1\n")
+    assertCommandOutput("set scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setglobal scrolloff?", "  scrolloff=20")
+    assertCommandOutput("setlocal scrolloff?", "  scrolloff=-1")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/SideScrollOffOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/SideScrollOffOptionMapperTest.kt
@@ -55,24 +55,24 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
   @Test
   fun `test 'sidescrolloff' option reports global intellij setting if not set`() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
 
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 20
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
   }
 
   @Test
   fun `test local 'sidescrolloff' option reports unset value if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
   }
 
   @Test
   fun `test global 'sidescrolloff' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
   }
 
   @Test
@@ -81,8 +81,8 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
 
     enterCommand("set sidescrolloff=20")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
     assertEquals(10, EditorSettingsExternalizable.getInstance().horizontalScrollOffset)
 
     // We set the local value to 0 so that IntelliJ's scrolling does nothing, so IdeaVim can control scrolling
@@ -95,8 +95,8 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
 
     enterCommand("setlocal sidescrolloff=20")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20")
     assertEquals(10, EditorSettingsExternalizable.getInstance().horizontalScrollOffset)
 
     // We set the local value to 0 so that IntelliJ's scrolling does nothing, so IdeaVim can control scrolling
@@ -143,9 +143,9 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     enterCommand("set sidescrolloff=10")
 
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 20
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
   }
 
   @Test
@@ -153,9 +153,9 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     enterCommand("setlocal sidescrolloff=10")
 
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 20
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
   }
 
   @Test
@@ -164,31 +164,31 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
 
     // Changing the global setting should update the new editor
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
   }
 
   @Test
   fun `test open new window after setting the global option correctly updates local intellij value for new window`() {
     enterCommand("set sidescrolloff=20")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
 
     // Changing the global IntelliJ setting syncs with the global Vim value
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
 
     // We don't support externally changing the local editor setting
     enterCommand("setlocal sidescrolloff=30")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=30\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=30\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=30")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=30")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
     assertEquals(10, EditorSettingsExternalizable.getInstance().horizontalScrollOffset)
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
@@ -200,7 +200,7 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
   }
 
   // :set[local|global] {option}& - reset to default value
@@ -210,20 +210,20 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 20
 
     enterCommand("set sidescrolloff=10")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     // Vim: global=10, local=-1 => global=default, local=unset
     enterCommand("set sidescrolloff&")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 15
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
   }
 
   @Test
@@ -235,9 +235,9 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
 
     // Vim: global=10, local=20 => global=default, local=default
     enterCommand("set sidescrolloff&")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=5\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=5\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=5\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=5")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=5")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=5")
 
     // Note that global=default, local=default is the same as global=default, local=unset
     // Changing the IDE value is reflected in the global Vim value, and also the local value
@@ -245,9 +245,9 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     // would also change the local value, so it's reasonable that changing the default value (by changing the IDE value)
     // is reflected in the local Vim value.
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 15
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=15\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=15")
   }
 
   @Test
@@ -259,25 +259,25 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     switchToNewFile("bbb.txt", "lorem ipsum")
 
     enterCommand("set sidescrolloff=10")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
     assertEquals(10, injector.options(firstEditor.vim).sidescrolloff) // Equivalent to `set sidescrolloff?`
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
 
     enterCommand("set sidescrolloff&")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
     assertEquals(20, injector.options(firstEditor.vim).sidescrolloff) // Equivalent to `set sidescrolloff?`
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
 
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 15
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
     assertEquals(15, injector.options(firstEditor.vim).sidescrolloff) // Equivalent to `set sidescrolloff?`
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
@@ -294,9 +294,9 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     enterCommand("set sidescrolloff=10")
     enterCommand("setlocal sidescrolloff=5")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=5\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=5\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=5")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=5")
     assertEquals(7, injector.options(firstEditor.vim).sidescrolloff) // Equivalent to `set sidescrolloff?`
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
@@ -304,17 +304,17 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     // Vim: global=10, local=5 => global=default, local=default
     // local=default behaves like local=unset
     enterCommand("set sidescrolloff&")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20")
     assertEquals(7, injector.options(firstEditor.vim).sidescrolloff) // Equivalent to `set sidescrolloff?`
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
 
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 15
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=15\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=15")
     assertEquals(7, injector.options(firstEditor.vim).sidescrolloff) // Equivalent to `set sidescrolloff?`
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
@@ -329,26 +329,26 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     switchToNewFile("bbb.txt", "lorem ipsum")
 
     enterCommand("set sidescrolloff=10")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
     assertEquals(7, injector.options(firstEditor.vim).sidescrolloff) // `set sidescrolloff?` for first editor
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
 
     // Vim: global=10, local=-1 => global=default, local=unset
     enterCommand("set sidescrolloff&")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
     assertEquals(7, injector.options(firstEditor.vim).sidescrolloff) // `set sidescrolloff?` for first editor
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
 
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 15
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
     assertEquals(7, injector.options(firstEditor.vim).sidescrolloff) // `set sidescrolloff?` for first editor
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
@@ -365,9 +365,9 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     enterCommand("set sidescrolloff=10")
     enterCommand("setlocal sidescrolloff=5")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=5\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=5\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=5")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=5")
     assertEquals(7, injector.options(firstEditor.vim).sidescrolloff) // Equivalent to `set sidescrolloff?`
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
@@ -376,17 +376,17 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     // Note that global=default, local=default behaves the same as global=default, local=unset
     enterCommand("set sidescrolloff&")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20")
     assertEquals(7, injector.options(firstEditor.vim).sidescrolloff) // Equivalent to `set sidescrolloff?`
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
 
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 15
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=15\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=15")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=15")
     assertEquals(7, injector.options(firstEditor.vim).sidescrolloff) // Equivalent to `set sidescrolloff?`
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
     assertEquals(0, firstEditor.settings.horizontalScrollOffset)
@@ -402,16 +402,16 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
 
     // This resets global to default + local to unset, but doesn't modify the local intellij value
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
 
     // Changing the intellij default value is reflected in IdeaVim
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 30
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=30\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=30\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=30")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=30")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
 
@@ -425,16 +425,16 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
 
     // set global value to default, but not resetting the local intellij value...
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n") // Vim is default of 0, but we want to use global intellij value
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20") // Vim is default of 0, but we want to use global intellij value
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10")
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
 
     // Changing the intellij default value is reflected in IdeaVim global, but not local
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 30
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=30\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=30")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10")
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
 
@@ -443,22 +443,22 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 20
     enterCommand("setglobal sidescrolloff=10")
     enterCommand("setlocal sidescrolloff=15")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=15\n")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=15")
 
     // Vim: global=10, local=15 => global=10, local=default
     // IdeaVim's defaults are transparent, so this should come from the IDE default value
     enterCommand("setlocal sidescrolloff&")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20")
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
 
     // Changing the intellij default value is reflected in IdeaVim
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 30
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=30\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=30\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=30\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=30")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=30")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=30")
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
 
@@ -471,16 +471,16 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     // local=default behaves like local=unset
     enterCommand("setlocal sidescrolloff&")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n") // Was originally default
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20") // Was originally default
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20")
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
 
     // Changing the intellij default value is reflected in IdeaVim
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 30
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=30\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=30\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=30\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=30")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=30")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=30")
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
 
@@ -493,26 +493,26 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
   fun `test reset effective 'sidescrolloff' to global default value does not modify unset local value`() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 20
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     // The local value is unset, so "set {option}<" does not modify it (effective value is still global)
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("set sidescrolloff<")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
 
     // Global is default and local is unset, so this should affect values
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
@@ -522,27 +522,27 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 20
 
     enterCommand("setlocal sidescrolloff=10")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10")
 
     // The local value has been set, so "set {option}<" copies the global value (effective value is still global)
     // Global was default, so now local is default too
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("set sidescrolloff<")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=20")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
 
     // Both global and local values should be defaults, so this should affect both
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
@@ -552,26 +552,26 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
 
     enterCommand("set sidescrolloff=20")  // No longer default
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     // The local value has been set, so "set {option}<" copies the global value (effective value is still global)
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("set sidescrolloff<")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
 
     // Global is explicitly set, and local is unset. Global changes should not affect values
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
@@ -581,26 +581,26 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 20
 
     enterCommand("setlocal sidescrolloff=10")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10")
 
     // "setlocal {option}<" always unsets number-based global-local options
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("setlocal sidescrolloff<")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
 
     // Global is default, so this should affect global only
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
@@ -611,26 +611,26 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
 
     enterCommand("set sidescrolloff=20")  // No longer default
     enterCommand("setlocal sidescrolloff=10")
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=10")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=10")
 
     // "setlocal {option}<" always unsets number-based global-local options
     // See `:help :setlocal` and https://github.com/vim/vim/issues/14062
     enterCommand("setlocal sidescrolloff<")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
 
     // Global is not default, so should not be affected by this change
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 10
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     assertEquals(0, fixture.editor.settings.horizontalScrollOffset)
   }
@@ -639,15 +639,15 @@ class SideScrollOffOptionMapperTest : VimTestCase() {
   fun `test reset global 'sidescrolloff' to global value does nothing`() {
     EditorSettingsExternalizable.getInstance().horizontalScrollOffset = 20
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
 
     // This copies the global value to the global value. It's a no-op
     enterCommand("setglobal sidescrolloff<")
 
-    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20\n")
-    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1\n")
+    assertCommandOutput("set sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setglobal sidescrolloff?", "  sidescrolloff=20")
+    assertCommandOutput("setlocal sidescrolloff?", "  sidescrolloff=-1")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/SideScrollOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/SideScrollOptionMapperTest.kt
@@ -62,11 +62,11 @@ class SideScrollOptionMapperTest : VimTestCase() {
   @Test
   fun `test 'sidescroll' option reports global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().horizontalScrollJump = 7
-    assertCommandOutput("set sidescroll?", "  sidescroll=7\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=7")
 
     // Also tests the value being modified in the IDE's settings
     EditorSettingsExternalizable.getInstance().horizontalScrollJump = 3
-    assertCommandOutput("set sidescroll?", "  sidescroll=3\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=3")
   }
 
   // 'sidescroll' is a global option, so we don't need to test `:setlocal` or `:setglobal`
@@ -77,11 +77,11 @@ class SideScrollOptionMapperTest : VimTestCase() {
     // values for scrolling during typing (when IdeaVim's scroll implementation isn't called early enough), we set the
     // local value for all editors
     fixture.editor.settings.horizontalScrollJump = 7
-    assertCommandOutput("set sidescroll?", "  sidescroll=7\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=7")
 
     // Also tests the value being modified in the IDE's settings
     fixture.editor.settings.horizontalScrollJump = 3
-    assertCommandOutput("set sidescroll?", "  sidescroll=3\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=3")
   }
 
   @Test
@@ -98,16 +98,16 @@ class SideScrollOptionMapperTest : VimTestCase() {
   fun `test setting global IDE value will update IdeaVim value`() {
     enterCommand("set sidescroll=7")
     EditorSettingsExternalizable.getInstance().horizontalScrollJump = 3
-    assertCommandOutput("setlocal sidescroll?", "  sidescroll=3\n")
-    assertCommandOutput("set sidescroll?", "  sidescroll=3\n")
-    assertCommandOutput("setglobal sidescroll?", "  sidescroll=3\n")
+    assertCommandOutput("setlocal sidescroll?", "  sidescroll=3")
+    assertCommandOutput("set sidescroll?", "  sidescroll=3")
+    assertCommandOutput("setglobal sidescroll?", "  sidescroll=3")
   }
 
   @Test
   fun `test reset 'sidescroll' to default resets to global intellij setting`() {
     EditorSettingsExternalizable.getInstance().horizontalScrollJump = 20
     fixture.editor.settings.horizontalScrollJump = 10
-    assertCommandOutput("set sidescroll?", "  sidescroll=10\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=10")
 
     enterCommand("set sidescroll&")
     assertEquals(20, fixture.editor.settings.horizontalScrollJump)
@@ -116,21 +116,21 @@ class SideScrollOptionMapperTest : VimTestCase() {
     // Unlike many other overridden options, this one allows us to reset it back to global-local, so it will correctly
     // pick up the global value
     EditorSettingsExternalizable.getInstance().horizontalScrollJump = 30
-    assertCommandOutput("set sidescroll?", "  sidescroll=30\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=30")
   }
 
   @Test
   fun `test open new window without setting the option correctly keeps global intellij setting`() {
     EditorSettingsExternalizable.getInstance().horizontalScrollJump = 20
-    assertCommandOutput("set sidescroll?", "  sidescroll=20\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=20")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set sidescroll?", "  sidescroll=20\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=20")
 
     // Changing the global intellij setting should update the new editor
     EditorSettingsExternalizable.getInstance().horizontalScrollJump = 30
-    assertCommandOutput("set sidescroll?", "  sidescroll=30\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=30")
   }
 
   @Test
@@ -140,7 +140,7 @@ class SideScrollOptionMapperTest : VimTestCase() {
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set sidescroll?", "  sidescroll=20\n")
+    assertCommandOutput("set sidescroll?", "  sidescroll=20")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/TextWidthOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/TextWidthOptionMapperTest.kt
@@ -103,46 +103,46 @@ class TextWidthOptionMapperTest : VimTestCase() {
   fun `test 'textwidth' option reports global intellij setting if not explicitly set`() {
     globalWrapOnTyping = true
     globalRightMargin = 50
-    assertCommandOutput("set textwidth?", "  textwidth=50\n")
+    assertCommandOutput("set textwidth?", "  textwidth=50")
 
     globalWrapOnTyping = false
-    assertCommandOutput("set textwidth?", "  textwidth=0\n")
+    assertCommandOutput("set textwidth?", "  textwidth=0")
   }
 
   @Test
   fun `test local 'textwidth' option reports global intellij setting if not explicitly set`() {
     globalWrapOnTyping = true
     globalRightMargin = 50
-    assertCommandOutput("setlocal textwidth?", "  textwidth=50\n")
+    assertCommandOutput("setlocal textwidth?", "  textwidth=50")
 
     globalWrapOnTyping = false
-    assertCommandOutput("setlocal textwidth?", "  textwidth=0\n")
+    assertCommandOutput("setlocal textwidth?", "  textwidth=0")
   }
 
   @Test
   fun `test 'textwidth' option reports local intellij setting if set via IDE`() {
     localWrapOnTyping = true
     localRightMargin = 60
-    assertCommandOutput("set textwidth?", "  textwidth=60\n")
+    assertCommandOutput("set textwidth?", "  textwidth=60")
 
     localRightMargin = 70
-    assertCommandOutput("set textwidth?", "  textwidth=70\n")
+    assertCommandOutput("set textwidth?", "  textwidth=70")
 
     localWrapOnTyping = false
-    assertCommandOutput("set textwidth?", "  textwidth=0\n")
+    assertCommandOutput("set textwidth?", "  textwidth=0")
   }
 
   @Test
   fun `test local 'textwidth' option reports local intellij setting if set via IDE`() {
     localWrapOnTyping = true
     localRightMargin = 60
-    assertCommandOutput("setlocal textwidth?", "  textwidth=60\n")
+    assertCommandOutput("setlocal textwidth?", "  textwidth=60")
 
     localRightMargin = 70
-    assertCommandOutput("setlocal textwidth?", "  textwidth=70\n")
+    assertCommandOutput("setlocal textwidth?", "  textwidth=70")
 
     localWrapOnTyping = false
-    assertCommandOutput("setlocal textwidth?", "  textwidth=0\n")
+    assertCommandOutput("setlocal textwidth?", "  textwidth=0")
   }
 
   @Test
@@ -194,10 +194,10 @@ class TextWidthOptionMapperTest : VimTestCase() {
   fun `test setglobal 'textwidth' does not modify global intellij setting`() {
     assertFalse(globalWrapOnTyping)
     assertEquals(defaultRightMargin, globalRightMargin)
-    assertCommandOutput("setglobal textwidth?", "  textwidth=0\n")
+    assertCommandOutput("setglobal textwidth?", "  textwidth=0")
 
     enterCommand("setglobal textwidth=60")
-    assertCommandOutput("setglobal textwidth?", "  textwidth=60\n")
+    assertCommandOutput("setglobal textwidth?", "  textwidth=60")
     assertFalse(globalWrapOnTyping)
     assertEquals(defaultRightMargin, globalRightMargin)
   }
@@ -205,8 +205,8 @@ class TextWidthOptionMapperTest : VimTestCase() {
   @Test
   fun `test set 'textwidth' updates local and global ideavim values`() {
     enterCommand("set textwidth=40")
-    assertCommandOutput("set textwidth?", "  textwidth=40\n")
-    assertCommandOutput("setglobal textwidth?", "  textwidth=40\n")
+    assertCommandOutput("set textwidth?", "  textwidth=40")
+    assertCommandOutput("setglobal textwidth?", "  textwidth=40")
   }
 
   @Test
@@ -215,9 +215,9 @@ class TextWidthOptionMapperTest : VimTestCase() {
     // local value
     localWrapOnTyping = true
     localRightMargin = 80
-    assertCommandOutput("setlocal textwidth?", "  textwidth=80\n")
-    assertCommandOutput("set textwidth?", "  textwidth=80\n")
-    assertCommandOutput("setglobal textwidth?", "  textwidth=0\n")
+    assertCommandOutput("setlocal textwidth?", "  textwidth=80")
+    assertCommandOutput("set textwidth?", "  textwidth=80")
+    assertCommandOutput("setglobal textwidth?", "  textwidth=0")
   }
 
   @Test
@@ -227,16 +227,16 @@ class TextWidthOptionMapperTest : VimTestCase() {
 
     localWrapOnTyping = false
     localRightMargin = 90
-    assertCommandOutput("set textwidth?", "  textwidth=0\n")
+    assertCommandOutput("set textwidth?", "  textwidth=0")
 
     enterCommand("set textwidth&")
-    assertCommandOutput("set textwidth?", "  textwidth=80\n")
+    assertCommandOutput("set textwidth?", "  textwidth=80")
     assertTrue(localWrapOnTyping)
     assertEquals(80, localRightMargin)
 
     // Verify that we've only copied the values instead of resetting the editor local settings
     globalWrapOnTyping = false
-    assertCommandOutput("set textwidth?", "  textwidth=80\n")
+    assertCommandOutput("set textwidth?", "  textwidth=80")
   }
 
   @Test
@@ -246,16 +246,16 @@ class TextWidthOptionMapperTest : VimTestCase() {
 
     localWrapOnTyping = false
     localRightMargin = 90
-    assertCommandOutput("set textwidth?", "  textwidth=0\n")
+    assertCommandOutput("set textwidth?", "  textwidth=0")
 
     enterCommand("setlocal textwidth&")
-    assertCommandOutput("set textwidth?", "  textwidth=80\n")
+    assertCommandOutput("set textwidth?", "  textwidth=80")
     assertTrue(localWrapOnTyping)
     assertEquals(80, localRightMargin)
 
     // Verify that we've only copied the values instead of resetting the editor local settings
     globalWrapOnTyping = false
-    assertCommandOutput("set textwidth?", "  textwidth=80\n")
+    assertCommandOutput("set textwidth?", "  textwidth=80")
   }
 
   @Test
@@ -263,15 +263,15 @@ class TextWidthOptionMapperTest : VimTestCase() {
     // 'textwidth' is local-to-buffer, so doesn't get copied to new windows. We should have the default
     globalWrapOnTyping = true
     globalRightMargin = 80
-    assertCommandOutput("set textwidth?", "  textwidth=80\n")
+    assertCommandOutput("set textwidth?", "  textwidth=80")
 
     openNewBufferWindow("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set textwidth?", "  textwidth=80\n")
+    assertCommandOutput("set textwidth?", "  textwidth=80")
 
     // Changing the global setting should update the new editor
     globalRightMargin = 100
-    assertCommandOutput("set textwidth?", "  textwidth=100\n")
+    assertCommandOutput("set textwidth?", "  textwidth=100")
   }
 
   @Test
@@ -279,15 +279,15 @@ class TextWidthOptionMapperTest : VimTestCase() {
     globalWrapOnTyping = true
     globalRightMargin = 80
     enterCommand("set textwidth=78")
-    assertCommandOutput("set textwidth?", "  textwidth=78\n")
+    assertCommandOutput("set textwidth?", "  textwidth=78")
 
     openNewBufferWindow("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set textwidth?", "  textwidth=78\n")
+    assertCommandOutput("set textwidth?", "  textwidth=78")
 
     // Changing the global setting should NOT update the new editor
     globalRightMargin = 100
-    assertCommandOutput("set textwidth?", "  textwidth=78\n")
+    assertCommandOutput("set textwidth?", "  textwidth=78")
   }
 
   @Test
@@ -296,11 +296,11 @@ class TextWidthOptionMapperTest : VimTestCase() {
 
     openNewBufferWindow("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set textwidth?", "  textwidth=50\n")
+    assertCommandOutput("set textwidth?", "  textwidth=50")
 
     // Changing the global value should NOT update the editor
     globalWrapOnTyping = false
-    assertCommandOutput("set textwidth?", "  textwidth=50\n")
+    assertCommandOutput("set textwidth?", "  textwidth=50")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/WrapOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/WrapOptionMapperTest.kt
@@ -72,37 +72,37 @@ class WrapOptionMapperTest : VimTestCase() {
   @Test
   fun `test 'wrap' option reports current global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = false
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
 
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = true
-    assertCommandOutput("set wrap?", "  wrap\n")
+    assertCommandOutput("set wrap?", "  wrap")
   }
 
   @Test
   fun `test local 'wrap' option reports current global intellij setting if not explicitly set`() {
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = false
-    assertCommandOutput("setlocal wrap?", "nowrap\n")
+    assertCommandOutput("setlocal wrap?", "nowrap")
 
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = true
-    assertCommandOutput("setlocal wrap?", "  wrap\n")
+    assertCommandOutput("setlocal wrap?", "  wrap")
   }
 
   @Test
   fun `test 'wrap' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isUseSoftWraps = true
-    assertCommandOutput("set wrap?", "  wrap\n")
+    assertCommandOutput("set wrap?", "  wrap")
 
     fixture.editor.settings.isUseSoftWraps = false
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
   }
 
   @Test
   fun `test local 'wrap' option reports local intellij setting if set via IDE`() {
     fixture.editor.settings.isUseSoftWraps = true
-    assertCommandOutput("setlocal wrap?", "  wrap\n")
+    assertCommandOutput("setlocal wrap?", "  wrap")
 
     fixture.editor.settings.isUseSoftWraps = false
-    assertCommandOutput("setlocal wrap?", "nowrap\n")
+    assertCommandOutput("setlocal wrap?", "nowrap")
   }
 
   @Test
@@ -132,11 +132,11 @@ class WrapOptionMapperTest : VimTestCase() {
   @Test
   fun `test setglobal 'wrap' option affects IdeaVim global value only`() {
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = false
-    assertCommandOutput("setglobal wrap?", "  wrap\n")  // Default for IdeaVim option is true
+    assertCommandOutput("setglobal wrap?", "  wrap")  // Default for IdeaVim option is true
 
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = true
     enterCommand("setglobal nowrap")
-    assertCommandOutput("setglobal wrap?", "nowrap\n")
+    assertCommandOutput("setglobal wrap?", "nowrap")
     assertTrue(EditorSettingsExternalizable.getInstance().isUseSoftWraps)
   }
 
@@ -144,7 +144,7 @@ class WrapOptionMapperTest : VimTestCase() {
   fun `test set updates IdeaVim global value as well as local`() {
     // `:set` will update both the local value, and the IdeaVim-only global value
     enterCommand("set nowrap")
-    assertCommandOutput("setglobal wrap?", "nowrap\n")
+    assertCommandOutput("setglobal wrap?", "nowrap")
   }
 
   @Test
@@ -152,9 +152,9 @@ class WrapOptionMapperTest : VimTestCase() {
     // If we use `:set`, it updates the local and per-window global values. If we set the value from the IDE, it only
     // affects the local value
     fixture.editor.settings.isUseSoftWraps = false
-    assertCommandOutput("setlocal wrap?", "nowrap\n")
-    assertCommandOutput("set wrap?", "nowrap\n")
-    assertCommandOutput("setglobal wrap?", "  wrap\n")
+    assertCommandOutput("setlocal wrap?", "nowrap")
+    assertCommandOutput("set wrap?", "nowrap")
+    assertCommandOutput("setglobal wrap?", "  wrap")
   }
 
   @Test
@@ -162,14 +162,14 @@ class WrapOptionMapperTest : VimTestCase() {
     enterCommand("set nowrap")
 
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = false
-    assertCommandOutput("setlocal wrap?", "nowrap\n")
-    assertCommandOutput("set wrap?", "nowrap\n")
-    assertCommandOutput("setglobal wrap?", "nowrap\n")
+    assertCommandOutput("setlocal wrap?", "nowrap")
+    assertCommandOutput("set wrap?", "nowrap")
+    assertCommandOutput("setglobal wrap?", "nowrap")
 
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = true
-    assertCommandOutput("setlocal wrap?", "nowrap\n")
-    assertCommandOutput("set wrap?", "nowrap\n")
-    assertCommandOutput("setglobal wrap?", "nowrap\n")
+    assertCommandOutput("setlocal wrap?", "nowrap")
+    assertCommandOutput("set wrap?", "nowrap")
+    assertCommandOutput("setglobal wrap?", "nowrap")
   }
 
   @Test
@@ -185,9 +185,9 @@ class WrapOptionMapperTest : VimTestCase() {
     // Default is true, so reset it to false, then set back to true
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = false
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = true
-    assertCommandOutput("setlocal wrap?", "  wrap\n")
-    assertCommandOutput("set wrap?", "  wrap\n")
-    assertCommandOutput("setglobal wrap?", "  wrap\n")
+    assertCommandOutput("setlocal wrap?", "  wrap")
+    assertCommandOutput("set wrap?", "  wrap")
+    assertCommandOutput("setglobal wrap?", "  wrap")
   }
 
   @Test
@@ -206,7 +206,7 @@ class WrapOptionMapperTest : VimTestCase() {
   fun `test reset 'wrap' to default copies current global intellij setting`() {
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = true
     fixture.editor.settings.isUseSoftWraps = false
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
 
     enterCommand("set wrap&")
     assertTrue(fixture.editor.settings.isUseSoftWraps)
@@ -220,7 +220,7 @@ class WrapOptionMapperTest : VimTestCase() {
   @Test
   fun `test reset local 'wrap' to default copies current global intellij setting`() {
     fixture.editor.settings.isUseSoftWraps = false
-    assertCommandOutput("setlocal wrap?", "nowrap\n")
+    assertCommandOutput("setlocal wrap?", "nowrap")
 
     enterCommand("setlocal wrap&")
     assertTrue(fixture.editor.settings.isUseSoftWraps)
@@ -235,59 +235,59 @@ class WrapOptionMapperTest : VimTestCase() {
   fun `test open new window without setting the option copies value as not-explicitly set`() {
     // New window will clone local and global local-to-window options, then apply global to local. This tests that our
     // handling of per-window "global" values is correct.
-    assertCommandOutput("set wrap?", "  wrap\n")
+    assertCommandOutput("set wrap?", "  wrap")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set wrap?", "  wrap\n")
+    assertCommandOutput("set wrap?", "  wrap")
 
     // Changing the global setting should update the new editor
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = false
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
   }
 
   @Test
   fun `test open new window after setting option copies value as explicitly set`() {
     enterCommand("set nowrap")
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = true
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
   }
 
   @Test
   fun `test setglobal 'wrap' used when opening new window`() {
     enterCommand("setglobal nowrap")
-    assertCommandOutput("setglobal wrap?", "nowrap\n")
-    assertCommandOutput("set wrap?", "  wrap\n")
+    assertCommandOutput("setglobal wrap?", "nowrap")
+    assertCommandOutput("set wrap?", "  wrap")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = true
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
   }
 
   @Test
   fun `test setlocal 'wrap' then open new window uses value from setglobal`() {
     enterCommand("setlocal nowrap")
-    assertCommandOutput("setglobal wrap?", "  wrap\n")
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("setglobal wrap?", "  wrap")
+    assertCommandOutput("set wrap?", "nowrap")
 
     switchToNewFile("bbb.txt", "lorem ipsum")
 
-    assertCommandOutput("set wrap?", "  wrap\n")
+    assertCommandOutput("set wrap?", "  wrap")
 
     // Changing the global setting should NOT update the editor
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = false
-    assertCommandOutput("set wrap?", "  wrap\n")
+    assertCommandOutput("set wrap?", "  wrap")
   }
 
   @Test
@@ -301,12 +301,12 @@ class WrapOptionMapperTest : VimTestCase() {
     }
 
     switchToNewFile("bbb.txt", "lorem ipsum")
-    assertCommandOutput("set wrap?", "nowrap\n")
+    assertCommandOutput("set wrap?", "nowrap")
 
     // Changing the global setting should update the editor, because it was initially set during plugin startup
     // Default is true, so reset before changing again
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = false
     EditorSettingsExternalizable.getInstance().isUseSoftWraps = true
-    assertCommandOutput("set wrap?", "  wrap\n")
+    assertCommandOutput("set wrap?", "  wrap")
   }
 }

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -672,7 +672,7 @@ abstract class VimTestCase {
 
   fun assertNoExOutput() {
     val actual = ExOutputModel.getInstance(fixture.editor).text
-    assertNull(actual, "Ex output not null")
+    assertEquals("", actual)
   }
 
   fun assertPluginError(isError: Boolean) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/PrintCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/PrintCommand.kt
@@ -44,7 +44,8 @@ public data class PrintCommand(val range: Range, val argument: String) : Command
       // make sure it's clear
       exOutputModel.clear()
     }
-    exOutputModel.output((exOutputModel.text ?: "") + text)
+    val existingText = exOutputModel.text?.let { if (it.isNotEmpty()) it.plus("\n") else it } ?: ""
+    exOutputModel.output(existingText + text)
     return ExecutionResult.Success
   }
 }


### PR DESCRIPTION
This PR fixes various issues.

### Options:

- [x] The `'fileencoding'` option should not be copied during initialisation, but not all scenarios were handled. Setting the option will convert the file immediately (unlike Vim which waits until the file is saved. IntelliJ's saves are less deterministic). If the option is set in `~/.ideavimrc`, the value can be applied to new files being opened, and can result in a disruptive dialog prompting to convert the file. [VIM-3467](https://youtrack.jetbrains.com/issue/VIM-3467).
- [x] Fix soft wrap inconsistency between the main editor and the console output in the Run tool window. This is because IntelliJ has multiple soft wrap settings, for main editors, consoles, previews and others. IdeaVim will no longer copy options between different kinds of editor. IdeaVim will also look at the correct soft wrap type to check if the local value differs to the global value. [VIM-3450](https://youtrack.jetbrains.com/issue/VIM-3450).
- [x] Fixes an infinite recursion initialising editors that create a dummy inner editor while downloading the real file. When initialising options after an editor is created, IdeaVim checks for the currently selected editor, which could cause the dummy editor to be created, which would need options to be initialised… This recursion doesn't appear to happen any more in 241 (coroutines!), but the protection is still sensible. [VIM-3066](https://youtrack.jetbrains.com/issue/VIM-3066).
- [x] Fix a regression in the new regex engine causing `:global` to not honour `'ignorecase'` and `'smartcase'` options

### Ex text field

- [x] Fix text field not handling IDE zoom, or editor zoom.  [VIM-3417](https://youtrack.jetbrains.com/issue/VIM-3417).
- [x] Fix regression in ex output panel clearing text instead of closing when clicking outside of panel
- [x] Fix regression with missing newlines in `:print` output. The ex text field would strip trailing newlines, but not add them when concatenating. The test helper would not strip the newlines, so tests would pass. The `ExOutputModel.text` property will now strip trailing new lines, so tests match the UI behaviour. This means all asserts no longer require a trailing newline, so lots of changes for that, too

Also:
- [x] Fix incorrectly automatically switching to Insert mode for diff windows. IdeaVim will switch to Insert mode for some editors, e.g. consoles, git commit editor, and other editors that are not backed by a file. This change will keep IdeaVim in Normal mode for diff windows that do not have a disk based file. [VIM-3442](https://youtrack.jetbrains.com/issue/VIM-3442).