### PR TITLE
Add some missing maps

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageDownActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/scroll/ScrollPageDownActionTest.kt
@@ -58,6 +58,16 @@ class ScrollPageDownActionTest : VimTestCase() {
 
   @TestWithoutNeovim(SkipNeovimReason.SCROLL)
   @Test
+  fun `test scroll single page down with S-Enter`() {
+    configureByPages(5)
+    setPositionAndScroll(0, 0)
+    typeText("<S-Enter>")
+    assertPosition(33, 0)
+    assertVisibleArea(33, 67)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.SCROLL)
+  @Test
   fun `test scroll page down in insert mode with S-Down`() {
     configureByPages(5)
     setPositionAndScroll(0, 0)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageDownAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/scroll/MotionScrollPageDownAction.kt
@@ -22,7 +22,24 @@ import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.enumSetOf
 import java.util.*
 
-@CommandOrMotion(keys = ["<C-F>", "<PageDown>"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
+// The <S-Enter> mapping is interesting. Vim has multiple mappings to move the caret down: <Down>, obviously, but also
+// <Enter>, <C-N>, `+` and `j`. While there are some differences (<Enter> and `+` have a flag that moves the caret to
+// the start of the line), there is just one function to handle all of these keys and move the caret down.
+// This function checks if Shift is held down, in which case it will scroll the page forward, because <S-Down> behaves
+// the same as <C-F>. The side effect is that all shift+"down" shortcuts will now scroll forward, including <S-Enter>.
+// However, Vim does not support shifted ctrl shortcuts because terminals only support simple ascii control characters.
+// So <C-S-N> doesn't scroll forward. Shift+j becomes `J`, which joins multiple lines. And on a typical US/UK keyboard,
+// `+` requires shift to type, so can only be typed with the numpad. Vim does not allow remapping <s-+>.
+// (IdeaVim does not get shift+numpadPlus, only "typed +". We might get it for a keypress, but by the time it's
+// converted to a typed char, we lose the modifier).
+// The same logic holds for <Up> and shift - <C-P>, `k` and `-` should scroll backwards, but <C-S-P> isn't valid, `K` is
+// a different action, and shift+numpadMinus works but can't be remapped (or handled by IdeaVim).
+// Ironically, Vim registers separate functions for <S-Down> and <S-Up>, so the non-shifted functions don't actually
+// need to check for shift. So this is all side effect...
+// See https://github.com/vim/vim/issues/15107
+// Note that IdeaVim handles <S-Down> separately because it behaves differently based on 'keymodel'
+// TODO: Is there any way for IdeaVim to handle shift+numpadPlus?
+@CommandOrMotion(keys = ["<C-F>", "<PageDown>", "<S-Enter>"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
 class MotionScrollPageDownAction : VimActionHandler.SingleExecution() {
 
   override val type: Command.Type = Command.Type.OTHER_READONLY

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/window/tabs/NextTabAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/window/tabs/NextTabAction.kt
@@ -16,7 +16,7 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.VimActionHandler
 
-@CommandOrMotion(keys = ["gt"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
+@CommandOrMotion(keys = ["gt", "<C-PageDown>"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
 class NextTabAction : VimActionHandler.SingleExecution() {
   override fun execute(
     editor: VimEditor,
@@ -24,6 +24,22 @@ class NextTabAction : VimActionHandler.SingleExecution() {
     cmd: Command,
     operatorArguments: OperatorArguments,
   ): Boolean {
+    injector.motion.moveCaretGotoNextTab(editor, context, cmd.rawCount)
+    return true
+  }
+
+  override val type: Command.Type = Command.Type.OTHER_SELF_SYNCHRONIZED
+}
+
+@CommandOrMotion(keys = ["<C-PageDown>"], modes = [Mode.INSERT])
+class InsertNextTabAction : VimActionHandler.SingleExecution() {
+  override fun execute(
+    editor: VimEditor,
+    context: ExecutionContext,
+    cmd: Command,
+    operatorArguments: OperatorArguments,
+  ): Boolean {
+    // Vim doesn't change mode
     injector.motion.moveCaretGotoNextTab(editor, context, cmd.rawCount)
     return true
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/window/tabs/PreviousTabAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/window/tabs/PreviousTabAction.kt
@@ -16,8 +16,23 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.VimActionHandler
 
-@CommandOrMotion(keys = ["gT"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
+@CommandOrMotion(keys = ["gT", "<C-PageUp>"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
 class PreviousTabAction : VimActionHandler.SingleExecution() {
+  override fun execute(
+    editor: VimEditor,
+    context: ExecutionContext,
+    cmd: Command,
+    operatorArguments: OperatorArguments,
+  ): Boolean {
+    injector.motion.moveCaretGotoPreviousTab(editor, context, cmd.rawCount)
+    return true
+  }
+
+  override val type: Command.Type = Command.Type.OTHER_SELF_SYNCHRONIZED
+}
+
+@CommandOrMotion(keys = ["<C-PageUp>"], modes = [Mode.INSERT])
+class InsertPreviousTabAction : VimActionHandler.SingleExecution() {
   override fun execute(
     editor: VimEditor,
     context: ExecutionContext,

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -845,6 +845,11 @@
         "modes": "INXS"
     },
     {
+        "keys": "<S-Enter>",
+        "class": "com.maddyhome.idea.vim.action.motion.scroll.MotionScrollPageDownAction",
+        "modes": "NXO"
+    },
+    {
         "keys": "<S-Home>",
         "class": "com.maddyhome.idea.vim.action.motion.leftright.MotionShiftHomeAction",
         "modes": "INXS"

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -360,6 +360,26 @@
         "modes": "I"
     },
     {
+        "keys": "<C-PageDown>",
+        "class": "com.maddyhome.idea.vim.action.window.tabs.InsertNextTabAction",
+        "modes": "I"
+    },
+    {
+        "keys": "<C-PageDown>",
+        "class": "com.maddyhome.idea.vim.action.window.tabs.NextTabAction",
+        "modes": "NXO"
+    },
+    {
+        "keys": "<C-PageUp>",
+        "class": "com.maddyhome.idea.vim.action.window.tabs.InsertPreviousTabAction",
+        "modes": "I"
+    },
+    {
+        "keys": "<C-PageUp>",
+        "class": "com.maddyhome.idea.vim.action.window.tabs.PreviousTabAction",
+        "modes": "NXO"
+    },
+    {
         "keys": "<C-Q>",
         "class": "com.maddyhome.idea.vim.action.change.insert.InsertCompletedLiteralAction",
         "modes": "IC"


### PR DESCRIPTION
* Adds a map for `<C-PageUp/Down>` and `i_<C-PageUp/PageDown>` to switch tabs - [VIM-2044](https://youtrack.jetbrains.com/issue/VIM-2044)
* Adds a map for `<S-Enter>` to scroll page forward - [VIM-2752](https://youtrack.jetbrains.com/issue/VIM-2752)
* Removes some old extended handling of special keys that was required when keys for actions were registered via a comma separated string in an XML attribute. Removes recognising `«` and `»` and also `<Comma>`