### PR TITLE
Add support for CTRL-J

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertEnterActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertEnterActionTest.kt
@@ -119,6 +119,23 @@ class InsertEnterActionTest : VimTestCase() {
     doTest(listOf("i", "<C-M>"), before, after, Mode.INSERT)
   }
 
+  @TestWithoutNeovim(SkipNeovimReason.CTRL_CODES)
+  @RepeatedTest(3)
+  fun `test insert enter with C-J`() {
+    val before = """Lorem ipsum dolor sit amet,
+        |${c}consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+    """.trimMargin()
+    val after = """Lorem ipsum dolor sit amet,
+        |
+        |${c}consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+    """.trimMargin()
+    doTest(listOf("i", "<C-J>"), before, after, Mode.INSERT)
+  }
+
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @RepeatedTest(3)
   fun `test insert enter scrolls view up at scrolloff`() {
@@ -156,4 +173,3 @@ internal class DestroyerHandlerSingle(private val nextHandler: EditorActionHandl
     return nextHandler.isEnabled(editor, caret, dataContext)
   }
 }
-

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectEnterActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectEnterActionTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+@file:Suppress("RemoveCurlyBracesFromTemplate")
+
+package org.jetbrains.plugins.ideavim.action.motion.select
+
+import com.maddyhome.idea.vim.state.mode.Mode
+import com.maddyhome.idea.vim.state.mode.SelectionType
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class SelectEnterActionTest : VimTestCase() {
+  @Test
+  fun `test enter in Select`() {
+    doTest(
+      "gh<CR>",
+      """
+        |Lorem ipsum
+        |
+        |Lorem ip${c}sum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem ipsum
+        |
+        |Lorem ip
+        |${c}um dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.CTRL_CODES)
+  @Test
+  fun `test CTRL-J in Select`() {
+    doTest(
+      "gh<C-J>",
+      """
+        |Lorem ipsum
+        |
+        |Lorem ip${c}sum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem ipsum
+        |
+        |Lorem ip
+        |${c}um dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.CTRL_CODES)
+  @Test
+  fun `test CTRL-M in Select`() {
+    doTest(
+      "gh<C-M>",
+      """
+        |Lorem ipsum
+        |
+        |Lorem ip${c}sum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem ipsum
+        |
+        |Lorem ip
+        |${c}um dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE),
+    )
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionDownActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionDownActionTest.kt
@@ -23,6 +23,74 @@ import org.junit.jupiter.api.Test
  */
 class MotionDownActionTest : VimTestCase() {
   @Test
+  fun `test motion down with CTRL-J`() {
+    doTest(
+      "<C-J>",
+      """
+        |Lorem ipsum
+        |
+        |Lorem ${c}ipsum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem ipsum
+        |
+        |Lorem ipsum dolor sit amet,
+        |consec${c}tetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test motion down with CTRL-J in Visual`() {
+    doTest(
+      "v<C-J>",
+      """
+        |Lorem ipsum
+        |
+        |Lorem ${c}ipsum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem ipsum
+        |
+        |Lorem ${s}ipsum dolor sit amet,
+        |consec${c}t${se}etur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE),
+    )
+  }
+
+  @Test
+  fun `test motion down with CTRL-J in Operator-pending`() {
+    doTest(
+      "d<C-J>",
+      """
+        |Lorem ipsum
+        |
+        |Lorem ${c}ipsum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem ipsum
+        |
+        |${c}Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+    )
+  }
+
+  @Test
   fun `test motion down in visual block mode`() {
     val keys = "<C-V>2kjjj"
     val before = """

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertEnterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertEnterAction.kt
@@ -19,10 +19,9 @@ import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.enumSetOf
 import java.util.*
 
-@CommandOrMotion(keys = ["<C-M>", "<CR>"], modes = [Mode.INSERT])
+@CommandOrMotion(keys = ["<CR>", "<C-M>", "<C-J>"], modes = [Mode.INSERT])
 class InsertEnterAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
-
   override val flags: EnumSet<CommandFlags> = enumSetOf(CommandFlags.FLAG_SAVE_STROKE)
 
   override fun execute(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectEnterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectEnterAction.kt
@@ -21,9 +21,8 @@ import com.maddyhome.idea.vim.handler.VimActionHandler
  * @author Alex Plate
  */
 
-@CommandOrMotion(keys = ["<Enter>"], modes = [Mode.SELECT])
+@CommandOrMotion(keys = ["<CR>", "<C-J>", "<C-M>"], modes = [Mode.SELECT])
 class SelectEnterAction : VimActionHandler.SingleExecution() {
-
   override val type: Command.Type = Command.Type.INSERT
 
   override fun execute(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionDownActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/updown/MotionDownActions.kt
@@ -21,7 +21,7 @@ import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.MotionActionHandler
 import com.maddyhome.idea.vim.handler.toMotion
 
-@CommandOrMotion(keys = ["j"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
+@CommandOrMotion(keys = ["j", "<C-J>"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
 open class MotionDownAction : MotionActionHandler.ForEachCaret() {
   override val motionType: MotionType = MotionType.LINE_WISE
   override val keepFold: Boolean = true

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -281,8 +281,23 @@
     },
     {
         "keys": "<C-J>",
+        "class": "com.maddyhome.idea.vim.action.change.insert.InsertEnterAction",
+        "modes": "I"
+    },
+    {
+        "keys": "<C-J>",
         "class": "com.maddyhome.idea.vim.action.ex.ProcessExEntryAction",
         "modes": "C"
+    },
+    {
+        "keys": "<C-J>",
+        "class": "com.maddyhome.idea.vim.action.motion.select.SelectEnterAction",
+        "modes": "S"
+    },
+    {
+        "keys": "<C-J>",
+        "class": "com.maddyhome.idea.vim.action.motion.updown.MotionDownAction",
+        "modes": "NXO"
     },
     {
         "keys": "<C-K>",
@@ -313,6 +328,11 @@
         "keys": "<C-M>",
         "class": "com.maddyhome.idea.vim.action.ex.ProcessExEntryAction",
         "modes": "C"
+    },
+    {
+        "keys": "<C-M>",
+        "class": "com.maddyhome.idea.vim.action.motion.select.SelectEnterAction",
+        "modes": "S"
     },
     {
         "keys": "<C-M>",
@@ -666,6 +686,11 @@
     },
     {
         "keys": "<CR>",
+        "class": "com.maddyhome.idea.vim.action.motion.select.SelectEnterAction",
+        "modes": "S"
+    },
+    {
+        "keys": "<CR>",
         "class": "com.maddyhome.idea.vim.action.motion.updown.EnterNormalAction",
         "modes": "NXO"
     },
@@ -713,11 +738,6 @@
         "keys": "<End>",
         "class": "com.maddyhome.idea.vim.action.motion.leftright.MotionLastColumnInsertAction",
         "modes": "I"
-    },
-    {
-        "keys": "<Enter>",
-        "class": "com.maddyhome.idea.vim.action.motion.select.SelectEnterAction",
-        "modes": "S"
     },
     {
         "keys": "<Esc>",


### PR DESCRIPTION
Adds `<C-J>` support in Normal, Insert, Visual, Select and Operator-pending. Also adds support for `<C-M>` in Select.

Fixes [VIM-3740](https://youtrack.jetbrains.com/issue/VIM-3740) 