### PR TITLE
[VIM-3731] Add support for "jump to previous/next lowercase mark".

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/MarkTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/MarkTest.kt
@@ -271,6 +271,186 @@ class MarkTest : VimTestCase() {
     assertOffset(14)
   }
 
+  // VIM-3731 |m| |[`|
+  @Test
+  fun testGotoPreviousMark() {
+    typeTextInFile(
+      injector.parser.parseKeys("ma" + "jmb" + "wmc" + "[`"),
+      """
+      one two
+      <caret>three
+      four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(14)
+  }
+
+  // VIM-3731 |m| |[`|
+  @Test
+  fun testGotoPreviousMarkIgnoresPlacingOrder() {
+    typeTextInFile(
+      injector.parser.parseKeys("mb" + "kma" + "jwmc" + "[`"),
+      """
+      one two
+      three
+      <caret>four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(14)
+  }
+
+  // VIM-3731 |m| |[`|
+  @Test
+  fun testGotoPreviousMarkMultipleMarksOnSamePosition() {
+    typeTextInFile(
+      injector.parser.parseKeys("mb" + "kma" + "jwmcmd" + "[`"),
+      """
+      one two
+      three
+      <caret>four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(14)
+  }
+
+  // VIM-3731 |m| |[`|
+  @Test
+  fun testGotoPreviousMarkWithCount() {
+    typeTextInFile(
+      injector.parser.parseKeys("ma" + "jmb" + "wmc" + "2[`"),
+      """
+      one two
+      <caret>three
+      four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(8)
+  }
+
+  // VIM-3731 |m| |[`|
+  @Test
+  fun testGotoPreviousMarkWithExcessiveCount() {
+    typeTextInFile(
+      injector.parser.parseKeys("ma" + "jmb" + "wmc" + "5[`"),
+      """
+      one two
+      <caret>three
+      four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(8)
+  }
+
+  // VIM-3731 |m| |[`|
+  @Test
+  fun testGotoPreviousMarkBeforeFirstMarkDoesNothing() {
+    typeTextInFile(
+      injector.parser.parseKeys("ma" + "jmb" + "wmc" + "ggw"+ "[`"),
+      """
+      one two
+      <caret>three
+      four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(4)
+  }
+
+  // VIM-3731 |m| |]`|
+  @Test
+  fun testGotoNextMark() {
+    typeTextInFile(
+      injector.parser.parseKeys("ma" + "jmb" + "wmc" + "gg" + "]`"),
+      """
+      one two
+      <caret>three
+      four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(8)
+  }
+
+  // VIM-3731 |m| |]`|
+  @Test
+  fun testGotoNextMarkIgnoresPlacingOrder() {
+    typeTextInFile(
+      injector.parser.parseKeys("mb" + "kma" + "jwmc" + "gg" + "]`"),
+      """
+      one two
+      three
+      <caret>four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(8)
+  }
+
+  // VIM-3731 |m| |]`|
+  @Test
+  fun testGotoNextMarkMultipleMarksOnSamePosition() {
+    typeTextInFile(
+      injector.parser.parseKeys("mbmd" + "kma" + "jwmc" + "ggjj" + "]`"),
+      """
+      one two
+      three
+      <caret>four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(19)
+  }
+
+  // VIM-3731 |m| |]`|
+  @Test
+  fun testGotoNextMarkWithCount() {
+    typeTextInFile(
+      injector.parser.parseKeys("ma" + "jmb" + "wmc" + "gg" + "2]`"),
+      """
+      one two
+      <caret>three
+      four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(14)
+  }
+
+  // VIM-3731 |m| |]`|
+  @Test
+  fun testGotoNextMarkWithExcessiveCount() {
+    typeTextInFile(
+      injector.parser.parseKeys("ma" + "jmb" + "wmc" + "gg" + "5]`"),
+      """
+      one two
+      <caret>three
+      four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(19)
+  }
+
+  // VIM-3731 |m| |]`|
+  @Test
+  fun testGotoNextMarkAfterLastMarkDoesNothing() {
+    typeTextInFile(
+      injector.parser.parseKeys("ma" + "jmb" + "wmc" + "ll"+ "]`"),
+      """
+      one two
+      <caret>three
+      four five
+     
+      """.trimIndent(),
+    )
+    assertOffset(21)
+  }
+
   // |i| |`]|
   @Test
   fun testGotoLastChangePositionEnd() {
@@ -538,6 +718,69 @@ class MarkTest : VimTestCase() {
     My mother <selection>taugh<caret>t</selection> me this trick:taught
     if you repeat something <selection>ove<caret>r</selection> and over again it loses its meaning.over
     For example: homework, homework, homework, homework, <selection>homewor<caret>k</selection>, homework, homework, homework, homework.homework
+    See, nothing.
+    
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testMulticaretPreviousNextMark() {
+    configureByText(
+      """
+    My mother <caret>taught me this trick:
+    if you repeat something <caret>over and over again it loses its meaning.
+    For example: homework, homework, homework, homework, <caret>homework, homework, homework, homework, homework.
+    See, nothing.
+    
+      """.trimIndent(),
+    )
+    typeText("mawmbw")
+    assertState(
+      """
+    My mother taught me <caret>this trick:
+    if you repeat something over and <caret>over again it loses its meaning.
+    For example: homework, homework, homework, homework, homework, <caret>homework, homework, homework, homework.
+    See, nothing.
+    
+      """.trimIndent(),
+    )
+    typeText("[`")
+    assertState(
+      """
+    My mother taught <caret>me this trick:
+    if you repeat something over <caret>and over again it loses its meaning.
+    For example: homework, homework, homework, homework, homework<caret>, homework, homework, homework, homework.
+    See, nothing.
+    
+      """.trimIndent(),
+    )
+    typeText("[`")
+    assertState(
+      """
+    My mother <caret>taught me this trick:
+    if you repeat something <caret>over and over again it loses its meaning.
+    For example: homework, homework, homework, homework, <caret>homework, homework, homework, homework, homework.
+    See, nothing.
+    
+      """.trimIndent(),
+    )
+    typeText("[`") // Does nothing on first mark.
+    assertState(
+      """
+    My mother <caret>taught me this trick:
+    if you repeat something <caret>over and over again it loses its meaning.
+    For example: homework, homework, homework, homework, <caret>homework, homework, homework, homework, homework.
+    See, nothing.
+    
+      """.trimIndent(),
+    )
+    typeText("5]`") // Excessive count goes to last mark.
+    assertState(
+      """
+    My mother taught <caret>me this trick:
+    if you repeat something over <caret>and over again it loses its meaning.
+    For example: homework, homework, homework, homework, homework<caret>, homework, homework, homework, homework.
     See, nothing.
     
       """.trimIndent(),

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/mark/MotionGotoMarkAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/mark/MotionGotoMarkAction.kt
@@ -63,3 +63,26 @@ class MotionGotoMarkNoSaveJumpAction : MotionActionHandler.ForEachCaret() {
     return injector.motion.moveCaretToMark(caret, mark, false)
   }
 }
+
+@CommandOrMotion(keys = ["]`"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
+class MotionGotoNextMarkAction: MotionGotoRelativeMarkAction(countMultiplier = 1) {
+}
+
+@CommandOrMotion(keys = ["[`"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
+class MotionGotoPreviousMarkAction: MotionGotoRelativeMarkAction(countMultiplier = -1) {
+}
+
+sealed class MotionGotoRelativeMarkAction(private val countMultiplier: Int) : MotionActionHandler.ForEachCaret() {
+  override val motionType: MotionType = MotionType.EXCLUSIVE
+
+  override fun getOffset(
+    editor: VimEditor,
+    caret: ImmutableVimCaret,
+    context: ExecutionContext,
+    argument: Argument?,
+    operatorArguments: OperatorArguments,
+  ): Motion {
+    return injector.motion.moveCaretToMarkRelative(caret, operatorArguments.count1 * countMultiplier)
+  }
+
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMarkService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMarkService.kt
@@ -46,6 +46,11 @@ interface VimMarkService {
   fun getMark(caret: ImmutableVimCaret, char: Char): Mark?
 
   /**
+   * Get previous / next lowercase mark for specified caret
+   */
+  fun getRelativeLowercaseMark(caret: ImmutableVimCaret, count: Int): Mark?
+
+  /**
    * Gets all marks for caret
    */
   fun getAllLocalMarks(caret: ImmutableVimCaret): Set<Mark>

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroup.kt
@@ -59,6 +59,7 @@ interface VimMotionGroup {
 
   // Move caret to other
   fun moveCaretToMark(caret: ImmutableVimCaret, ch: Char, toLineStart: Boolean): Motion
+  fun moveCaretToMarkRelative(caret: ImmutableVimCaret, count: Int): Motion
   fun moveCaretToJump(editor: VimEditor, caret: ImmutableVimCaret, count: Int): Motion
   fun moveCaretToMatchingPair(editor: VimEditor, caret: ImmutableVimCaret): Motion
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
@@ -283,6 +283,13 @@ abstract class VimMotionGroupBase : VimMotionGroup {
     return Motion.Error
   }
 
+  override fun moveCaretToMarkRelative(caret: ImmutableVimCaret, count: Int): Motion {
+    val markService = injector.markService
+    val mark = markService.getRelativeLowercaseMark(caret, count) ?: return Motion.Error
+    val offset = caret.editor.bufferPositionToOffset(BufferPosition(mark.line, mark.col, false))
+    return offset.toMotionOrError()
+  }
+
   override fun moveCaretToJump(editor: VimEditor, caret: ImmutableVimCaret, count: Int): Motion {
     val jumpService = injector.jumpService
     val spot = jumpService.getJumpSpot(editor)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Marks.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/mark/Marks.kt
@@ -10,6 +10,7 @@ package com.maddyhome.idea.vim.mark
 
 import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.mark.Mark.KeySorter.ORDER
 import org.jetbrains.annotations.NonNls
 
 interface Mark {
@@ -27,6 +28,13 @@ interface Mark {
 
     override fun compare(o1: Mark, o2: Mark): Int {
       return ORDER.indexOf(o1.key) - ORDER.indexOf(o2.key)
+    }
+  }
+  // Same as in BufferPosition.
+  // TODO: Consider having a shared Interface / comparator for Mark and BufferPosition to avoid this duplication.
+  object PositionSorter: Comparator<Mark> {
+    override fun compare(o1: Mark, o2: Mark): Int {
+      return if (o1.line != o2.line) o1.line - o2.line else o1.col - o2.col
     }
   }
 }

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -1215,6 +1215,11 @@
         "modes": "NXO"
     },
     {
+        "keys": "[`",
+        "class": "com.maddyhome.idea.vim.action.motion.mark.MotionGotoPreviousMarkAction",
+        "modes": "NXO"
+    },
+    {
         "keys": "[b",
         "class": "com.maddyhome.idea.vim.action.motion.text.MotionCamelLeftAction",
         "modes": "NXO"
@@ -1277,6 +1282,11 @@
     {
         "keys": "]]",
         "class": "com.maddyhome.idea.vim.action.motion.text.MotionSectionForwardStartAction",
+        "modes": "NXO"
+    },
+    {
+        "keys": "]`",
+        "class": "com.maddyhome.idea.vim.action.motion.mark.MotionGotoNextMarkAction",
         "modes": "NXO"
     },
     {


### PR DESCRIPTION
Fixes [VIM-3731](https://youtrack.jetbrains.com/issue/VIM-3731/Add-support-for-jump-to-previous-next-lowercase-mark).

Let me know if I should do anything else with `Mark.PositionSorter`.  The two data structures are in different packages, so I wasn't sure if sharing the code would be desired or where you'd want the shared code to live.