### PR TITLE
Update minimum version to 242

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,6 @@ val ideaVersion: String by project
 val ideaType: String by project
 val instrumentPluginCode: String by project
 val remoteRobotVersion: String by project
-val splitModeVersion: String by project
 
 val publishChannels: String by project
 val publishToken: String by project
@@ -233,6 +232,7 @@ tasks {
 
   // Uncomment to run the plugin in a custom IDE, rather than the IDE specified as a compile target in dependencies
   // Note that the version must be greater than the plugin's target version, for obvious reasons
+  // You can also set splitMode and splitModeTarget here to test split mode in a custom IDE
 //  val runIdeCustom by intellijPlatformTesting.runIde.registering {
 //    type = IntelliJPlatformType.Rider
 //    version = "2024.1.2"
@@ -265,10 +265,6 @@ tasks {
   val runIdeSplitMode by intellijPlatformTesting.runIde.registering {
     splitMode = true
     splitModeTarget = SplitModeAware.SplitModeTarget.FRONTEND
-
-    // Frontend split mode support requires 242+
-    // TODO: Remove this once IdeaVim targets 242, as the task will naturally use the target version to run
-    version.set(splitModeVersion)
   }
 
   // Add plugin open API sources to the plugin ZIP

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # https://data.services.jetbrains.com/products?code=IC
 # Maven releases are here: https://www.jetbrains.com/intellij-repository/releases
 # And snapshots: https://www.jetbrains.com/intellij-repository/snapshots
-ideaVersion=2024.1.1
+ideaVersion=2024.2.1
 # Values for type: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 ideaType=IC
 instrumentPluginCode=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,12 +25,6 @@ javaVersion=17
 remoteRobotVersion=0.11.23
 antlrVersion=4.10.1
 
-# [VERSION UPDATE] 2024.2 - remove when IdeaVim targets 2024.2
-# Running IdeaVim in split mode requires 242. Update this version once 242 has been released, and remove it completely
-# when IdeaVim targets 242, at which point runIdeSplitMode will run correctly with the target version.
-# See also runIdeSplitMode
-splitModeVersion=242-EAP-SNAPSHOT
-
 
 # Please don't forget to update kotlin version in buildscript section
 # Also update kotlinxSerializationVersion version

--- a/src/main/java/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/highlightedyank/VimHighlightedYank.kt
@@ -24,7 +24,6 @@ import com.intellij.util.Alarm.ThreadToUse
 import com.jetbrains.rd.util.first
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.ImmutableVimCaret
-import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.common.ModeChangeListener

--- a/src/main/java/com/maddyhome/idea/vim/group/FileGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/FileGroup.kt
@@ -42,7 +42,6 @@ import com.maddyhome.idea.vim.newapi.IjEditorExecutionContext
 import com.maddyhome.idea.vim.newapi.IjVimEditor
 import com.maddyhome.idea.vim.newapi.execute
 import com.maddyhome.idea.vim.newapi.globalIjOptions
-import com.maddyhome.idea.vim.state.VimStateMachine.Companion.getInstance
 import com.maddyhome.idea.vim.state.mode.Mode.VISUAL
 import java.io.File
 import java.util.*

--- a/src/main/java/com/maddyhome/idea/vim/group/VimMarkServiceImpl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/VimMarkServiceImpl.kt
@@ -7,7 +7,6 @@
  */
 package com.maddyhome.idea.vim.group
 
-import com.intellij.codeWithMe.ClientId
 import com.intellij.ide.bookmark.Bookmark
 import com.intellij.ide.bookmark.BookmarkGroup
 import com.intellij.ide.bookmark.BookmarksListener

--- a/src/main/java/com/maddyhome/idea/vim/group/visual/VimVisualTimer.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/visual/VimVisualTimer.kt
@@ -9,8 +9,6 @@
 package com.maddyhome.idea.vim.group.visual
 
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.group.visual.VimVisualTimer.mode
-import com.maddyhome.idea.vim.group.visual.VimVisualTimer.singleTask
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.state.mode.Mode
 import java.awt.event.ActionEvent

--- a/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
@@ -91,12 +91,7 @@ private fun Editor.updatePrimaryCaretVisualAttributes() {
   caretModel.primaryCaret.visualAttributes = AttributesCache.getCaretVisualAttributes(this)
 
   // Make sure the caret is visible as soon as it's set. It might be invisible while blinking
-  // NOTE: At the moment, this causes project leak in tests
-  // IJPL-928 - this will be fixed in 2024.2
-  // [VERSION UPDATE] 2024.2 - remove if wrapping
-  if (!ApplicationManager.getApplication().isUnitTestMode) {
-    (this as? EditorEx)?.setCaretVisible(true)
-  }
+  (this as? EditorEx)?.setCaretVisible(true)
 }
 
 private fun Editor.updateSecondaryCaretsVisualAttributes() {

--- a/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
@@ -8,7 +8,6 @@
 
 package com.maddyhome.idea.vim.helper
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.CaretVisualAttributes
@@ -59,7 +58,7 @@ internal fun Editor.updateCaretsVisualAttributes() {
  * Used when Vim emulation is disabled
  */
 internal fun Editor.removeCaretsVisualAttributes() {
-  caretModel.allCarets.forEach { it.visualAttributes = CaretVisualAttributes.DEFAULT }
+  caretModel.allCarets.forEach { it.visualAttributes = CaretVisualAttributes.getDefault() }
 }
 
 internal fun Editor.hasBlockOrUnderscoreCaret() = isBlockCursorOverride() ||

--- a/src/main/java/com/maddyhome/idea/vim/helper/ScrollViewHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/ScrollViewHelper.kt
@@ -29,7 +29,6 @@ import com.maddyhome.idea.vim.helper.EditorHelper.scrollVisualLineToBottomOfScre
 import com.maddyhome.idea.vim.helper.EditorHelper.scrollVisualLineToMiddleOfScreen
 import com.maddyhome.idea.vim.helper.EditorHelper.scrollVisualLineToTopOfScreen
 import com.maddyhome.idea.vim.newapi.vim
-import com.maddyhome.idea.vim.state.VimStateMachine
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt

--- a/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/UserDataManager.kt
@@ -21,13 +21,12 @@ import com.intellij.openapi.util.UserDataHolder
 import com.maddyhome.idea.vim.api.CaretRegisterStorageBase
 import com.maddyhome.idea.vim.api.LocalMarkStorage
 import com.maddyhome.idea.vim.api.SelectionInfo
+import com.maddyhome.idea.vim.common.InsertSequence
+import com.maddyhome.idea.vim.common.VimEditorReplaceMask
 import com.maddyhome.idea.vim.ex.ExOutputModel
 import com.maddyhome.idea.vim.group.visual.VisualChange
 import com.maddyhome.idea.vim.group.visual.vimLeadSelectionOffset
-import com.maddyhome.idea.vim.common.InsertSequence
-import com.maddyhome.idea.vim.common.VimEditorReplaceMask
 import com.maddyhome.idea.vim.newapi.vim
-import com.maddyhome.idea.vim.state.VimStateMachine
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.ui.ExOutputPanel

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -62,7 +62,6 @@ import com.maddyhome.idea.vim.api.coerceOffset
 import com.maddyhome.idea.vim.api.getLineEndForOffset
 import com.maddyhome.idea.vim.api.getLineStartForOffset
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.ex.ExOutputModel
 import com.maddyhome.idea.vim.group.EditorGroup
 import com.maddyhome.idea.vim.group.FileGroup
 import com.maddyhome.idea.vim.group.IjOptions

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
@@ -22,7 +22,6 @@ import com.maddyhome.idea.vim.api.VimApplication
 import com.maddyhome.idea.vim.api.VimChangeGroup
 import com.maddyhome.idea.vim.api.VimClipboardManager
 import com.maddyhome.idea.vim.api.VimCommandGroup
-import com.maddyhome.idea.vim.api.VimCommandLine
 import com.maddyhome.idea.vim.api.VimCommandLineService
 import com.maddyhome.idea.vim.api.VimDigraphGroup
 import com.maddyhome.idea.vim.api.VimEditor

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimSearchGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimSearchGroup.kt
@@ -18,11 +18,8 @@ import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.editor.event.DocumentListener
 import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
-import com.intellij.openapi.util.Ref
 import com.maddyhome.idea.vim.VimPlugin
-import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.Options
-import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimSearchGroupBase
 import com.maddyhome.idea.vim.api.globalOptions
@@ -30,21 +27,16 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.common.Direction
 import com.maddyhome.idea.vim.common.Direction.Companion.fromInt
 import com.maddyhome.idea.vim.diagnostic.vimLogger
-import com.maddyhome.idea.vim.helper.MessageHelper
-import com.maddyhome.idea.vim.helper.TestInputModel.Companion.getInstance
 import com.maddyhome.idea.vim.helper.addSubstitutionConfirmationHighlight
 import com.maddyhome.idea.vim.helper.highlightSearchResults
-import com.maddyhome.idea.vim.helper.isCloseKeyStroke
 import com.maddyhome.idea.vim.helper.shouldIgnoreCase
 import com.maddyhome.idea.vim.helper.updateSearchHighlights
 import com.maddyhome.idea.vim.helper.vimLastHighlighters
 import com.maddyhome.idea.vim.options.GlobalOptionChangeListener
-import com.maddyhome.idea.vim.ui.ModalEntry
 import com.maddyhome.idea.vim.vimscript.model.functions.handlers.SubmatchFunctionHandler
 import org.jdom.Element
 import org.jetbrains.annotations.Contract
 import org.jetbrains.annotations.TestOnly
-import javax.swing.KeyStroke
 
 @State(
   name = "VimSearchSettings",

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEditorKit.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEditorKit.kt
@@ -7,7 +7,6 @@
  */
 package com.maddyhome.idea.vim.ui.ex
 
-import com.intellij.openapi.diagnostic.logger
 import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.newapi.vim

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/commands/ActionListCommand.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/commands/ActionListCommand.kt
@@ -15,10 +15,8 @@ import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.OperatorArguments
-import com.maddyhome.idea.vim.ex.ExOutputModel
 import com.maddyhome.idea.vim.ex.ranges.Range
 import com.maddyhome.idea.vim.helper.MessageHelper
-import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.vimscript.model.ExecutionResult
 import java.util.*
 

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/commands/CmdFilterCommand.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/commands/CmdFilterCommand.kt
@@ -18,7 +18,6 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.ex.ExException
-import com.maddyhome.idea.vim.ex.ExOutputModel
 import com.maddyhome.idea.vim.ex.ranges.Range
 import com.maddyhome.idea.vim.ex.ranges.toTextRange
 import com.maddyhome.idea.vim.helper.EditorHelper

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/PrintCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/PrintCommandTest.kt
@@ -10,7 +10,6 @@ package org.jetbrains.plugins.ideavim.ex.implementation.commands
 
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.options
-import com.maddyhome.idea.vim.ex.ExOutputModel
 import com.maddyhome.idea.vim.newapi.vim
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/LineNumberOptionsMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/LineNumberOptionsMapperTest.kt
@@ -14,7 +14,6 @@ import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.maddyhome.idea.vim.api.Options
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.group.IjOptions
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseLowerMotionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseLowerMotionAction.kt
@@ -19,7 +19,6 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.DuplicableOperatorAction
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
-import com.maddyhome.idea.vim.helper.CharacterHelper
 
 @CommandOrMotion(keys = ["gu"], modes = [Mode.NORMAL])
 class ChangeCaseLowerMotionAction : ChangeEditorActionHandler.ForEachCaret(), DuplicableOperatorAction {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseLowerVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseLowerVisualAction.kt
@@ -18,7 +18,6 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.CharacterHelper
 
 /**
  * @author vlan

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseToggleVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseToggleVisualAction.kt
@@ -18,7 +18,6 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.CharacterHelper
 
 /**
  * @author vlan

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseUpperMotionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseUpperMotionAction.kt
@@ -19,7 +19,6 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.DuplicableOperatorAction
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
-import com.maddyhome.idea.vim.helper.CharacterHelper
 
 @CommandOrMotion(keys = ["gU"], modes = [Mode.NORMAL])
 class ChangeCaseUpperMotionAction : ChangeEditorActionHandler.ForEachCaret(), DuplicableOperatorAction {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseUpperVisualAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseUpperVisualAction.kt
@@ -18,7 +18,6 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
-import com.maddyhome.idea.vim.helper.CharacterHelper
 
 /**
  * @author vlan

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBackspaceAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBackspaceAction.kt
@@ -12,7 +12,6 @@ import com.intellij.vim.annotations.CommandOrMotion
 import com.intellij.vim.annotations.Mode
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
-import com.maddyhome.idea.vim.api.getLineStartForOffset
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimScriptExecutorBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimScriptExecutorBase.kt
@@ -11,7 +11,6 @@ package com.maddyhome.idea.vim.api
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.ex.FinishException
-import com.maddyhome.idea.vim.history.HistoryConstants
 import com.maddyhome.idea.vim.history.VimHistory
 import com.maddyhome.idea.vim.register.RegisterConstants.LAST_COMMAND_REGISTER
 import com.maddyhome.idea.vim.vimscript.model.CommandLineVimLContext

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimListenersNotifier.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimListenersNotifier.kt
@@ -9,7 +9,6 @@
 package com.maddyhome.idea.vim.common
 
 import com.maddyhome.idea.vim.api.ImmutableVimCaret
-import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.state.mode.Mode

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
@@ -13,7 +13,6 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.options
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.options.OptionConstants
-import com.maddyhome.idea.vim.state.VimStateMachine
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.state.mode.isSingleModeActive

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/regexp/engine/nfa/matcher/VisualAreaMatcher.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/regexp/engine/nfa/matcher/VisualAreaMatcher.kt
@@ -8,13 +8,10 @@
 
 package com.maddyhome.idea.vim.regexp.engine.nfa.matcher
 
-import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimCaret
-import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.regexp.match.VimMatchGroupCollection
-import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.inVisualMode
-import com.maddyhome.idea.vim.state.mode.returnTo
 
 /**
  * Matcher used to check if index is inside the visual area.


### PR DESCRIPTION
Updates the build target/minium version to 2024.2.1 (2024.2.0 is no longer available), fixes a deprecated API usage, and cleans up some unused imports.

I haven't made any changes to the usages of "2024.1" in the `.teamcity` folder.

It's also worth checking `IjActionExecutor`. There is a usage of the deprecated `AnAction.beforeActionPerformed` API that is marked as an error because it's scheduled for removal.