### PR TITLE
Add search widget

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -101,10 +101,12 @@ import com.maddyhome.idea.vim.state.mode.inSelectMode
 import com.maddyhome.idea.vim.state.mode.selectionType
 import com.maddyhome.idea.vim.ui.ShowCmdOptionChangeListener
 import com.maddyhome.idea.vim.ui.ShowCmdWidgetUpdater
+import com.maddyhome.idea.vim.ui.widgets.search.searchWidgetOptionListener
 import com.maddyhome.idea.vim.ui.widgets.macro.MacroWidgetListener
 import com.maddyhome.idea.vim.ui.widgets.macro.macroWidgetOptionListener
 import com.maddyhome.idea.vim.ui.widgets.mode.listeners.ModeWidgetListener
 import com.maddyhome.idea.vim.ui.widgets.mode.modeWidgetOptionListener
+import com.maddyhome.idea.vim.ui.widgets.search.SearchWidgetListener
 import org.jetbrains.annotations.TestOnly
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
@@ -169,6 +171,10 @@ internal object VimListenerManager {
     injector.listenersNotifier.myEditorListeners.add(modeWidgetListener)
     injector.listenersNotifier.vimPluginListeners.add(modeWidgetListener)
 
+    val searchWidgetListener = SearchWidgetListener()
+    injector.listenersNotifier.searchListeners.add(searchWidgetListener)
+    injector.listenersNotifier.vimPluginListeners.add(searchWidgetListener)
+
     val macroWidgetListener = MacroWidgetListener()
     injector.listenersNotifier.macroRecordingListeners.add(macroWidgetListener)
     injector.listenersNotifier.vimPluginListeners.add(macroWidgetListener)
@@ -205,8 +211,10 @@ internal object VimListenerManager {
       // This code is executed after ideavimrc execution, so we trigger onGlobalOptionChanged just in case
       optionGroup.addGlobalOptionChangeListener(Options.showmode, modeWidgetOptionListener)
       optionGroup.addGlobalOptionChangeListener(Options.showmode, macroWidgetOptionListener)
+      optionGroup.addGlobalOptionChangeListener(Options.showmode, searchWidgetOptionListener)
       modeWidgetOptionListener.onGlobalOptionChanged()
       macroWidgetOptionListener.onGlobalOptionChanged()
+      searchWidgetOptionListener.onGlobalOptionChanged()
 
       // Listen for and initialise new editors
       EventFacade.getInstance().addEditorFactoryListener(VimEditorFactoryListener, VimPlugin.getInstance().onOffDisposable)
@@ -224,6 +232,7 @@ internal object VimListenerManager {
       optionGroup.removeGlobalOptionChangeListener(Options.showcmd, ShowCmdOptionChangeListener)
       optionGroup.removeGlobalOptionChangeListener(Options.showmode, modeWidgetOptionListener)
       optionGroup.removeGlobalOptionChangeListener(Options.showmode, macroWidgetOptionListener)
+      optionGroup.removeGlobalOptionChangeListener(Options.showmode, searchWidgetOptionListener)
       optionGroup.removeEffectiveOptionValueChangeListener(Options.guicursor, GuicursorChangeListener)
     }
   }

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimSearchGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimSearchGroup.kt
@@ -116,6 +116,7 @@ open class IjVimSearchGroup : VimSearchGroupBase(), PersistentStateComponent<Ele
 
   override fun clearSearchHighlight() {
     showSearchHighlight = false
+    injector.listenersNotifier.notifySearchStopped()
     updateSearchHighlights(false)
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/ui/widgets/search/SearchWidgetFactory.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/widgets/search/SearchWidgetFactory.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.ui.widgets.search
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.globalOptions
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.common.SearchListener
+import com.maddyhome.idea.vim.helper.vimLastHighlighters
+import com.maddyhome.idea.vim.newapi.ij
+import com.maddyhome.idea.vim.ui.widgets.VimWidgetListener
+import com.maddyhome.idea.vim.ui.widgets.mode.VimStatusBarWidget
+import java.awt.Component
+
+private const val ID = "IdeaVimSearch"
+
+internal class SearchWidgetFactory : StatusBarWidgetFactory {
+
+  override fun getId(): String {
+    return ID
+  }
+
+  override fun getDisplayName(): String {
+    return "IdeaVim Search"
+  }
+
+  override fun createWidget(project: Project): StatusBarWidget {
+    return VimSearchWidget()
+  }
+
+  override fun isAvailable(project: Project): Boolean {
+    return VimPlugin.isEnabled() && injector.globalOptions().showmode
+  }
+}
+
+fun updateSearchWidget() {
+  val factory = StatusBarWidgetFactory.EP_NAME.findExtension(SearchWidgetFactory::class.java) ?: return
+  for (project in ProjectManager.getInstance().openProjects) {
+    val statusBarWidgetsManager = project.service<StatusBarWidgetsManager>()
+    statusBarWidgetsManager.updateWidget(factory)
+  }
+}
+
+class VimSearchWidget : StatusBarWidget, VimStatusBarWidget {
+  var content: String = ""
+
+  override fun ID(): String {
+    return ID
+  }
+
+  override fun getPresentation(): StatusBarWidget.WidgetPresentation {
+    return VimModeWidgetPresentation()
+  }
+
+  private inner class VimModeWidgetPresentation : StatusBarWidget.TextPresentation {
+    override fun getAlignment(): Float = Component.CENTER_ALIGNMENT
+
+    override fun getText(): String {
+      return content
+    }
+
+    override fun getTooltipText(): String {
+      return content.ifEmpty {
+        "No search in progress"
+      }
+    }
+  }
+}
+
+class SearchWidgetListener : SearchListener, VimWidgetListener({ updateSearchWidget() }) {
+
+  override fun searchUpdated(editor: VimEditor, offset: Int) {
+    val ijEditor = editor.ij
+    var currentHighlighter = 1
+    val numHighlighters = ijEditor.vimLastHighlighters?.size ?: 0
+    for (highlighter in ijEditor.vimLastHighlighters!!) {
+      if (highlighter.startOffset == offset) {
+        break
+      }
+      currentHighlighter++
+    }
+    for (project in ProjectManager.getInstance().openProjects) {
+      val searchWidget = getWidget(project) ?: continue
+      searchWidget.content = String.format("Occurrence: %s of %s", currentHighlighter, numHighlighters)
+      searchWidget.updateWidgetInStatusBar(ID, project)
+    }
+  }
+
+  override fun searchStopped() {
+    for (project in ProjectManager.getInstance().openProjects) {
+      val searchWidget = getWidget(project) ?: continue
+      searchWidget.content = ""
+      searchWidget.updateWidgetInStatusBar(ID, project)
+    }
+  }
+
+  private fun getWidget(project: Project): VimSearchWidget? {
+    val statusBar = WindowManager.getInstance()?.getStatusBar(project) ?: return null
+    return statusBar.getWidget(ID) as? VimSearchWidget
+  }
+
+}
+
+val searchWidgetOptionListener: VimWidgetListener = VimWidgetListener { updateSearchWidget() }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -62,6 +62,7 @@
     <statusBarWidgetFactory id="IdeaVim-Icon" implementation="com.maddyhome.idea.vim.ui.StatusBarIconFactory" order="last, before IdeaVimMode"/>
     <statusBarWidgetFactory id="IdeaVimShowCmd" implementation="com.maddyhome.idea.vim.ui.ShowCmdStatusBarWidgetFactory" order="first"/>
     <statusBarWidgetFactory id="IdeaVimMacro" implementation="com.maddyhome.idea.vim.ui.widgets.macro.MacroWidgetFactory" order="first, after IdeaVimShowCmd"/>
+    <statusBarWidgetFactory id="IdeaVimSearch" implementation="com.maddyhome.idea.vim.ui.widgets.search.SearchWidgetFactory" order="first, after IdeaVimShowCmd"/>
 
     <applicationService serviceImplementation="com.maddyhome.idea.vim.VimPlugin"/>
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
@@ -1340,6 +1340,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
       } else if (lastPatternTrailing!![ppos + 1] == '?') {
         Direction.BACKWARDS
       } else {
+        injector.listenersNotifier.notifySearchUpdated(editor, res)
         return if (res == -1) null else Pair(res, motionType)
       }
       if (lastPatternTrailing!!.length - ppos > 2) {
@@ -1347,6 +1348,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
       }
       res = processSearchCommand(editor, lastPatternTrailing!!.substring(ppos + 1), res, 1, nextDir)?.first ?: -1
     }
+    injector.listenersNotifier.notifySearchUpdated(editor, res)
     return if (res == -1) null else Pair(res, motionType)
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/SearchListener.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/SearchListener.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.common
+
+import com.maddyhome.idea.vim.api.VimEditor
+
+interface SearchListener {
+
+  fun searchUpdated(editor: VimEditor, offset: Int)
+  fun searchStopped()
+
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimListenersNotifier.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimListenersNotifier.kt
@@ -20,6 +20,7 @@ class VimListenersNotifier {
   val modeChangeListeners: MutableCollection<ModeChangeListener> = ConcurrentLinkedDeque()
   val myEditorListeners: MutableCollection<EditorListener> = ConcurrentLinkedDeque()
   val macroRecordingListeners: MutableCollection<MacroRecordingListener> = ConcurrentLinkedDeque()
+  val searchListeners: MutableCollection<SearchListener> = ConcurrentLinkedDeque()
   val vimPluginListeners: MutableCollection<VimPluginListener> = ConcurrentLinkedDeque()
   val isReplaceCharListeners: MutableCollection<IsReplaceCharListener> = ConcurrentLinkedDeque()
   val yankListeners: MutableCollection<VimYankListener> = ConcurrentLinkedDeque()
@@ -47,6 +48,16 @@ class VimListenersNotifier {
   fun notifyEditorFocusLost(editor: VimEditor) {
     if (!injector.enabler.isEnabled()) return // we remove all the listeners when turning the plugin off, but let's do it just in case
     myEditorListeners.forEach { it.focusLost(editor) }
+  }
+
+  fun notifySearchUpdated(editor: VimEditor, offset: Int) {
+    if (!injector.enabler.isEnabled()) return // we remove all the listeners when turning the plugin off, but let's do it just in case
+    searchListeners.forEach { it.searchUpdated(editor, offset) }
+  }
+
+  fun notifySearchStopped() {
+    if (!injector.enabler.isEnabled()) return // we remove all the listeners when turning the plugin off, but let's do it just in case
+    searchListeners.forEach { it.searchStopped() }
   }
 
   fun notifyMacroRecordingStarted() {


### PR DESCRIPTION
This widget is activated while doing a search (forward/backward, word search, etc.). It shows the current occurrence that you're on, as well as the total number of occurrences for the search terms. Works similarly to IntelliJ's built-in search tool.

This relies on search highlights being shown. But perhaps this is acceptable since the users who would care about this widget would also likely have highlights turned on?

If tests are expected for this, could you point me to some similar examples? I couldn't find tests, for example, for the macro widget.

![2024-12-01_22-51-10](https://github.com/user-attachments/assets/33e9584e-c189-479a-9a78-4a1e6ef06efe)
