### PR TITLE
Show possible action IDs when tracking, based on current shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,13 @@ Ex commands or via `:map` command mappings:
     * Execute an action by `{action_id}`. Works from Ex command line.
     * Please don't use `:action` in mappings. Use `<Action>` instead.
 
-### Finding action ids:
+### Finding action IDs:
 
-* IJ provides `IdeaVim: track action Ids` command to show the id of the executed actions.
+* IJ provides `IdeaVim: track action IDs` command to show the id of the executed actions.
   This command can be found in "Search everywhere" (double `shift`).
 
     <details>
-        <summary><strong>"Track action Ids" Details</strong> (click to see)</summary>
+        <summary><strong>"Track action IDs" Details</strong> (click to see)</summary>
         <picture>
             <source media="(prefers-color-scheme: dark)" srcset="assets/readme/track_action_dark.gif">
             <img src="assets/readme/track_action_light.gif" alt="track action ids"/>

--- a/doc/marketplace-plugin-example.md
+++ b/doc/marketplace-plugin-example.md
@@ -5,7 +5,7 @@ Using actions from external plugins is the same, as tracking and reusing any IDE
 1. Install the plugin via Marketplace
 2. Enable action tracking. You can enable it by one of the following ways:
     * Execute `:set trackactionids` ex command or just `:set tai`
-    * Open the "Find actions" window by pressing `Ctrl-Shift-A` and search for "Track Action Ids" to find the toggle that enables and disables action tracking
+    * Open the "Find actions" window by pressing `Ctrl-Shift-A` and search for "Track Action IDs" to find the toggle that enables and disables action tracking
 3. Execute the plugin action the way intended by plugin author "See Edit menu or use ⇧ + ⌥ + U / Shift + Alt + U" or just find the `Toggle Camel Case` action in the "Find actions" window (`Ctrl-Shift-A`). If you action tracking is on, you will see this notification in your right bottom corner:
    
    <img alt="Notification" src="images/action-id-notification.png"/>

--- a/src/main/resources/messages/IdeaVimBundle.properties
+++ b/src/main/resources/messages/IdeaVimBundle.properties
@@ -100,8 +100,8 @@ action.not.found.0=Action not found: {0}
 
 action.CustomizeModeWidget.text=Mode Widget Settings
 
-action.VimFindActionIdAction.text=IdeaVim: Track Action Ids
-action.VimFindActionIdAction.description=Starts tracking ids of executed actions
+action.VimFindActionIdAction.text=IdeaVim: Track Action IDs
+action.VimFindActionIdAction.description=Starts tracking IDs of executed actions
 
 ex.show.all.actions.0.1=--- Actions ---{0}{1}
 


### PR DESCRIPTION
Some actions are registered with a local component, and not with `ActionManager`, for example `NextTab` has a different implementation for editor tabs and tool window tabs. This means we can't use the action instance to look up an action ID from `ActionManager`, and the "track action IDs" feature can't show the executed action ID.

However, the action is a copy of the global "template" action, including shortcuts. We can use the shortcuts to look up and display all possible action IDs as candidates. The notification might therefore include multiple actions, but it is likely to include the required action.

Fixes [VIM-3499](https://youtrack.jetbrains.com/issue/VIM-3499).