### PR TITLE
Update IntelliJ Gradle plugin to beta 8

### DIFF
--- a/.github/workflows/closeYoutrackOnCommit.yml
+++ b/.github/workflows/closeYoutrackOnCommit.yml
@@ -34,7 +34,7 @@ jobs:
           echo "LAST_COMMIT=$(git rev-list -n 1 tags/workflow-close-youtrack)" >> $GITHUB_ENV
 
       - name: Update YouTrack
-        run: ./gradlew updateYoutrackOnCommit
+        run: ./gradlew --no-configuration-cache updateYoutrackOnCommit
         env:
           SUCCESS_COMMIT: ${{ env.LAST_COMMIT }}
           YOUTRACK_TOKEN: ${{ secrets.YOUTRACK_TOKEN }}

--- a/.github/workflows/mergePr.yml
+++ b/.github/workflows/mergePr.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Update authors
         id: update_authors
-        run: ./gradlew updateMergedPr -PprId=${{ github.event.number }}
+        run: ./gradlew --no-configuration-cache updateMergedPr -PprId=${{ github.event.number }}
         env:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/updateAuthors.yml
+++ b/.github/workflows/updateAuthors.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Update authors
         id: update_authors
-        run: ./gradlew updateAuthors --stacktrace
+        run: ./gradlew --no-configuration-cache updateAuthors --stacktrace
         env:
           SUCCESS_COMMIT: ${{ env.LAST_COMMIT }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updateChangelog.yml
+++ b/.github/workflows/updateChangelog.yml
@@ -36,7 +36,7 @@ jobs:
           echo "LAST_COMMIT=$(git rev-list -n 1 tags/workflow-changelog)" >> $GITHUB_ENV
 
       - name: Update changelog
-        run: ./gradlew updateChangelog
+        run: ./gradlew --no-configuration-cache updateChangelog
         env:
           SUCCESS_COMMIT: ${{ env.LAST_COMMIT }}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,6 @@ import org.eclipse.jgit.lib.RepositoryBuilder
 import org.intellij.markdown.ast.getTextInNode
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
-import org.jetbrains.intellij.platform.gradle.tasks.CustomRunIdeTask
 import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware
 import org.kohsuke.github.GHUser
 import java.net.HttpURLConnection
@@ -70,7 +69,7 @@ plugins {
   kotlin("jvm") version "1.9.22"
   application
   id("java-test-fixtures")
-  id("org.jetbrains.intellij.platform") version "2.0.0-beta7"
+  id("org.jetbrains.intellij.platform") version "2.0.0-beta8"
   id("org.jetbrains.changelog") version "2.2.0"
   id("org.jetbrains.kotlinx.kover") version "0.6.1"
   id("com.dorongold.task-tree") version "4.0.0"
@@ -211,17 +210,17 @@ tasks {
 
   // Uncomment to run the plugin in a custom IDE, rather than the IDE specified as a compile target in dependencies
   // Note that the version must be greater than the plugin's target version, for obvious reasons
-//  val runIdeCustom by registering(CustomRunIdeTask::class) {
+//  val runIdeCustom by intellijPlatformTesting.runIde.registering {
 //    type = IntelliJPlatformType.Rider
 //    version = "2024.1.2"
 //  }
 
   // Uncomment to run the plugin in a locally installed IDE
-//  val runIdeLocal by registering(CustomRunIdeTask::class) {
+//  val runIdeLocal by intellijPlatformTesting.runIde.registering {
 //    localPath = file("/Users/{user}/Applications/WebStorm.app")
 //  }
 
-  val runIdeSplitMode by registering(CustomRunIdeTask::class) {
+  val runIdeSplitMode by intellijPlatformTesting.runIde.registering {
     splitMode = true
     splitModeTarget = SplitModeAware.SplitModeTarget.FRONTEND
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,17 +8,14 @@
 
 # suppress inspection "UnusedProperty" for whole file
 
-# ideaVersion is the version of the IDE that we'll add as a dependency. The format of the version string depends on the
-# value of the `org.jetbrains.intellij.platform.buildFeature.useBinaryReleases` property/build feature.
-# If enabled (default) then the IDE will be a normal, packaged release, which you could install and run like a retail
-# version of the IDE, downloaded from CDN. The `ideaVersion` property should be a marketing version such as `2024.1` or
-# `2024.1.1` (note no trailing `0`). You can find an example list of all versions for IDEA Community here:
+# ideaVersion is the version of the IDE that will be added as a compile-time dependency. The format can be either
+# product version (e.g. 2024.1, 2024.1.1) or build (e.g. 241.15989.150, 241-EAP-SNAPSHOT). The dependency will be
+# resolved against the configured repositories, which by default includes Maven releases and snapshots, the CDN used to
+# download consumer releases, the plugin marketplace and so on.
+# You can find an example list of all CDN based versions for IDEA Community here:
 # https://data.services.jetbrains.com/products?code=IC
-# If the build feature is disabled, the IDE will be downloaded from Maven, and should match the format published in
-# Maven, such as `2024.1` (again, no trailing `.0`), `2024.1.1`, `241-EAP-SNAPSHOT`, etc.
-# You can see a list of release versions here: https://www.jetbrains.com/intellij-repository/releases
-# And a list of snapshot versions here: https://www.jetbrains.com/intellij-repository/snapshots
-#ideaVersion=LATEST-EAP-SNAPSHOT
+# Maven releases are here: https://www.jetbrains.com/intellij-repository/releases
+# And snapshots: https://www.jetbrains.com/intellij-repository/snapshots
 ideaVersion=2024.1.1
 # Values for type: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 ideaType=IC

--- a/tests/long-running-tests/build.gradle.kts
+++ b/tests/long-running-tests/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
-import org.jetbrains.intellij.platform.gradle.tasks.CustomTestIdeTask
 
 plugins {
   java
@@ -48,9 +47,12 @@ tasks {
     useJUnitPlatform()
   }
 
-  register<CustomTestIdeTask>("testLongRunning") {
-    group = "verification"
-    useJUnitPlatform()
+  // The `test` task is automatically set up with IntelliJ goodness. A custom test task needs to be configured for it
+  val testLongRunning by intellijPlatformTesting.testIde.registering {
+    task {
+      group = "verification"
+      useJUnitPlatform()
+    }
   }
 }
 

--- a/tests/property-tests/build.gradle.kts
+++ b/tests/property-tests/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
-import org.jetbrains.intellij.platform.gradle.tasks.CustomTestIdeTask
 
 plugins {
   java
@@ -48,9 +47,12 @@ tasks {
     enabled = false
   }
 
-  register<CustomTestIdeTask>("testPropertyBased") {
-    group = "verification"
-    useJUnitPlatform()
+  // The `test` task is automatically set up with IntelliJ goodness. A custom test task needs to be configured for it
+  val testPropertyBased by intellijPlatformTesting.testIde.registering {
+    task {
+      group = "verification"
+      useJUnitPlatform()
+    }
   }
 }
 

--- a/vim-engine/build.gradle.kts
+++ b/vim-engine/build.gradle.kts
@@ -67,8 +67,8 @@ dependencies {
 }
 
 tasks {
-    val test by getting(Test::class) {
-        useJUnitPlatform()
+    test {
+      useJUnitPlatform()
     }
 
     generateGrammarSource {


### PR DESCRIPTION
This fixes an issue with the sandbox not being properly reset if the IDE is killed rather than gracefully exits. Updates to the current syntax for running tests.

Also disables the configuration cache for Gradle tasks in GitHub actions. The tasks should be updated to work with the cache, but in the meantime, this change should make them work again as actions.