### PR TITLE
[ai-completion] LLM-11886: make AI completion invoke on Enter when IdeaVim is turned on

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/handler/VimEnterHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/handler/VimEnterHandler.kt
@@ -183,6 +183,7 @@ internal abstract class OctopusHandler(private val nextHandler: EditorActionHand
  * - App code - set handler after
  * - Template - doesn't intersect with enter anymore
  * - rd.client.editor.enter - set handler before. Otherwise, rider will add new line on enter even in normal mode
+ * - inline.completion.enter - set handler before. Otherwise, AI completion is not invoked on enter.
  *
  * This rule is disabled due to VIM-3124
  * - before terminalEnter - not necessary, but terminalEnter causes "file is read-only" tooltip for readonly files VIM-3122

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -103,7 +103,7 @@
 <!--    Do not care about red handlers in order. They are necessary for proper ordering, and they'll be resolved when needed -->
     <editorActionHandler action="EditorEnter" implementationClass="com.maddyhome.idea.vim.handler.VimEnterHandler"
                          id="ideavim-enter"
-                         order="before editorEnter, before rd.client.editor.enter, after smart-step-into-enter, after AceHandlerEnter, after jupyterCommandModeEnterKeyHandler, after swift.placeholder.enter"/>
+                         order="before editorEnter, before inline.completion.enter, before rd.client.editor.enter, after smart-step-into-enter, after AceHandlerEnter, after jupyterCommandModeEnterKeyHandler, after swift.placeholder.enter"/>
     <editorActionHandler action="EditorEnter" implementationClass="com.maddyhome.idea.vim.handler.CaretShapeEnterEditorHandler"
                          id="ideavim-enter-shape"
                          order="before jupyterCommandModeEnterKeyHandler"/>


### PR DESCRIPTION
Before, the Inline Completion providers (like Full Line Code Completion and AI Assistant Completion) weren't triggered by an Enter hit. It fixes the problem.

Please note that `inline.completion.enter` handler will be available since the tomorrow build. But it looks like it doesn't create problems for the previous versions of IDE (the missing action handler).