### PR TITLE
Fix `verifyPlugin` Gradle task

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -56,11 +56,3 @@ kotlin.stdlib.default.dependency=false
 
 # Disable incremental annotation processing
 ksp.incremental=false
-
-# Build features
-# Temporarily disable downloading the IDE dependency from CDN, and use Maven The Plugin DevKit plugin is currently
-# unable to download sources when the IDE is packaged as a normal binary release. This only affects developers working
-# with and debugging IdeaVim. Once the fixed version of DevKit is available, IdeaVim developers can update and this flag
-# can be removed.
-# DevKit will be fixed in IDEA 2024.1.4 and a future EAP of 2024.2
-org.jetbrains.intellij.platform.buildFeature.useBinaryReleases=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,6 +50,8 @@ youtrackToken=
 
 # Gradle settings
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
+org.gradle.configuration-cache=true
+org.gradle.caching=true
 
 # Disable warning from gradle-intellij-plugin. Kotlin stdlib is included as compileOnly, so the warning is unnecessary
 kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
This PR fixes the `verifyPlugin` Gradle task after migrating to v2 of the Gradle IntelliJ Plugin. It was broken due to disabling the `useBinaryReleases` build feature, which controls whether the referenced IDE is downloaded as a consumer binary release from the main CDN, or from Maven. The default is to use consumer binary releases, but the Plugin DevKit plugin wasn't able to download sources for these references during debugging, etc. The Plugin DevKit has now been updated, and supports downloading sources for binary releases in 2024.1.4 and the latest 242 EAP.

This PR also enables Gradle caching. Without this, Gradle appears to re-run the "extractor transformer" on each run, which seems to extract the IDE ready to be referenced. This means running tests can have additional overhead, up to 1 minute. Enabling caching removes this delay.