### PR TITLE
Small refactorings around CommandBuilder

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/MotionActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/MotionActionTest.kt
@@ -767,6 +767,11 @@ class MotionActionTest : VimTestCase() {
   }
 
   @Test
+  fun testDeleteToLiteral() {
+    doTest("d/<C-V>333<CR>", "ab${c}cdōef", "abōef")
+  }
+
+  @Test
   fun testDeleteBackwardsToSearchResult() {
     val before = "Lorem ipsum dolor sit amet, ${c}consectetur adipiscing elit"
     val after = "Lorem ipsum dolor ${c}consectetur adipiscing elit"

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCharacterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCharacterAction.kt
@@ -23,6 +23,7 @@ import com.maddyhome.idea.vim.diagnostic.debug
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
 import com.maddyhome.idea.vim.helper.enumSetOf
+import com.maddyhome.idea.vim.state.KeyHandlerState
 import java.util.*
 
 @CommandOrMotion(keys = ["r"], modes = [Mode.NORMAL])
@@ -32,6 +33,10 @@ class ChangeCharacterAction : ChangeEditorActionHandler.ForEachCaret() {
   override val argumentType: Argument.Type = Argument.Type.DIGRAPH
 
   override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_ALLOW_DIGRAPH)
+
+  override fun onStartWaitingForArgument(editor: VimEditor, context: ExecutionContext, keyState: KeyHandlerState) {
+    editor.isReplaceCharacter = true
+  }
 
   override fun execute(
     editor: VimEditor,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualCharacterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeVisualCharacterAction.kt
@@ -23,6 +23,7 @@ import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
 import com.maddyhome.idea.vim.helper.enumSetOf
+import com.maddyhome.idea.vim.state.KeyHandlerState
 import java.util.*
 
 /**
@@ -35,6 +36,10 @@ class ChangeVisualCharacterAction : VisualOperatorActionHandler.ForEachCaret() {
   override val argumentType: Argument.Type = Argument.Type.DIGRAPH
 
   override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_ALLOW_DIGRAPH)
+
+  override fun onStartWaitingForArgument(editor: VimEditor, context: ExecutionContext, keyState: KeyHandlerState) {
+    editor.isReplaceCharacter = true
+  }
 
   override fun executeAction(
     editor: VimEditor,
@@ -68,7 +73,7 @@ private fun changeCharacterRange(editor: VimEditor, caret: VimCaret, range: Text
   for (j in ends.indices.reversed()) {
     for (i in starts[j] until ends[j]) {
       if (i < chars.length && '\n' != chars[i]) {
-        injector.changeGroup.replaceText(editor, caret, i, i + 1, Character.toString(ch))
+        injector.changeGroup.replaceText(editor, caret, i, i + 1, ch.toString())
       }
     }
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertCompletedLiteralAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertCompletedLiteralAction.kt
@@ -17,12 +17,38 @@ import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.state.KeyHandlerState
 import javax.swing.KeyStroke
 
 @CommandOrMotion(keys = ["<C-V>", "<C-Q>"], modes = [Mode.INSERT, Mode.CMD_LINE])
 class InsertCompletedLiteralAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
+
+  // TODO: This should really just be CHARACTER
+  // The DIGRAPH type indicates that the key handler can start the digraph state machine, but we've already started it.
+  // We're waiting for it to complete and give us a CHARACTER
   override val argumentType: Argument.Type = Argument.Type.DIGRAPH
+
+  /**
+   * Perform additional initialisation when starting to wait for an argument
+   *
+   * IdeaVim has two ways of handling digraphs/literals. Actions such as `r` or `f` can accept a digraph, which really
+   * means it accepts a character, but the user can use `<C-K>`/`<C-V>` to type a digraph or literal and convert it into
+   * a character. Unfortunately, there is no mode that can be used to register an "insert digraph/literal" action for
+   * these keys while replace or find is active. So the key handler hard codes these keys and will check for them when
+   * an action expects a digraph (and like Vim, these keys cannot be mapped). Once the state machine has matched a
+   * character, the expected argument is reset to [Argument.Type.CHARACTER] and the character is passed through the key
+   * handler again, potentially mapped, and then attached as an argument to the current command, which is now complete
+   * and executed.
+   *
+   * In Insert and Command-line mode, the `<C-K>` and `<C-V>` keys are actions that will wait for a character argument,
+   * and then insert it. Commands are only executed once complete, so we use [onStartWaitingForArgument] to start the
+   * digraph state machine. This also gives us a repeatable command and captures the keys for `'showcmd'`.
+   */
+  override fun onStartWaitingForArgument(editor: VimEditor, context: ExecutionContext, keyState: KeyHandlerState) {
+    val result = keyState.digraphSequence.startLiteralSequence()
+    KeyHandler.getInstance().setPromptCharacterEx(result.promptCharacter)
+  }
 
   override fun execute(editor: VimEditor, context: ExecutionContext, cmd: Command, operatorArguments: OperatorArguments): Boolean {
     // The converted literal character has been captured as an argument, push it back through key handler

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/InsertRegisterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/InsertRegisterAction.kt
@@ -18,6 +18,7 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.handler.VimActionHandler
+import com.maddyhome.idea.vim.state.KeyHandlerState
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
@@ -26,7 +27,7 @@ class InsertRegisterAction: VimActionHandler.SingleExecution() {
   override val argumentType: Argument.Type = Argument.Type.CHARACTER
   override val type: Command.Type = Command.Type.OTHER_WRITABLE
 
-  override fun onStartWaitingForArgument(editor: VimEditor, context: ExecutionContext) {
+  override fun onStartWaitingForArgument(editor: VimEditor, context: ExecutionContext, keyState: KeyHandlerState) {
     val cmdLine = injector.commandLine.getActiveCommandLine() ?: return
     cmdLine.setPromptCharacter('"')
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/macro/ToggleRecordingAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/macro/ToggleRecordingAction.kt
@@ -21,7 +21,8 @@ import com.maddyhome.idea.vim.handler.VimActionHandler
 class ToggleRecordingAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_READONLY
 
-  override val argumentType: Argument.Type = Argument.Type.CHARACTER
+  override val argumentType: Argument.Type?
+    get() = if (!injector.registerGroup.isRecording) Argument.Type.CHARACTER else null
 
   override fun execute(editor: VimEditor, context: ExecutionContext, cmd: Command, operatorArguments: OperatorArguments): Boolean {
     return if (!injector.registerGroup.isRecording) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
@@ -23,10 +23,20 @@ import javax.swing.KeyStroke
 
 class CommandBuilder(
   private var currentCommandPartNode: CommandPartNode<LazyVimCommand>,
-  initialUncommittedRawCount: Int = 0,
+  private val commandParts: ArrayDeque<Command>,
+  private val keyList: MutableList<KeyStroke>,
+  initialUncommittedRawCount: Int,
 ) : Cloneable {
-  private var commandParts = ArrayDeque<Command>()
-  private var keyList = mutableListOf<KeyStroke>()
+
+  constructor(
+    currentCommandPartNode: CommandPartNode<LazyVimCommand>,
+    initialUncommittedRawCount: Int = 0
+  ) : this(
+    currentCommandPartNode,
+    ArrayDeque(),
+    mutableListOf(),
+    initialUncommittedRawCount
+  )
 
   var commandState: CurrentCommandState = CurrentCommandState.NEW_COMMAND
 
@@ -266,9 +276,7 @@ class CommandBuilder(
   }
 
   public override fun clone(): CommandBuilder {
-    val result = CommandBuilder(currentCommandPartNode, count)
-    result.commandParts = ArrayDeque(commandParts)
-    result.keyList = keyList.toMutableList()
+    val result = CommandBuilder(currentCommandPartNode, ArrayDeque(commandParts), keyList.toMutableList(), count)
     result.commandState = commandState
     result.expectedArgumentType = expectedArgumentType
     result.prevExpectedArgumentType = prevExpectedArgumentType

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
@@ -191,7 +191,7 @@ class CommandBuilder(
   }
 
   fun hasCurrentCommandPartArgument(): Boolean {
-    return commandParts.firstOrNull()?.argument != null
+    return commandParts.lastOrNull()?.argument != null
   }
 
   fun buildCommand(): Command {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
@@ -77,7 +77,6 @@ class CommandBuilder(
   private var prevExpectedArgumentType: Argument.Type? = null
 
   val isReady: Boolean get() = commandState == CurrentCommandState.READY
-  val isBad: Boolean get() = commandState == CurrentCommandState.BAD_COMMAND
   val isEmpty: Boolean get() = commandParts.isEmpty()
   val isAtDefaultState: Boolean get() = isEmpty && count == 0 && expectedArgumentType == null
 
@@ -103,13 +102,6 @@ class CommandBuilder(
     commandParts.add(Command(count, register))
     expectedArgumentType = null
     count = 0
-  }
-
-  fun popCommandPart(): Command {
-    logger.trace { "popCommandPart is executed" }
-    val command = commandParts.removeLast()
-    expectedArgumentType = if (commandParts.size > 0) commandParts.last().action.argumentType else null
-    return command
   }
 
   fun fallbackToCharacterArgument() {
@@ -193,15 +185,6 @@ class CommandBuilder(
   fun hasCurrentCommandPartArgument(): Boolean {
     return commandParts.firstOrNull()?.argument != null
   }
-
-  /**
-   * Get the count given to the current command part, coerced to 1
-   *
-   * If there isn't a current command part, this will return 0. Not to be confused with [count], which is the count for
-   * the _next_ command part.
-   */
-  val currentCommandPartCount1: Int
-    get() = commandParts.firstOrNull()?.count ?: 0
 
   fun buildCommand(): Command {
     if (commandParts.last().action.id == "VimInsertCompletedDigraphAction" || commandParts.last().action.id == "VimResetModeAction") {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
@@ -201,12 +201,6 @@ class CommandBuilder(
   }
 
   fun buildCommand(): Command {
-    if (commandParts.last().action.id == "VimInsertCompletedDigraphAction" || commandParts.last().action.id == "VimResetModeAction") {
-      expectedArgumentType = prevExpectedArgumentType
-      prevExpectedArgumentType = null
-      return commandParts.removeLast()
-    }
-
     var command: Command = commandParts.removeFirst()
     while (commandParts.size > 0) {
       val next = commandParts.removeFirst()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
@@ -65,8 +65,16 @@ class CommandBuilder(
     get() = (commandParts.map { it.count }.reduceOrNull { acc, i -> acc * i } ?: 1) * count.coerceAtLeast(1)
 
   val keys: Iterable<KeyStroke> get() = keyList
+
+  // TODO: Try to remove this. We shouldn't be looking at the unbuilt command
+  // This is used by the extension mapping handler, to select the current register before invoking the extension. We
+  // need better handling of extensions so that they integrate better with half-built commands, either by finishing or
+  // resetting the command.
+  // If we keep this, consider renaming to something like `uncommittedRegister`, to reflect that the register could
+  // still change, if more keys are processed. E.g., it's perfectly valid to select register multiple times `"a"b`.
+  // This doesn't cause any issues with existing extensions
   val register: Char?
-    get() = commandParts.lastOrNull()?.register
+    get() = commandParts.lastOrNull { it.register != null }?.register
 
   // The argument type for the current command part's action. Kept separate to handle digraphs and characters. We first
   // try to accept a digraph. If we get it, set expected argument type to character and handle the converted key. If we

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
@@ -169,10 +169,6 @@ class CommandBuilder(
     return isMultikey
   }
 
-  fun isPuttingLiteral(): Boolean {
-    return !commandParts.isEmpty() && commandParts.last().action.id == "VimInsertCompletedLiteralAction"
-  }
-
   fun isDone(): Boolean {
     return commandParts.isEmpty()
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/DigraphResult.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/DigraphResult.kt
@@ -9,59 +9,27 @@ package com.maddyhome.idea.vim.common
 
 import javax.swing.KeyStroke
 
-class DigraphResult {
-  val result: Int
-  val stroke: KeyStroke?
-  var promptCharacter: Char = 0.toChar()
-    private set
-
-  private constructor(result: Int) {
-    this.result = result
-    stroke = null
-  }
-
-  private constructor(result: Int, promptCharacter: Char) {
-    this.result = result
-    this.promptCharacter = promptCharacter
-    stroke = null
-  }
-
-  private constructor(stroke: KeyStroke?) {
-    result = RES_DONE
-    this.stroke = stroke
-  }
+sealed class DigraphResult private constructor(
+  val stroke: KeyStroke? = null,
+  val promptCharacter: Char = 0.toChar(),
+) {
+  open class Handled(promptCharacter: Char) : DigraphResult(null, promptCharacter)
+  data object HandledDigraph : Handled('?')
+  data object HandledLiteral : Handled('^')
+  class Done(stroke: KeyStroke?) : DigraphResult(stroke)
+  data object Unhandled : DigraphResult()
+  data object Bad : DigraphResult()
 
   companion object {
-    const val RES_HANDLED: Int = 0
-    const val RES_UNHANDLED: Int = 1
-    const val RES_DONE: Int = 3
-    const val RES_BAD: Int = 4
-
-    @JvmField
-    val HANDLED_DIGRAPH: DigraphResult = DigraphResult(RES_HANDLED, '?')
-
-    @JvmField
-    val HANDLED_LITERAL: DigraphResult = DigraphResult(RES_HANDLED, '^')
-
-    @JvmField
-    val UNHANDLED: DigraphResult = DigraphResult(RES_UNHANDLED)
-
-    @JvmField
-    val BAD: DigraphResult = DigraphResult(RES_BAD)
-
-    @JvmStatic
     fun done(stroke: KeyStroke?): DigraphResult {
-      // for some reason vim does not let to insert char 10 as a digraph, it inserts 10 instead
+      // For some reason, vim does not let to insert char 10 as a digraph; it inserts 10 instead
       return if (stroke == null || stroke.keyCode != 10) {
-        DigraphResult(stroke)
+        Done(stroke)
       } else {
-        DigraphResult(KeyStroke.getKeyStroke(0.toChar()))
+        Done(KeyStroke.getKeyStroke(0.toChar()))
       }
     }
 
-    @JvmStatic
-    fun handled(promptCharacter: Char): DigraphResult {
-      return DigraphResult(RES_HANDLED, promptCharacter)
-    }
+    fun handled(promptCharacter: Char) = Handled(promptCharacter)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/DigraphResult.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/DigraphResult.kt
@@ -12,7 +12,8 @@ import javax.swing.KeyStroke
 class DigraphResult {
   val result: Int
   val stroke: KeyStroke?
-  private var promptCharacter: Char = 0.toChar()
+  var promptCharacter: Char = 0.toChar()
+    private set
 
   private constructor(result: Int) {
     this.result = result

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/DigraphSequence.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/DigraphSequence.kt
@@ -37,7 +37,7 @@ class DigraphSequence: Cloneable {
   fun startDigraphSequence(): DigraphResult {
     logger.debug("startDigraphSequence")
     digraphState = DIG_STATE_DIG_ONE
-    return DigraphResult.HANDLED_DIGRAPH
+    return DigraphResult.HandledDigraph
   }
 
   fun startLiteralSequence(): DigraphResult {
@@ -45,7 +45,7 @@ class DigraphSequence: Cloneable {
     digraphState = DIG_STATE_CODE_START
     codeChars = CharArray(8)
     codeCnt = 0
-    return DigraphResult.HANDLED_LITERAL
+    return DigraphResult.HandledLiteral
   }
 
   fun processKey(key: KeyStroke, editor: VimEditor): DigraphResult {
@@ -57,7 +57,7 @@ class DigraphSequence: Cloneable {
         } else if (key.keyChar != KeyEvent.CHAR_UNDEFINED) {
           digraphChar = key.keyChar
         }
-        DigraphResult.UNHANDLED
+        DigraphResult.Unhandled
       }
       DIG_STATE_BACK_SPACE -> {
         logger.debug("DIG_STATE_BACK_SPACE")
@@ -67,7 +67,7 @@ class DigraphSequence: Cloneable {
           digraphChar = 0.toChar()
           return done(KeyStroke.getKeyStroke(ch))
         }
-        DigraphResult.UNHANDLED
+        DigraphResult.Unhandled
       }
       DIG_STATE_DIG_ONE -> {
         logger.debug("DIG_STATE_DIG_ONE")
@@ -77,7 +77,7 @@ class DigraphSequence: Cloneable {
           return handled(digraphChar)
         }
         digraphState = DIG_STATE_PENDING
-        DigraphResult.BAD
+        DigraphResult.Bad
       }
       DIG_STATE_DIG_TWO -> {
         logger.debug("DIG_STATE_DIG_TWO")
@@ -86,7 +86,7 @@ class DigraphSequence: Cloneable {
           val ch = injector.digraphGroup.getDigraph(digraphChar, key.keyChar)
           return done(KeyStroke.getKeyStroke(ch))
         }
-        DigraphResult.BAD
+        DigraphResult.Bad
       }
       DIG_STATE_CODE_START -> {
         logger.debug("DIG_STATE_CODE_START")
@@ -96,28 +96,28 @@ class DigraphSequence: Cloneable {
             digraphState = DIG_STATE_CODE_CHAR
             codeType = 8
             logger.debug("Octal")
-            DigraphResult.HANDLED_LITERAL
+            DigraphResult.HandledLiteral
           }
           'x', 'X' -> {
             codeMax = 2
             digraphState = DIG_STATE_CODE_CHAR
             codeType = 16
             logger.debug("hex2")
-            DigraphResult.HANDLED_LITERAL
+            DigraphResult.HandledLiteral
           }
           'u' -> {
             codeMax = 4
             digraphState = DIG_STATE_CODE_CHAR
             codeType = 16
             logger.debug("hex4")
-            DigraphResult.HANDLED_LITERAL
+            DigraphResult.HandledLiteral
           }
           'U' -> {
             codeMax = 8
             digraphState = DIG_STATE_CODE_CHAR
             codeType = 16
             logger.debug("hex8")
-            DigraphResult.HANDLED_LITERAL
+            DigraphResult.HandledLiteral
           }
           '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> {
             codeMax = 3
@@ -125,7 +125,7 @@ class DigraphSequence: Cloneable {
             codeType = 10
             codeChars[codeCnt++] = key.keyChar
             logger.debug("decimal")
-            DigraphResult.HANDLED_LITERAL
+            DigraphResult.HandledLiteral
           }
           else -> {
             if (key.keyCode == KeyEvent.VK_TAB) {
@@ -167,7 +167,7 @@ class DigraphSequence: Cloneable {
             digraphState = DIG_STATE_PENDING
             done(code)
           } else {
-            DigraphResult.HANDLED_LITERAL
+            DigraphResult.HandledLiteral
           }
         } else if (codeCnt > 0) {
           logger.debug("invalid")
@@ -189,9 +189,9 @@ class DigraphSequence: Cloneable {
             done(key)
           }
         }
-        DigraphResult.BAD
+        DigraphResult.Bad
       }
-      else -> DigraphResult.BAD
+      else -> DigraphResult.Bad
     }
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/EditorActionHandlerBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/EditorActionHandlerBase.kt
@@ -72,7 +72,7 @@ abstract class EditorActionHandlerBase(private val myRunForEachCaret: Boolean) {
    */
   open val flags: EnumSet<CommandFlags> = noneOfEnum()
 
-  abstract fun baseExecute(
+  protected abstract fun baseExecute(
     editor: VimEditor,
     caret: VimCaret,
     context: ExecutionContext,
@@ -83,7 +83,7 @@ abstract class EditorActionHandlerBase(private val myRunForEachCaret: Boolean) {
   /**
    * Post execute is executed only one time after the main execute method
    */
-  open fun postExecute(
+  protected open fun postExecute(
     editor: VimEditor,
     context: ExecutionContext,
     cmd: Command,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/EditorActionHandlerBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/EditorActionHandlerBase.kt
@@ -18,6 +18,7 @@ import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.helper.noneOfEnum
+import com.maddyhome.idea.vim.state.KeyHandlerState
 import org.jetbrains.annotations.NonNls
 import java.util.*
 import javax.swing.KeyStroke
@@ -60,7 +61,7 @@ abstract class EditorActionHandlerBase(private val myRunForEachCaret: Boolean) {
    * This method will be executed only for actions with [argumentType != null]
    * when such actions start to await for their argument
    */
-  open fun onStartWaitingForArgument(editor: VimEditor, context: ExecutionContext) {}
+  open fun onStartWaitingForArgument(editor: VimEditor, context: ExecutionContext, keyState: KeyHandlerState) {}
 
   /**
    * Returns various binary flags for the command.

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
@@ -117,7 +117,7 @@ class CommandConsumer : KeyConsumer {
       }
       return
     }
-    if (action.argumentType == null || stopMacroRecord(node)) {
+    if (action.argumentType == null) {
       logger.trace("Set command state to READY")
       commandBuilder.commandState = CurrentCommandState.READY
     } else {
@@ -141,10 +141,6 @@ class CommandConsumer : KeyConsumer {
         commandBuilder.completeCommandPart(Argument(label[0], text, processing))
       }
     }
-  }
-
-  private fun stopMacroRecord(node: CommandNode<LazyVimCommand>): Boolean {
-    return injector.registerGroup.isRecording && node.actionHolder.instance.id == "VimToggleRecordingAction"
   }
 
   private fun startWaitingForArgument(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
@@ -170,13 +170,12 @@ class CommandConsumer : KeyConsumer {
         // the key handler when it's complete.
 
         // TODO
-//        if (action is InsertCompletedDigraphAction) {
         if (action.id == "VimInsertCompletedDigraphAction") {
-          keyState.digraphSequence.startDigraphSequence()
-          KeyHandler.getInstance().setPromptCharacterEx('?')
+          val result = keyState.digraphSequence.startDigraphSequence()
+          KeyHandler.getInstance().setPromptCharacterEx(result.promptCharacter)
         } else if (action.id == "VimInsertCompletedLiteralAction") {
-          keyState.digraphSequence.startLiteralSequence()
-          KeyHandler.getInstance().setPromptCharacterEx('^')
+          val result = keyState.digraphSequence.startLiteralSequence()
+          KeyHandler.getInstance().setPromptCharacterEx(result.promptCharacter)
         }
 
       else -> Unit

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DigraphConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DigraphConsumer.kt
@@ -60,8 +60,7 @@ class DigraphConsumer : KeyConsumer {
     when (res.result) {
       DigraphResult.RES_HANDLED -> {
         keyProcessResultBuilder.addExecutionStep { lambdaKeyState, _, _ ->
-          val commandLine = injector.commandLine.getActiveCommandLine()
-          commandLine?.setPromptCharacter(if (lambdaKeyState.commandBuilder.isPuttingLiteral()) '^' else key.keyChar)
+          keyHandler.setPromptCharacterEx(res.promptCharacter)
           lambdaKeyState.commandBuilder.addKey(key)
         }
         return true

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DigraphConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DigraphConsumer.kt
@@ -42,6 +42,7 @@ class DigraphConsumer : KeyConsumer {
     val keyState = keyProcessResultBuilder.state
     val commandBuilder = keyState.commandBuilder
     val digraphSequence = keyState.digraphSequence
+
     if (commandBuilder.expectedArgumentType == Argument.Type.DIGRAPH) {
       logger.trace("Expected argument is digraph")
       if (digraphSequence.isDigraphStart(key)) {
@@ -55,17 +56,19 @@ class DigraphConsumer : KeyConsumer {
         return true
       }
     }
+
     val res = digraphSequence.processKey(key, editor)
     val keyHandler = KeyHandler.getInstance()
-    when (res.result) {
-      DigraphResult.RES_HANDLED -> {
+    when (res) {
+      is DigraphResult.Handled -> {
         keyProcessResultBuilder.addExecutionStep { lambdaKeyState, _, _ ->
           keyHandler.setPromptCharacterEx(res.promptCharacter)
           lambdaKeyState.commandBuilder.addKey(key)
         }
         return true
       }
-      DigraphResult.RES_DONE -> {
+
+      is DigraphResult.Done -> {
         val commandLine = injector.commandLine.getActiveCommandLine()
         if (commandLine != null) {
           if (key.keyCode == KeyEvent.VK_C && key.modifiers and InputEvent.CTRL_DOWN_MASK != 0) {
@@ -89,7 +92,8 @@ class DigraphConsumer : KeyConsumer {
         }
         return true
       }
-      DigraphResult.RES_BAD -> {
+
+      is DigraphResult.Bad -> {
         val commandLine = injector.commandLine.getActiveCommandLine()
         if (commandLine != null) {
           if (key.keyCode == KeyEvent.VK_C && key.modifiers and InputEvent.CTRL_DOWN_MASK != 0) {
@@ -108,7 +112,8 @@ class DigraphConsumer : KeyConsumer {
         }
         return true
       }
-      DigraphResult.RES_UNHANDLED -> {
+
+      is DigraphResult.Unhandled -> {
         // UNHANDLED means the keystroke made no sense in the context of a digraph, but isn't an error in the current
         // state. E.g. waiting for {char} <BS> {char}. Let the key handler have a go at it.
         if (commandBuilder.expectedArgumentType === Argument.Type.DIGRAPH) {
@@ -121,6 +126,5 @@ class DigraphConsumer : KeyConsumer {
         return false
       }
     }
-    return false
   }
 }


### PR DESCRIPTION
I've been looking at how extensions interact with `CommandBuilder` (spoiler: badly) and before fixing some of these extension related things, I've done some small refactorings in the following:

* Removing some unused functions + properties from `CommandBuilder`
* Removing some special case code in `CommandConsumer` that were based on action names
* Refactor `DigraphResult` implementation to use sealed classes
* Fixing some minor correctness issues with `CommandBuilder` not using the proper command part when trying to get the in-progress count or register

Pinging @lippfi as I know you're working with `CommandBuilder`. These changes should be more about implementation details than significant changes, so hopefully shouldn't cause conflicts.