### PR TITLE
Add partial support for getcmdtype() function

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/GetCmdTypeFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/GetCmdTypeFunctionTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.functions
+
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.ui.ex.ExEntryPanel
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class GetCmdTypeFunctionTest : VimTestCase() {
+
+  @Test
+  fun `test getcmdtype() for a regular command`() {
+    configureByText("\n")
+    enterCommand("cmap <expr> z getcmdtype()")
+    typeText(":fooz")
+    assertEquals("foo:", (injector.commandLine.getActiveCommandLine() as ExEntryPanel).visibleText)
+  }
+
+  @Test
+  fun `test getcmdtype() for a forward search`() {
+    configureByText("\n")
+    enterCommand("cmap <expr> z getcmdtype()")
+    typeText("/fooz")
+    assertEquals("foo/", (injector.commandLine.getActiveCommandLine() as ExEntryPanel).visibleText)
+  }
+
+  @Test
+  fun `test getcmdtype() for a backward search`() {
+    configureByText("\n")
+    enterCommand("cmap <expr> z getcmdtype()")
+    typeText("?fooz")
+    assertEquals("foo?", (injector.commandLine.getActiveCommandLine() as ExEntryPanel).visibleText)
+  }
+
+  @Test
+  fun `test getcmdtype() for an expression command`() {
+    configureByText("\n")
+    enterCommand("cmap <expr> z getcmdtype()")
+    typeText("i<C-r>=fooz")
+    assertEquals("foo=", (injector.commandLine.getActiveCommandLine() as ExEntryPanel).visibleText)
+  }
+
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/GetCmdTypeFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/GetCmdTypeFunctionHandler.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.functions.handlers
+
+import com.intellij.vim.annotations.VimscriptFunction
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.state.mode.Mode
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDataType
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
+import com.maddyhome.idea.vim.vimscript.model.expressions.Expression
+import com.maddyhome.idea.vim.vimscript.model.functions.FunctionHandler
+
+/*
+Return the current command-line type. Possible return values are:
+    :	normal Ex command
+    >	debug mode command debug-mode
+    /	forward search command
+    ?	backward search command
+    =	i_CTRL-R_=
+
+Returns an empty string otherwise.
+
+Not yet implemented:
+    @	input() command
+    -	:insert or :append command
+ */
+@VimscriptFunction(name = "getcmdtype")
+internal class GetCmdTypeFunctionHandler : FunctionHandler() {
+    override val minimumNumberOfArguments = 0
+    override val maximumNumberOfArguments = 0
+
+  override fun doFunction(
+    argumentValues: List<Expression>,
+    editor: VimEditor,
+    context: ExecutionContext,
+    vimContext: VimLContext,
+  ): VimDataType {
+    val mode = editor.mode
+    return when (mode) {
+      is Mode.CMD_LINE -> VimString(injector.commandLine.getActiveCommandLine()?.label ?: "")
+      else -> VimString("")
+    }
+  }
+
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/GetCmdTypeFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/GetCmdTypeFunctionHandler.kt
@@ -22,7 +22,6 @@ import com.maddyhome.idea.vim.vimscript.model.functions.FunctionHandler
 /*
 Return the current command-line type. Possible return values are:
     :	normal Ex command
-    >	debug mode command debug-mode
     /	forward search command
     ?	backward search command
     =	i_CTRL-R_=
@@ -30,6 +29,7 @@ Return the current command-line type. Possible return values are:
 Returns an empty string otherwise.
 
 Not yet implemented:
+    >	debug mode command debug-mode
     @	input() command
     -	:insert or :append command
  */

--- a/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
@@ -5,6 +5,7 @@
     "funcref": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.FuncrefFunctionHandler",
     "function": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.FunctionFunctionHandler",
     "get": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.GetFunctionHandler",
+    "getcmdtype": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.GetCmdTypeFunctionHandler",
     "join": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.JoinFunctionHandler",
     "len": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.LenFunctionHandler",
     "sin": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.SinFunctionHandler",


### PR DESCRIPTION
The `getcmdtype()` could be called from inside a prompt (search, expression, command), or from a remapping. Apparently IdeaVim currently doesn't support nested prompts (e.g. by typing `:<C-r>=` to show an expression prompt inside a command prompt), so it wouldn't be functional in that case.

It should work in a remapping though, e.g.: `:cnoremap <F2> <C-r>=getcmdtype()<CR>`. Could you advise on how I could unit test this?

For context, this is the remap that I'm using this for:

```
cnoremap <expr> <Esc> getcmdtype() =~ '[/?]' ? '<CR><Esc>' : '<Esc>'
```

This is so that if you press `<Escape>` during a search before you press enter, it keeps the cursor at the first search result instead of jumping back to where the cursor was before the search started. This enforces a behavior that you find in most text search tools, including IntelliJ's built-in search.