### PR TITLE
Fix incsearch with result before caret and wrapscan

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/group/SearchGroupTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/group/SearchGroupTest.kt
@@ -1063,6 +1063,38 @@ class SearchGroupTest : VimTestCase() {
     assertPosition(1, 14)
   }
 
+  @Test
+  fun `test incsearch + hlsearch at bottom of file with wrapscan`() {
+    // Make sure the caret wraps during incsearch
+    configureByText(
+      """
+        |Lorem ipsum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci ${c}mauris.
+        |Cras id tellus in ex imperdiet egestas. 
+      """.trimMargin()
+    )
+    enterCommand("set incsearch hlsearch wrapscan")
+    typeText("/it")
+    assertPosition(0, 19)
+  }
+
+  @Test
+  fun `test incsearch + hlsearch at bottom of file with nowrapscan`() {
+    // This will highlight the occurrences above/before the caret, but should not move the caret
+    configureByText(
+      """
+        |Lorem ipsum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci ${c}mauris.
+        |Cras id tellus in ex imperdiet egestas. 
+      """.trimMargin()
+    )
+    enterCommand("set incsearch hlsearch nowrapscan")
+    typeText("/it")
+    assertPosition(2, 12)
+  }
+
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @Test
   fun `test incsearch moves caret to start of first match (backwards)`() {


### PR DESCRIPTION
If all results are before the caret, make sure it's still possible to find the closest match.

Fixes [VIM-3505](https://youtrack.jetbrains.com/issue/VIM-3505)