### PR TITLE
Fleet

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/VimProjectService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/VimProjectService.kt
@@ -18,7 +18,7 @@ import com.maddyhome.idea.vim.ui.ex.ExEntryPanel
 internal class VimProjectService(val project: Project) : Disposable {
   override fun dispose() {
     // Not sure if this is a best solution
-    ExEntryPanel.getInstance().editor = null
+    ExEntryPanel.getInstance().setEditor(null)
   }
 
   companion object {

--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -257,7 +257,7 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
   private fun getEditor(e: AnActionEvent): Editor? {
     return e.getData(PlatformDataKeys.EDITOR)
       ?: if (e.getData(PlatformDataKeys.CONTEXT_COMPONENT) is ExTextField) {
-        ExEntryPanel.getInstance().editor
+        ExEntryPanel.getInstance().ijEditor
       } else {
         null
       }

--- a/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
@@ -109,7 +109,7 @@ class ExOutputModel(private val myEditor: WeakReference<Editor>) : VimOutputPane
     get() {
       val notNullEditor = editor ?: return false
       val panel = ExOutputPanel.getNullablePanel(notNullEditor) ?: return false
-      return panel.myAtEnd
+      return panel.isAtEnd()
     }
 
   override fun onBadKey() {

--- a/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
@@ -9,14 +9,15 @@ package com.maddyhome.idea.vim.ex
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
-import com.maddyhome.idea.vim.api.VimOutputPanel
+import com.maddyhome.idea.vim.api.VimOutputPanelBase
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.helper.vimExOutput
 import com.maddyhome.idea.vim.ui.ExOutputPanel
 import java.lang.ref.WeakReference
+import javax.swing.KeyStroke
 
 // TODO: We need a nicer way to handle output, especially wrt testing, appending + clearing
-class ExOutputModel(private val myEditor: WeakReference<Editor>) : VimOutputPanel {
+class ExOutputModel(private val myEditor: WeakReference<Editor>) : VimOutputPanelBase() {
   private var isActiveInTestMode = false
 
   val editor get() = myEditor.get()
@@ -48,6 +49,24 @@ class ExOutputModel(private val myEditor: WeakReference<Editor>) : VimOutputPane
     }
   }
 
+  override fun scrollPage() {
+    val notNullEditor = editor ?: return
+    val panel = ExOutputPanel.getNullablePanel(notNullEditor) ?: return
+    panel.scrollPage()
+  }
+
+  override fun scrollHalfPage() {
+    val notNullEditor = editor ?: return
+    val panel = ExOutputPanel.getNullablePanel(notNullEditor) ?: return
+    panel.scrollHalfPage()
+  }
+
+  override fun scrollLine() {
+    val notNullEditor = editor ?: return
+    val panel = ExOutputPanel.getNullablePanel(notNullEditor) ?: return
+    panel.scrollLine()
+  }
+
   override var text: String = ""
     get() = if (!ApplicationManager.getApplication().isUnitTestMode) {
       editor?.let { ExOutputPanel.getInstance(it).text } ?: ""
@@ -73,6 +92,25 @@ class ExOutputModel(private val myEditor: WeakReference<Editor>) : VimOutputPane
 
   fun clear() {
     text = ""
+  }
+
+  override val atEnd: Boolean
+    get() {
+      val notNullEditor = editor ?: return false
+      val panel = ExOutputPanel.getNullablePanel(notNullEditor) ?: return false
+      return panel.myAtEnd
+    }
+
+  override fun onBadKey() {
+    val notNullEditor = editor ?: return
+    val panel = ExOutputPanel.getNullablePanel(notNullEditor) ?: return
+    panel.onBadKey()
+  }
+
+  override fun close(key: KeyStroke?) {
+    val notNullEditor = editor ?: return
+    val panel = ExOutputPanel.getNullablePanel(notNullEditor) ?: return
+    panel.close(key)
   }
 
   override fun close() {

--- a/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ex/ExOutputModel.kt
@@ -85,6 +85,17 @@ class ExOutputModel(private val myEditor: WeakReference<Editor>) : VimOutputPane
         isActiveInTestMode = newValue.isNotEmpty()
       }
     }
+  override var label: String
+    get() {
+      val notNullEditor = editor ?: return ""
+      val panel = ExOutputPanel.getNullablePanel(notNullEditor) ?: return ""
+      return panel.myLabel.text
+    }
+    set(value) {
+      val notNullEditor = editor ?: return
+      val panel = ExOutputPanel.getNullablePanel(notNullEditor) ?: return
+      panel.myLabel.text = value
+    }
 
   fun output(text: String) {
     this.text = text

--- a/src/main/java/com/maddyhome/idea/vim/extension/VimExtensionFacade.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/VimExtensionFacade.kt
@@ -31,6 +31,7 @@ import com.maddyhome.idea.vim.key.OperatorFunction
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.ui.ModalEntry
+import com.maddyhome.idea.vim.ui.ex.ExEntryPanelService
 import com.maddyhome.idea.vim.vimscript.model.Executable
 import com.maddyhome.idea.vim.vimscript.model.ExecutionResult
 import com.maddyhome.idea.vim.vimscript.model.VimLContext
@@ -182,7 +183,7 @@ object VimExtensionFacade {
   /** Returns a string typed in the input box similar to 'input()'. */
   @JvmStatic
   fun inputString(editor: Editor, context: DataContext, prompt: String, finishOn: Char?): String {
-    return injector.commandLine.inputString(editor.vim, context.vim, prompt, finishOn) ?: ""
+    return (injector.commandLine as ExEntryPanelService).inputString(editor.vim, context.vim, prompt, finishOn) ?: ""
   }
 
   /** Get the current contents of the given register similar to 'getreg()'. */

--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -377,7 +377,7 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
           // Note that IDE scale is handled by LafManager.lookAndFeelChanged
           VimCommandLine activeCommandLine = injector.getCommandLine().getActiveCommandLine();
           if (activeCommandLine != null) {
-            activeCommandLine.close(true, false, true);
+            activeCommandLine.close(true, false);
           }
           ExOutputModel exOutputModel = ExOutputModel.tryGetInstance(editor);
           if (exOutputModel != null) {

--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -383,6 +383,10 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
           if (exOutputModel != null) {
             exOutputModel.close();
           }
+          VimModalInput modalInput = injector.getModalInput().getCurrentModalInput();
+          if (modalInput != null) {
+            modalInput.deactivate(true, false);
+          }
         }
       }
     }

--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -377,7 +377,7 @@ public class EditorGroup implements PersistentStateComponent<Element>, VimEditor
           // Note that IDE scale is handled by LafManager.lookAndFeelChanged
           VimCommandLine activeCommandLine = injector.getCommandLine().getActiveCommandLine();
           if (activeCommandLine != null) {
-            injector.getProcessGroup().cancelExEntry(new IjVimEditor(editor), true, false);
+            activeCommandLine.close(true, false, true);
           }
           ExOutputModel exOutputModel = ExOutputModel.tryGetInstance(editor);
           if (exOutputModel != null) {

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
@@ -313,7 +313,7 @@ internal class MotionGroup : VimMotionGroupBase() {
               }
               is Mode.CMD_LINE -> {
                 val commandLine = injector.commandLine.getActiveCommandLine() ?: return
-                commandLine.close(refocusOwningEditor = false, resetCaret = false, isCancel = true)
+                commandLine.close(refocusOwningEditor = false, resetCaret = false)
                 ExOutputModel.tryGetInstance(editor)?.close()
               }
               else -> {}

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
@@ -312,7 +312,8 @@ internal class MotionGroup : VimMotionGroupBase() {
                 KeyHandler.getInstance().reset(vimEditor)
               }
               is Mode.CMD_LINE -> {
-                injector.processGroup.cancelExEntry(vimEditor, refocusOwningEditor = false, resetCaret = false)
+                val commandLine = injector.commandLine.getActiveCommandLine() ?: return
+                commandLine.close(refocusOwningEditor = false, resetCaret = false, isCancel = true)
                 ExOutputModel.tryGetInstance(editor)?.close()
               }
               else -> {}

--- a/src/main/java/com/maddyhome/idea/vim/group/ProcessGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/ProcessGroup.kt
@@ -95,8 +95,6 @@ class ProcessGroup : VimProcessGroupBase() {
         val progressIndicator = ProgressIndicatorProvider.getInstance().progressIndicator
         val output = handler.runProcessWithProgressIndicator(progressIndicator)
 
-        lastCommand = command
-
         if (output.isCancelled) {
           // TODO: Vim will use whatever text has already been written to stdout
           // For whatever reason, we're not getting any here, so just throw an exception

--- a/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
@@ -29,6 +29,11 @@ import com.maddyhome.idea.vim.newapi.ij
  */
 class IJEditorFocusListener : EditorListener {
   override fun focusGained(editor: VimEditor) {
+    val editorInFocus = KeyHandler.getInstance().editorInFocus
+    if (editorInFocus != null && editorInFocus.ij == editor.ij) return
+
+    KeyHandler.getInstance().editorInFocus = editor
+
     // We add Vim bindings to all opened editors, including editors used as UI controls rather than just project file
     // editors. This includes editors used as part of the UI, such as the VCS commit message, or used as read-only
     // viewers for text output, such as log files in run configurations or the Git Console tab. And editors are used for

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -735,10 +735,7 @@ internal object VimListenerManager {
 
       if (event.area == EditorMouseEventArea.EDITING_AREA) {
         val editor = event.editor
-        val commandLine = injector.commandLine.getActiveCommandLine()
-        if (commandLine != null) {
-          injector.processGroup.cancelExEntry(editor.vim, refocusOwningEditor = true, resetCaret = false)
-        }
+        injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
 
         ExOutputModel.tryGetInstance(editor)?.close()
 
@@ -766,10 +763,7 @@ internal object VimListenerManager {
         event.area != EditorMouseEventArea.FOLDING_OUTLINE_AREA &&
         event.mouseEvent.button != MouseEvent.BUTTON3
       ) {
-        val commandLine = injector.commandLine.getActiveCommandLine()
-        if (commandLine != null) {
-          injector.processGroup.cancelExEntry(event.editor.vim, refocusOwningEditor = true, resetCaret = false)
-        }
+        injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
 
         ExOutputModel.getInstance(event.editor).close()
       }

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -736,6 +736,7 @@ internal object VimListenerManager {
       if (event.area == EditorMouseEventArea.EDITING_AREA) {
         val editor = event.editor
         injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
+        injector.modalInput.getCurrentModalInput()?.deactivate(refocusOwningEditor = true, resetCaret = false)
 
         ExOutputModel.tryGetInstance(editor)?.close()
 
@@ -764,6 +765,7 @@ internal object VimListenerManager {
         event.mouseEvent.button != MouseEvent.BUTTON3
       ) {
         injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
+        injector.modalInput.getCurrentModalInput()?.deactivate(refocusOwningEditor = true, resetCaret = false)
 
         ExOutputModel.getInstance(event.editor).close()
       }

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -735,7 +735,7 @@ internal object VimListenerManager {
 
       if (event.area == EditorMouseEventArea.EDITING_AREA) {
         val editor = event.editor
-        injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
+        injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false)
         injector.modalInput.getCurrentModalInput()?.deactivate(refocusOwningEditor = true, resetCaret = false)
 
         ExOutputModel.tryGetInstance(editor)?.close()
@@ -764,7 +764,7 @@ internal object VimListenerManager {
         event.area != EditorMouseEventArea.FOLDING_OUTLINE_AREA &&
         event.mouseEvent.button != MouseEvent.BUTTON3
       ) {
-        injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
+        injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false)
         injector.modalInput.getCurrentModalInput()?.deactivate(refocusOwningEditor = true, resetCaret = false)
 
         ExOutputModel.getInstance(event.editor).close()

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
@@ -22,6 +22,7 @@ import com.maddyhome.idea.vim.api.VimApplication
 import com.maddyhome.idea.vim.api.VimChangeGroup
 import com.maddyhome.idea.vim.api.VimClipboardManager
 import com.maddyhome.idea.vim.api.VimCommandGroup
+import com.maddyhome.idea.vim.api.VimCommandLine
 import com.maddyhome.idea.vim.api.VimCommandLineService
 import com.maddyhome.idea.vim.api.VimDigraphGroup
 import com.maddyhome.idea.vim.api.VimEditor
@@ -36,6 +37,7 @@ import com.maddyhome.idea.vim.api.VimKeyGroup
 import com.maddyhome.idea.vim.api.VimLookupManager
 import com.maddyhome.idea.vim.api.VimMarkService
 import com.maddyhome.idea.vim.api.VimMessages
+import com.maddyhome.idea.vim.api.VimModalInputService
 import com.maddyhome.idea.vim.api.VimMotionGroup
 import com.maddyhome.idea.vim.api.VimOptionGroup
 import com.maddyhome.idea.vim.api.VimOutputPanelService
@@ -83,6 +85,7 @@ import com.maddyhome.idea.vim.put.VimPut
 import com.maddyhome.idea.vim.register.VimRegisterGroup
 import com.maddyhome.idea.vim.state.VimStateMachine
 import com.maddyhome.idea.vim.ui.VimRcFileState
+import com.maddyhome.idea.vim.ui.ex.ExEntryPanelService
 import com.maddyhome.idea.vim.undo.VimUndoRedo
 import com.maddyhome.idea.vim.vimscript.Executor
 import com.maddyhome.idea.vim.vimscript.services.VariableService
@@ -183,6 +186,8 @@ internal class IjVimInjector : VimInjectorBase() {
     get() = com.maddyhome.idea.vim.vimscript.parser.VimscriptParser
   override val commandLine: VimCommandLineService
     get() = service()
+  override val modalInput: VimModalInputService
+    get() = commandLine as ExEntryPanelService
   override val outputPanel: VimOutputPanelService
     get() = service()
 

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimSearchGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimSearchGroup.kt
@@ -97,59 +97,6 @@ open class IjVimSearchGroup : VimSearchGroupBase(), PersistentStateComponent<Ele
     updateSearchHighlights(getLastUsedPattern(), lastIgnoreSmartCase, showSearchHighlight, true)
   }
 
-  override fun confirmChoice(
-    editor: VimEditor,
-    context: ExecutionContext,
-    match: String,
-    caret: VimCaret,
-    startOffset: Int,
-  ): ReplaceConfirmationChoice {
-    val result: Ref<ReplaceConfirmationChoice> = Ref.create(ReplaceConfirmationChoice.QUIT)
-    val keyStrokeProcessor: Function1<KeyStroke, Boolean> = label@{ key: KeyStroke ->
-      val choice: ReplaceConfirmationChoice
-      val c = key.keyChar
-      choice = if (key.isCloseKeyStroke() || c == 'q') {
-        ReplaceConfirmationChoice.QUIT
-      } else if (c == 'y') {
-        ReplaceConfirmationChoice.SUBSTITUTE_THIS
-      } else if (c == 'l') {
-        ReplaceConfirmationChoice.SUBSTITUTE_LAST
-      } else if (c == 'n') {
-        ReplaceConfirmationChoice.SKIP
-      } else if (c == 'a') {
-        ReplaceConfirmationChoice.SUBSTITUTE_ALL
-      } else {
-        return@label true
-      }
-      // TODO: Handle <C-E> and <C-Y>
-      result.set(choice)
-      false
-    }
-    if (ApplicationManager.getApplication().isUnitTestMode) {
-      caret.moveToOffset(startOffset)
-      val inputModel = getInstance(editor.ij)
-      var key = inputModel.nextKeyStroke()
-      while (key != null) {
-        if (!keyStrokeProcessor.invoke(key)) {
-          break
-        }
-        key = inputModel.nextKeyStroke()
-      }
-    } else {
-      // XXX: The Ex entry panel is used only for UI here, its logic might be inappropriate for this method
-      val exEntryPanel = injector.commandLine.createWithoutShortcuts(
-        editor,
-        context,
-        MessageHelper.message("replace.with.0", match),
-        "",
-      )
-      caret.moveToOffset(startOffset)
-      ModalEntry.activate(editor, keyStrokeProcessor)
-      exEntryPanel.deactivate(refocusOwningEditor = true, resetCaret = false)
-    }
-    return result.get()
-  }
-
   override fun addSubstitutionConfirmationHighlight(
     editor: VimEditor,
     startOffset: Int,

--- a/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
@@ -47,7 +47,7 @@ import static com.maddyhome.idea.vim.api.VimInjectorKt.injector;
 public class ExOutputPanel extends JPanel {
   private final @NotNull Editor myEditor;
 
-  private final @NotNull JLabel myLabel = new JLabel("more");
+  public final @NotNull JLabel myLabel = new JLabel("more");
   private final @NotNull JTextArea myText = new JTextArea();
   private final @NotNull JScrollPane myScrollPane =
     new JBScrollPane(myText, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);

--- a/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
@@ -52,7 +52,6 @@ public class ExOutputPanel extends JPanel {
   private final @NotNull JScrollPane myScrollPane =
     new JBScrollPane(myText, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
   private final @NotNull ComponentAdapter myAdapter;
-  public boolean myAtEnd = false;
   private int myLineHeight = 0;
 
   private @Nullable JComponent myOldGlass = null;
@@ -245,19 +244,22 @@ public class ExOutputPanel extends JPanel {
   }
 
   private void scrollOffset(int more) {
-    myAtEnd = false;
     int val = myScrollPane.getVerticalScrollBar().getValue();
     myScrollPane.getVerticalScrollBar().setValue(val + more);
     myScrollPane.getHorizontalScrollBar().setValue(0);
     if (val + more >=
         myScrollPane.getVerticalScrollBar().getMaximum() - myScrollPane.getVerticalScrollBar().getVisibleAmount()) {
-      myAtEnd = true;
       myLabel.setText(MessageHelper.message("hit.enter.or.type.command.to.continue"));
     }
     else {
       myLabel.setText(MessageHelper.message("ex.output.panel.more"));
     }
     myLabel.setFont(UiHelper.selectEditorFont(myEditor, myLabel.getText()));
+  }
+
+  public boolean isAtEnd() {
+    int val = myScrollPane.getVerticalScrollBar().getValue();
+    return val >= myScrollPane.getVerticalScrollBar().getMaximum() - myScrollPane.getVerticalScrollBar().getVisibleAmount();
   }
 
   private void positionPanel() {
@@ -315,7 +317,9 @@ public class ExOutputPanel extends JPanel {
         }
         KeyHandler.getInstance().getKeyStack().addKeys(keys);
         ExecutionContext context = injector.getExecutionContextManager().getEditorExecutionContext(new IjVimEditor(myEditor));
-        VimPlugin.getMacro().playbackKeys(new IjVimEditor(myEditor), context, 1);
+        injector.getApplication().runWriteAction(() -> { VimPlugin.getMacro().playbackKeys(new IjVimEditor(myEditor), context, 1);
+          return null;
+        });
       }
     });
   }

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEditorKit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEditorKit.kt
@@ -120,7 +120,8 @@ internal object ExEditorKit : DefaultEditorKit() {
           val c = key.keyChar
           if (c.code > 0) {
             if (target.useHandleKeyFromEx) {
-              val entry = ((injector.commandLine.getActiveCommandLine() ?: injector.modalInput.getCurrentModalInput()) as ExEntryPanel?)?.entry ?: return
+              val panel = ((injector.commandLine.getActiveCommandLine() as? ExEntryPanel) ?: (injector.modalInput.getCurrentModalInput() as? WrappedAsModalInputExEntryPanel)?.exEntryPanel) ?: return
+              val entry = panel.entry
               val editor = entry.editor
               val keyHandler = KeyHandler.getInstance()
               keyHandler.handleKey(editor!!.vim, key, entry.context.vim, keyHandler.keyHandlerState)

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEditorKit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEditorKit.kt
@@ -10,6 +10,7 @@ package com.maddyhome.idea.vim.ui.ex
 import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.diagnostic.logger
 import com.maddyhome.idea.vim.KeyHandler
+import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.newapi.vim
 import org.jetbrains.annotations.NonNls
 import java.awt.event.ActionEvent
@@ -119,7 +120,7 @@ internal object ExEditorKit : DefaultEditorKit() {
           val c = key.keyChar
           if (c.code > 0) {
             if (target.useHandleKeyFromEx) {
-              val entry = ExEntryPanel.getInstance().entry
+              val entry = ((injector.commandLine.getActiveCommandLine() ?: injector.modalInput.getCurrentModalInput()) as ExEntryPanel?)?.entry ?: return
               val editor = entry.editor
               val keyHandler = KeyHandler.getInstance()
               keyHandler.handleKey(editor!!.vim, key, entry.context.vim, keyHandler.keyHandlerState)

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
@@ -35,6 +35,8 @@ import com.maddyhome.idea.vim.vimscript.model.commands.Command;
 import com.maddyhome.idea.vim.vimscript.model.commands.GlobalCommand;
 import com.maddyhome.idea.vim.vimscript.model.commands.SubstituteCommand;
 import com.maddyhome.idea.vim.vimscript.parser.VimscriptParser;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -60,7 +62,10 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
   public static ExEntryPanel instanceWithoutShortcuts;
   private boolean isReplaceMode = false;
   private WeakReference<Editor> weakEditor = null;
+
   public VimInputInterceptor myInputInterceptor = null;
+  public Function1<String, Unit> inputProcessing = null;
+  public Character finishOn = null;
 
   private ExEntryPanel(boolean enableShortcuts) {
     label = new JLabel(" ");
@@ -263,6 +268,9 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
 
     // We have this in the end, because `entry.deactivate()` communicates with active panel during deactivation
     active = false;
+    finishOn = null;
+    myInputInterceptor = null;
+    inputProcessing = null;
   }
 
   private void reset() {
@@ -569,6 +577,18 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
 
   public void setInputInterceptor(@NotNull VimInputInterceptor<?> vimInputInterceptor) {
     myInputInterceptor = vimInputInterceptor;
+  }
+
+  @Nullable
+  @Override
+  public Function1<String, Unit> getInputProcessing() {
+    return inputProcessing;
+  }
+
+  @Nullable
+  @Override
+  public Character getFinishOn() {
+    return finishOn;
   }
 
   public static class LafListener implements LafManagerListener {

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
@@ -63,7 +63,7 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
   private boolean isReplaceMode = false;
   private WeakReference<Editor> weakEditor = null;
 
-  public VimInputInterceptor myInputInterceptor = null;
+  private VimInputInterceptor myInputInterceptor = null;
   public Function1<String, Unit> inputProcessing = null;
   public Character finishOn = null;
 
@@ -569,7 +569,7 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
     IdeFocusManager.findInstance().requestFocus(entry, true);
   }
 
-  @NotNull
+  @Nullable
   public VimInputInterceptor<?> getInputInterceptor() {
     return myInputInterceptor;
   }
@@ -579,7 +579,7 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
     VimCommandLine.super.insertText(offset, string);
   }
 
-  public void setInputInterceptor(@NotNull VimInputInterceptor<?> vimInputInterceptor) {
+  public void setInputInterceptor(@Nullable VimInputInterceptor<?> vimInputInterceptor) {
     myInputInterceptor = vimInputInterceptor;
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
@@ -125,8 +125,16 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
     }
   }
 
-  public @Nullable Editor getEditor() {
+  public @Nullable Editor getIjEditor() {
     return weakEditor != null ? weakEditor.get() : null;
+  }
+
+  public @NotNull VimEditor getEditor() {
+    Editor editor = getIjEditor();
+    if (editor == null) {
+      throw new RuntimeException("Editor was disposed for active command line");
+    }
+    return new IjVimEditor(editor);
   }
 
   public void setEditor(@Nullable Editor editor) {
@@ -279,7 +287,7 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
     @Override
     protected void textChanged(@NotNull DocumentEvent e) {
       String text = entry.getText();
-      Font newFont = UiHelper.selectEditorFont(getEditor(), text);
+      Font newFont = UiHelper.selectEditorFont(getIjEditor(), text);
       if (newFont != entry.getFont()) {
         entry.setFont(newFont);
       }
@@ -460,8 +468,8 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
   }
 
   private void setFontForElements() {
-    label.setFont(UiHelper.selectEditorFont(getEditor(), label.getText()));
-    entry.setFont(UiHelper.selectEditorFont(getEditor(), getVisibleText()));
+    label.setFont(UiHelper.selectEditorFont(getIjEditor(), label.getText()));
+    entry.setFont(UiHelper.selectEditorFont(getIjEditor(), getVisibleText()));
   }
 
   private void positionPanel() {

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
@@ -55,7 +55,7 @@ import static com.maddyhome.idea.vim.group.KeyGroup.toShortcutSet;
 /**
  * This is used to enter ex commands such as searches and "colon" commands
  */
-public class ExEntryPanel extends JPanel implements VimCommandLine, VimModalInput {
+public class ExEntryPanel extends JPanel implements VimCommandLine {
   public static ExEntryPanel instance;
   public static ExEntryPanel instanceWithoutShortcuts;
   private boolean isReplaceMode = false;
@@ -79,15 +79,13 @@ public class ExEntryPanel extends JPanel implements VimCommandLine, VimModalInpu
     layout.setConstraints(entry, gbc);
     add(entry);
 
-    if (enableShortcuts) {
-      // This does not need to be unregistered, it's registered as a custom UI property on this
-      EventFacade.getInstance().registerCustomShortcutSet(
-        VimShortcutKeyAction.getInstance(),
-        toShortcutSet(((VimKeyGroupBase) injector.getKeyGroup()).getRequiredShortcutKeys()),
-        entry
-      );
-      new ExShortcutKeyAction(this).registerCustomShortcutSet();
-    }
+    // This does not need to be unregistered, it's registered as a custom UI property on this
+    EventFacade.getInstance().registerCustomShortcutSet(
+      VimShortcutKeyAction.getInstance(),
+      toShortcutSet(((VimKeyGroupBase) injector.getKeyGroup()).getRequiredShortcutKeys()),
+      entry
+    );
+    new ExShortcutKeyAction(this).registerCustomShortcutSet();
 
     updateUI();
   }
@@ -552,20 +550,8 @@ public class ExEntryPanel extends JPanel implements VimCommandLine, VimModalInpu
   }
 
   @NotNull
-  @Override
   public VimInputInterceptor<?> getInputInterceptor() {
     return myInputInterceptor;
-  }
-
-  @NotNull
-  @Override
-  public String getText() {
-    return getVisibleText();
-  }
-
-  @Override
-  public void handleKey(@NotNull KeyStroke key, @NotNull VimEditor editor, @NotNull ExecutionContext executionContext) {
-    getInputInterceptor().consumeKey(key, editor, executionContext);
   }
 
   @Override
@@ -573,7 +559,6 @@ public class ExEntryPanel extends JPanel implements VimCommandLine, VimModalInpu
     VimCommandLine.super.insertText(offset, string);
   }
 
-  @Override
   public void setInputInterceptor(@NotNull VimInputInterceptor<?> vimInputInterceptor) {
     myInputInterceptor = vimInputInterceptor;
   }

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
@@ -439,6 +439,10 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
   @Override
   public void handleKey(@NotNull KeyStroke stroke) {
     entry.handleKey(stroke);
+    if (finishOn != null && stroke.getKeyChar() == finishOn && inputProcessing != null) {
+      inputProcessing.invoke(getActualText());
+      close(true, true, false);
+    }
   }
 
   // Called automatically when the LAF is changed and the component is visible, and manually by the LAF listener handler

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.java
@@ -441,7 +441,7 @@ public class ExEntryPanel extends JPanel implements VimCommandLine {
     entry.handleKey(stroke);
     if (finishOn != null && stroke.getKeyChar() == finishOn && inputProcessing != null) {
       inputProcessing.invoke(getActualText());
-      close(true, true, false);
+      close(true, true);
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
@@ -163,11 +163,6 @@ internal class WrappedAsModalInputExEntryPanel(internal val exEntryPanel: ExEntr
     set(value) { exEntryPanel.myInputInterceptor = value }
   override val caret: VimCommandLineCaret = exEntryPanel.caret
   override val label: String = exEntryPanel.label
-  override val text: String = exEntryPanel.actualText
-
-  override fun setText(string: String) {
-    exEntryPanel.setText(string)
-  }
 
   override fun deactivate(refocusOwningEditor: Boolean, resetCaret: Boolean) {
     exEntryPanel.deactivate(refocusOwningEditor, resetCaret)

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
@@ -147,7 +147,7 @@ class ExEntryPanelService : VimCommandLineServiceBase(), VimModalInputService {
   }
 
   override fun getCurrentModalInput(): VimModalInput? {
-    return ExEntryPanel.getInstanceWithoutShortcuts()?.takeIf { it.isActive }?.let { WrappedAsModalInputExEntryPanel(it) }
+    return ExEntryPanel.getInstanceWithoutShortcuts()?.takeIf { it.isActive && it.myInputInterceptor != null }?.let { WrappedAsModalInputExEntryPanel(it) }
   }
 
   override fun create(editor: VimEditor, context: ExecutionContext, label: String, inputInterceptor: VimInputInterceptor<*>): VimModalInput {

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
@@ -36,7 +36,8 @@ class ExEntryPanelService : VimCommandLineServiceBase(), VimModalInputService {
     return if (instance.isActive) instance else null
   }
 
-  override fun inputString(vimEditor: VimEditor, context: ExecutionContext, prompt: String, finishOn: Char?): String? {
+  @Deprecated("Please use readInputAndProcess")
+  fun inputString(vimEditor: VimEditor, context: ExecutionContext, prompt: String, finishOn: Char?): String? {
     val editor = vimEditor.ij
     if (vimEditor.inRepeatMode) {
       val input = Extension.consumeString()

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
@@ -12,7 +12,7 @@ import com.maddyhome.idea.vim.action.change.Extension
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimCommandLine
 import com.maddyhome.idea.vim.api.VimCommandLineCaret
-import com.maddyhome.idea.vim.api.VimCommandLineService
+import com.maddyhome.idea.vim.api.VimCommandLineServiceBase
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimModalInput
 import com.maddyhome.idea.vim.api.VimModalInputBase
@@ -30,7 +30,7 @@ import com.maddyhome.idea.vim.ui.ModalEntry
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-class ExEntryPanelService : VimCommandLineService, VimModalInputService {
+class ExEntryPanelService : VimCommandLineServiceBase(), VimModalInputService {
   override fun getActiveCommandLine(): VimCommandLine? {
     val instance = ExEntryPanel.instance ?: return null
     return if (instance.isActive) instance else null
@@ -65,7 +65,7 @@ class ExEntryPanelService : VimCommandLineService, VimModalInputService {
     } else {
       var text: String? = null
       // XXX: The Ex entry panel is used only for UI here, its logic might be inappropriate for input()
-      val commandLine = injector.commandLine.create(vimEditor, context, prompt.ifEmpty { " " }, "")
+      val commandLine = injector.commandLine.createSearchPrompt(vimEditor, context, prompt.ifEmpty { " " }, "")
       ModalEntry.activate(editor.vim) { key: KeyStroke ->
         return@activate when {
           key.isCloseKeyStroke() -> {
@@ -129,7 +129,7 @@ class ExEntryPanelService : VimCommandLineService, VimModalInputService {
     panel.activate(editor.ij, context.ij, prompt, "")
   }
 
-  override fun create(editor: VimEditor, context: ExecutionContext, label: String, initText: String): VimCommandLine {
+  override fun createPanel(editor: VimEditor, context: ExecutionContext, label: String, initText: String): VimCommandLine {
     val panel = ExEntryPanel.getInstance()
     panel.activate(editor.ij, context.ij, label, initText)
     return panel

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
@@ -147,12 +147,12 @@ class ExEntryPanelService : VimCommandLineServiceBase(), VimModalInputService {
   }
 
   override fun getCurrentModalInput(): VimModalInput? {
-    return ExEntryPanel.getInstanceWithoutShortcuts()?.takeIf { it.isActive && it.myInputInterceptor != null }?.let { WrappedAsModalInputExEntryPanel(it) }
+    return ExEntryPanel.getInstanceWithoutShortcuts()?.takeIf { it.isActive && it.inputInterceptor != null }?.let { WrappedAsModalInputExEntryPanel(it) }
   }
 
   override fun create(editor: VimEditor, context: ExecutionContext, label: String, inputInterceptor: VimInputInterceptor<*>): VimModalInput {
     val panel = ExEntryPanel.getInstanceWithoutShortcuts()
-    panel.myInputInterceptor = inputInterceptor
+    panel.inputInterceptor = inputInterceptor
     panel.activate(editor.ij, context.ij, label, "")
     return WrappedAsModalInputExEntryPanel(panel)
   }
@@ -160,8 +160,8 @@ class ExEntryPanelService : VimCommandLineServiceBase(), VimModalInputService {
 
 internal class WrappedAsModalInputExEntryPanel(internal val exEntryPanel: ExEntryPanel) : VimModalInputBase() {
   override var inputInterceptor: VimInputInterceptor<*>
-    get() = exEntryPanel.myInputInterceptor
-    set(value) { exEntryPanel.myInputInterceptor = value }
+    get() = exEntryPanel.inputInterceptor!!
+    set(value) { exEntryPanel.inputInterceptor = value }
   override val caret: VimCommandLineCaret = exEntryPanel.caret
   override val label: String = exEntryPanel.label
 

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
@@ -13,19 +13,22 @@ import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimCommandLine
 import com.maddyhome.idea.vim.api.VimCommandLineService
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.VimModalInput
+import com.maddyhome.idea.vim.api.VimModalInputService
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.helper.TestInputModel
 import com.maddyhome.idea.vim.helper.inRepeatMode
 import com.maddyhome.idea.vim.helper.isCloseKeyStroke
+import com.maddyhome.idea.vim.key.interceptors.VimInputInterceptor
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.ui.ModalEntry
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-class ExEntryPanelService : VimCommandLineService {
+class ExEntryPanelService : VimCommandLineService, VimModalInputService {
   override fun getActiveCommandLine(): VimCommandLine? {
-    val instance = ExEntryPanel.instance ?: ExEntryPanel.instanceWithoutShortcuts ?: return null
+    val instance = ExEntryPanel.instance ?: return null
     return if (instance.isActive) instance else null
   }
 
@@ -103,5 +106,16 @@ class ExEntryPanelService : VimCommandLineService {
 
   override fun fullReset() {
     ExEntryPanel.fullReset()
+  }
+
+  override fun getCurrentModalInput(): VimModalInput? {
+    return ExEntryPanel.getInstanceWithoutShortcuts()?.takeIf { it.isActive }
+  }
+
+  override fun create(editor: VimEditor, context: ExecutionContext, label: String, inputInterceptor: VimInputInterceptor<*>): VimModalInput {
+    val panel = ExEntryPanel.getInstanceWithoutShortcuts()
+    panel.myInputInterceptor = inputInterceptor
+    panel.activate(editor.ij, context.ij, label, "")
+    return panel
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.java
@@ -294,7 +294,7 @@ public class ExTextField extends JTextField {
     clearCurrentAction();
     VimCommandLine commandLine = injector.getCommandLine().getActiveCommandLine();
     if (commandLine != null) {
-      commandLine.close(true, true, true);
+      commandLine.close(true, true);
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.java
@@ -16,6 +16,7 @@ import com.intellij.util.ui.JBUI;
 import com.maddyhome.idea.vim.VimPlugin;
 import com.maddyhome.idea.vim.api.VimCommandLine;
 import com.maddyhome.idea.vim.api.VimCommandLineCaret;
+import com.maddyhome.idea.vim.api.VimEditor;
 import com.maddyhome.idea.vim.helper.UiHelper;
 import com.maddyhome.idea.vim.history.HistoryConstants;
 import com.maddyhome.idea.vim.history.HistoryEntry;
@@ -211,7 +212,7 @@ public class ExTextField extends JTextField {
   }
 
   public @Nullable Editor getEditor() {
-    return ExEntryPanel.getInstance().getEditor();
+    return ExEntryPanel.getInstance().getIjEditor();
   }
 
   public DataContext getContext() {
@@ -291,9 +292,9 @@ public class ExTextField extends JTextField {
    */
   void cancel() {
     clearCurrentAction();
-    Editor editor = ExEntryPanel.instance.getEditor();
-    if (editor != null) {
-      VimPlugin.getProcess().cancelExEntry(new IjVimEditor(editor), true, true);
+    VimCommandLine commandLine = injector.getCommandLine().getActiveCommandLine();
+    if (commandLine != null) {
+      commandLine.close(true, true, true);
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/commands/CmdFilterCommand.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/commands/CmdFilterCommand.kt
@@ -39,7 +39,7 @@ internal data class CmdFilterCommand(val range: Range, val argument: String) : C
       argument.forEach { c ->
         when {
           !inBackslash && c == '!' -> {
-            val last = VimPlugin.getProcess().lastCommand
+            val last = lastCommand
             if (last.isNullOrEmpty()) {
               VimPlugin.showMessage(MessageHelper.message("e_noprev"))
               return ExecutionResult.Error
@@ -76,6 +76,7 @@ internal data class CmdFilterCommand(val range: Range, val argument: String) : C
         VimPlugin.getProcess().executeCommand(editor, command, null, workingDirectory)?.let {
           ExOutputModel.getInstance(editor.ij).output(it)
         }
+        lastCommand = command
         ExecutionResult.Success
       } else {
         // Filter
@@ -92,6 +93,7 @@ internal data class CmdFilterCommand(val range: Range, val argument: String) : C
             }
           }
         }
+        lastCommand = command
         ExecutionResult.Success
       }
     } catch (e: ProcessCanceledException) {
@@ -103,5 +105,6 @@ internal data class CmdFilterCommand(val range: Range, val argument: String) : C
 
   companion object {
     private val logger = Logger.getInstance(CmdFilterCommand::class.java.name)
+    private var lastCommand: String? = null
   }
 }

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -223,6 +223,7 @@ abstract class VimTestCase {
     VimPlugin.getKey().savedShortcutConflicts.clear()
     assertTrue(KeyHandler.getInstance().keyStack.isEmpty())
     injector.outputPanel.getCurrentOutputPanel()?.close()
+    injector.modalInput.getCurrentModalInput()?.deactivate(refocusOwningEditor = false, resetCaret = false)
 
     // Tear down neovim
     NeovimTesting.tearDown(testInfo)

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/impl/TestInjector.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/impl/TestInjector.kt
@@ -27,6 +27,9 @@ class TestInjector(val injector: VimInjector) : VimInjector by injector {
     tracers[key] = collector
   }
 
+  override val modalInput
+    get() = injector.modalInput
+
   override val vimState
     get() = injector.vimState
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -135,12 +135,12 @@ class KeyHandler {
 
       injector.messages.clearError()
       // We only record unmapped keystrokes. If we've recursed to handle mapping, don't record anything.
-      val shouldRecord = MutableBoolean(handleKeyRecursionCount == 0 && injector.registerGroup.isRecording)
+      val shouldRecord = handleKeyRecursionCount == 0 && injector.registerGroup.isRecording
 
       handleKeyRecursionCount++
       try {
         val isProcessed = keyConsumers.any {
-          it.consumeKey(key, editor, allowKeyMappings, mappingCompleted, processBuilder, shouldRecord)
+          it.consumeKey(key, editor, allowKeyMappings, mappingCompleted, processBuilder)
         }
         if (isProcessed) {
           logger.trace { "Key was successfully caught by consumer" }
@@ -166,7 +166,7 @@ class KeyHandler {
     editor: VimEditor,
     context: ExecutionContext,
     key: KeyStroke?,
-    shouldRecord: MutableBoolean,
+    shouldRecord: Boolean,
     keyState: KeyHandlerState,
   ) {
     // Do we have a fully entered command at this point? If so, let's execute it.
@@ -178,7 +178,7 @@ class KeyHandler {
     }
 
     // Don't record the keystroke that stops the recording (unmapped this is `q`)
-    if (shouldRecord.value && injector.registerGroup.isRecording && key != null) {
+    if (shouldRecord && injector.registerGroup.isRecording && key != null) {
       injector.registerGroup.recordKeyStroke(key)
       modalEntryKeys.forEach { injector.registerGroup.recordKeyStroke(it) }
       modalEntryKeys.clear()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -31,6 +31,7 @@ import com.maddyhome.idea.vim.key.consumers.CommandCountConsumer
 import com.maddyhome.idea.vim.key.consumers.DeleteCommandConsumer
 import com.maddyhome.idea.vim.key.consumers.DigraphConsumer
 import com.maddyhome.idea.vim.key.consumers.EditorResetConsumer
+import com.maddyhome.idea.vim.key.consumers.ModalInputConsumer
 import com.maddyhome.idea.vim.key.consumers.ModeInputConsumer
 import com.maddyhome.idea.vim.key.consumers.RegisterConsumer
 import com.maddyhome.idea.vim.key.consumers.SelectRegisterConsumer
@@ -51,7 +52,7 @@ import javax.swing.KeyStroke
 // 2. maybe we can live without allowKeyMappings: Boolean & mappingCompleted: Boolean
 class KeyHandler {
   private var editorInFocusReference: WeakReference<VimEditor>? = null
-  private val keyConsumers: List<KeyConsumer> = listOf(MappingProcessor, CommandCountConsumer(), DeleteCommandConsumer(), EditorResetConsumer(), CharArgumentConsumer(), RegisterConsumer(), DigraphConsumer(), CommandConsumer(), SelectRegisterConsumer(), ModeInputConsumer())
+  private val keyConsumers: List<KeyConsumer> = listOf(ModalInputConsumer(), MappingProcessor, CommandCountConsumer(), DeleteCommandConsumer(), EditorResetConsumer(), CharArgumentConsumer(), RegisterConsumer(), DigraphConsumer(), CommandConsumer(), SelectRegisterConsumer(), ModeInputConsumer())
   private var handleKeyRecursionCount = 0
 
   var keyHandlerState: KeyHandlerState = KeyHandlerState()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -39,6 +39,7 @@ import com.maddyhome.idea.vim.state.VimStateMachine
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.ReturnTo
 import com.maddyhome.idea.vim.state.mode.returnTo
+import java.lang.ref.WeakReference
 import javax.swing.KeyStroke
 
 /**
@@ -49,6 +50,7 @@ import javax.swing.KeyStroke
 // 1. avoid using handleKeyRecursionCount & shouldRecord
 // 2. maybe we can live without allowKeyMappings: Boolean & mappingCompleted: Boolean
 class KeyHandler {
+  private var editorInFocusReference: WeakReference<VimEditor>? = null
   private val keyConsumers: List<KeyConsumer> = listOf(MappingProcessor, CommandCountConsumer(), DeleteCommandConsumer(), EditorResetConsumer(), CharArgumentConsumer(), RegisterConsumer(), DigraphConsumer(), CommandConsumer(), SelectRegisterConsumer(), ModeInputConsumer())
   private var handleKeyRecursionCount = 0
 
@@ -57,6 +59,12 @@ class KeyHandler {
 
   val keyStack: KeyStack = KeyStack()
   val modalEntryKeys: MutableList<KeyStroke> = ArrayList()
+
+  var editorInFocus: VimEditor?
+    get() = editorInFocusReference?.get()
+    set(value) {
+      editorInFocusReference = WeakReference(value)
+    }
 
   /**
    * This is the main key handler for the Vim plugin. Every keystroke not handled directly by Idea is sent here for

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/FilterMotionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/FilterMotionAction.kt
@@ -70,6 +70,6 @@ class FilterMotionAction : VimActionHandler.SingleExecution(), FilterCommand, Du
 
 interface FilterCommand {
   fun startFilterCommand(editor: VimEditor, context: ExecutionContext, cmd: Command) {
-    injector.processGroup.startExEntry(editor, context, cmd, initialCommandText = "!")
+    injector.commandLine.createCommandPrompt(editor, context, cmd, initialText = "!")
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertRegisterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertRegisterAction.kt
@@ -68,9 +68,7 @@ class InsertRegisterAction : VimActionHandler.SingleExecution() {
           val textToStore = expression.toInsertableString()
           injector.registerGroup.storeTextSpecial('=', textToStore)
         }
-        injector.application.runWriteAction {
-          insertRegister(editor, context, '=', operatorArguments)
-        }
+        insertRegister(editor, context, '=', operatorArguments)
       } catch (e: ExException) {
         injector.messages.indicateError()
         injector.messages.showStatusBarMessage(editor, e.message)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ExEntryAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ExEntryAction.kt
@@ -26,7 +26,7 @@ internal class ExEntryAction : VimActionHandler.SingleExecution() {
 
   override fun execute(editor: VimEditor, context: ExecutionContext, cmd: Command, operatorArguments: OperatorArguments): Boolean {
     if (editor.isOneLineMode()) return false
-    injector.processGroup.startExEntry(editor, context, cmd)
+    injector.commandLine.createCommandPrompt(editor, context, cmd, initialText = "")
     return true
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ProcessExEntryActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ProcessExEntryActions.kt
@@ -100,9 +100,6 @@ class ProcessExCommandEntryAction : MotionActionHandler.SingleExecution() {
     } catch (bad: Exception) {
       logger.error("Error during command execution", bad)
       injector.messages.indicateError()
-    } finally {
-      injector.processGroup.isCommandProcessing = false
-      injector.processGroup.modeBeforeCommandProcessing = null
     }
     // TODO support motions for commands
     return Motion.NoMotion

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ProcessExEntryActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ProcessExEntryActions.kt
@@ -34,7 +34,26 @@ class ProcessExEntryAction : MotionActionHandler.AmbiguousExecution()  {
   override var motionType: MotionType = MotionType.EXCLUSIVE
 
   override fun getMotionActionHandler(argument: Argument?): MotionActionHandler {
+    if (argument?.processing != null) return ExecuteDefinedInputProcessingAction()
     return if (argument?.character == ':') ProcessExCommandEntryAction() else ProcessSearchEntryAction(this)
+  }
+}
+
+class ExecuteDefinedInputProcessingAction : MotionActionHandler.SingleExecution() {
+  override val motionType: MotionType = MotionType.LINE_WISE
+
+  override fun getOffset(
+    editor: VimEditor,
+    context: ExecutionContext,
+    argument: Argument?,
+    operatorArguments: OperatorArguments,
+  ): Motion {
+    if (argument == null) return Motion.Error
+    val input = argument.string
+    val processing = argument.processing!!
+
+    processing.invoke(input)
+    return Motion.NoMotion
   }
 }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/search/SearchEntryActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/search/SearchEntryActions.kt
@@ -17,7 +17,6 @@ import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.enumSetOf
-import com.maddyhome.idea.vim.state.mode.ReturnableFromCmd
 import java.util.*
 
 @CommandOrMotion(keys = ["/"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
@@ -43,15 +42,5 @@ class SearchEntryRevAction : VimActionHandler.SingleExecution() {
 }
 
 private fun startSearchCommand(label: Char, editor: VimEditor, context: ExecutionContext) {
-  // Don't allow searching in one line editors
-  if (editor.isOneLineMode()) return
-
-  // Switch to Command-line mode. Unlike ex command entry, search does not switch to Normal first, and does not remove
-  // selection (neither does IdeaVim's ex command entry, to be honest. See startExEntry for implementation details).
-  // We maintain the current mode so that we can return to it correctly when search is done.
-  val currentMode = editor.mode
-  check(currentMode is ReturnableFromCmd) { "Cannot enable command line mode $currentMode" }
-  editor.mode = com.maddyhome.idea.vim.state.mode.Mode.CMD_LINE(currentMode)
-
-  injector.commandLine.create(editor, context, label.toString(), "")
+  injector.commandLine.createSearchPrompt(editor, context, label.toString(), "")
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
@@ -9,7 +9,6 @@
 package com.maddyhome.idea.vim.api
 
 import com.maddyhome.idea.vim.state.mode.returnTo
-import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import javax.swing.KeyStroke
 import kotlin.math.min
@@ -91,24 +90,11 @@ interface VimCommandLine {
    * TODO remove me, close is safer
    */
   fun deactivate(refocusOwningEditor: Boolean, resetCaret: Boolean)
-  fun close(refocusOwningEditor: Boolean, resetCaret: Boolean, isCancel: Boolean) {
+  fun close(refocusOwningEditor: Boolean, resetCaret: Boolean) {
     // If 'cpoptions' contains 'x', then Escape should execute the command line. This is the default for Vi but not Vim.
     // IdeaVim does not (currently?) support 'cpoptions', so sticks with Vim's default behaviour. Escape cancels.
     editor.mode = editor.mode.returnTo()
     deactivate(refocusOwningEditor, resetCaret)
-  }
-
-  fun close(refocusOwningEditor: Boolean, resetCaret: Boolean) {
-    // If 'cpoptions' contains 'x', then Escape should execute the command line. This is the default for Vi but not Vim.
-    // IdeaVim does not (currently?) support 'cpoptions', so sticks with Vim's default behaviour. Escape cancels.
-    val editorSnapshot = editor
-    if (editorSnapshot != null) {
-      editorSnapshot.mode = editorSnapshot.mode.returnTo()
-      KeyHandler.getInstance().reset(editorSnapshot)
-    } else {
-      logger.error("Editor was disposed while command line was still active")
-    }
-    injector.commandLine.getActiveCommandLine()?.deactivate(refocusOwningEditor, resetCaret)
   }
 
   // FIXME I don't want it to conflict with Swings `requestFocus` and can suggest a better name

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
@@ -88,7 +88,7 @@ interface VimCommandLine {
   fun clearCurrentAction()
 
   /**
-   * TODO remove me
+   * TODO remove me, close is safer
    */
   fun deactivate(refocusOwningEditor: Boolean, resetCaret: Boolean)
   fun close(refocusOwningEditor: Boolean, resetCaret: Boolean, isCancel: Boolean) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
@@ -9,10 +9,19 @@
 package com.maddyhome.idea.vim.api
 
 import com.maddyhome.idea.vim.state.mode.returnTo
+import com.maddyhome.idea.vim.KeyHandler
+import com.maddyhome.idea.vim.diagnostic.vimLogger
 import javax.swing.KeyStroke
 import kotlin.math.min
 
 interface VimCommandLine {
+  companion object {
+    private val logger = vimLogger<VimCommandLine>()
+  }
+
+  val inputProcessing: ((String) -> Unit)?
+  val finishOn: Char?
+
   val editor: VimEditor
   val caret: VimCommandLineCaret
 
@@ -87,6 +96,19 @@ interface VimCommandLine {
     // IdeaVim does not (currently?) support 'cpoptions', so sticks with Vim's default behaviour. Escape cancels.
     editor.mode = editor.mode.returnTo()
     deactivate(refocusOwningEditor, resetCaret)
+  }
+
+  fun close(refocusOwningEditor: Boolean, resetCaret: Boolean) {
+    // If 'cpoptions' contains 'x', then Escape should execute the command line. This is the default for Vi but not Vim.
+    // IdeaVim does not (currently?) support 'cpoptions', so sticks with Vim's default behaviour. Escape cancels.
+    val editorSnapshot = editor
+    if (editorSnapshot != null) {
+      editorSnapshot.mode = editorSnapshot.mode.returnTo()
+      KeyHandler.getInstance().reset(editorSnapshot)
+    } else {
+      logger.error("Editor was disposed while command line was still active")
+    }
+    injector.commandLine.getActiveCommandLine()?.deactivate(refocusOwningEditor, resetCaret)
   }
 
   // FIXME I don't want it to conflict with Swings `requestFocus` and can suggest a better name

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
@@ -13,6 +13,14 @@ import com.maddyhome.idea.vim.diagnostic.vimLogger
 import javax.swing.KeyStroke
 import kotlin.math.min
 
+/**
+ * This interface is not supposed to have any implementation logic.
+ * The reason why we have implementation details here is
+ * that this class extended by [ExEntryPanel] that already extends [JPanel]
+ * and can't extend a base implementation of [VimCommandLine].
+ * It will also be hard to wrap [ExEntryPanel] into some other class that extends [VimCommandLine],
+ * because [ExEntryPanel] has a listener that should use the [actualText] field, so it must implement [VimCommandLine]
+ */
 interface VimCommandLine {
   companion object {
     private val logger = vimLogger<VimCommandLine>()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
@@ -8,10 +8,12 @@
 
 package com.maddyhome.idea.vim.api
 
+import com.maddyhome.idea.vim.state.mode.returnTo
 import javax.swing.KeyStroke
 import kotlin.math.min
 
 interface VimCommandLine {
+  val editor: VimEditor
   val caret: VimCommandLineCaret
 
   val label: String
@@ -76,7 +78,16 @@ interface VimCommandLine {
 
   fun clearCurrentAction()
 
+  /**
+   * TODO remove me
+   */
   fun deactivate(refocusOwningEditor: Boolean, resetCaret: Boolean)
+  fun close(refocusOwningEditor: Boolean, resetCaret: Boolean, isCancel: Boolean) {
+    // If 'cpoptions' contains 'x', then Escape should execute the command line. This is the default for Vi but not Vim.
+    // IdeaVim does not (currently?) support 'cpoptions', so sticks with Vim's default behaviour. Escape cancels.
+    editor.mode = editor.mode.returnTo()
+    deactivate(refocusOwningEditor, resetCaret)
+  }
 
   // FIXME I don't want it to conflict with Swings `requestFocus` and can suggest a better name
   fun focus()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineService.kt
@@ -8,6 +8,8 @@
 
 package com.maddyhome.idea.vim.api
 
+import com.maddyhome.idea.vim.command.Command
+
 interface VimCommandLineService {
   fun getActiveCommandLine(): VimCommandLine?
 
@@ -22,9 +24,10 @@ interface VimCommandLineService {
    * @param editor   The editor to use for display
    * @param context  The data context
    * @param label    The label for the command line (i.e. :, /, or ?)
-   * @param initText The initial text for the entry
+   * @param initialText The initial text for the entry
    */
-  fun create(editor: VimEditor, context: ExecutionContext, label: String, initText: String): VimCommandLine
+  fun createSearchPrompt(editor: VimEditor, context: ExecutionContext, label: String, initialText: String): VimCommandLine
+  fun createCommandPrompt(editor: VimEditor, context: ExecutionContext, command: Command, initialText: String): VimCommandLine
 
   @Deprecated("Please use ModalInputService.create()")
   fun createWithoutShortcuts(editor: VimEditor, context: ExecutionContext, label: String, initText: String): VimCommandLine

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineService.kt
@@ -11,6 +11,7 @@ package com.maddyhome.idea.vim.api
 interface VimCommandLineService {
   fun getActiveCommandLine(): VimCommandLine?
 
+  @Deprecated("Please use ModalInputService")
   fun inputString(vimEditor: VimEditor, context: ExecutionContext, prompt: String, finishOn: Char?): String?
 
   /**
@@ -23,6 +24,7 @@ interface VimCommandLineService {
    */
   fun create(editor: VimEditor, context: ExecutionContext, label: String, initText: String): VimCommandLine
 
+  @Deprecated("Please use ModalInputService.create()")
   fun createWithoutShortcuts(editor: VimEditor, context: ExecutionContext, label: String, initText: String): VimCommandLine
 
   fun fullReset()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineService.kt
@@ -11,8 +11,10 @@ package com.maddyhome.idea.vim.api
 interface VimCommandLineService {
   fun getActiveCommandLine(): VimCommandLine?
 
-  @Deprecated("Please use ModalInputService")
+  @Deprecated("Please use readInputAndProcess")
   fun inputString(vimEditor: VimEditor, context: ExecutionContext, prompt: String, finishOn: Char?): String?
+
+  fun readInputAndProcess(vimEditor: VimEditor, context: ExecutionContext, prompt: String, finishOn: Char?, processing: (String) -> Unit)
 
   /**
    * Turns on the command line for the given editor

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineService.kt
@@ -13,9 +13,6 @@ import com.maddyhome.idea.vim.command.Command
 interface VimCommandLineService {
   fun getActiveCommandLine(): VimCommandLine?
 
-  @Deprecated("Please use readInputAndProcess")
-  fun inputString(vimEditor: VimEditor, context: ExecutionContext, prompt: String, finishOn: Char?): String?
-
   fun readInputAndProcess(vimEditor: VimEditor, context: ExecutionContext, prompt: String, finishOn: Char?, processing: (String) -> Unit)
 
   /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineServiceBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineServiceBase.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.api
+
+import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.ex.ExException
+import com.maddyhome.idea.vim.state.mode.Mode
+import com.maddyhome.idea.vim.state.mode.ReturnableFromCmd
+import com.maddyhome.idea.vim.state.mode.inVisualMode
+
+abstract class VimCommandLineServiceBase : VimCommandLineService {
+  abstract fun createPanel(editor: VimEditor, context: ExecutionContext, label: String, initText: String): VimCommandLine
+
+  private fun createCommandLinePrompt(editor: VimEditor, context: ExecutionContext, removeSelections: Boolean, label: String, initialText: String): VimCommandLine {
+    if (editor.isOneLineMode()) throw ExException("Command line is not allowed in one line editors")
+
+    val currentMode = editor.mode
+    check(currentMode is ReturnableFromCmd) {
+      "Cannot enable cmd mode from current mode $currentMode"
+    }
+
+    if (removeSelections) {
+      // Make sure the Visual selection marks are up to date before we use them.
+      injector.markService.setVisualSelectionMarks(editor)
+      // Note that we should remove selection and reset caret offset before we switch back to Normal mode and then enter
+      // Command-line mode. However, some IdeaVim commands can handle multiple carets, including multiple carets with
+      // selection (which might or might not be a block selection). Unfortunately, because we're just entering
+      // Command-line mode, we don't know which command is going to be entered, so we can't remove selection here.
+      // Therefore, we switch to Normal and then Command-line even though we might still have a Visual selection...
+      // On the plus side, it means we still show selection while editing the command line, which Vim also does
+      // (Normal then Command-line is not strictly necessary, but done for completeness and autocmd)
+      // Caret selection is finally handled in Command.execute
+      editor.mode = Mode.NORMAL()
+    }
+    editor.mode = Mode.CMD_LINE(currentMode)
+    return createPanel(editor, context, label, initialText)
+  }
+
+  override fun createSearchPrompt(editor: VimEditor, context: ExecutionContext, label: String, initialText: String): VimCommandLine {
+    return createCommandLinePrompt(editor, context, removeSelections = false, label, initialText)
+  }
+
+  override fun createCommandPrompt(editor: VimEditor, context: ExecutionContext, command: Command, initialText: String): VimCommandLine {
+    val rangeText = getRange(editor, command)
+    return createCommandLinePrompt(editor, context, removeSelections = true, label = ":", rangeText + initialText)
+  }
+
+  protected fun getRange(editor: VimEditor, cmd: Command) = when {
+    editor.inVisualMode -> "'<,'>"
+    cmd.rawCount == 1 -> "."
+    cmd.rawCount > 1 -> ".,.+" + (cmd.count - 1)
+    else -> ""
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
@@ -175,6 +175,7 @@ interface VimInjector {
   // !! in progress
   val variableService: VariableService
 
+  val modalInput: VimModalInputService
   val commandLine: VimCommandLineService
   val outputPanel: VimOutputPanelService
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInput.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInput.kt
@@ -15,11 +15,6 @@ interface VimModalInput {
   var inputInterceptor: VimInputInterceptor<*>
   val caret: VimCommandLineCaret
   val label: String
-  val text: String
-
-  fun setText(string: String)
-  fun insertText(offset: Int, string: String)
-  fun typeText(string: String)
 
   fun handleKey(key: KeyStroke, editor: VimEditor, executionContext: ExecutionContext)
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInput.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInput.kt
@@ -19,6 +19,7 @@ interface VimModalInput {
 
   fun setText(string: String)
   fun insertText(offset: Int, string: String)
+  fun typeText(string: String)
 
   fun handleKey(key: KeyStroke, editor: VimEditor, executionContext: ExecutionContext)
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInput.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInput.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.api
+
+import com.maddyhome.idea.vim.key.interceptors.VimInputInterceptor
+import javax.swing.KeyStroke
+
+interface VimModalInput {
+  var inputInterceptor: VimInputInterceptor<*>
+  val caret: VimCommandLineCaret
+  val label: String
+  val text: String
+
+  fun setText(string: String)
+  fun insertText(offset: Int, string: String)
+
+  fun handleKey(key: KeyStroke, editor: VimEditor, executionContext: ExecutionContext)
+
+  fun deactivate(refocusOwningEditor: Boolean, resetCaret: Boolean)
+
+  fun focus()
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInputBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInputBase.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.api
+
+import javax.swing.KeyStroke
+
+abstract class VimModalInputBase : VimModalInput {
+  override fun insertText(offset: Int, string: String) {
+    val newText = StringBuilder(text).insert(offset, string).toString()
+    setText(newText)
+  }
+
+  override fun handleKey(key: KeyStroke, editor: VimEditor, executionContext: ExecutionContext) {
+    inputInterceptor.consumeKey(key, editor, executionContext)
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInputBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInputBase.kt
@@ -16,6 +16,12 @@ abstract class VimModalInputBase : VimModalInput {
     setText(newText)
   }
 
+  override fun typeText(string: String) {
+    val caretOffset = caret.offset
+    insertText(caretOffset, string)
+    caret.offset += string.length
+  }
+
   override fun handleKey(key: KeyStroke, editor: VimEditor, executionContext: ExecutionContext) {
     inputInterceptor.consumeKey(key, editor, executionContext)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInputBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInputBase.kt
@@ -11,17 +11,6 @@ package com.maddyhome.idea.vim.api
 import javax.swing.KeyStroke
 
 abstract class VimModalInputBase : VimModalInput {
-  override fun insertText(offset: Int, string: String) {
-    val newText = StringBuilder(text).insert(offset, string).toString()
-    setText(newText)
-  }
-
-  override fun typeText(string: String) {
-    val caretOffset = caret.offset
-    insertText(caretOffset, string)
-    caret.offset += string.length
-  }
-
   override fun handleKey(key: KeyStroke, editor: VimEditor, executionContext: ExecutionContext) {
     inputInterceptor.consumeKey(key, editor, executionContext)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInputService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimModalInputService.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.api
+
+import com.maddyhome.idea.vim.key.interceptors.VimInputInterceptor
+
+interface VimModalInputService {
+  fun getCurrentModalInput(): VimModalInput?
+  fun create(editor: VimEditor, context: ExecutionContext, label: String, inputInterceptor: VimInputInterceptor<*>): VimModalInput
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOutputPanel.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOutputPanel.kt
@@ -8,6 +8,8 @@
 
 package com.maddyhome.idea.vim.api
 
+import javax.swing.KeyStroke
+
 interface VimOutputPanel {
   /**
    * The current text displayed in the output panel.
@@ -36,4 +38,9 @@ interface VimOutputPanel {
    * This may free any associated resources.
    */
   fun close()
+
+  fun handleKey(key: KeyStroke)
+  fun scrollPage()
+  fun scrollHalfPage()
+  fun scrollLine()
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOutputPanel.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOutputPanel.kt
@@ -18,6 +18,11 @@ interface VimOutputPanel {
   val text: String
 
   /**
+   * The text in the bottom of the output panel, e.g. `-- MORE --`
+   */
+  var label: String
+
+  /**
    * Appends the specified text to the existing content of the output panel.
    * If 'isNewLine' is true, the text will begin on a new line.
    *

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOutputPanelBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOutputPanelBase.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.api
+
+import java.awt.event.KeyEvent
+import javax.swing.KeyStroke
+
+abstract class VimOutputPanelBase : VimOutputPanel {
+  protected abstract val atEnd: Boolean
+
+  override fun handleKey(key: KeyStroke) {
+    if (atEnd) {
+      close(key)
+      return
+    }
+
+    when (key.keyChar) {
+      ' ' -> scrollPage()
+      'd' -> scrollHalfPage()
+      'q', '\u001b' -> close()
+      '\n' -> scrollLine()
+      KeyEvent.CHAR_UNDEFINED -> {
+        when (key.keyCode) {
+          KeyEvent.VK_ENTER -> scrollLine()
+          KeyEvent.VK_ESCAPE -> close()
+          else -> onBadKey()
+        }
+      }
+      else -> onBadKey()
+    }
+  }
+
+  protected abstract fun onBadKey()
+  protected abstract fun close(key: KeyStroke?)
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
@@ -14,8 +14,6 @@ import javax.swing.KeyStroke
 
 interface VimProcessGroup {
   val lastCommand: String?
-  var isCommandProcessing: Boolean
-  var modeBeforeCommandProcessing: Mode?
 
   fun startExEntry(editor: VimEditor, context: ExecutionContext, command: Command, label: String = ":", initialCommandText: String = "")
   // TODO remove me

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
@@ -21,7 +21,6 @@ interface VimProcessGroup {
   // TODO remove me
   // TODO: Why ^^ ? Should that also include startExEntry?
   fun processExKey(editor: VimEditor, stroke: KeyStroke, processResultBuilder: KeyProcessResult.KeyProcessResultBuilder): Boolean
-  fun cancelExEntry(editor: VimEditor, refocusOwningEditor: Boolean, resetCaret: Boolean)
 
   @kotlin.jvm.Throws(java.lang.Exception::class)
   fun executeCommand(editor: VimEditor, command: String, input: CharSequence?, currentDirectoryPath: String?): String?

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
@@ -9,12 +9,9 @@ package com.maddyhome.idea.vim.api
 
 import com.maddyhome.idea.vim.KeyProcessResult
 import com.maddyhome.idea.vim.command.Command
-import com.maddyhome.idea.vim.state.mode.Mode
 import javax.swing.KeyStroke
 
 interface VimProcessGroup {
-  val lastCommand: String?
-
   fun startExEntry(editor: VimEditor, context: ExecutionContext, command: Command, label: String = ":", initialCommandText: String = "")
   // TODO remove me
   // TODO: Why ^^ ? Should that also include startExEntry?

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
@@ -7,14 +7,7 @@
  */
 package com.maddyhome.idea.vim.api
 
-import com.maddyhome.idea.vim.KeyProcessResult
-import javax.swing.KeyStroke
-
 interface VimProcessGroup {
-  // TODO remove me
-  // TODO: Why ^^ ? Should that also include startExEntry?
-  fun processExKey(editor: VimEditor, stroke: KeyStroke, processResultBuilder: KeyProcessResult.KeyProcessResultBuilder): Boolean
-
   @kotlin.jvm.Throws(java.lang.Exception::class)
   fun executeCommand(editor: VimEditor, command: String, input: CharSequence?, currentDirectoryPath: String?): String?
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroup.kt
@@ -8,11 +8,9 @@
 package com.maddyhome.idea.vim.api
 
 import com.maddyhome.idea.vim.KeyProcessResult
-import com.maddyhome.idea.vim.command.Command
 import javax.swing.KeyStroke
 
 interface VimProcessGroup {
-  fun startExEntry(editor: VimEditor, context: ExecutionContext, command: Command, label: String = ":", initialCommandText: String = "")
   // TODO remove me
   // TODO: Why ^^ ? Should that also include startExEntry?
   fun processExKey(editor: VimEditor, stroke: KeyStroke, processResultBuilder: KeyProcessResult.KeyProcessResultBuilder): Boolean

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
@@ -14,13 +14,10 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.ReturnableFromCmd
 import com.maddyhome.idea.vim.state.mode.inVisualMode
-import com.maddyhome.idea.vim.state.mode.returnTo
 import javax.swing.KeyStroke
 
 abstract class VimProcessGroupBase : VimProcessGroup {
   override var lastCommand: String? = null
-  override var isCommandProcessing: Boolean = false
-  override var modeBeforeCommandProcessing: Mode? = null
 
   override fun startExEntry(editor: VimEditor, context: ExecutionContext, command: Command, label: String, initialCommandText: String) {
     // Don't allow ex commands in one line editors
@@ -30,9 +27,6 @@ abstract class VimProcessGroupBase : VimProcessGroup {
     check(currentMode is ReturnableFromCmd) {
       "Cannot enable cmd mode from current mode $currentMode"
     }
-
-    isCommandProcessing = true
-    modeBeforeCommandProcessing = currentMode
 
     // Make sure the Visual selection marks are up to date before we use them.
     injector.markService.setVisualSelectionMarks(editor)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
@@ -75,14 +75,6 @@ abstract class VimProcessGroupBase : VimProcessGroup {
     }
   }
 
-  override fun cancelExEntry(editor: VimEditor, refocusOwningEditor: Boolean, resetCaret: Boolean) {
-    // If 'cpoptions' contains 'x', then Escape should execute the command line. This is the default for Vi but not Vim.
-    // IdeaVim does not (currently?) support 'cpoptions', so sticks with Vim's default behaviour. Escape cancels.
-    editor.mode = editor.mode.returnTo()
-    getInstance().reset(editor)
-    injector.commandLine.getActiveCommandLine()?.deactivate(refocusOwningEditor, resetCaret)
-  }
-
   private fun getRange(editor: VimEditor, cmd: Command) = when {
     editor.inVisualMode -> "'<,'>"
     cmd.rawCount == 1 -> "."

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
@@ -17,8 +17,6 @@ import com.maddyhome.idea.vim.state.mode.inVisualMode
 import javax.swing.KeyStroke
 
 abstract class VimProcessGroupBase : VimProcessGroup {
-  override var lastCommand: String? = null
-
   override fun startExEntry(editor: VimEditor, context: ExecutionContext, command: Command, label: String, initialCommandText: String) {
     // Don't allow ex commands in one line editors
     if (editor.isOneLineMode()) return

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
@@ -10,41 +10,10 @@ package com.maddyhome.idea.vim.api
 
 import com.maddyhome.idea.vim.KeyHandler.Companion.getInstance
 import com.maddyhome.idea.vim.KeyProcessResult
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.ReturnableFromCmd
-import com.maddyhome.idea.vim.state.mode.inVisualMode
 import javax.swing.KeyStroke
 
 abstract class VimProcessGroupBase : VimProcessGroup {
-  override fun startExEntry(editor: VimEditor, context: ExecutionContext, command: Command, label: String, initialCommandText: String) {
-    // Don't allow ex commands in one line editors
-    if (editor.isOneLineMode()) return
-
-    val currentMode = editor.mode
-    check(currentMode is ReturnableFromCmd) {
-      "Cannot enable cmd mode from current mode $currentMode"
-    }
-
-    // Make sure the Visual selection marks are up to date before we use them.
-    injector.markService.setVisualSelectionMarks(editor)
-
-    val rangeText = getRange(editor, command)
-
-    // Note that we should remove selection and reset caret offset before we switch back to Normal mode and then enter
-    // Command-line mode. However, some IdeaVim commands can handle multiple carets, including multiple carets with
-    // selection (which might or might not be a block selection). Unfortunately, because we're just entering
-    // Command-line mode, we don't know which command is going to be entered, so we can't remove selection here.
-    // Therefore, we switch to Normal and then Command-line even though we might still have a Visual selection...
-    // On the plus side, it means we still show selection while editing the command line, which Vim also does
-    // (Normal then Command-line is not strictly necessary, but done for completeness and autocmd)
-    // Caret selection is finally handled in Command.execute
-    editor.mode = Mode.NORMAL()
-    editor.mode = Mode.CMD_LINE(currentMode)
-
-    injector.commandLine.create(editor, context, ":", rangeText + initialCommandText)
-  }
-
   override fun processExKey(editor: VimEditor, stroke: KeyStroke, processResultBuilder: KeyProcessResult.KeyProcessResultBuilder): Boolean {
     // This will only get called if somehow the key focus ended up in the editor while the ex entry window
     // is open. So I'll put focus back in the editor and process the key.
@@ -67,10 +36,4 @@ abstract class VimProcessGroupBase : VimProcessGroup {
     }
   }
 
-  private fun getRange(editor: VimEditor, cmd: Command) = when {
-    editor.inVisualMode -> "'<,'>"
-    cmd.rawCount == 1 -> "."
-    cmd.rawCount > 1 -> ".,.+" + (cmd.count - 1)
-    else -> ""
-  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimProcessGroupBase.kt
@@ -8,32 +8,4 @@
 
 package com.maddyhome.idea.vim.api
 
-import com.maddyhome.idea.vim.KeyHandler.Companion.getInstance
-import com.maddyhome.idea.vim.KeyProcessResult
-import com.maddyhome.idea.vim.state.mode.Mode
-import javax.swing.KeyStroke
-
-abstract class VimProcessGroupBase : VimProcessGroup {
-  override fun processExKey(editor: VimEditor, stroke: KeyStroke, processResultBuilder: KeyProcessResult.KeyProcessResultBuilder): Boolean {
-    // This will only get called if somehow the key focus ended up in the editor while the ex entry window
-    // is open. So I'll put focus back in the editor and process the key.
-    // FIXME comment above is not true. This method is called all the time. Is there a way to make it work like in the comment above?
-    // TODO maybe something like `Propagate.CONTINUE` will help
-
-    val panel = injector.commandLine.getActiveCommandLine()
-    if (panel != null) {
-      processResultBuilder.addExecutionStep { _, _, _ ->
-        panel.focus()
-        panel.handleKey(stroke)
-      }
-      return true
-    } else {
-      processResultBuilder.addExecutionStep { _, lambdaEditor, _ ->
-        lambdaEditor.mode = Mode.NORMAL()
-        getInstance().reset(lambdaEditor)
-      }
-      return false
-    }
-  }
-
-}
+abstract class VimProcessGroupBase : VimProcessGroup

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
@@ -716,37 +716,36 @@ abstract class VimSearchGroupBase : VimSearchGroup {
       if (hasExpression) match = evaluateExpression(substituteString.substring(2), editor, context, parent, exceptions)
 
       var didReplace = false
-      if (doAll || line != editor.lineCount()) {
-        var doReplace = true
-        if (doAsk) {
-          val highlight = addSubstitutionConfirmationHighlight(editor, matchRange.startOffset, matchRange.endOffset)
-          val choice: ReplaceConfirmationChoice = confirmChoice(editor, context, match, caret, matchRange.startOffset)
-          when (choice) {
-            ReplaceConfirmationChoice.SUBSTITUTE_THIS -> {}
-            ReplaceConfirmationChoice.SKIP -> doReplace = false
-            ReplaceConfirmationChoice.SUBSTITUTE_ALL -> doAsk = false
-            ReplaceConfirmationChoice.QUIT -> {
-              doReplace = false
-              gotQuit = true
-            }
 
-            ReplaceConfirmationChoice.SUBSTITUTE_LAST -> {
-              doAll = false
-              line2 = line
-            }
+      var doReplace = true
+      if (doAsk) {
+        val highlight = addSubstitutionConfirmationHighlight(editor, matchRange.startOffset, matchRange.endOffset)
+        val choice: ReplaceConfirmationChoice = confirmChoice(editor, context, match, caret, matchRange.startOffset)
+        when (choice) {
+          ReplaceConfirmationChoice.SUBSTITUTE_THIS -> {}
+          ReplaceConfirmationChoice.SKIP -> doReplace = false
+          ReplaceConfirmationChoice.SUBSTITUTE_ALL -> doAsk = false
+          ReplaceConfirmationChoice.QUIT -> {
+            doReplace = false
+            gotQuit = true
           }
-          highlight.remove()
-        }
-        if (doReplace) {
-          val endPositionWithoutReplace = editor.offsetToBufferPosition(matchRange.endOffset)
 
-          replaceString(editor, matchRange.startOffset, matchRange.endOffset, match)
-          didReplace = true
-
-          val endPositionWithReplace = editor.offsetToBufferPosition(matchRange.startOffset + match.length)
-          line += max(0, endPositionWithReplace.line - endPositionWithoutReplace.line)
-          line2 += endPositionWithReplace.line - endPositionWithoutReplace.line
+          ReplaceConfirmationChoice.SUBSTITUTE_LAST -> {
+            doAll = false
+            line2 = line
+          }
         }
+        highlight.remove()
+      }
+      if (doReplace) {
+        val endPositionWithoutReplace = editor.offsetToBufferPosition(matchRange.endOffset)
+
+        replaceString(editor, matchRange.startOffset, matchRange.endOffset, match)
+        didReplace = true
+
+        val endPositionWithReplace = editor.offsetToBufferPosition(matchRange.startOffset + match.length)
+        line += max(0, endPositionWithReplace.line - endPositionWithoutReplace.line)
+        line2 += endPositionWithReplace.line - endPositionWithoutReplace.line
       }
 
       if (doAll && matchRange.startOffset != matchRange.endOffset) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
@@ -119,23 +119,6 @@ abstract class VimSearchGroupBase : VimSearchGroup {
   }
 
   /**
-   * Asks the user how to deal with a substitution confirmation choice.
-   * Used when the 'c' flag is present in a substitute command.
-   *
-   * @param editor      The editor where the substitution would be made.
-   * @param match       The string that would replace the old one.
-   * @param caret       The current caret.
-   * @param startOffset The index where the substitution would be made.
-   */
-  protected abstract fun confirmChoice(
-    editor: VimEditor,
-    context: ExecutionContext,
-    match: String,
-    caret: VimCaret,
-    startOffset: Int,
-  ): ReplaceConfirmationChoice
-
-  /**
    * Highlights the string that would be replaced (pending user confimation) in
    * a substitute command.
    *

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
@@ -705,17 +705,11 @@ abstract class VimSearchGroupBase : VimSearchGroup {
         column = 0
         continue
       }
-
-      injector.jumpService.saveJumpLocation(editor)
       val matchRange = substituteResult.first.range
       var match = substituteResult.second
       lastMatchStartOffset = matchRange.startOffset
 
-      caret.moveToOffset(matchRange.startOffset)
-      setLatestMatch(editor.getText(TextRange(matchRange.startOffset, matchRange.endOffset)))
-      if (hasExpression) match = evaluateExpression(substituteString.substring(2), editor, context, parent, exceptions)
-
-      var didReplace = false
+      injector.jumpService.saveJumpLocation(editor)
 
       var doReplace = true
       if (doAsk) {
@@ -737,6 +731,14 @@ abstract class VimSearchGroupBase : VimSearchGroup {
         }
         highlight.remove()
       }
+
+      // PERFORM REPLACE START
+      caret.moveToOffset(matchRange.startOffset)
+      setLatestMatch(editor.getText(TextRange(matchRange.startOffset, matchRange.endOffset)))
+      if (hasExpression) match = evaluateExpression(substituteString.substring(2), editor, context, parent, exceptions)
+
+      var didReplace = false
+
       if (doReplace) {
         val endPositionWithoutReplace = editor.offsetToBufferPosition(matchRange.endOffset)
 
@@ -763,6 +765,8 @@ abstract class VimSearchGroupBase : VimSearchGroup {
         column = 0
         line++
       }
+      // PERFORM REPLACE END
+
     }
 
     if (!gotQuit) {
@@ -785,6 +789,10 @@ abstract class VimSearchGroupBase : VimSearchGroup {
 
     // TODO: Support reporting number of changes (:help 'report')
     return true
+  }
+
+  private fun performReplace() {
+
   }
 
   private fun evaluateExpression(exprString: String, editor: VimEditor, context: ExecutionContext, parent: VimLContext, exceptions: MutableList<ExException>): String {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
@@ -694,7 +694,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     setShouldShowSearchHighlights()
     updateSearchHighlights(true)
 
-    var lastMatchStartOffset = -1
+    var lastMatchLine = -1
     var gotQuit = false
     var column = 0
     var line = line1
@@ -706,7 +706,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
         continue
       }
       preparationResult as SubstitutePreparationResult.Prepared
-      lastMatchStartOffset = preparationResult.matchRange.startOffset
+      lastMatchLine = line
       gotQuit = preparationResult.gotQuit
 
       // Can we skip this if [gotQuit]?
@@ -717,10 +717,8 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     }
 
     if (!gotQuit) {
-      if (lastMatchStartOffset != -1) {
-        caret.moveToOffset(
-          injector.motion.moveCaretToLineStartSkipLeading(editor, editor.offsetToBufferPosition(lastMatchStartOffset).line)
-        )
+      if (lastMatchLine != -1) {
+        caret.moveToOffset(injector.motion.moveCaretToLineStartSkipLeading(editor, lastMatchLine))
       } else {
         injector.messages.showStatusBarMessage(null, "E486: Pattern not found: $pattern")
       }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
@@ -9,26 +9,14 @@
 package com.maddyhome.idea.vim.api.stubs
 
 import com.maddyhome.idea.vim.KeyProcessResult
-import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimProcessGroupBase
-import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import javax.swing.KeyStroke
 
 class VimProcessGroupStub : VimProcessGroupBase() {
   init {
     vimLogger<ExecutionContextManagerStub>().warn("VimProcessGroupStub is used. Please replace it with your own implementation of VimProcessGroup.")
-  }
-
-  override fun startExEntry(
-    editor: VimEditor,
-    context: ExecutionContext,
-    command: Command,
-    label: String,
-    initialCommandText: String
-  ) {
-    TODO("Not yet implemented")
   }
 
   override fun processExKey(editor: VimEditor, stroke: KeyStroke, processResultBuilder: KeyProcessResult.KeyProcessResultBuilder): Boolean {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
@@ -14,7 +14,6 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimProcessGroupBase
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.diagnostic.vimLogger
-import com.maddyhome.idea.vim.state.mode.Mode
 import javax.swing.KeyStroke
 
 class VimProcessGroupStub : VimProcessGroupBase() {
@@ -23,8 +22,6 @@ class VimProcessGroupStub : VimProcessGroupBase() {
   }
 
   override var lastCommand: String? = null
-  override var isCommandProcessing: Boolean = false
-  override var modeBeforeCommandProcessing: Mode? = null
 
   override fun startExEntry(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
@@ -40,10 +40,6 @@ class VimProcessGroupStub : VimProcessGroupBase() {
     TODO("Not yet implemented")
   }
 
-  override fun cancelExEntry(editor: VimEditor, refocusOwningEditor: Boolean, resetCaret: Boolean) {
-    TODO("Not yet implemented")
-  }
-
   override fun executeCommand(
     editor: VimEditor,
     command: String,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
@@ -8,19 +8,13 @@
 
 package com.maddyhome.idea.vim.api.stubs
 
-import com.maddyhome.idea.vim.KeyProcessResult
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimProcessGroupBase
 import com.maddyhome.idea.vim.diagnostic.vimLogger
-import javax.swing.KeyStroke
 
 class VimProcessGroupStub : VimProcessGroupBase() {
   init {
     vimLogger<ExecutionContextManagerStub>().warn("VimProcessGroupStub is used. Please replace it with your own implementation of VimProcessGroup.")
-  }
-
-  override fun processExKey(editor: VimEditor, stroke: KeyStroke, processResultBuilder: KeyProcessResult.KeyProcessResultBuilder): Boolean {
-    TODO("Not yet implemented")
   }
 
   override fun executeCommand(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimProcessGroupStub.kt
@@ -21,8 +21,6 @@ class VimProcessGroupStub : VimProcessGroupBase() {
     vimLogger<ExecutionContextManagerStub>().warn("VimProcessGroupStub is used. Please replace it with your own implementation of VimProcessGroup.")
   }
 
-  override var lastCommand: String? = null
-
   override fun startExEntry(
     editor: VimEditor,
     context: ExecutionContext,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/Argument.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/Argument.kt
@@ -25,11 +25,12 @@ class Argument private constructor(
   val motion: Command = EMPTY_COMMAND,
   val offsets: Map<ImmutableVimCaret, VimSelection> = emptyMap(),
   val string: String = "",
+  val processing: ((String) -> Unit)? = null,
   val type: Type,
 ) {
   constructor(motionArg: Command) : this(motion = motionArg, type = Type.MOTION)
   constructor(charArg: Char) : this(character = charArg, type = Type.CHARACTER)
-  constructor(label: Char, strArg: String) : this(character = label, string = strArg, type = Type.EX_STRING)
+  constructor(label: Char, strArg: String, processing: ((String) -> Unit)?) : this(character = label, string = strArg, processing = processing, type = Type.EX_STRING)
   constructor(offsets: Map<ImmutableVimCaret, VimSelection>) : this(offsets = offsets, type = Type.OFFSETS)
 
   enum class Type {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/MappingProcessor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/MappingProcessor.kt
@@ -34,7 +34,6 @@ object MappingProcessor: KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     log.trace { "Entered MappingProcessor" }
     if (!allowKeyMappings) return false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyConsumer.kt
@@ -8,7 +8,6 @@
 
 package com.maddyhome.idea.vim.key
 
-import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.KeyProcessResult
 import com.maddyhome.idea.vim.api.VimEditor
 import javax.swing.KeyStroke
@@ -23,6 +22,5 @@ interface KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/MappingInfo.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/MappingInfo.kt
@@ -172,7 +172,7 @@ class ToHandlerMappingInfo(
               editor,
               context,
               null,
-              KeyHandler.MutableBoolean(false),
+              false,
               keyState,
             )
           }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CharArgumentConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CharArgumentConsumer.kt
@@ -31,7 +31,6 @@ class CharArgumentConsumer: KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     logger.trace { "Entered CharArgumentConsumer" }
     if (!isExpectingCharArgument(keyProcessResultBuilder.state.commandBuilder)) return false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
@@ -136,7 +136,7 @@ class CommandConsumer : KeyConsumer {
         val label = commandLine.label
         val text = commandLine.actualText
         val processing = commandLine.inputProcessing
-        commandLine.close(refocusOwningEditor = true, resetCaret = true, isCancel = true)
+        commandLine.close(refocusOwningEditor = true, resetCaret = true)
 
         commandBuilder.completeCommandPart(Argument(label[0], text, processing))
       }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
@@ -136,10 +136,10 @@ class CommandConsumer : KeyConsumer {
         val commandLine = injector.commandLine.getActiveCommandLine()!!
         val label = commandLine.label
         val text = commandLine.actualText
-        commandLine.deactivate(refocusOwningEditor = true, resetCaret = true)
+        val processing = commandLine.inputProcessing
+        commandLine.close(refocusOwningEditor = true, resetCaret = true, isCancel = true)
 
-        commandBuilder.completeCommandPart(Argument(label[0], text))
-        lambdaEditor.mode = lambdaEditor.mode.returnTo()
+        commandBuilder.completeCommandPart(Argument(label[0], text, processing))
       }
     }
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
@@ -43,7 +43,6 @@ class CommandConsumer : KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     logger.trace { "Entered CommandConsumer" }
     val commandBuilder = keyProcessResultBuilder.state.commandBuilder

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandCountConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandCountConsumer.kt
@@ -31,7 +31,6 @@ class CommandCountConsumer : KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     logger.trace { "Entered CommandCountConsumer" }
     val chKey: Char = if (key.keyChar == KeyEvent.CHAR_UNDEFINED) 0.toChar() else key.keyChar

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DeleteCommandConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DeleteCommandConsumer.kt
@@ -31,7 +31,6 @@ class DeleteCommandConsumer : KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     logger.trace { "Entered DeleteCommandConsumer" }
     if (!isDeleteCommandCountKey(key, keyProcessResultBuilder.state, editor.mode)) return false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DigraphConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DigraphConsumer.kt
@@ -32,7 +32,6 @@ class DigraphConsumer : KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     logger.trace { "Entered DigraphConsumer" }
     logger.debug("Handling digraph")

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/EditorResetConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/EditorResetConsumer.kt
@@ -34,7 +34,6 @@ class EditorResetConsumer : KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     logger.trace { "Entered EditorResetConsumer" }
     if (!isEditorReset(key, editor)) return false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModalInputConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModalInputConsumer.kt
@@ -8,7 +8,6 @@
 
 package com.maddyhome.idea.vim.key.consumers
 
-import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.KeyProcessResult
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
@@ -22,7 +21,6 @@ class ModalInputConsumer : KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     val modalInput = injector.modalInput.getCurrentModalInput() ?: return false
     keyProcessResultBuilder.addExecutionStep { _, lambdaVimEditor, lambdaExecutionContext ->

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModalInputConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModalInputConsumer.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.key.consumers
+
+import com.maddyhome.idea.vim.KeyHandler
+import com.maddyhome.idea.vim.KeyProcessResult
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.key.KeyConsumer
+import javax.swing.KeyStroke
+
+class ModalInputConsumer : KeyConsumer {
+  override fun consumeKey(
+    key: KeyStroke,
+    editor: VimEditor,
+    allowKeyMappings: Boolean,
+    mappingCompleted: Boolean,
+    keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
+    shouldRecord: KeyHandler.MutableBoolean,
+  ): Boolean {
+    val modalInput = injector.modalInput.getCurrentModalInput() ?: return false
+    keyProcessResultBuilder.addExecutionStep { _, lambdaVimEditor, lambdaExecutionContext ->
+      modalInput.inputInterceptor.consumeKey(key, lambdaVimEditor, lambdaExecutionContext)
+    }
+    return true
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModeInputConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModeInputConsumer.kt
@@ -46,10 +46,19 @@ class ModeInputConsumer: KeyConsumer {
         keyProcessed
       }
       is Mode.CMD_LINE -> {
-        logger.trace("Process cmd line")
-        val keyProcessed = injector.processGroup.processExKey(editor, key, keyProcessResultBuilder)
-        shouldRecord.value = keyProcessed && shouldRecord.value
-        keyProcessed
+        val commandLine = injector.commandLine.getActiveCommandLine()
+        if (commandLine != null) {
+          keyProcessResultBuilder.addExecutionStep { _, _, _ ->
+            commandLine.focus()
+            commandLine.handleKey(key)
+          }
+        } else {
+          keyProcessResultBuilder.addExecutionStep { _, lambdaEditor, _ ->
+            lambdaEditor.mode = Mode.NORMAL()
+            KeyHandler.getInstance().reset(lambdaEditor)
+          }
+        }
+        true
       }
       else -> {
         false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModeInputConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModeInputConsumer.kt
@@ -29,20 +29,17 @@ class ModeInputConsumer: KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     logger.trace { "Entered ModeInputConsumer" }
     val isProcessed = when (editor.mode) {
       Mode.INSERT, Mode.REPLACE -> {
         logger.trace("Process insert or replace")
         val keyProcessed = injector.changeGroup.processKey(editor, key, keyProcessResultBuilder)
-        shouldRecord.value = keyProcessed && shouldRecord.value
         keyProcessed
       }
       is Mode.SELECT -> {
         logger.trace("Process select")
         val keyProcessed = injector.changeGroup.processKeyInSelectMode(editor, key, keyProcessResultBuilder)
-        shouldRecord.value = keyProcessed && shouldRecord.value
         keyProcessed
       }
       is Mode.CMD_LINE -> {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/RegisterConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/RegisterConsumer.kt
@@ -29,7 +29,6 @@ class RegisterConsumer : KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     logger.trace { "Entered RegisterConsumer" }
     if (!injector.vimState.isRegisterPending) return false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/SelectRegisterConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/SelectRegisterConsumer.kt
@@ -16,7 +16,6 @@ import com.maddyhome.idea.vim.diagnostic.trace
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.key.KeyConsumer
 import com.maddyhome.idea.vim.state.KeyHandlerState
-import com.maddyhome.idea.vim.state.VimStateMachine
 import com.maddyhome.idea.vim.state.mode.Mode
 import javax.swing.KeyStroke
 
@@ -31,7 +30,6 @@ class SelectRegisterConsumer : KeyConsumer {
     allowKeyMappings: Boolean,
     mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
-    shouldRecord: KeyHandler.MutableBoolean,
   ): Boolean {
     logger.trace { "Entered SelectRegisterConsumer" }
     val state = keyProcessResultBuilder.state

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptor.kt
@@ -29,10 +29,10 @@ interface VimInputInterceptor<T> {
   /**
    * Attempt to build a complete input from the given keystroke.
    *
-   * @param keystroke The current keystroke to process.
+   * @param key The current keystroke to process.
    * @return The complete input of type [T] if it can be constructed, or null if more keystrokes are needed.
    */
-  fun buildInput(keystroke: KeyStroke): T?
+  fun buildInput(key: KeyStroke): T?
 
   /**
    * Execute the action associated with the complete input.

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptor.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.key.interceptors
+
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import javax.swing.KeyStroke
+
+/**
+ * Modal key interceptor
+ * It receives keys until it can build an input and handle it
+ */
+interface VimInputInterceptor<T> {
+  /**
+   * Process a single keystroke and attempt to build a complete input of type [T].
+   */
+  fun consumeKey(
+    key: KeyStroke,
+    editor: VimEditor,
+    context: ExecutionContext
+  )
+
+  /**
+   * Attempt to build a complete input from the given keystroke.
+   *
+   * @param keystroke The current keystroke to process.
+   * @return The complete input of type [T] if it can be constructed, or null if more keystrokes are needed.
+   */
+  fun buildInput(keystroke: KeyStroke): T?
+
+  /**
+   * Execute the action associated with the complete input.
+   *
+   * @param input The complete input of type T.
+   * @param editor The active editor instance.
+   * @param context The current execution context.
+   */
+  fun executeInput(
+    input: T,
+    editor: VimEditor,
+    context: ExecutionContext
+  )
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptorBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptorBase.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.key.interceptors
+
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.helper.isCloseKeyStroke
+import java.awt.event.KeyEvent
+import javax.swing.KeyStroke
+
+abstract class VimInputInterceptorBase<T> : VimInputInterceptor<T> {
+  override fun consumeKey(
+    key: KeyStroke,
+    editor: VimEditor,
+    context: ExecutionContext
+  ) {
+    if (key.isCloseKeyStroke() || key.keyCode == KeyEvent.VK_ENTER) {
+      closeModalInputPrompt()
+      return
+    }
+
+    val completeInput = buildInput(key) ?: return
+    executeInput(completeInput, editor, context)
+    onFinish()
+  }
+
+  protected open fun onFinish() {
+    closeModalInputPrompt()
+  }
+
+  protected open fun closeModalInputPrompt() {
+    val prompt = injector.modalInput.getCurrentModalInput() ?: return
+    prompt.deactivate(refocusOwningEditor = true, resetCaret = true)
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptorBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptorBase.kt
@@ -22,7 +22,6 @@ abstract class VimInputInterceptorBase<T> : VimInputInterceptor<T> {
   ) {
     val completeInput = buildInput(key) ?: return
     executeInput(completeInput, editor, context)
-    onFinish()
   }
 
   protected open fun onFinish() {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptorBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/interceptors/VimInputInterceptorBase.kt
@@ -11,21 +11,15 @@ package com.maddyhome.idea.vim.key.interceptors
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.helper.isCloseKeyStroke
-import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
+// TODO make it safer to utilise key.isCloseKeystroke and similar logic
 abstract class VimInputInterceptorBase<T> : VimInputInterceptor<T> {
   override fun consumeKey(
     key: KeyStroke,
     editor: VimEditor,
     context: ExecutionContext
   ) {
-    if (key.isCloseKeyStroke() || key.keyCode == KeyEvent.VK_ENTER) {
-      closeModalInputPrompt()
-      return
-    }
-
     val completeInput = buildInput(key) ?: return
     executeInput(completeInput, editor, context)
     onFinish()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/regexp/engine/nfa/matcher/VisualAreaMatcher.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/regexp/engine/nfa/matcher/VisualAreaMatcher.kt
@@ -14,6 +14,7 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.regexp.match.VimMatchGroupCollection
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.inVisualMode
+import com.maddyhome.idea.vim.state.mode.returnTo
 
 /**
  * Matcher used to check if index is inside the visual area.
@@ -26,16 +27,12 @@ internal class VisualAreaMatcher : Matcher {
     isCaseInsensitive: Boolean,
     possibleCursors: MutableList<VimCaret>
   ): MatcherResult {
-    val processGroup = injector.processGroup
     val newPossibleCursors = if (editor.inVisualMode) {
       possibleCursors.filter { it.hasSelection() && index >= it.selectionStart && index < it.selectionEnd }
     }
     // IdeaVim exits visual mode before command processing (e.g. substitute), so we work with lastSelectionInfo
-    else if ((processGroup.isCommandProcessing || injector.vimscriptExecutor.executingVimscript)
-      && processGroup.modeBeforeCommandProcessing is Mode.VISUAL) {
+    else {
       possibleCursors.filter { it.lastSelectionInfo.isSelected(index, editor) }
-    } else {
-      emptyList()
     }
 
     return if (newPossibleCursors.isNotEmpty()) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
@@ -33,7 +33,7 @@ sealed interface Mode {
   data class VISUAL(val selectionType: SelectionType, val returnTo: ReturnTo? = null) : Mode,
     ReturnableFromCmd
   data class SELECT(val selectionType: SelectionType, val returnTo: ReturnTo? = null) : Mode
-  object INSERT : Mode
+  object INSERT : Mode, ReturnableFromCmd
   object REPLACE : Mode
   data class CMD_LINE(val returnTo: ReturnableFromCmd) : Mode
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
@@ -48,7 +48,7 @@ data class NormalCommand(val range: Range, val argument: String) : Command.Singl
           editor.currentCaret().moveToBufferPosition(BufferPosition(selectionStart.line, selectionStart.col))
         }
       }
-      is Mode.CMD_LINE -> injector.processGroup.cancelExEntry(editor, refocusOwningEditor = true, resetCaret = false)
+      is Mode.CMD_LINE -> injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
       Mode.INSERT, Mode.REPLACE -> editor.exitInsertMode(context, OperatorArguments(false, 1, editor.mode))
       is Mode.SELECT -> editor.exitSelectModeNative(false)
       is Mode.OP_PENDING, is Mode.NORMAL -> Unit
@@ -76,7 +76,7 @@ data class NormalCommand(val range: Range, val argument: String) : Command.Singl
       // Exit if state leaves as insert or cmd_line
       val mode = editor.mode
       if (mode is Mode.CMD_LINE) {
-        injector.processGroup.cancelExEntry(editor, refocusOwningEditor = true, resetCaret = false)
+        injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
       }
       if (mode is Mode.INSERT || mode is Mode.REPLACE) {
         editor.exitInsertMode(context, OperatorArguments(false, 1, mode))

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
@@ -48,7 +48,7 @@ data class NormalCommand(val range: Range, val argument: String) : Command.Singl
           editor.currentCaret().moveToBufferPosition(BufferPosition(selectionStart.line, selectionStart.col))
         }
       }
-      is Mode.CMD_LINE -> injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
+      is Mode.CMD_LINE -> injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false)
       Mode.INSERT, Mode.REPLACE -> editor.exitInsertMode(context, OperatorArguments(false, 1, editor.mode))
       is Mode.SELECT -> editor.exitSelectModeNative(false)
       is Mode.OP_PENDING, is Mode.NORMAL -> Unit
@@ -76,7 +76,7 @@ data class NormalCommand(val range: Range, val argument: String) : Command.Singl
       // Exit if state leaves as insert or cmd_line
       val mode = editor.mode
       if (mode is Mode.CMD_LINE) {
-        injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false, isCancel = true)
+        injector.commandLine.getActiveCommandLine()?.close(refocusOwningEditor = true, resetCaret = false)
       }
       if (mode is Mode.INSERT || mode is Mode.REPLACE) {
         editor.exitInsertMode(context, OperatorArguments(false, 1, mode))


### PR DESCRIPTION
- move output panels to vim-engine. slightly better logic (in some cases it required more keypresses than it was needed to close it)
- no more secondary loops (1. It is Swing 2. There was a bug where this thing was running in background and eating key presses without command line active)
- supported shortcuts in input prompts (e.g. expression register)

AFAIK after this commit the only Swing thing that will be left in IdeaVim is KeyStroke