### PR TITLE
Fix memory leak with non-disposed listeners

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/listener/VimListenersTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/listener/VimListenersTest.kt
@@ -8,30 +8,84 @@
 
 package org.jetbrains.plugins.ideavim.listener
 
+import com.intellij.openapi.components.ComponentManagerEx
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
+import com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl
+import com.intellij.platform.util.coroutines.childScope
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import com.intellij.testFramework.replaceService
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.listener.VimListenerTestObject
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import kotlin.test.assertEquals
 
 class VimListenersTest : VimTestCase() {
+  @BeforeEach
+  override fun setUp(testInfo: TestInfo) {
+    super.setUp(testInfo)
+
+    val manager = FileEditorManagerImpl(fixture.project, (fixture.project as ComponentManagerEx).getCoroutineScope().childScope())
+    fixture.project.replaceService(FileEditorManager::class.java, manager, fixture.testRootDisposable)
+
+    VimListenerTestObject.disposedCounter = 0
+    VimListenerTestObject.enabled = true
+  }
+
   @AfterEach
   fun tearDown() {
     VimListenerTestObject.disposedCounter = 0
     VimListenerTestObject.enabled = false
   }
 
-  @Test
-  fun `disposable is called on plugin disable`() {
-    configureByText("XYZ")
-    VimListenerTestObject.disposedCounter = 0
-    VimListenerTestObject.enabled = true
+  override fun createFixture(factory: IdeaTestFixtureFactory): CodeInsightTestFixture {
+    val fixture = factory.createFixtureBuilder("IdeaVim").fixture
+    return factory.createCodeInsightFixture(fixture)
+  }
 
-    VimPlugin.setEnabled(false)
+  @Test
+  fun `disposable is called when disabling IdeaVim functionality`() {
+    configureByText("XYZ")
+
+    try {
+      VimPlugin.setEnabled(false)
+      assertEquals(1, VimListenerTestObject.disposedCounter)
+    }
+    finally {
+      VimPlugin.setEnabled(true)
+    }
+  }
+
+  @Test
+  fun `disposable is called when closing editor`() {
+    configureByText("XYZ")
+
+    val fileManager = FileEditorManagerEx.getInstanceEx(fixture.project)
+    fileManager.closeFile(fixture.editor.virtualFile)
 
     assertEquals(1, VimListenerTestObject.disposedCounter)
+  }
 
-    VimPlugin.setEnabled(true)
+  @Test
+  fun `disposable is called once when disabling IdeaVim functionality and then closing the editor`() {
+    configureByText("XYZ")
+
+    try {
+      VimPlugin.setEnabled(false)
+      assertEquals(1, VimListenerTestObject.disposedCounter)
+
+      val fileManager = FileEditorManagerEx.getInstanceEx(fixture.project)
+      fileManager.closeFile(fixture.editor.virtualFile)
+
+      assertEquals(1, VimListenerTestObject.disposedCounter)
+    }
+    finally {
+      VimPlugin.setEnabled(true)
+    }
   }
 }


### PR DESCRIPTION
When an editor is initialised, IdeaVim registers various listeners and uses a new per-editor disposable to remove the registrations. When the IdeaVim plugin is disabled/unloaded by the platform, the parent disposable is disposed, and all listeners are unregistered. All per-editor disposables are also disposed when IdeaVim disables Vim functionality without disbaling the whole plugin. However, the per-editor disposable is not disposed at any other time, e.g., when the editor is closed. So IdeaVim is leaking disposables.

Since each registration's disposable needs to call an editor method to remove the listener, each disposable captures a reference to the editor. Because the disposables are not removed when an editor is closed, that means IdeaVim is leaking editor instances.

(Some listener registrations simply add a reference _from_ the editor to a singleton listener handler. If there was no disposable to remove the registration, there would be no reference to the editor to keep it alive and GC could collect it. However, the disposable does maintain a reference, and all listener registrations keep the editor from being collected)

This PR will explicitly dispose the per-editor disposable when the editor is released, and adds tests to confirm this.

Fixes [VIM-3319](https://youtrack.jetbrains.com/issue/VIM-3319)