### PR TITLE
VIM-1824: surround - remove whitespace with closing bracket

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
@@ -354,6 +354,12 @@ class VimSurroundExtensionTest : VimTestCase() {
   }
 
   @Test
+  fun testChangeSurroundingEmptyParens() {
+    doTest(listOf("cs)}"), "${c}()", "${c}{}", Mode.NORMAL())
+    doTest(listOf("cs)}"), "(${c})", "${c}{}", Mode.NORMAL())
+  }
+
+  @Test
   fun testChangeSurroundingBlock() {
     val before = "if (condition) {${c}return;}"
     val after = "if (condition) (return;)"
@@ -621,18 +627,30 @@ class VimSurroundExtensionTest : VimTestCase() {
   }
 
   // VIM-1824
-  @ParameterizedTest(name = "testRemoveWhiteSpaceWithOpeningBracket for {2}")
+  @ParameterizedTest(name = "testRemoveWhiteSpaceWithClosingBracket for ({0}, {1}, {2})")
   @MethodSource("removeWhiteSpaceWithClosingBracketParams")
   fun testRemoveWhiteSpaceWithClosingBracket(before: String, after: String, motion: String) {
-    doTest(listOf("cs${motion}"), before, after, Mode.NORMAL())
+    doTest(listOf(motion), before, after, Mode.NORMAL())
   }
 
   companion object {
     @JvmStatic
     fun removeWhiteSpaceWithClosingBracketParams() = listOf(
-      arrayOf("{ ${c}example }", "${c}{example}", "{}"),
-      arrayOf("( ${c}example )", "${c}(example)", "()"),
-      arrayOf("[ ${c}example ]", "${c}[example]", "[]"),
+      arrayOf("{ ${c}example }", "${c}{example}", "cs{}"),
+      arrayOf("( ${c}example )", "${c}(example)", "cs()"),
+      arrayOf("[ ${c}example ]", "${c}[example]", "cs[]"),
+
+      // mutliple surrounding spaces are trimmed at once
+      arrayOf("[  ${c}example  ]", "${c}[example]", "cs[]"),
+      arrayOf("[${c}  ]", "${c}[]", "cs[]"),
+      arrayOf("[${c} ]", "${c}[]", "cs[]"),
+
+      // asymetric spaces are also trimmed at once
+      arrayOf("[ ${c}example]", "${c}[example]", "cs[]"),
+      arrayOf("[   ${c}example ]", "${c}[example]", "cs[]"),
+
+      // empty brackets are not removed
+      arrayOf("[${c}]", "${c}[]", "cs[]"),
     )
   }
 }


### PR DESCRIPTION
**Context**:

In vim surround extension closing brackets (`}, ], )`) should remove whitespace when using `cs` movement.

Example:
- Before: `{ example }`
- Movement: `cs{}`
- After: `{example}`

This doesn't work currently. The text is left unchanged.

**Solution**:

The bug was because brackets were replaced with a string from `SURROUND_PAIRS` map, which does not have any context about removing characters.

Inspired from VSCode's VIM plugin[^1], I have introduced new class `SurroundPair` that will carry this context about the need to trim characters.

**Disclaimer**:

I have never written in `Kotlin` so solution may be not use best practices, though at least this PR seems to fix the problem and tests are passing.

**Ticket**:
- https://youtrack.jetbrains.com/issue/VIM-1824/Vim-Surround-Does-not-remove-whitespace-with-the-closing-bracket

[^1]: https://github.com/VSCodeVim/Vim/blob/04fe42aa815f638af14e4cf4c92e88109242c3e6/src/actions/plugins/surround.ts#L455