### PR TITLE
VIM-566: Add za motion support for toggling folds

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/IjActionExecutor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/IjActionExecutor.kt
@@ -60,6 +60,8 @@ internal class IjActionExecutor : VimActionExecutor {
     get() = IdeActions.ACTION_EXPAND_REGION
   override val ACTION_EXPAND_REGION_RECURSIVELY: String
     get() = IdeActions.ACTION_EXPAND_REGION_RECURSIVELY
+  override val ACTION_EXPAND_COLLAPSE_TOGGLE: String
+    get() = "ExpandCollapseToggleAction"
 
   /**
    * Execute an action

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/ChangeActionJavaTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/ChangeActionJavaTest.kt
@@ -16,6 +16,7 @@ import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimBehaviorDiffers
 import org.jetbrains.plugins.ideavim.VimJavaTestCase
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class ChangeActionJavaTest : VimJavaTestCase() {
   // VIM-511 |.|
@@ -118,6 +119,28 @@ and some text after""",
 $c
 and some text after""",
     )
+  }
+
+  // VIM-566
+  @TestWithoutNeovim(SkipNeovimReason.FOLDING)
+  @Test
+  fun testInsertAfterToggleFold() {
+    configureByJavaText(
+      """
+          $c/**
+           * I should be fold
+           * a little more text
+           * and final fold
+           */
+          and some text after
+      """.trimIndent(),
+    )
+    CodeFoldingManager.getInstance(fixture.project).updateFoldRegions(fixture.editor)
+    assertEquals(FoldingUtil.findFoldRegionStartingAtLine(fixture.editor, 0)!!.isExpanded, true)
+    typeText(injector.parser.parseKeys("za"))
+    assertEquals(FoldingUtil.findFoldRegionStartingAtLine(fixture.editor, 0)!!.isExpanded, false)
+    typeText(injector.parser.parseKeys("za"))
+    assertEquals(FoldingUtil.findFoldRegionStartingAtLine(fixture.editor, 0)!!.isExpanded, true)
   }
 
   // VIM-287 |zc| |o|

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/fold/FoldActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/fold/FoldActions.kt
@@ -33,6 +33,22 @@ class VimCollapseAllRegions : VimActionHandler.SingleExecution() {
   }
 }
 
+@CommandOrMotion(keys = ["za"], modes = [Mode.NORMAL, Mode.VISUAL])
+class VimExpandCollapseToggleRegion : VimActionHandler.SingleExecution() {
+
+  override val type: Command.Type = Command.Type.OTHER_READONLY
+
+  override fun execute(
+    editor: VimEditor,
+    context: ExecutionContext,
+    cmd: Command,
+    operatorArguments: OperatorArguments,
+  ): Boolean {
+    injector.actionExecutor.executeAction(editor, name = injector.actionExecutor.ACTION_EXPAND_COLLAPSE_TOGGLE, context = context)
+    return true
+  }
+}
+
 @CommandOrMotion(keys = ["zc"], modes = [Mode.NORMAL, Mode.VISUAL])
 class VimCollapseRegion : VimActionHandler.SingleExecution() {
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimActionExecutor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimActionExecutor.kt
@@ -20,6 +20,7 @@ interface VimActionExecutor {
   val ACTION_EXPAND_ALL_REGIONS: String
   val ACTION_EXPAND_REGION: String
   val ACTION_EXPAND_REGION_RECURSIVELY: String
+  val ACTION_EXPAND_COLLAPSE_TOGGLE: String
 
   /**
    * Execute an action


### PR DESCRIPTION
Original request for `za` I could find [here](https://youtrack.jetbrains.com/issue/VIM-566/Support-more-Vim-folding-commands)

Personally, I wanted this so adding it.

`ExpandCollapseToggleAction` is not yet exposed in `IdeActions` I have a PR [here](https://github.com/JetBrains/intellij-community/pull/2825) to expose it.

It's up to the maintainers here if you'd prefer I wait till that's merged so I dont have a hard-coded string.


I was able to build intelliJ with this change and validated the toggling works as I expect it, feedback welcome!

Note: I dont really understand the `@TestWithoutNeovim(SkipNeovimReason.FOLDING)` so please direct me if I should remove it