### PR TITLE
Fix null reference initialising output panel fonts

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
@@ -70,5 +70,8 @@ class ExOutputModel private constructor(private val myEditor: Editor) : VimExOut
       }
       return model
     }
+
+    @JvmStatic
+    fun tryGetInstance(editor: Editor) = editor.vimExOutput
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -417,7 +417,10 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
           if (activeCommandLine != null) {
             injector.getProcessGroup().cancelExEntry(new IjVimEditor(editor), false);
           }
-          ExOutputModel.getInstance(editor).close();
+          ExOutputModel exOutputModel = ExOutputModel.tryGetInstance(editor);
+          if (exOutputModel != null) {
+            exOutputModel.close();
+          }
         }
       }
     }

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
@@ -314,7 +314,7 @@ internal class MotionGroup : VimMotionGroupBase() {
               }
               is Mode.CMD_LINE -> {
                 injector.processGroup.cancelExEntry(vimEditor, false)
-                ExOutputModel.getInstance(editor).close()
+                ExOutputModel.tryGetInstance(editor)?.close()
               }
               else -> {}
             }

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -741,7 +741,7 @@ internal object VimListenerManager {
           injector.processGroup.cancelExEntry(editor.vim, false)
         }
 
-        ExOutputModel.getInstance(editor).close()
+        ExOutputModel.tryGetInstance(editor)?.close()
 
         val caretModel = editor.caretModel
         if (editor.vim.mode.selectionType != null) {

--- a/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
@@ -267,6 +267,12 @@ public class ExOutputPanel extends JPanel {
   private void positionPanel() {
     final JComponent contentComponent = myEditor.getContentComponent();
     Container scroll = SwingUtilities.getAncestorOfClass(JScrollPane.class, contentComponent);
+    JRootPane rootPane = SwingUtilities.getRootPane(contentComponent);
+    if (scroll == null || rootPane == null) {
+      // These might be null if we're invoked during component initialisation and before it's been added to the tree
+      return;
+    }
+
     setSize(scroll.getSize());
 
     myLineHeight = myText.getFontMetrics(myText.getFont()).getHeight();
@@ -280,8 +286,7 @@ public class ExOutputPanel extends JPanel {
     Rectangle bounds = scroll.getBounds();
     bounds.translate(0, scroll.getHeight() - height);
     bounds.height = height;
-    Point pos = SwingUtilities.convertPoint(scroll.getParent(), bounds.getLocation(),
-                                            SwingUtilities.getRootPane(contentComponent).getGlassPane());
+    Point pos = SwingUtilities.convertPoint(scroll.getParent(), bounds.getLocation(), rootPane.getGlassPane());
     bounds.setLocation(pos);
     setBounds(bounds);
 


### PR DESCRIPTION
Fixes an exception that would prevent debugging in Rider. The Debug tool window would create an `Editor` instance during initialisation and set the font size. If the font size was changed (e.g. the editor was zoomed), then IdeaVim's font property change listener would try to hide the ex command line and the output panel. Unfortunately, this forced creation of the output panel, which would try to position itself, but because the `Editor` instance hadn't been added to the UI, the editor component's root pane would be null, and lead to a `NullPointerException`.

This PR adds a null check to avoid the exception, and also avoids creating the panel just to make sure it's hidden.

Fixes [VIM-3515](https://youtrack.jetbrains.com/issue/VIM-3515)