### PR TITLE
Fix repeating change action with count

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/change/ChangeMotionActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/change/ChangeMotionActionTest.kt
@@ -194,4 +194,16 @@ Mode.INSERT,
   fun testLastSymbolInWord() {
     doTest("cw", "fo${c}o", "fo${c}", Mode.INSERT)
   }
+
+  // VIM-3729
+  @Test
+  fun `test change with count applies only to motion when repeated`() {
+    doTest(listOf("2c3l", "foo<Esc>", "w", "."),
+      """
+        banana banana
+      """.trimIndent(),
+      """
+        foo foo
+      """.trimIndent())
+  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeMotionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeMotionAction.kt
@@ -15,15 +15,18 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.CommandFlags
+import com.maddyhome.idea.vim.command.CommandFlags.FLAG_NO_REPEAT_INSERT
 import com.maddyhome.idea.vim.command.DuplicableOperatorAction
 import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.helper.enumSetOf
+import java.util.EnumSet
 
 @CommandOrMotion(keys = ["c"], modes = [Mode.NORMAL])
 class ChangeMotionAction : ChangeInInsertSequenceAction(), DuplicableOperatorAction {
   override val type: Command.Type = Command.Type.CHANGE
-
+  override val flags: EnumSet<CommandFlags> = enumSetOf(FLAG_NO_REPEAT_INSERT)
   override val argumentType: Argument.Type = Argument.Type.MOTION
-
   override val duplicateWith: Char = 'c'
 
   override fun executeInInsertSequence(


### PR DESCRIPTION
Repeating the `c` command should not repeat inserting the text. This is mostly visible when the command is initially made with a count. E.g. `2c3l` will change 6 characters. Hitting `.` should also change 6 characters and shouldn't repeat inserting the text 6 times.

This PR adds `CommandFlags.FLAG_NO_REPEAT_INSERT`, as used by `s`, `S` and `C`.

Fixes [VIM-3729](https://youtrack.jetbrains.com/issue/VIM-3729)