### PR TITLE
Fix options initialisation in 2024.2+

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/WrapOptionMapperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/overrides/WrapOptionMapperTest.kt
@@ -21,7 +21,6 @@ import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import kotlin.test.assertFalse
@@ -248,7 +247,6 @@ class WrapOptionMapperTest : VimTestCase() {
   }
 
   @Test
-  @Disabled("Doesn't work in 242")
   fun `test open new window after setting option copies value as explicitly set`() {
     enterCommand("set nowrap")
     assertCommandOutput("set wrap?", "nowrap")
@@ -278,7 +276,6 @@ class WrapOptionMapperTest : VimTestCase() {
   }
 
   @Test
-  @Disabled("Doesn't work in 242")
   fun `test setlocal 'wrap' then open new window uses value from setglobal`() {
     enterCommand("setlocal nowrap")
     assertCommandOutput("setglobal wrap?", "  wrap")
@@ -294,7 +291,6 @@ class WrapOptionMapperTest : VimTestCase() {
   }
 
   @Test
-  @Disabled("Doesn't work in 242")
   fun `test setting global IDE value will update effective Vim value in new window initialised from value set during startup`() {
     try {
       injector.optionGroup.startInitVimRc()

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -259,6 +259,9 @@ abstract class VimNoWriteActionTestCase {
     injector.modalInput.getCurrentModalInput()?.deactivate(refocusOwningEditor = false, resetCaret = false)
     (injector.digraphGroup as VimDigraphGroupBase).clearCustomDigraphs()
 
+    // Important to reset in tearDown as well as setUp, so we reset modified test options
+    resetAllOptions()
+
     // Tear down neovim
     NeovimTesting.tearDown(testInfo)
   }

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -73,6 +73,7 @@ import com.maddyhome.idea.vim.helper.getGuiCursorMode
 import com.maddyhome.idea.vim.key.MappingOwner
 import com.maddyhome.idea.vim.key.ToKeysMappingInfo
 import com.maddyhome.idea.vim.listener.SelectionVimListenerSuppressor
+import com.maddyhome.idea.vim.listener.VimListenerManager
 import com.maddyhome.idea.vim.newapi.IjVimEditor
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.newapi.ijOptions
@@ -242,6 +243,7 @@ abstract class VimNoWriteActionTestCase {
     bookmarksManager?.bookmarks?.forEach { bookmark ->
       bookmarksManager.remove(bookmark)
     }
+    VimListenerManager.VimLastSelectedEditorTracker.resetLastSelectedEditor(fixture.project)
     SelectionVimListenerSuppressor.lock().use { fixture.tearDown() }
     ExEntryPanel.getInstance().deactivate(false)
     VimPlugin.getVariableService().clear()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimOptionGroupBase.kt
@@ -260,20 +260,29 @@ abstract class VimOptionGroupBase : VimOptionGroup {
 
 
   private fun <T : VimDataType> initialiseNewOptionDefaultValues(option: Option<T>) {
-    if (option.declaredScope != LOCAL_TO_WINDOW) {
-      storage.setOptionValue(option, OptionAccessScope.GLOBAL(null), OptionValue.Default(option.defaultValue))
-    }
-    injector.editorGroup.getEditors().forEach { editor ->
+    fun initialiseNewOptionDefaultValuesForWindow(editor: VimEditor) {
       when (option.declaredScope) {
-        GLOBAL -> { }
-        LOCAL_TO_BUFFER, LOCAL_TO_WINDOW -> {
+        GLOBAL -> {}
+        LOCAL_TO_BUFFER -> {
           storage.setOptionValue(option, OptionAccessScope.LOCAL(editor), OptionValue.Default(option.defaultValue))
         }
+
+        LOCAL_TO_WINDOW -> {
+          storage.setOptionValue(option, OptionAccessScope.GLOBAL(editor), OptionValue.Default(option.defaultValue))
+          storage.setOptionValue(option, OptionAccessScope.LOCAL(editor), OptionValue.Default(option.defaultValue))
+        }
+
         GLOBAL_OR_LOCAL_TO_BUFFER, GLOBAL_OR_LOCAL_TO_WINDOW -> {
           storage.setOptionValue(option, OptionAccessScope.LOCAL(editor), OptionValue.Default(option.unsetValue))
         }
       }
     }
+
+    if (option.declaredScope != LOCAL_TO_WINDOW) {
+      storage.setOptionValue(option, OptionAccessScope.GLOBAL(null), OptionValue.Default(option.defaultValue))
+    }
+    initialiseNewOptionDefaultValuesForWindow(injector.fallbackWindow)
+    injector.editorGroup.getEditors().forEach(::initialiseNewOptionDefaultValuesForWindow)
   }
 }
 


### PR DESCRIPTION
This PR will fix options initialisation in 2024.2 and above.

Options are initialised based on the currently selected editor (Vim "window"). In 2024.1, we could use `FileEditorManager.selectedTextEditor` to get the last selected text editor while creating a new editor. This value can no longer be relied upon in 2024.2, as the value is reset to `null` when a new editor (that will become the next selected editor) is being created.

This meant we were always initialising window options based on the "fallback" window. Vim always has at least one window open, so there is always a window to initialise _from_. IntelliJ can close all windows, so we need to keep track of the options used by the window that was last to be closed - so if there are no open windows, we can initialise from the "fallback" window.

However, a further change in behaviour meant that we were updating this fallback window too frequently -  whenever _any_ window closed. This mostly mitigated the first problem, except for options that are mapped to IntelliJ settings, e.g. `'wrap'`. This lead to some tests for `'wrap'` being disabled for 242.

This PR will:
* Update option tests to make them easier to understand and to ensure that the fallback window is updated correctly. This should help diagnose similar problems if behaviour changes in the future
* Change the method of updating the fallback window so it's only updated when the last window in a project is closed
* Start manually tracking the last selected editor/window so that unexpected `null` values don't cause trouble
* Reinstate disabled `'wrap'` tests