### PR TITLE
Small bug fix to use exclusive Visual caret shape from 'guicursor'

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/helper/CaretVisualAttributesHelperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/helper/CaretVisualAttributesHelperTest.kt
@@ -80,6 +80,15 @@ class CaretVisualAttributesHelperTest : VimTestCase() {
 
   @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
   @Test
+  fun `test default exclusive visual mode caret is bar`() {
+    configureByText("Lorem ipsum dolor sit amet,")
+    enterCommand("set selection=exclusive")
+    typeText("ve")
+    assertCaretVisualAttributes(CaretVisualAttributes.Shape.BAR, 0.35F)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
+  @Test
   fun `test visual block hides secondary carets`() {
     configureByLines(5, "Lorem ipsum dolor sit amet,")
     typeText("w", "<C-V>2j5l")
@@ -91,14 +100,19 @@ class CaretVisualAttributesHelperTest : VimTestCase() {
     }
   }
 
-  @VimBehaviorDiffers(description = "Vim does not change the caret for select mode", shouldBeFixed = false)
+  @VimBehaviorDiffers(
+    description = "IdeaVim treats Select mode as exclusive, rather than acting the same as Visual",
+    shouldBeFixed = true
+  )
   @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
   @Test
-  fun `test select mode uses insert mode caret`() {
-    // Vim doesn't have a different caret for SELECT, and doesn't have an option in guicursor to change SELECT mode
+  fun `test select mode uses visual-exclusive mode caret`() {
+    // TODO: Select mode should use the same caret as Visual, based on the 'selection' option
+    // IdeaVim has implemented Select mode to always be exclusive, rather than based on the 'selection' option.
+    // Therefore, we must always use the `ve` Visual-exclusive caret
     configureByText("Lorem ipsum dolor sit amet,")
     typeText("v7l", "<C-G>")
-    assertCaretVisualAttributes(CaretVisualAttributes.Shape.BAR, 0.25F)
+    assertCaretVisualAttributes(CaretVisualAttributes.Shape.BAR, 0.35F)
   }
 
   @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)

--- a/src/test/java/org/jetbrains/plugins/ideavim/helper/CaretVisualAttributesHelperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/helper/CaretVisualAttributesHelperTest.kt
@@ -89,6 +89,16 @@ class CaretVisualAttributesHelperTest : VimTestCase() {
 
   @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
   @Test
+  fun `test exclusive visual falls back to visual if not specified`() {
+    configureByText("Lorem ipsum dolor sit amet,")
+    enterCommand("set guicursor=v:hor10-Cursor/lCursor")
+    enterCommand("set selection=exclusive")
+    typeText("ve")
+    assertCaretVisualAttributes(CaretVisualAttributes.Shape.UNDERSCORE, 0.1F)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
+  @Test
   fun `test visual block hides secondary carets`() {
     configureByLines(5, "Lorem ipsum dolor sit amet,")
     typeText("w", "<C-V>2j5l")

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/helpers/GuiCursorOptionHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/helpers/GuiCursorOptionHelper.kt
@@ -76,7 +76,11 @@ object GuiCursorOptionHelper {
 
   fun getAttributes(mode: GuiCursorMode): GuiCursorAttributes {
     val attributes = injector.optionGroup.getParsedEffectiveOptionValue(Options.guicursor, null, ::parseGuicursor)
-    return attributes[mode] ?: GuiCursorAttributes.DEFAULT
+
+    // `ve` falls back to `v` if not specified
+    return attributes[mode]
+      ?: (if (mode == GuiCursorMode.VISUAL_EXCLUSIVE) attributes[GuiCursorMode.VISUAL] else null)
+      ?: GuiCursorAttributes.DEFAULT
   }
 
   private fun parseGuicursor(guicursor: VimString) = GuiCursorAttributeBuilders().also { builders ->


### PR DESCRIPTION
This PR will use the caret shape specified by `ve` in the `'guicursor'` option when Visual mode is active and the `'selection'` option equals `exclusive`. If the `ve` element isn't specified in `'guicursor'`, the `v` element is used instead.

This PR will also now use the `ve` element for Select mode. Previously, we were using the `i` Insert mode cursor (Vim doesn't have a separate Select cursor). This felt like a reasonable change at the time for several reasons. Firstly, Select mode is more similar to a traditional editor selection where typing inserts the text, replacing the selection, so using the Insert mode caret was an intuitive indicator of this. Secondly, when used in refactorings, the caret would be positioned after the selection, so a bar caret looks better.

However, the caret being positioned after the selection is because IdeaVim incorrectly treats Select mode as exclusive at all times, rather than based on the `'selection'` option, like Visual. It is therefore more appropriate to use the `ve` cursor than the `i` cursor. Fortunately, the default for this is a bar caret, so there is little visual difference with this change. It is, however, more correct.

At some point, we need to fix Select's implementation and make it inclusive by default ([VIM-3687](https://youtrack.jetbrains.com/issue/VIM-3687)). At this point, we will need to review the Select mode caret shape, as the bar will no longer be appropriate, but it will also be less intuitive for those coming from traditional editors.