### PR TITLE
Minor fixes for incsearch highlighting and caret/scroll position for undo

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
@@ -102,7 +102,8 @@ private fun updateSearchHighlights(
   // Update highlights in all visible editors. We update non-visible editors when they get focus.
   // Note that this now includes all editors - main, diff windows, even toolwindows like the Commit editor and consoles
   val editors = injector.editorGroup.getEditors().filter {
-    injector.application.isUnitTest() || it.ij.component.isShowing
+    (injector.application.isUnitTest() || it.ij.component.isShowing)
+      && (currentEditor == null || it.projectId == currentEditor.projectId)
   }
 
   editors.forEach {

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/UndoActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/UndoActionTest.kt
@@ -162,6 +162,16 @@ class UndoActionTest : VimTestCase() {
     configureByText("Lorem ${c}ipsum dolor sit amet")
   }
 
+  @Test
+  @TestFor(issues = ["VIM-3671"])
+  fun `test undo scrolls caret to reset scrolloff`() {
+    configureByLines(200, "lorem ipsum dolor sit amet")
+    enterCommand("set scrolloff=10")
+    typeText("50G", "dd", "G", "u")
+    assertPosition(49, 0)
+    assertVisibleArea(39, 73)
+  }
+
   private fun hasSelection(): Boolean {
     val editor = fixture.editor
     return editor.caretModel.primaryCaret.hasSelection()

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/RedoCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/RedoCommandTest.kt
@@ -8,6 +8,7 @@
 
 package org.jetbrains.plugins.ideavim.ex.implementation.commands
 
+import com.intellij.idea.TestFor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.vimscript.model.commands.RedoCommand
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -19,5 +20,16 @@ class RedoCommandTest : VimTestCase() {
   fun `command parsing`() {
     val command = injector.vimscriptParser.parseCommand("redo")
     assertTrue(command is RedoCommand)
+  }
+
+  @Test
+  @TestFor(issues = ["VIM-3671"])
+  fun `test redo scrolls caret to reset scrolloff`() {
+    configureByLines(200, "lorem ipsum dolor sit amet")
+    enterCommand("set scrolloff=10")
+    typeText("50G", "dd", "u", "G")
+    enterCommand("redo")
+    assertPosition(49, 0)
+    assertVisibleArea(39, 73)
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/UndoCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/UndoCommandTest.kt
@@ -8,6 +8,7 @@
 
 package org.jetbrains.plugins.ideavim.ex.implementation.commands
 
+import com.intellij.idea.TestFor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.vimscript.model.commands.UndoCommand
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -19,5 +20,16 @@ class UndoCommandTest : VimTestCase() {
   fun `command parsing`() {
     val command = injector.vimscriptParser.parseCommand("undo")
     assertTrue(command is UndoCommand)
+  }
+
+  @Test
+  @TestFor(issues = ["VIM-3671"])
+  fun `test undo scrolls caret to reset scrolloff`() {
+    configureByLines(200, "lorem ipsum dolor sit amet")
+    enterCommand("set scrolloff=10")
+    typeText("50G", "dd", "G")
+    enterCommand("undo")
+    assertPosition(49, 0)
+    assertVisibleArea(39, 73)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/RedoAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/RedoAction.kt
@@ -31,6 +31,7 @@ class RedoAction : VimActionHandler.SingleExecution() {
     while ((--count > 0) && result) {
       result = injector.undo.redo(editor, context)
     }
+    injector.scroll.scrollCaretIntoView(editor)
     return result
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/UndoAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/UndoAction.kt
@@ -31,6 +31,7 @@ class UndoAction : VimActionHandler.SingleExecution() {
     while ((--count > 0) && result) {
       result = injector.undo.undo(editor, context)
     }
+    injector.scroll.scrollCaretIntoView(editor)
     return result
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/RedoCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/RedoCommand.kt
@@ -23,6 +23,9 @@ import com.maddyhome.idea.vim.vimscript.model.ExecutionResult
 data class RedoCommand(val range: Range, val argument: String) : Command.SingleExecution(range, argument) {
   override val argFlags: CommandHandlerFlags = flags(RangeFlag.RANGE_FORBIDDEN, ArgumentFlag.ARGUMENT_FORBIDDEN, Access.WRITABLE)
   override fun processCommand(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments): ExecutionResult {
-    return if (injector.undo.redo(editor, context)) ExecutionResult.Success else ExecutionResult.Error
+    return if (injector.undo.redo(editor, context)) {
+      injector.scroll.scrollCaretIntoView(editor)
+      ExecutionResult.Success
+    } else ExecutionResult.Error
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/UndoCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/UndoCommand.kt
@@ -24,6 +24,9 @@ data class UndoCommand(val range: Range, val argument: String) : Command.SingleE
   override val argFlags: CommandHandlerFlags = flags(RangeFlag.RANGE_FORBIDDEN, ArgumentFlag.ARGUMENT_FORBIDDEN, Access.WRITABLE)
 
   override fun processCommand(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments): ExecutionResult {
-    return if (injector.undo.undo(editor, context)) ExecutionResult.Success else ExecutionResult.Error
+    return if (injector.undo.undo(editor, context)) {
+      injector.scroll.scrollCaretIntoView(editor)
+      ExecutionResult.Success
+    } else ExecutionResult.Error
   }
 }


### PR DESCRIPTION
This PR fixes a couple of small bugs:

1. Highlighting for `'incsearch'` now only applies to editors in the current project, rather than all open projects - [VIM-3682](https://youtrack.jetbrains.com/issue/VIM-3682)
2. Fixes an issues where undo/redo does not move the caret when used in an editor with a preview, such as Markdown files, or all source files in Android Studio (which includes a preview based on the code). IdeaVim will also ensure that `'scrolloff'` is applied after undo/redo - [VIM-3671](https://youtrack.jetbrains.com/issue/VIM-3671)