### PR TITLE
Refactor Mode API and implement v_CTRL-O

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
@@ -47,7 +47,6 @@ import com.maddyhome.idea.vim.state.mode.selectionType
 import org.jetbrains.annotations.NonNls
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
-import com.maddyhome.idea.vim.state.mode.returnTo
 
 /**
  * Port of vim-surround.
@@ -289,7 +288,7 @@ internal class VimSurroundExtension : VimExtension {
     private fun getSurroundRange(caret: VimCaret): TextRange? {
       val editor = caret.editor
       if (editor.mode is Mode.CMD_LINE) {
-        editor.mode = (editor.mode as Mode.CMD_LINE).returnTo()
+        editor.mode = editor.mode.returnTo
       }
       return when (editor.mode) {
         is Mode.NORMAL -> injector.markService.getChangeMarks(caret)
@@ -337,7 +336,7 @@ private fun getSurroundPair(c: Char): SurroundPair? = if (c in SURROUND_PAIRS) {
 private fun inputTagPair(editor: Editor, context: DataContext): SurroundPair? {
   val tagInput = inputString(editor, context, "<", '>')
   if (editor.vim.mode is Mode.CMD_LINE) {
-    editor.vim.mode = editor.vim.mode.returnTo()
+    editor.vim.mode = editor.vim.mode.returnTo
   }
   val matcher = tagNameAndAttributesCapturePattern.matcher(tagInput)
   return if (matcher.find()) {
@@ -356,7 +355,7 @@ private fun inputFunctionName(
 ): SurroundPair? {
   val functionNameInput = inputString(editor, context, "function: ", null)
   if (editor.vim.mode is Mode.CMD_LINE) {
-    editor.vim.mode = editor.vim.mode.returnTo()
+    editor.vim.mode = editor.vim.mode.returnTo
   }
   if (functionNameInput.isEmpty()) return null
   return if (withInternalSpaces) {

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
@@ -53,8 +53,6 @@ import com.maddyhome.idea.vim.newapi.IjEditorExecutionContext
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.ReturnTo
-import com.maddyhome.idea.vim.state.mode.returnTo
 import org.jetbrains.annotations.Range
 import kotlin.math.max
 import kotlin.math.min
@@ -332,12 +330,7 @@ internal class MotionGroup : VimMotionGroupBase() {
       } else {
         val state = injector.vimState as VimStateMachineImpl
         if (state.mode is Mode.VISUAL) {
-          val returnTo = state.mode.returnTo
-          when (returnTo) {
-            ReturnTo.INSERT -> state.mode = Mode.INSERT
-            ReturnTo.REPLACE -> state.mode = Mode.REPLACE
-            null -> state.mode = Mode.NORMAL()
-          }
+          state.mode = state.mode.returnTo
         }
         val keyHandler = KeyHandler.getInstance()
         KeyHandler.getInstance().reset(keyHandler.keyHandlerState, state.mode)

--- a/src/main/java/com/maddyhome/idea/vim/group/copy/PutGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/copy/PutGroup.kt
@@ -80,7 +80,7 @@ internal class PutGroup : VimPutBase() {
     vimEditor: VimEditor,
     vimContext: ExecutionContext,
     text: ProcessedTextData,
-    subMode: SelectionType,
+    selectionType: SelectionType,
     data: PutData,
     additionalData: Map<String, Any>,
   ) {
@@ -148,7 +148,7 @@ internal class PutGroup : VimPutBase() {
         startOffset,
         endOffset,
         text.typeInRegister,
-        subMode,
+        selectionType,
         data.caretAfterInsertedText,
       )
     }

--- a/src/main/java/com/maddyhome/idea/vim/group/visual/IdeaSelectionControl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/visual/IdeaSelectionControl.kt
@@ -33,7 +33,6 @@ import com.maddyhome.idea.vim.state.mode.inCommandLineMode
 import com.maddyhome.idea.vim.state.mode.inNormalMode
 import com.maddyhome.idea.vim.state.mode.inSelectMode
 import com.maddyhome.idea.vim.state.mode.inVisualMode
-import com.maddyhome.idea.vim.state.mode.returnTo
 import com.maddyhome.idea.vim.vimscript.model.options.helpers.IdeaRefactorModeHelper
 import com.maddyhome.idea.vim.vimscript.model.options.helpers.isIdeaRefactorModeKeep
 import com.maddyhome.idea.vim.vimscript.model.options.helpers.isIdeaRefactorModeSelect
@@ -75,7 +74,7 @@ internal object IdeaSelectionControl {
       }
 
       if (hasSelection) {
-        if (editor.vim.inCommandLineMode && editor.vim.mode.returnTo().hasVisualSelection) {
+        if (editor.vim.inCommandLineMode && editor.vim.mode.returnTo.hasVisualSelection) {
           logger.trace { "Modifying selection while in Command-line mode, most likely incsearch" }
           return@singleTask
         }

--- a/src/main/java/com/maddyhome/idea/vim/group/visual/IdeaSelectionControl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/visual/IdeaSelectionControl.kt
@@ -157,23 +157,23 @@ internal object IdeaSelectionControl {
     return when {
       editor.isOneLineMode -> {
         if (logReason) logger.debug("Enter select mode. Reason: one line mode")
-        Mode.SELECT(VimPlugin.getVisualMotion().autodetectVisualSubmode(editor.vim))
+        Mode.SELECT(VimPlugin.getVisualMotion().detectSelectionType(editor.vim))
       }
       selectionSource == VimListenerManager.SelectionSource.MOUSE && OptionConstants.selectmode_mouse in selectmode -> {
         if (logReason) logger.debug("Enter select mode. Selection source is mouse and selectMode option has mouse")
-        Mode.SELECT(VimPlugin.getVisualMotion().autodetectVisualSubmode(editor.vim))
+        Mode.SELECT(VimPlugin.getVisualMotion().detectSelectionType(editor.vim))
       }
       editor.isTemplateActive() && editor.vim.isIdeaRefactorModeSelect -> {
         if (logReason) logger.debug("Enter select mode. Template is active and selectMode has template")
-        Mode.SELECT(VimPlugin.getVisualMotion().autodetectVisualSubmode(editor.vim))
+        Mode.SELECT(VimPlugin.getVisualMotion().detectSelectionType(editor.vim))
       }
       selectionSource == VimListenerManager.SelectionSource.OTHER && OptionConstants.selectmode_ideaselection in selectmode -> {
         if (logReason) logger.debug("Enter select mode. Selection source is OTHER and selectMode has refactoring")
-        Mode.SELECT(VimPlugin.getVisualMotion().autodetectVisualSubmode(editor.vim))
+        Mode.SELECT(VimPlugin.getVisualMotion().detectSelectionType(editor.vim))
       }
       else -> {
         if (logReason) logger.debug("Enter visual mode")
-        Mode.VISUAL(VimPlugin.getVisualMotion().autodetectVisualSubmode(editor.vim))
+        Mode.VISUAL(VimPlugin.getVisualMotion().detectSelectionType(editor.vim))
       }
     }
   }

--- a/src/main/java/com/maddyhome/idea/vim/group/visual/VisualMotionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/visual/VisualMotionGroup.kt
@@ -18,13 +18,13 @@ import com.maddyhome.idea.vim.state.mode.SelectionType
  * @author Alex Plate
  */
 internal class VisualMotionGroup : VimVisualMotionGroupBase() {
-  override fun autodetectVisualSubmode(editor: VimEditor): SelectionType {
+  override fun detectSelectionType(editor: VimEditor): SelectionType {
     // IJ specific. See https://youtrack.jetbrains.com/issue/VIM-1924.
     val project = editor.ij.project
     if (project != null && FindManager.getInstance(project).selectNextOccurrenceWasPerformed()) {
       return SelectionType.CHARACTER_WISE
     }
 
-    return super.autodetectVisualSubmode(editor)
+    return super.detectSelectionType(editor)
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/listener/AppCodeTemplates.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/AppCodeTemplates.kt
@@ -20,7 +20,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.Key
 import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.VimPlugin
-import com.maddyhome.idea.vim.action.motion.select.SelectToggleVisualMode
+import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.group.visual.VimVisualTimer
 import com.maddyhome.idea.vim.helper.fileSize
 import com.maddyhome.idea.vim.helper.inVisualMode
@@ -56,7 +56,7 @@ internal object AppCodeTemplates {
         if (myEditor != null) {
           VimVisualTimer.doNow()
           if (myEditor.inVisualMode) {
-            SelectToggleVisualMode.toggleMode(myEditor.vim)
+            injector.visualMotionGroup.toggleSelectVisual(myEditor.vim)
             KeyHandler.getInstance().partialReset(myEditor.vim)
           }
         }

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanelService.kt
@@ -25,7 +25,6 @@ import com.maddyhome.idea.vim.key.interceptors.VimInputInterceptor
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.ReturnableFromCmd
 import com.maddyhome.idea.vim.ui.ModalEntry
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
@@ -91,7 +90,7 @@ class ExEntryPanelService : VimCommandLineServiceBase(), VimModalInputService {
         }
       }
       if (text != null) {
-        Extension.addString(text!!)
+        Extension.addString(text)
       }
       return text
     }
@@ -105,9 +104,6 @@ class ExEntryPanelService : VimCommandLineServiceBase(), VimModalInputService {
     processing: (String) -> Unit,
   ) {
     val currentMode = editor.mode
-    check(currentMode is ReturnableFromCmd) {
-      "Cannot enable cmd mode from current mode $currentMode"
-    }
 
     // Make sure the Visual selection marks are up to date before we use them.
     injector.markService.setVisualSelectionMarks(editor)
@@ -136,6 +132,7 @@ class ExEntryPanelService : VimCommandLineServiceBase(), VimModalInputService {
     return panel
   }
 
+  @Deprecated("Please use ModalInputService.create()")
   override fun createWithoutShortcuts(editor: VimEditor, context: ExecutionContext, label: String, initText: String): VimCommandLine {
     val panel = ExEntryPanel.getInstanceWithoutShortcuts()
     panel.activate(editor.ij, context.ij, label, initText)

--- a/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/VimModeWidget.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/VimModeWidget.kt
@@ -31,7 +31,7 @@ import javax.swing.JComponent
 import kotlin.math.max
 
 class VimModeWidget(val project: Project) : CustomStatusBarWidget, VimStatusBarWidget {
-  private companion object {
+  companion object {
     private const val INSERT = "INSERT"
     private const val NORMAL = "NORMAL"
     private const val INSERT_NORMAL = "(insert)"
@@ -46,6 +46,50 @@ class VimModeWidget(val project: Project) : CustomStatusBarWidget, VimStatusBarW
     private const val SELECT = "SELECT"
     private const val SELECT_LINE = "S-LINE"
     private const val SELECT_BLOCK = "S-BLOCK"
+
+    fun getModeText(mode: Mode?): String? {
+      return when (mode) {
+        Mode.INSERT -> INSERT
+        Mode.REPLACE -> REPLACE
+        is Mode.NORMAL -> getNormalModeText(mode)
+        is Mode.CMD_LINE -> COMMAND
+        is Mode.VISUAL -> getVisualModeText(mode)
+        is Mode.SELECT -> getSelectModeText(mode)
+        is Mode.OP_PENDING, null -> null
+      }
+    }
+
+    private fun getNormalModeText(mode: Mode.NORMAL) = when {
+      mode.isInsertPending -> INSERT_NORMAL
+      mode.isReplacePending -> REPLACE_NORMAL
+      else -> NORMAL
+    }
+
+    private fun getVisualModeText(mode: Mode.VISUAL): String {
+      val prefix = when {
+        mode.isInsertPending -> INSERT_PENDING_PREFIX
+        mode.isReplacePending -> REPLACE_PENDING_PREFIX
+        else -> ""
+      }
+      return prefix + when (mode.selectionType) {
+        SelectionType.CHARACTER_WISE -> VISUAL
+        SelectionType.LINE_WISE -> VISUAL_LINE
+        SelectionType.BLOCK_WISE -> VISUAL_BLOCK
+      }
+    }
+
+    private fun getSelectModeText(mode: Mode.SELECT): String {
+      val prefix = when {
+        mode.isInsertPending -> INSERT_PENDING_PREFIX
+        mode.isReplacePending -> REPLACE_PENDING_PREFIX
+        else -> ""
+      }
+      return prefix + when (mode.selectionType) {
+        SelectionType.CHARACTER_WISE -> SELECT
+        SelectionType.LINE_WISE -> SELECT_LINE
+        SelectionType.BLOCK_WISE -> SELECT_BLOCK
+      }
+    }
   }
 
   private val label = JBLabelWiderThan(setOf(REPLACE)).apply { isOpaque = true }
@@ -95,50 +139,6 @@ class VimModeWidget(val project: Project) : CustomStatusBarWidget, VimStatusBarW
   private fun getFocusedEditor(project: Project): Editor? {
     val fileEditorManager = FileEditorManager.getInstance(project)
     return fileEditorManager.selectedTextEditor
-  }
-
-  private fun getModeText(mode: Mode?): String? {
-    return when (mode) {
-      Mode.INSERT -> INSERT
-      Mode.REPLACE -> REPLACE
-      is Mode.NORMAL -> getNormalModeText(mode)
-      is Mode.CMD_LINE -> COMMAND
-      is Mode.VISUAL -> getVisualModeText(mode)
-      is Mode.SELECT -> getSelectModeText(mode)
-      is Mode.OP_PENDING, null -> null
-    }
-  }
-
-  private fun getNormalModeText(mode: Mode.NORMAL) = when {
-    mode.isInsertPending -> INSERT_NORMAL
-    mode.isReplacePending -> REPLACE_NORMAL
-    else -> NORMAL
-  }
-
-  private fun getVisualModeText(mode: Mode.VISUAL): String {
-    val prefix = when {
-      mode.isInsertPending -> INSERT_PENDING_PREFIX
-      mode.isReplacePending -> REPLACE_PENDING_PREFIX
-      else -> ""
-    }
-    return prefix + when (mode.selectionType) {
-      SelectionType.CHARACTER_WISE -> VISUAL
-      SelectionType.LINE_WISE -> VISUAL_LINE
-      SelectionType.BLOCK_WISE -> VISUAL_BLOCK
-    }
-  }
-
-  private fun getSelectModeText(mode: Mode.SELECT): String {
-    val prefix = when {
-      mode.isInsertPending -> INSERT_PENDING_PREFIX
-      mode.isReplacePending -> REPLACE_PENDING_PREFIX
-      else -> ""
-    }
-    return prefix + when (mode.selectionType) {
-      SelectionType.CHARACTER_WISE -> SELECT
-      SelectionType.LINE_WISE -> SELECT_LINE
-      SelectionType.BLOCK_WISE -> SELECT_BLOCK
-    }
   }
 
   private class JBLabelWiderThan(private val words: Collection<String>): JBLabel("", CENTER) {

--- a/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/VimModeWidget.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/VimModeWidget.kt
@@ -35,10 +35,8 @@ class VimModeWidget(val project: Project) : CustomStatusBarWidget, VimStatusBarW
   companion object {
     private const val INSERT = "INSERT"
     private const val NORMAL = "NORMAL"
-    private const val INSERT_NORMAL = "(insert)"
     private const val INSERT_PENDING_PREFIX = "(insert) "
     private const val REPLACE = "REPLACE"
-    private const val REPLACE_NORMAL = "(replace)"
     private const val REPLACE_PENDING_PREFIX = "(replace) "
     private const val COMMAND = "COMMAND"
     private const val VISUAL = "VISUAL"
@@ -47,6 +45,7 @@ class VimModeWidget(val project: Project) : CustomStatusBarWidget, VimStatusBarW
     private const val SELECT = "SELECT"
     private const val SELECT_LINE = "S-LINE"
     private const val SELECT_BLOCK = "S-BLOCK"
+    private const val SELECT_PENDING_PREFIX = "(select) "
 
     fun getModeText(mode: Mode?): String? {
       return when (mode) {
@@ -60,16 +59,30 @@ class VimModeWidget(val project: Project) : CustomStatusBarWidget, VimStatusBarW
       }
     }
 
+    /**
+     * Return the text to show in Normal mode
+     *
+     * Vim doesn't show any text for Normal, but that doesn't work for IdeaVim's status widget. We also show "NORMAL"
+     * when Insert or Replace is pending. I.e. "(insert) NORMAL" and "(replace) NORMAL". Vim only shows the pending mode
+     */
     private fun getNormalModeText(mode: Mode.NORMAL) = when {
-      mode.isInsertPending -> INSERT_NORMAL
-      mode.isReplacePending -> REPLACE_NORMAL
+      mode.isInsertPending -> INSERT_PENDING_PREFIX + NORMAL
+      mode.isReplacePending -> REPLACE_PENDING_PREFIX + NORMAL
       else -> NORMAL
     }
 
+    /**
+     * Return the text to show in Visual mode
+     *
+     * IdeaVim shows the Insert and Replace pending modes, but we also show Select pending - "(select) VISUAL". Vim
+     * doesn't show this, but IdeaVim's status widget isn't like Vim's status bar, and this addition keeps things a
+     * little more consistent.
+     */
     private fun getVisualModeText(mode: Mode.VISUAL): String {
       val prefix = when {
         mode.isInsertPending -> INSERT_PENDING_PREFIX
         mode.isReplacePending -> REPLACE_PENDING_PREFIX
+        mode.isSelectPending -> SELECT_PENDING_PREFIX
         else -> ""
       }
       return prefix + when (mode.selectionType) {

--- a/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/VimModeWidget.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/VimModeWidget.kt
@@ -28,6 +28,7 @@ import java.awt.Point
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.JComponent
+import javax.swing.SwingUtilities
 import kotlin.math.max
 
 class VimModeWidget(val project: Project) : CustomStatusBarWidget, VimStatusBarWidget {
@@ -100,14 +101,20 @@ class VimModeWidget(val project: Project) : CustomStatusBarWidget, VimStatusBarW
 
     label.addMouseListener(object : MouseAdapter() {
       override fun mouseClicked(e: MouseEvent) {
-        val popup = ModeWidgetPopup.createPopup() ?: return
-        val dimension = popup.content.preferredSize
+        if (SwingUtilities.isLeftMouseButton(e)) {
+          val popup = ModeWidgetPopup.createPopup() ?: return
+          val dimension = popup.content.preferredSize
 
-        val widgetLocation = e.component.locationOnScreen
-        popup.show(RelativePoint(Point(
-          widgetLocation.x + e.component.width - dimension.width,
-          widgetLocation.y - dimension.height,
-        )))
+          val widgetLocation = e.component.locationOnScreen
+          popup.show(
+            RelativePoint(
+              Point(
+                widgetLocation.x + e.component.width - dimension.width,
+                widgetLocation.y - dimension.height,
+              )
+            )
+          )
+        }
       }
     })
   }

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/options/helpers/IdeaRefactorModeHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/options/helpers/IdeaRefactorModeHelper.kt
@@ -90,12 +90,11 @@ internal object IdeaRefactorModeHelper {
       corrections.add(Action.RemoveSelection)
     }
     if (mode.hasVisualSelection && editor.selectionModel.hasSelection()) {
-      val autodetectedSubmode = VimPlugin.getVisualMotion().autodetectVisualSubmode(editor.vim)
-      if (mode.selectionType != autodetectedSubmode) {
-        // Update the submode
+      val selectionType = VimPlugin.getVisualMotion().detectSelectionType(editor.vim)
+      if (mode.selectionType != selectionType) {
         val newMode = when (mode) {
-          is Mode.SELECT -> mode.copy(selectionType = autodetectedSubmode)
-          is Mode.VISUAL -> mode.copy(selectionType = autodetectedSubmode)
+          is Mode.SELECT -> mode.copy(selectionType)
+          is Mode.VISUAL -> mode.copy(selectionType)
           else -> error("IdeaVim should be either in visual or select modes")
         }
         corrections.add(Action.SetMode(newMode))

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/ChangeActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/ChangeActionTest.kt
@@ -10,7 +10,6 @@ package org.jetbrains.plugins.ideavim.action
 import com.intellij.idea.TestFor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.ReturnTo
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
@@ -52,7 +51,7 @@ class ChangeActionTest : VimTestCase() {
       listOf("i", "<C-O>", "v"),
       "12${c}345",
       "12${s}${c}3${se}45",
-      Mode.VISUAL(SelectionType.CHARACTER_WISE, ReturnTo.INSERT)
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, Mode.INSERT)
     )
   }
 
@@ -87,7 +86,7 @@ class ChangeActionTest : VimTestCase() {
       listOf("i", "<C-O>", "v", "<C-G>"),
       "12${c}345",
       "12${s}3${c}${se}45",
-      Mode.SELECT(SelectionType.CHARACTER_WISE, ReturnTo.INSERT),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, Mode.INSERT),
     )
   }
 
@@ -99,7 +98,7 @@ class ChangeActionTest : VimTestCase() {
       listOf("i", "<C-O>", "gh"),
       "12${c}345",
       "12${s}3${c}${se}45",
-      Mode.SELECT(SelectionType.CHARACTER_WISE, ReturnTo.INSERT),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, Mode.INSERT),
     )
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertNormalExitModeActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertNormalExitModeActionTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action.change.insert
+
+import com.maddyhome.idea.vim.state.mode.Mode
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class InsertNormalExitModeActionTest : VimTestCase() {
+  @Test
+  fun `test exit insert normal mode`() {
+    doTest("i<C-O><Esc>", "12${c}3", "12${c}3", Mode.INSERT)
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionShiftLeftActionHandlerTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionShiftLeftActionHandlerTest.kt
@@ -82,6 +82,62 @@ class MotionShiftLeftActionHandlerTest : VimTestCase() {
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @OptionTest(
     VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [""]),
+  )
+  fun `test visual shift left in Insert enters Insert Visual mode`() {
+    doTest(
+      listOf("i<S-Left>"),
+      """
+                A Discovery
+
+                I foun${c}d it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I fou${s}${c}nd${se} it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.INSERT),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [""]),
+  )
+  fun `test visual shift left in Replace enters Replace Visual mode`() {
+    doTest(
+      listOf("R<S-Left>"),
+      """
+                A Discovery
+
+                I foun${c}d it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I fou${s}${c}nd${se} it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.REPLACE),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
     VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
   )
   fun `test select left`() {
@@ -132,6 +188,62 @@ class MotionShiftLeftActionHandlerTest : VimTestCase() {
                 hard by the torrent of a mountain pass.
       """.trimIndent(),
       Mode.SELECT(SelectionType.CHARACTER_WISE)
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
+  )
+  fun `test select shift left in Insert enters Insert Visual mode`() {
+    doTest(
+      listOf("i<S-Left>"),
+      """
+                A Discovery
+
+                I foun${c}d it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I fou${s}${c}n${se}d it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, returnTo = Mode.INSERT),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
+  )
+  fun `test select shift left in Replace enters Replace Visual mode`() {
+    doTest(
+      listOf("R<S-Left>"),
+      """
+                A Discovery
+
+                I foun${c}d it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I fou${s}${c}n${se}d it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, returnTo = Mode.REPLACE),
     )
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionShiftRightActionHandlerTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/leftright/MotionShiftRightActionHandlerTest.kt
@@ -82,6 +82,62 @@ class MotionShiftRightActionHandlerTest : VimTestCase() {
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @OptionTest(
     VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [""]),
+  )
+  fun `test visual shift right in Insert mode enters Insert Visual mode`() {
+    doTest(
+      listOf("i<S-Right>"),
+      """
+                A Discovery
+
+                I ${c}found it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}f${c}o${se}und it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.INSERT),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [""]),
+  )
+  fun `test visual shift right in Replace mode enters Replace Visual mode`() {
+    doTest(
+      listOf("R<S-Right>"),
+      """
+                A Discovery
+
+                I ${c}found it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}f${c}o${se}und it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.REPLACE),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
     VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
   )
   fun `test select right`() {
@@ -132,6 +188,62 @@ class MotionShiftRightActionHandlerTest : VimTestCase() {
                 hard by the torrent of a mountain pass.
       """.trimIndent(),
       Mode.SELECT(SelectionType.CHARACTER_WISE)
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
+  )
+  fun `test select shift right in Insert enters Insert Select mode`() {
+    doTest(
+      listOf("i<S-Right>"),
+      """
+                A Discovery
+
+                I ${c}found it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}f${c}${se}ound it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, returnTo = Mode.INSERT),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
+  )
+  fun `test select shift right in Replace enters Replace Select mode`() {
+    doTest(
+      listOf("R<S-Right>"),
+      """
+                A Discovery
+
+                I ${c}found it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}f${c}${se}ound it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, returnTo = Mode.REPLACE),
     )
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/search/SearchEntryFwdActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/search/SearchEntryFwdActionTest.kt
@@ -50,13 +50,13 @@ class SearchEntryFwdActionTest : VimTestCase() {
         |${c}consectetur adipiscing elit
         |Sed in orci mauris.
         |Cras id tellus in ex imperdiet egestas.
-    """.trimMargin(),
+      """.trimMargin(),
       """Lorem ipsum dolor sit amet,
-        |consectetur adipiscing elit
+        |${s}consectetur adipiscing elit
         |Sed in orci mauris.
-        |Cras ${c}id tellus in ex imperdiet egestas.
-    """.trimMargin(),
-      Mode.INSERT,
+        |Cras ${c}i${se}d tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.INSERT),
     )
   }
 
@@ -68,13 +68,13 @@ class SearchEntryFwdActionTest : VimTestCase() {
         |${c}consectetur adipiscing elit
         |Sed in orci mauris.
         |Cras id tellus in ex imperdiet egestas.
-    """.trimMargin(),
+      """.trimMargin(),
       """Lorem ipsum dolor sit amet,
-        |consectetur adipiscing elit
+        |${s}consectetur adipiscing elit
         |Sed in orci mauris.
-        |Cras ${c}id tellus in ex imperdiet egestas.
-    """.trimMargin(),
-      Mode.REPLACE,
+        |Cras ${c}i${se}d tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.REPLACE),
     )
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectToggleSingleVisualCommandActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectToggleSingleVisualCommandActionTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action.motion.select
+
+import com.maddyhome.idea.vim.state.mode.Mode
+import com.maddyhome.idea.vim.state.mode.SelectionType
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+@Suppress("SpellCheckingInspection")
+@TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
+class SelectToggleSingleVisualCommandActionTest : VimTestCase() {
+  @Test
+  fun `test enter Visual mode for single command`() {
+    doTest(
+      "gh<C-O>",
+      "Lorem ${c}ipsum dolor sit amet",
+      "Lorem ${s}${c}i${se}psum dolor sit amet",
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.SELECT(SelectionType.CHARACTER_WISE)),
+    )
+  }
+
+  @Test
+  fun `test enter Visual mode for single motion`() {
+    doTest(
+      "gh<C-O>e",
+      "Lorem ${c}ipsum dolor sit amet",
+      "Lorem ${s}ipsum${se}${c} dolor sit amet",
+      Mode.SELECT(SelectionType.CHARACTER_WISE),
+    )
+  }
+
+  // AFAICT, all Visual operators remove the selection
+  @Test
+  fun `test returns to Normal if Visual operator removes selection`() {
+    doTest(
+      "gh<C-O>U",
+      "Lorem ${c}ipsum dolor sit amet",
+      "Lorem ${c}Ipsum dolor sit amet",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `test Escape returns to Normal after entering Visual for a single command`() {
+    // Escape doesn't "pop the stack", but returns to Normal
+    doTest(
+      "gh<C-O><Esc>",
+      "Lorem ${c}ipsum dolor sit amet",
+      "Lorem ${c}ipsum dolor sit amet",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `test exit Visual mode with same shortcut`() {
+    doTest(
+      "gh<C-O><C-O>",
+      "Lorem ${c}ipsum dolor sit amet",
+      "Lorem ${s}i${c}${se}psum dolor sit amet",
+      Mode.SELECT(SelectionType.CHARACTER_WISE),
+    )
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionShiftDownActionHandlerTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionShiftDownActionHandlerTest.kt
@@ -110,6 +110,62 @@ class MotionShiftDownActionHandlerTest : VimTestCase() {
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @OptionTest(
     VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [""]),
+  )
+  fun `test Visual shift down in Insert mode enters Insert Visual mode`() {
+    doTest(
+      listOf("i<S-Down>"),
+      """
+                A Discovery
+
+                I ${c}found it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}found it in a legendary land
+                al${c}l${se} rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.INSERT),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [""]),
+  )
+  fun `test Visual shift down in Replace mode enters Replace Visual mode`() {
+    doTest(
+      listOf("R<S-Down>"),
+      """
+                A Discovery
+
+                I ${c}found it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}found it in a legendary land
+                al${c}l${se} rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.REPLACE),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
     VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
   )
   fun `test select down`() {
@@ -160,6 +216,62 @@ class MotionShiftDownActionHandlerTest : VimTestCase() {
                 hard by the torrent of a mountain pass.
       """.trimIndent(),
       Mode.SELECT(SelectionType.CHARACTER_WISE)
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
+  )
+  fun `test Select shift down in Insert mode enters Insert Select mode`() {
+    doTest(
+      listOf("i<S-Down>"),
+      """
+                A Discovery
+
+                I ${c}found it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}found it in a legendary land
+                al${c}${se}l rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, returnTo = Mode.INSERT),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
+  )
+  fun `test Select shift down in Replace mode enters Replace Select mode`() {
+    doTest(
+      listOf("R<S-Down>"),
+      """
+                A Discovery
+
+                I ${c}found it in a legendary land
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}found it in a legendary land
+                al${c}${se}l rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, returnTo = Mode.REPLACE),
     )
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionShiftUpActionHandlerTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionShiftUpActionHandlerTest.kt
@@ -110,6 +110,62 @@ class MotionShiftUpActionHandlerTest : VimTestCase() {
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @OptionTest(
     VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [""]),
+  )
+  fun `test Visual shift up in Insert mode enters Insert Visual mode`() {
+    doTest(
+      listOf("i<S-Up>"),
+      """
+                A Discovery
+
+                I found it in a legendary land
+                al${c}l rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}${c}found it in a legendary land
+                all${se} rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.INSERT),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [""]),
+  )
+  fun `test Visual shift up in Replace mode enters Replace Visual mode`() {
+    doTest(
+      listOf("R<S-Up>"),
+      """
+                A Discovery
+
+                I found it in a legendary land
+                al${c}l rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}${c}found it in a legendary land
+                all${se} rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.CHARACTER_WISE, returnTo = Mode.REPLACE),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
     VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
   )
   fun `test select up`() {
@@ -160,6 +216,62 @@ class MotionShiftUpActionHandlerTest : VimTestCase() {
                 hard by the torrent of a mountain pass.
       """.trimIndent(),
       Mode.SELECT(SelectionType.CHARACTER_WISE)
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
+  )
+  fun `test Select shift up in Insert mode enters Insert Select mode`() {
+    doTest(
+      listOf("i<S-Up>"),
+      """
+                A Discovery
+
+                I found it in a legendary land
+                al${c}l rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}${c}found it in a legendary land
+                al${se}l rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, returnTo = Mode.INSERT),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @OptionTest(
+    VimOption(TestOptionConstants.keymodel, limitedValues = [OptionConstants.keymodel_startsel]),
+    VimOption(TestOptionConstants.selectmode, limitedValues = [OptionConstants.selectmode_key]),
+  )
+  fun `test Select shift up in Replace mode enters Replace Select mode`() {
+    doTest(
+      listOf("R<S-Up>"),
+      """
+                A Discovery
+
+                I found it in a legendary land
+                al${c}l rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I ${s}${c}found it in a legendary land
+                al${se}l rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.SELECT(SelectionType.CHARACTER_WISE, returnTo = Mode.REPLACE),
     )
   }
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/command/VimShowModeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/command/VimShowModeTest.kt
@@ -94,7 +94,7 @@ class VimShowModeTest : VimTestCase() {
     configureByText("123")
     typeText("i<C-O>")
     val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
-    assertEquals("(insert)", statusString)
+    assertEquals("(insert) NORMAL", statusString)
   }
 
   @Test
@@ -110,7 +110,7 @@ class VimShowModeTest : VimTestCase() {
     configureByText("123")
     typeText("R<C-O>")
     val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
-    assertEquals("(replace)", statusString)
+    assertEquals("(replace) NORMAL", statusString)
   }
 
   @Test
@@ -192,5 +192,14 @@ class VimShowModeTest : VimTestCase() {
     typeText("i<C-O>gH")
     val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
     assertEquals("(insert) S-LINE", statusString)
+  }
+
+  @Test
+  fun `test status string in Visual with Select pending`() {
+    configureByText("123")
+    enterCommand("set selectmode=key keymodel=startsel")
+    typeText("<S-Right><C-O>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(select) VISUAL", statusString)
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/command/VimShowModeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/command/VimShowModeTest.kt
@@ -8,162 +8,184 @@
 
 package org.jetbrains.plugins.ideavim.command
 
-import com.intellij.openapi.wm.WindowManager
-import com.maddyhome.idea.vim.ui.widgets.mode.ModeWidgetFactory
+import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.ui.widgets.mode.VimModeWidget
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
-// TODO it would be cool to test widget, but status bar is not initialized
+@TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
 class VimShowModeTest : VimTestCase() {
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in normal`() {
-//    configureByText("123")
-//    val widget = getModeWidget()
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in insert`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("i"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- INSERT --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in replace`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("R"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- REPLACE --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in visual`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("v"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- VISUAL --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in visual line`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("V"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- VISUAL LINE --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in visual block`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("<C-V>"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- VISUAL BLOCK --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in select`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("gh"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- SELECT --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in select line`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("gH"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- SELECT LINE --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in select block`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("g<C-H>"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- SELECT BLOCK --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in one command`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("i<C-O>"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- (insert) --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in one command visual`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("i<C-O>v"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- (insert) VISUAL --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in one command visual block`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("i<C-O><C-V>"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- (insert) VISUAL BLOCK --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in one command visual line`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("i<C-O>V"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- (insert) VISUAL LINE --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in one command select`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("i<C-O>gh"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- (insert) SELECT --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in one command select block`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("i<C-O>g<C-H>"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- (insert) SELECT BLOCK --", statusString)
-//  }
-//
-//  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
-//  @Test
-//  fun `test status string in one command select line`() {
-//    configureByText("123")
-//    typeText(injector.parser.parseKeys("i<C-O>gH"))
-//    val statusString = fixture.editor.vim.getStatusString()
-//    kotlin.test.assertEquals("-- (insert) SELECT LINE --", statusString)
-//  }
-//
+  @Test
+  fun `test status string in normal`() {
+    configureByText("123")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("NORMAL", statusString)
+  }
 
-  // Always return null
-  private fun getModeWidget(): VimModeWidget? {
-    val project = fixture.editor?.project ?: return null
-    val statusBar = WindowManager.getInstance()?.getStatusBar(project) ?: return null
-    return statusBar.getWidget(ModeWidgetFactory.ID) as? VimModeWidget
+  @Test
+  fun `test status string in insert`() {
+    configureByText("123")
+    typeText("i")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("INSERT", statusString)
+  }
+
+  @Test
+  fun `test status string in replace`() {
+    configureByText("123")
+    typeText("R")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("REPLACE", statusString)
+  }
+
+  @Test
+  fun `test status string in visual`() {
+    configureByText("123")
+    typeText("v")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("VISUAL", statusString)
+  }
+
+  @Test
+  fun `test status string in visual line`() {
+    configureByText("123")
+    typeText("V")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("V-LINE", statusString)
+  }
+
+  @Test
+  fun `test status string in visual block`() {
+    configureByText("123")
+    typeText("<C-V>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("V-BLOCK", statusString)
+  }
+
+  @Test
+  fun `test status string in select`() {
+    configureByText("123")
+    typeText("gh")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("SELECT", statusString)
+  }
+
+  @Test
+  fun `test status string in select line`() {
+    configureByText("123")
+    typeText("gH")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("S-LINE", statusString)
+  }
+
+  @Test
+  fun `test status string in select block`() {
+    configureByText("123")
+    typeText("g<C-H>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("S-BLOCK", statusString)
+  }
+
+  @Test
+  fun `test status string for Insert Normal mode`() {
+    configureByText("123")
+    typeText("i<C-O>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(insert)", statusString)
+  }
+
+  @Test
+  fun `test status string for Replace pending Normal mode`() {
+    configureByText("123")
+    typeText("R<C-O>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(replace)", statusString)
+  }
+
+  @Test
+  fun `test status string in Insert Visual mode`() {
+    configureByText("123")
+    typeText("i<C-O>v")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(insert) VISUAL", statusString)
+  }
+
+  @Test
+  fun `test status string in Replace pending Visual mode`() {
+    configureByText("123")
+    typeText("R<C-O>v")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(replace) VISUAL", statusString)
+  }
+
+  @Test
+  fun `test status string in Insert Visual block mode`() {
+    configureByText("123")
+    typeText("i<C-O><C-V>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(insert) V-BLOCK", statusString)
+  }
+
+  @Test
+  fun `test status string in Replace pending Visual block mode`() {
+    configureByText("123")
+    typeText("R<C-O><C-V>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(replace) V-BLOCK", statusString)
+  }
+
+  @Test
+  fun `test status string in Insert Visual line mode`() {
+    configureByText("123")
+    typeText("i<C-O>V")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(insert) V-LINE", statusString)
+  }
+
+  @Test
+  fun `test status string in Replace pending Visual line mode`() {
+    configureByText("123")
+    typeText("R<C-O>V")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(replace) V-LINE", statusString)
+  }
+
+  @Test
+  fun `test status string in Insert Select mode`() {
+    configureByText("123")
+    typeText("i<C-O>gh")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(insert) SELECT", statusString)
+  }
+
+  // TODO: Not currently working
+  @Disabled
+  @Test
+  fun `test status string in Insert Select mode 2`() {
+    configureByText("123")
+    enterCommand("set selectmode=key keymodel=startsel")
+    typeText("i<S-Right>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(insert) SELECT", statusString)
+  }
+
+  @Test
+  fun `test status string in Insert Select block mode`() {
+    configureByText("123")
+    typeText("i<C-O>g<C-H>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(insert) S-BLOCK", statusString)
+  }
+
+  @Test
+  fun `test status string in Insert Select line mode`() {
+    configureByText("123")
+    typeText("i<C-O>gH")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("(insert) S-LINE", statusString)
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/command/VimShowModeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/command/VimShowModeTest.kt
@@ -13,7 +13,6 @@ import com.maddyhome.idea.vim.ui.widgets.mode.VimModeWidget
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -170,8 +169,6 @@ class VimShowModeTest : VimTestCase() {
     assertEquals("(insert) SELECT", statusString)
   }
 
-  // TODO: Not currently working
-  @Disabled
   @Test
   fun `test status string in Insert Select mode 2`() {
     configureByText("123")

--- a/src/test/java/org/jetbrains/plugins/ideavim/command/VimShowModeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/command/VimShowModeTest.kt
@@ -99,6 +99,14 @@ class VimShowModeTest : VimTestCase() {
   }
 
   @Test
+  fun `test status string after escape out of Insert Normal mode`() {
+    configureByText("123")
+    typeText("i<C-O><Esc>")
+    val statusString = VimModeWidget.getModeText(fixture.editor.vim.mode)
+    assertEquals("INSERT", statusString)
+  }
+
+  @Test
   fun `test status string for Replace pending Normal mode`() {
     configureByText("123")
     typeText("R<C-O>")

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -34,8 +34,6 @@ import com.maddyhome.idea.vim.key.consumers.SelectRegisterConsumer
 import com.maddyhome.idea.vim.state.KeyHandlerState
 import com.maddyhome.idea.vim.state.VimStateMachine
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.ReturnTo
-import com.maddyhome.idea.vim.state.mode.returnTo
 import javax.swing.KeyStroke
 
 /**
@@ -334,11 +332,7 @@ class KeyHandler {
       // mode commands. An exception is if this command should leave us in the temporary mode such as
       // "select register"
       if (editorState.mode is Mode.NORMAL && !cmd.flags.contains(CommandFlags.FLAG_EXPECT_MORE)) {
-        when (editorState.mode.returnTo) {
-          ReturnTo.INSERT -> editor.mode = Mode.INSERT
-          ReturnTo.REPLACE -> editor.mode = Mode.REPLACE
-          null -> {}
-        }
+        editor.mode = editorState.mode.returnTo
       }
 
       instance.reset(keyState, editorState.mode)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertSingleCommandAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertSingleCommandAction.kt
@@ -19,6 +19,7 @@ import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.enumSetOf
 import java.util.*
 
+// Remember that Insert mode mappings also apply to Replace
 @CommandOrMotion(keys = ["<C-O>"], modes = [Mode.INSERT])
 class InsertSingleCommandAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ProcessExEntryActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ProcessExEntryActions.kt
@@ -24,7 +24,6 @@ import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.handler.Motion
 import com.maddyhome.idea.vim.handler.MotionActionHandler
 import com.maddyhome.idea.vim.handler.toMotionOrError
-import com.maddyhome.idea.vim.state.mode.returnTo
 import com.maddyhome.idea.vim.vimscript.model.CommandLineVimLContext
 import java.util.*
 
@@ -87,7 +86,7 @@ class ProcessExCommandEntryAction : MotionActionHandler.SingleExecution() {
       // startExEntry). Remember from startExEntry that we might still have selection and/or multiple carets, even
       // though we're in Normal. This will be handled by Command.execute once we know if we should be clearing the
       // selection.
-      editor.mode = editor.mode.returnTo()
+      editor.mode = editor.mode.returnTo
 
       logger.debug("processing command")
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectToggleSingleVisualCommandAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectToggleSingleVisualCommandAction.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.action.motion.select
+
+import com.intellij.vim.annotations.CommandOrMotion
+import com.intellij.vim.annotations.Mode
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.handler.VimActionHandler
+
+// See `:help v_CTRL-O`
+@CommandOrMotion(keys = ["<C-O>"], modes = [Mode.SELECT, Mode.VISUAL])
+class SelectToggleSingleVisualCommandAction : VimActionHandler.SingleExecution() {
+  override val type: Command.Type = Command.Type.OTHER_SELF_SYNCHRONIZED
+
+  override fun execute(
+    editor: VimEditor,
+    context: ExecutionContext,
+    cmd: Command,
+    operatorArguments: OperatorArguments,
+  ): Boolean {
+    injector.visualMotionGroup.processSingleVisualCommand(editor)
+    return true
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectToggleVisualMode.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectToggleVisualMode.kt
@@ -17,7 +17,6 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.helper.pushVisualMode
-import com.maddyhome.idea.vim.helper.setSelectMode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 
 /**
@@ -43,7 +42,7 @@ class SelectToggleVisualMode : VimActionHandler.SingleExecution() {
     fun toggleMode(editor: VimEditor) {
       val myMode = editor.mode
       if (myMode is com.maddyhome.idea.vim.state.mode.Mode.VISUAL) {
-        editor.setSelectMode(myMode.selectionType)
+        injector.visualMotionGroup.enterSelectMode(editor, myMode.selectionType)
         if (myMode.selectionType != SelectionType.LINE_WISE) {
           editor.nativeCarets().forEach {
             if (it.offset + injector.visualMotionGroup.selectionAdj == it.selectionEnd) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectToggleVisualMode.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectToggleVisualMode.kt
@@ -16,7 +16,6 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.VimActionHandler
-import com.maddyhome.idea.vim.helper.pushVisualMode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 
 /**
@@ -51,7 +50,7 @@ class SelectToggleVisualMode : VimActionHandler.SingleExecution() {
           }
         }
       } else if (myMode is com.maddyhome.idea.vim.state.mode.Mode.SELECT) {
-        editor.pushVisualMode(myMode.selectionType)
+        injector.visualMotionGroup.enterVisualMode(editor, myMode.selectionType)
         if (myMode.selectionType != SelectionType.LINE_WISE) {
           editor.nativeCarets().forEach {
             if (it.offset == it.selectionEnd && it.visualLineStart <= it.offset - injector.visualMotionGroup.selectionAdj) {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectToggleVisualMode.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectToggleVisualMode.kt
@@ -16,7 +16,6 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.VimActionHandler
-import com.maddyhome.idea.vim.state.mode.SelectionType
 
 /**
  * @author Alex Plate
@@ -33,32 +32,7 @@ class SelectToggleVisualMode : VimActionHandler.SingleExecution() {
     cmd: Command,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    toggleMode(editor)
+    injector.visualMotionGroup.toggleSelectVisual(editor)
     return true
-  }
-
-  companion object {
-    fun toggleMode(editor: VimEditor) {
-      val myMode = editor.mode
-      if (myMode is com.maddyhome.idea.vim.state.mode.Mode.VISUAL) {
-        injector.visualMotionGroup.enterSelectMode(editor, myMode.selectionType)
-        if (myMode.selectionType != SelectionType.LINE_WISE) {
-          editor.nativeCarets().forEach {
-            if (it.offset + injector.visualMotionGroup.selectionAdj == it.selectionEnd) {
-              it.moveToInlayAwareOffset(it.offset + injector.visualMotionGroup.selectionAdj)
-            }
-          }
-        }
-      } else if (myMode is com.maddyhome.idea.vim.state.mode.Mode.SELECT) {
-        injector.visualMotionGroup.enterVisualMode(editor, myMode.selectionType)
-        if (myMode.selectionType != SelectionType.LINE_WISE) {
-          editor.nativeCarets().forEach {
-            if (it.offset == it.selectionEnd && it.visualLineStart <= it.offset - injector.visualMotionGroup.selectionAdj) {
-              it.moveToInlayAwareOffset(it.offset - injector.visualMotionGroup.selectionAdj)
-            }
-          }
-        }
-      }
-    }
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualToggleBlockModeAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualToggleBlockModeAction.kt
@@ -32,8 +32,7 @@ class VisualToggleBlockModeAction : VimActionHandler.SingleExecution() {
     return if (injector.options(editor).selectmode.contains(OptionConstants.selectmode_cmd)) {
       injector.visualMotionGroup.enterSelectMode(editor, SelectionType.BLOCK_WISE)
     } else {
-      injector.visualMotionGroup
-        .toggleVisual(editor, cmd.count, cmd.rawCount, SelectionType.BLOCK_WISE)
+      injector.visualMotionGroup.toggleVisual(editor, cmd.count, cmd.rawCount, SelectionType.BLOCK_WISE)
     }
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualToggleCharacterModeAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualToggleCharacterModeAction.kt
@@ -32,8 +32,7 @@ class VisualToggleCharacterModeAction : VimActionHandler.SingleExecution() {
     return if (injector.options(editor).selectmode.contains(OptionConstants.selectmode_cmd)) {
       injector.visualMotionGroup.enterSelectMode(editor, SelectionType.CHARACTER_WISE)
     } else {
-      injector.visualMotionGroup
-        .toggleVisual(editor, cmd.count, cmd.rawCount, SelectionType.CHARACTER_WISE)
+      injector.visualMotionGroup.toggleVisual(editor, cmd.count, cmd.rawCount, SelectionType.CHARACTER_WISE)
     }
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualToggleLineModeAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualToggleLineModeAction.kt
@@ -24,8 +24,8 @@ import com.maddyhome.idea.vim.options.OptionConstants
 
 @CommandOrMotion(keys = ["V"], modes = [Mode.NORMAL, Mode.VISUAL])
 class VisualToggleLineModeAction : VimActionHandler.ConditionalMulticaret() {
-
   override val type: Command.Type = Command.Type.OTHER_READONLY
+
   override fun runAsMulticaret(
     editor: VimEditor,
     context: ExecutionContext,
@@ -57,7 +57,6 @@ class VisualToggleLineModeAction : VimActionHandler.ConditionalMulticaret() {
     cmd: Command,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    return injector.visualMotionGroup
-      .toggleVisual(editor, cmd.count, cmd.rawCount, SelectionType.LINE_WISE)
+    return injector.visualMotionGroup.toggleVisual(editor, cmd.count, cmd.rawCount, SelectionType.LINE_WISE)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -39,7 +39,6 @@ import com.maddyhome.idea.vim.regexp.match.VimMatchResult
 import com.maddyhome.idea.vim.register.RegisterConstants.LAST_INSERTED_TEXT_REGISTER
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
-import com.maddyhome.idea.vim.state.mode.toReturnTo
 import com.maddyhome.idea.vim.undo.VimKeyBasedUndoService
 import com.maddyhome.idea.vim.undo.VimTimestampBasedUndoService
 import com.maddyhome.idea.vim.vimscript.model.commands.SortOption
@@ -660,7 +659,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
    * @param editor The editor to put into NORMAL mode for one command
    */
   override fun processSingleCommand(editor: VimEditor) {
-    editor.mode = Mode.NORMAL(returnTo = editor.mode.toReturnTo)
+    editor.mode = Mode.NORMAL(editor.mode)
     clearStrokes(editor)
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
@@ -12,7 +12,6 @@ import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.history.HistoryEntry
 import com.maddyhome.idea.vim.history.VimHistory
-import com.maddyhome.idea.vim.state.mode.returnTo
 import javax.swing.KeyStroke
 import kotlin.math.min
 
@@ -111,7 +110,7 @@ interface VimCommandLine {
   fun close(refocusOwningEditor: Boolean, resetCaret: Boolean) {
     // If 'cpoptions' contains 'x', then Escape should execute the command line. This is the default for Vi but not Vim.
     // IdeaVim does not (currently?) support 'cpoptions', so sticks with Vim's default behaviour. Escape cancels.
-    editor.mode = editor.mode.returnTo()
+    editor.mode = editor.mode.returnTo
     KeyHandler.getInstance().keyHandlerState.leaveCommandLine()
     deactivate(refocusOwningEditor, resetCaret)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineServiceBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLineServiceBase.kt
@@ -10,7 +10,6 @@ package com.maddyhome.idea.vim.api
 
 import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.ReturnableFromCmd
 import com.maddyhome.idea.vim.state.mode.inVisualMode
 
 abstract class VimCommandLineServiceBase : VimCommandLineService {
@@ -24,9 +23,6 @@ abstract class VimCommandLineServiceBase : VimCommandLineService {
     if (!isCommandLineSupported(editor)) throw ExException("Command line is not allowed in one line editors")
 
     val currentMode = editor.mode
-    check(currentMode is ReturnableFromCmd) {
-      "Cannot enable cmd mode from current mode $currentMode"
-    }
 
     if (removeSelections) {
       // Make sure the Visual selection marks are up to date before we use them.

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
@@ -13,9 +13,7 @@ import com.maddyhome.idea.vim.common.LiveRange
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.common.VimEditorReplaceMask
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.ReturnTo
 import com.maddyhome.idea.vim.state.mode.SelectionType
-import com.maddyhome.idea.vim.state.mode.returnTo
 
 /**
  * Every line in [VimEditor] ends with a new line TODO <- this is probably not true already
@@ -281,12 +279,7 @@ interface VimEditor {
 
   fun resetOpPending() {
     if (this.mode is Mode.OP_PENDING) {
-      val returnTo = this.mode.returnTo
-      mode = when (returnTo) {
-        ReturnTo.INSERT -> Mode.INSERT
-        ReturnTo.REPLACE -> Mode.INSERT
-        null -> Mode.NORMAL()
-      }
+      mode = mode.returnTo
     }
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
@@ -19,8 +19,21 @@ interface VimVisualMotionGroup {
    * Enters Visual mode, ensuring that the caret's selection start offset is correctly set
    *
    * Use this to programmatically enter Visual mode. Note that it does not modify the editor's selection.
+   *
+   * This overload needs to remain for compatibility with external IdeaVim extensions
    */
-  fun enterVisualMode(editor: VimEditor, selectionType: SelectionType): Boolean
+  fun enterVisualMode(editor: VimEditor, selectionType: SelectionType): Boolean {
+    return enterVisualMode(editor, selectionType, Mode.NORMAL())
+  }
+
+  /**
+   * Enters Visual mode, ensuring that the caret's selection start offset is correctly set
+   *
+   * Use this to programmatically enter Visual mode. Note that it does not modify the editor's selection. You can
+   * specify the mode to return to when Visual command exits. Typically, this is [Mode.NORMAL], but can be [Mode.INSERT]
+   * or [Mode.REPLACE] for "Insert Visual" or [Mode.SELECT] when processing a single Visual command in Select mode.
+   */
+  fun enterVisualMode(editor: VimEditor, selectionType: SelectionType, returnTo: Mode): Boolean
 
   /**
    * Enter Select mode with the given selection type

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
@@ -59,6 +59,17 @@ interface VimVisualMotionGroup {
   fun toggleVisual(editor: VimEditor, count: Int, rawCount: Int, selectionType: SelectionType, returnTo: Mode? = null): Boolean
 
   /**
+   * Toggles between Select and Visual modes
+   *
+   * IdeaVim treats Select mode as always exclusive, regardless of the value in `'selection'`. As such, when toggling
+   * between Visual and Select, the caret is adjusted to be more natural for exclusive selection. Specifically, when
+   * toggling from Visual with inclusive selection to Select (always exclusive), the caret is adjusted one character to
+   * the right, to put it as exclusive to the current selection. When toggling from Select (exclusive) to Visual with
+   * inclusive selection, the caret is adjusted one character to the left from exclusive position to inclusive.
+   */
+  fun toggleSelectVisual(editor: VimEditor)
+
+  /**
    * When in Select mode, enter Visual mode for a single command
    *
    * While the Vim docs state that this is for the duration of a single Visual command, it also includes motions. This

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
@@ -8,7 +8,7 @@
 
 package com.maddyhome.idea.vim.api
 
-import com.maddyhome.idea.vim.state.mode.ReturnTo
+import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 
 interface VimVisualMotionGroup {
@@ -22,7 +22,7 @@ interface VimVisualMotionGroup {
    * If visual mode is enabled, but [selectionType] differs, update visual according to new [selectionType]
    * If visual mode is enabled with the same [selectionType], disable it
    */
-  fun toggleVisual(editor: VimEditor, count: Int, rawCount: Int, selectionType: SelectionType, returnTo: ReturnTo? = null): Boolean
+  fun toggleVisual(editor: VimEditor, count: Int, rawCount: Int, selectionType: SelectionType, returnTo: Mode? = null): Boolean
   fun enterSelectMode(editor: VimEditor, subMode: SelectionType): Boolean
 
   /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
@@ -18,20 +18,32 @@ interface VimVisualMotionGroup {
   /**
    * This function toggles visual mode.
    *
-   * If visual mode is disabled, enable it
-   * If visual mode is enabled, but [selectionType] differs, update visual according to new [selectionType]
-   * If visual mode is enabled with the same [selectionType], disable it
+   * * If visual mode is disabled, enable it
+   * * If visual mode is enabled, but [selectionType] differs, update visual according to new [selectionType]
+   * * If visual mode is enabled with the same [selectionType], disable it
    */
   fun toggleVisual(editor: VimEditor, count: Int, rawCount: Int, selectionType: SelectionType, returnTo: Mode? = null): Boolean
-  fun enterSelectMode(editor: VimEditor, subMode: SelectionType): Boolean
+
+  /**
+   * Enter Select mode with the given selection type
+   *
+   * When used from Normal, Insert or Replace modes, it will enter Select mode using the current mode as the "return to"
+   * mode. I.e., if entered from Normal, will return to Normal. If entered from Insert or Replace (via shifted keys)
+   * will return to Insert or Replace (aka "Insert Select" mode).
+   *
+   * While it will toggle between Visual and Select modes, it doesn't update the character positions correctly. IdeaVim
+   * treats Select mode as exclusive and adjusts the character position when toggling modes.
+   */
+  fun enterSelectMode(editor: VimEditor, selectionType: SelectionType): Boolean
 
   /**
    * Enters visual mode based on current editor state.
+   *
    * If [subMode] is null, subMode will be detected automatically
    *
    * it:
    * - Updates command state
-   * - Updates [vimSelectionStart] property
+   * - Updates [VimCaret.vimSelectionStart] property
    * - Updates caret colors
    * - Updates care shape
    *

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
@@ -53,4 +53,16 @@ interface VimVisualMotionGroup {
    */
   fun enterVisualMode(editor: VimEditor, selectionType: SelectionType? = null): Boolean
   fun detectSelectionType(editor: VimEditor): SelectionType
+
+  /**
+   * When in Select mode, enter Visual mode for a single command
+   *
+   * While the Vim docs state that this is for the duration of a single Visual command, it also includes motions. This
+   * is different to "Insert Visual" mode (`i<C-O>v`) which allows multiple motions until an operator is invoked.
+   *
+   * If already in Visual, this function will return to Select.
+   *
+   * See `:help v_CTRL-O`.
+   */
+  fun processSingleVisualCommand(editor: VimEditor)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
@@ -39,7 +39,7 @@ interface VimVisualMotionGroup {
   /**
    * Enters visual mode based on current editor state.
    *
-   * If [subMode] is null, subMode will be detected automatically
+   * If [selectionType] is null, it will be detected automatically
    *
    * it:
    * - Updates command state
@@ -51,6 +51,6 @@ interface VimVisualMotionGroup {
    * - DOES NOT move caret
    * - DOES NOT check if carets actually have any selection
    */
-  fun enterVisualMode(editor: VimEditor, subMode: SelectionType? = null): Boolean
-  fun autodetectVisualSubmode(editor: VimEditor): SelectionType
+  fun enterVisualMode(editor: VimEditor, selectionType: SelectionType? = null): Boolean
+  fun detectSelectionType(editor: VimEditor): SelectionType
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
@@ -16,7 +16,9 @@ interface VimVisualMotionGroup {
   val selectionAdj: Int
 
   /**
-   * This function toggles visual mode.
+   * This function toggles visual mode according to the logic required for `v`, `V` and `<C-V>`
+   *
+   * This is the implementation for `v`, `V` and `<C-V>`. If you need to enter Visual mode, use [enterVisualMode].
    *
    * * If visual mode is disabled, enable it
    * * If visual mode is enabled, but [selectionType] differs, update visual according to new [selectionType]
@@ -37,21 +39,12 @@ interface VimVisualMotionGroup {
   fun enterSelectMode(editor: VimEditor, selectionType: SelectionType): Boolean
 
   /**
-   * Enters visual mode based on current editor state.
+   * Enters Visual mode, ensuring that the caret's selection start offset is correctly set
    *
-   * If [selectionType] is null, it will be detected automatically
-   *
-   * it:
-   * - Updates command state
-   * - Updates [VimCaret.vimSelectionStart] property
-   * - Updates caret colors
-   * - Updates care shape
-   *
-   * - DOES NOT change selection
-   * - DOES NOT move caret
-   * - DOES NOT check if carets actually have any selection
+   * Use this to programmatically enter Visual mode. Note that it does not modify the editor's selection.
    */
-  fun enterVisualMode(editor: VimEditor, selectionType: SelectionType? = null): Boolean
+  fun enterVisualMode(editor: VimEditor, selectionType: SelectionType): Boolean
+
   fun detectSelectionType(editor: VimEditor): SelectionType
 
   /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroup.kt
@@ -16,15 +16,11 @@ interface VimVisualMotionGroup {
   val selectionAdj: Int
 
   /**
-   * This function toggles visual mode according to the logic required for `v`, `V` and `<C-V>`
+   * Enters Visual mode, ensuring that the caret's selection start offset is correctly set
    *
-   * This is the implementation for `v`, `V` and `<C-V>`. If you need to enter Visual mode, use [enterVisualMode].
-   *
-   * * If visual mode is disabled, enable it
-   * * If visual mode is enabled, but [selectionType] differs, update visual according to new [selectionType]
-   * * If visual mode is enabled with the same [selectionType], disable it
+   * Use this to programmatically enter Visual mode. Note that it does not modify the editor's selection.
    */
-  fun toggleVisual(editor: VimEditor, count: Int, rawCount: Int, selectionType: SelectionType, returnTo: Mode? = null): Boolean
+  fun enterVisualMode(editor: VimEditor, selectionType: SelectionType): Boolean
 
   /**
    * Enter Select mode with the given selection type
@@ -39,13 +35,15 @@ interface VimVisualMotionGroup {
   fun enterSelectMode(editor: VimEditor, selectionType: SelectionType): Boolean
 
   /**
-   * Enters Visual mode, ensuring that the caret's selection start offset is correctly set
+   * This function toggles visual mode according to the logic required for `v`, `V` and `<C-V>`
    *
-   * Use this to programmatically enter Visual mode. Note that it does not modify the editor's selection.
+   * This is the implementation for `v`, `V` and `<C-V>`. If you need to enter Visual mode, use [enterVisualMode].
+   *
+   * * If visual mode is disabled, enable it
+   * * If visual mode is enabled, but [selectionType] differs, update visual according to new [selectionType]
+   * * If visual mode is enabled with the same [selectionType], disable it
    */
-  fun enterVisualMode(editor: VimEditor, selectionType: SelectionType): Boolean
-
-  fun detectSelectionType(editor: VimEditor): SelectionType
+  fun toggleVisual(editor: VimEditor, count: Int, rawCount: Int, selectionType: SelectionType, returnTo: Mode? = null): Boolean
 
   /**
    * When in Select mode, enter Visual mode for a single command
@@ -58,4 +56,11 @@ interface VimVisualMotionGroup {
    * See `:help v_CTRL-O`.
    */
   fun processSingleVisualCommand(editor: VimEditor)
+
+  /**
+   * Detect the current selection type based on the editor's current selection state
+   *
+   * If the IDE changes the selection, this function can be used to understand what the current selection type is.
+   */
+  fun detectSelectionType(editor: VimEditor): SelectionType
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
@@ -17,10 +17,8 @@ import com.maddyhome.idea.vim.helper.exitVisualMode
 import com.maddyhome.idea.vim.helper.pushVisualMode
 import com.maddyhome.idea.vim.helper.setSelectMode
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.ReturnTo
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.state.mode.inVisualMode
-import com.maddyhome.idea.vim.state.mode.returnTo
 import com.maddyhome.idea.vim.state.mode.selectionType
 
 abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
@@ -47,7 +45,7 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
     count: Int,
     rawCount: Int,
     selectionType: SelectionType,
-    returnTo: ReturnTo?
+    returnTo: Mode?
   ): Boolean {
     if (!editor.inVisualMode) {
       // Enable visual subMode

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
@@ -31,8 +31,8 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
    *
    * Use this to programmatically enter Visual mode. Note that it does not modify the editor's selection.
    */
-  override fun enterVisualMode(editor: VimEditor, selectionType: SelectionType): Boolean {
-    editor.mode = Mode.VISUAL(selectionType)
+  override fun enterVisualMode(editor: VimEditor, selectionType: SelectionType, returnTo: Mode): Boolean {
+    editor.mode = Mode.VISUAL(selectionType, returnTo)
 
     // vimLeadSelectionOffset requires read action
     injector.application.runReadAction {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
@@ -15,7 +15,6 @@ import com.maddyhome.idea.vim.group.visual.vimLeadSelectionOffset
 import com.maddyhome.idea.vim.group.visual.vimSetSelection
 import com.maddyhome.idea.vim.group.visual.vimUpdateEditorSelection
 import com.maddyhome.idea.vim.helper.exitVisualMode
-import com.maddyhome.idea.vim.helper.pushVisualMode
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.state.mode.inVisualMode
@@ -60,7 +59,7 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
     if (!editor.inVisualMode) {
       if (rawCount > 0) {
         val primarySelectionType = editor.primaryCaret().vimLastVisualOperatorRange?.type ?: selectionType
-        editor.pushVisualMode(primarySelectionType)
+        editor.mode = Mode.VISUAL(primarySelectionType, editor.mode.returnTo)
 
         editor.forEachCaret {
           val range = it.vimLastVisualOperatorRange ?: VisualChange.default(selectionType)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
@@ -27,9 +27,9 @@ import com.maddyhome.idea.vim.state.mode.selectionType
 fun setVisualSelection(selectionStart: Int, selectionEnd: Int, caret: VimCaret) {
   val (start, end) = if (selectionStart > selectionEnd) selectionEnd to selectionStart else selectionStart to selectionEnd
   val editor = caret.editor
-  val subMode = editor.mode.selectionType ?: SelectionType.CHARACTER_WISE
+  val selectionType = editor.mode.selectionType ?: SelectionType.CHARACTER_WISE
   val mode = editor.mode
-  when (subMode) {
+  when (selectionType) {
     SelectionType.CHARACTER_WISE -> {
       val (nativeStart, nativeEnd) = charToNativeSelection(editor, start, end, mode)
       caret.vimSetSystemSelectionSilently(nativeStart, nativeEnd)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VisualChange.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/VisualChange.kt
@@ -12,10 +12,10 @@ import com.maddyhome.idea.vim.state.mode.SelectionType
 
 data class VisualChange(val lines: Int, val columns: Int, val type: SelectionType) {
   companion object {
-    fun default(subMode: SelectionType): VisualChange =
-      when (subMode) {
-        SelectionType.LINE_WISE, SelectionType.CHARACTER_WISE -> VisualChange(1, 1, subMode)
-        SelectionType.BLOCK_WISE -> VisualChange(0, 1, subMode)
+    fun default(selectionType: SelectionType): VisualChange =
+      when (selectionType) {
+        SelectionType.LINE_WISE, SelectionType.CHARACTER_WISE -> VisualChange(1, 1, selectionType)
+        SelectionType.BLOCK_WISE -> VisualChange(0, 1, selectionType)
       }
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
@@ -275,6 +275,18 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
     return resultOffset
   }
 
+  override fun postExecute(
+    editor: VimEditor,
+    context: ExecutionContext,
+    cmd: Command,
+    operatorArguments: OperatorArguments
+  ) {
+    // If we're in single-execution Visual mode, return to Select. See `:help v_CTRL-O`
+    if ((editor.mode as? Mode.VISUAL)?.isSelectPending == true) {
+      injector.visualMotionGroup.processSingleVisualCommand(editor)
+    }
+  }
+
   private object CaretMergingWatcher : VimCaretListener {
     override fun caretRemoved(caret: ImmutableVimCaret?) {
       caret ?: return

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
@@ -132,7 +132,7 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
     cmd: Command,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    val blockSubmodeActive = editor.inBlockSelection
+    val blockSelectionActive = editor.inBlockSelection
 
     val handler = if (this is AmbiguousExecution) this.getMotionActionHandler(cmd.argument) else this
     when (handler) {
@@ -159,7 +159,7 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
       }
       is ForEachCaret -> run {
         when {
-          blockSubmodeActive || editor.carets().size == 1 -> {
+          blockSelectionActive || editor.carets().size == 1 -> {
             val primaryCaret = editor.primaryCaret()
             handler.doExecuteForEach(editor, primaryCaret, context, cmd, operatorArguments)
           }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/SpecialKeyHandlers.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/SpecialKeyHandlers.kt
@@ -61,7 +61,7 @@ abstract class ShiftedSpecialKeyHandler : VimActionHandler.ConditionalMulticaret
       if (injector.globalOptions().selectmode.contains(OptionConstants.selectmode_key)) {
         injector.visualMotionGroup.enterSelectMode(editor, SelectionType.CHARACTER_WISE)
       } else {
-        injector.visualMotionGroup.toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE)
+        injector.visualMotionGroup.enterVisualMode(editor, SelectionType.CHARACTER_WISE)
       }
     }
     return true
@@ -97,10 +97,10 @@ abstract class ShiftedArrowKeyHandler(private val runBothCommandsAsMulticaret: B
           injector.visualMotionGroup.enterSelectMode(editor, SelectionType.CHARACTER_WISE)
         } else {
           if (editor.isInsertionAllowed) {
-            // Enter Insert/Replace Visual mode
-            injector.visualMotionGroup.toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE, editor.mode)
+            // Enter Insert/Replace Visual mode, passing in the current Insert/Replace mode as pending
+            injector.visualMotionGroup.enterVisualMode(editor, SelectionType.CHARACTER_WISE, editor.mode)
           } else {
-            injector.visualMotionGroup.toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE)
+            injector.visualMotionGroup.enterVisualMode(editor, SelectionType.CHARACTER_WISE)
           }
         }
       }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/SpecialKeyHandlers.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/SpecialKeyHandlers.kt
@@ -19,7 +19,6 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.helper.exitVisualMode
 import com.maddyhome.idea.vim.options.OptionConstants
-import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.state.mode.isInsertionAllowed
 import com.maddyhome.idea.vim.state.mode.inSelectMode
@@ -94,10 +93,12 @@ abstract class ShiftedArrowKeyHandler(private val runBothCommandsAsMulticaret: B
     if (withKey) {
       if (!inVisualMode && !inSelectMode) {
         if (injector.globalOptions().selectmode.contains(OptionConstants.selectmode_key)) {
+          // Note that this will correctly choose either Select or Insert Select modes
           injector.visualMotionGroup.enterSelectMode(editor, SelectionType.CHARACTER_WISE)
         } else {
           if (editor.isInsertionAllowed) {
-            injector.visualMotionGroup.toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE, Mode.INSERT)
+            // Enter Insert/Replace Visual mode
+            injector.visualMotionGroup.toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE, editor.mode)
           } else {
             injector.visualMotionGroup.toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE)
           }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/SpecialKeyHandlers.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/SpecialKeyHandlers.kt
@@ -19,7 +19,7 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.helper.exitVisualMode
 import com.maddyhome.idea.vim.options.OptionConstants
-import com.maddyhome.idea.vim.state.mode.ReturnTo
+import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.state.mode.isInsertionAllowed
 import com.maddyhome.idea.vim.state.mode.inSelectMode
@@ -62,8 +62,7 @@ abstract class ShiftedSpecialKeyHandler : VimActionHandler.ConditionalMulticaret
       if (injector.globalOptions().selectmode.contains(OptionConstants.selectmode_key)) {
         injector.visualMotionGroup.enterSelectMode(editor, SelectionType.CHARACTER_WISE)
       } else {
-        injector.visualMotionGroup
-          .toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE)
+        injector.visualMotionGroup.toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE)
       }
     }
     return true
@@ -98,11 +97,9 @@ abstract class ShiftedArrowKeyHandler(private val runBothCommandsAsMulticaret: B
           injector.visualMotionGroup.enterSelectMode(editor, SelectionType.CHARACTER_WISE)
         } else {
           if (editor.isInsertionAllowed) {
-            injector.visualMotionGroup
-              .toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE, ReturnTo.INSERT)
+            injector.visualMotionGroup.toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE, Mode.INSERT)
           } else {
-            injector.visualMotionGroup
-              .toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE)
+            injector.visualMotionGroup.toggleVisual(editor, 1, 0, SelectionType.CHARACTER_WISE)
           }
         }
       }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
@@ -14,7 +14,6 @@ import com.maddyhome.idea.vim.api.options
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.options.OptionConstants
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.SelectionType
 import java.util.*
 
 inline fun <reified T : Enum<T>> noneOfEnum(): EnumSet<T> = EnumSet.noneOf(T::class.java)
@@ -59,8 +58,4 @@ inline fun <reified T : Enum<T>> enumSetOf(vararg value: T): EnumSet<T> = when (
   0 -> noneOfEnum()
   1 -> EnumSet.of(value[0])
   else -> EnumSet.of(value[0], *value.slice(1..value.lastIndex).toTypedArray())
-}
-
-fun VimEditor.pushVisualMode(selectionType: SelectionType) {
-  mode = Mode.VISUAL(selectionType, mode.returnTo)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
@@ -61,10 +61,6 @@ inline fun <reified T : Enum<T>> enumSetOf(vararg value: T): EnumSet<T> = when (
   else -> EnumSet.of(value[0], *value.slice(1..value.lastIndex).toTypedArray())
 }
 
-fun VimEditor.setSelectMode(submode: SelectionType) {
-  mode = Mode.SELECT(submode, mode.returnTo)
-}
-
 fun VimEditor.pushVisualMode(submode: SelectionType) {
   mode = Mode.VISUAL(submode, mode.returnTo)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
@@ -16,7 +16,6 @@ import com.maddyhome.idea.vim.options.OptionConstants
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.state.mode.isSingleModeActive
-import com.maddyhome.idea.vim.state.mode.returnTo
 import java.util.*
 
 inline fun <reified T : Enum<T>> noneOfEnum(): EnumSet<T> = EnumSet.noneOf(T::class.java)
@@ -50,9 +49,9 @@ inline fun <reified T : Enum<T>> enumSetOf(vararg value: T): EnumSet<T> = when (
 }
 
 fun VimEditor.setSelectMode(submode: SelectionType) {
-  mode = Mode.SELECT(submode, this.mode.returnTo)
+  mode = Mode.SELECT(submode, mode.returnTo)
 }
 
 fun VimEditor.pushVisualMode(submode: SelectionType) {
-  mode = Mode.VISUAL(submode, this.mode.returnTo)
+  mode = Mode.VISUAL(submode, mode.returnTo)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
@@ -61,6 +61,6 @@ inline fun <reified T : Enum<T>> enumSetOf(vararg value: T): EnumSet<T> = when (
   else -> EnumSet.of(value[0], *value.slice(1..value.lastIndex).toTypedArray())
 }
 
-fun VimEditor.pushVisualMode(submode: SelectionType) {
-  mode = Mode.VISUAL(submode, mode.returnTo)
+fun VimEditor.pushVisualMode(selectionType: SelectionType) {
+  mode = Mode.VISUAL(selectionType, mode.returnTo)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineModeExtensions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineModeExtensions.kt
@@ -12,40 +12,24 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.listener.SelectionVimListenerSuppressor
-import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.ReturnTo
-import com.maddyhome.idea.vim.state.mode.SelectionType.CHARACTER_WISE
+import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.state.mode.inBlockSelection
 import com.maddyhome.idea.vim.state.mode.inVisualMode
-import com.maddyhome.idea.vim.state.mode.returnTo
 import com.maddyhome.idea.vim.state.mode.selectionType
 
 fun VimEditor.exitVisualMode() {
-  val selectionType = this.mode.selectionType ?: CHARACTER_WISE
+  val selectionType = mode.selectionType ?: SelectionType.CHARACTER_WISE
   SelectionVimListenerSuppressor.lock().use {
     if (inBlockSelection) {
-      this.removeSecondaryCarets()
+      removeSecondaryCarets()
     }
-    this.nativeCarets().forEach(VimCaret::removeSelection)
+    nativeCarets().forEach(VimCaret::removeSelection)
   }
-  if (this.inVisualMode) {
-    this.vimLastSelectionType = selectionType
+  if (inVisualMode) {
+    vimLastSelectionType = selectionType
     injector.markService.setVisualSelectionMarks(this)
-    this.nativeCarets().forEach { it.vimSelectionStartClear() }
+    nativeCarets().forEach { it.vimSelectionStartClear() }
 
-    val returnTo = this.mode.returnTo
-    when (returnTo) {
-      ReturnTo.INSERT -> {
-        this.mode = Mode.INSERT
-      }
-
-      ReturnTo.REPLACE -> {
-        this.mode = Mode.REPLACE
-      }
-
-      null -> {
-        this.mode = Mode.NORMAL()
-      }
-    }
+    mode = mode.returnTo
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
@@ -24,7 +24,6 @@ import com.maddyhome.idea.vim.key.KeyConsumer
 import com.maddyhome.idea.vim.state.KeyHandlerState
 import com.maddyhome.idea.vim.state.VimStateMachine
 import com.maddyhome.idea.vim.state.mode.Mode
-import com.maddyhome.idea.vim.state.mode.returnTo
 import javax.swing.KeyStroke
 
 class CommandConsumer : KeyConsumer {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/EditorResetConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/EditorResetConsumer.kt
@@ -60,19 +60,26 @@ class EditorResetConsumer : KeyConsumer {
     if (commandBuilder.isEmpty) {
       val register = injector.registerGroup
       if (register.currentRegister == register.defaultRegister) {
-        var indicateError = true
-        if (key.keyCode == KeyEvent.VK_ESCAPE) {
-          val executed = arrayOf<Boolean?>(null)
-          injector.actionExecutor.executeCommand(
-            editor,
-            { executed[0] = injector.actionExecutor.executeEsc(editor, context) },
-            "",
-            null,
-          )
-          indicateError = !executed[0]!!
+        // Escape should exit "Insert Normal" mode. We don't have a handler for <Esc> in Normal mode, so we do it here
+        val mode = editor.mode
+        if (mode is Mode.NORMAL && (mode.isInsertPending || mode.isReplacePending)) {
+          editor.mode = mode.returnTo
         }
-        if (indicateError) {
-          injector.messages.indicateError()
+        else {
+          var indicateError = true
+          if (key.keyCode == KeyEvent.VK_ESCAPE) {
+            val executed = arrayOf<Boolean?>(null)
+            injector.actionExecutor.executeCommand(
+              editor,
+              { executed[0] = injector.actionExecutor.executeEsc(editor, context) },
+              "",
+              null,
+            )
+            indicateError = !executed[0]!!
+          }
+          if (indicateError) {
+            injector.messages.indicateError()
+          }
         }
       }
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPut.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPut.kt
@@ -46,7 +46,7 @@ interface VimPut {
     vimEditor: VimEditor,
     vimContext: ExecutionContext,
     text: ProcessedTextData,
-    subMode: SelectionType,
+    selectionType: SelectionType,
     data: PutData,
     additionalData: Map<String, Any>,
   )

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/put/VimPutBase.kt
@@ -491,9 +491,9 @@ abstract class VimPutBase : VimPut {
     val startOffsets = prepareDocumentAndGetStartOffsets(editor, updated, text.typeInRegister, data, additionalData)
 
     startOffsets.forEach { startOffset ->
-      val subMode = data.visualSelection?.typeInEditor ?: SelectionType.CHARACTER_WISE
+      val selectionType = data.visualSelection?.typeInEditor ?: SelectionType.CHARACTER_WISE
       val (endOffset, updatedCaret) = putTextInternal(
-        editor, updated, context, text.copiedText.text, text.typeInRegister, subMode,
+        editor, updated, context, text.copiedText.text, text.typeInRegister, selectionType,
         startOffset, data.count, data.indent, data.caretAfterInsertedText,
       )
       updated = updatedCaret
@@ -504,7 +504,7 @@ abstract class VimPutBase : VimPut {
         startOffset,
         endOffset,
         text.typeInRegister,
-        subMode,
+        selectionType,
         data.caretAfterInsertedText,
       )
     }
@@ -541,12 +541,12 @@ abstract class VimPutBase : VimPut {
     additionalData: Map<String, Any>,
   ) {
     val visualSelection = data.visualSelection
-    val subMode = visualSelection?.typeInEditor ?: SelectionType.CHARACTER_WISE
+    val selectionType = visualSelection?.typeInEditor ?: SelectionType.CHARACTER_WISE
     if (injector.globalOptions().clipboard.contains(OptionConstants.clipboard_ideaput)) {
       val idePasteProvider = getProviderForPasteViaIde(editor, text.typeInRegister, data)
       if (idePasteProvider != null) {
         logger.debug("Perform put via idea paste")
-        putTextViaIde(idePasteProvider, editor, context, text, subMode, data, additionalData)
+        putTextViaIde(idePasteProvider, editor, context, text, selectionType, data, additionalData)
         return
       }
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
@@ -87,8 +87,9 @@ sealed interface Mode {
     init {
       // VISUAL will normally return to NORMAL, but can return to INSERT or REPLACE if i_CTRL-O is followed by `v`
       // I.e. "Insert Visual mode" and "Replace Visual mode"
-      require(returnTo is NORMAL || returnTo is INSERT || returnTo is REPLACE) {
-        "VISUAL mode can be active only in NORMAL, INSERT or REPLACE modes, not ${returnTo.javaClass.simpleName}"
+      // VISUAL can return to SELECT after `<C-O>`
+      require(returnTo is NORMAL || returnTo is INSERT || returnTo is REPLACE || returnTo is SELECT) {
+        "VISUAL mode can be active only in NORMAL, INSERT, REPLACE or SELECT modes, not ${returnTo.javaClass.simpleName}"
       }
     }
 
@@ -106,6 +107,13 @@ sealed interface Mode {
      * Like "Insert Visual", but starting from (and returning to) Replace (`R<C-O>v`).
      */
     val isReplacePending = returnTo is REPLACE
+
+    /**
+     * Returns true if the mode is temporarily switched from Select to Visual for the duration of one command
+     *
+     * See `:help v_CTRL-O`
+     */
+    val isSelectPending = returnTo is SELECT
   }
 
   data class SELECT(val selectionType: SelectionType, override val returnTo: Mode = NORMAL()) : Mode {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
@@ -10,41 +10,101 @@
 
 package com.maddyhome.idea.vim.state.mode
 
+import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.state.VimStateMachine
 
 /**
  * Represents a mode in IdeaVim.
  *
- * If mode has [returnTo] variable, it can be active during the one-command-mode (':h i_Ctrl-o'). If this value
- *   is not null, the one-command-mode is active and we should get back to [returnTo] mode.
+ * IdeaVim's default mode is Normal, represented with the [NORMAL] subtype. It will enter other modes through keystrokes
+ * such as `i`, `v` or `R`. Leaving a mode is usually handled with `<Escape>`, and the current mode will usually return
+ * to the previous mode. For example, hitting `<Esc>` in Insert will return to Normal.
+ *
+ * Modes can be nested, too. For example, `v/foo` will start in Normal, switch to Visual (with character-wise selection)
+ * and then switch to Command-line. Hitting `<Escape>` in this nested Command-line mode will return to Visual. Hitting
+ * `<Enter>` to accept the search result will also exit Command-line and return to Visual. Commands such as `d` can also
+ * end Visual mode and return to Normal. See also `i<C-O>d/foo`, which starts in Normal, switches to Insert, then nested
+ * "Insert Normal", Operator-pending and finally Command-line.
+ *
+ * Not all modes are nested. For example, Select mode can be entered from Visual (`v<C-G>`), but this is a mode switch,
+ * rather than nesting - hitting `v<C-G><Escape>` will result in Normal mode.
+ *
+ * Furthermore, a mode can be active for a single command, via `<C-O>` in Insert or Replace mode (`:help i_CTRL-O`), or
+ * in Select mode (`:help v_CTRL-O`). When used in Insert or Replace mode, this enters Normal mode for a single command,
+ * and then returns to Insert or Replace respectively. When in Select mode, `<C-O>` will enter Visual for a single
+ * command, and will then return to Select or Normal, depending on if the selection has been removed or not. Note that
+ * it is hard to know when a specific command is active for a single command - for example, `i<C-O>d/foo` would need to
+ * recursively look at the [returnTo] value until it found a [NORMAL] mode that had a non-[NORMAL] return to mode, but
+ * this wouldn't work for `v<C-G><C-O>/foo`, which doesn't have a nested [NORMAL] mode, but a nested [VISUAL] mode.
+ *
+ * The [VimStateMachine.mode] property can be used to set or get the current mode, but it is usually preferable to use
+ * the [VimEditor.mode] property. There are also several extension functions such as [Mode.isSingleModeActive] and
+ * [VimEditor.inVisualMode]. Setting the current selection and entering Visual or Select mode are usually two
+ * (programmatic) operations, although there are helper functions for this.
  *
  * Modes with selection have [selectionType] variable representing if the selection is character-, line-, or block-wise.
  *
- * To update the current mode, use [VimStateMachine.mode]. To get the current mode use [VimStateMachine.mode].
- *
- * [Mode] also has a bunch of extension functions like [Mode.isSingleModeActive].
- *
  * Also read about how modes work in Vim: https://github.com/JetBrains/ideavim/wiki/how-many-modes-does-vim-have
+ *
+ * One word of warning: don't try to map all the state transitions! [vim/vim#12115](https://github.com/vim/vim/issues/12115)
  */
 sealed interface Mode {
-  data class NORMAL(val returnTo: ReturnTo? = null) : Mode
-  data class OP_PENDING(val returnTo: ReturnTo? = null, val forcedVisual: SelectionType? = null) : Mode
-  data class VISUAL(val selectionType: SelectionType, val returnTo: ReturnTo? = null) : Mode
-  data class SELECT(val selectionType: SelectionType, val returnTo: ReturnTo? = null) : Mode
-  object INSERT : Mode
-  object REPLACE : Mode
-  data class CMD_LINE(val returnTo: Mode) : Mode {
+  /**
+   * The mode to return to when Escape is pressed, or the current command is finished
+   */
+  val returnTo: Mode
+
+  data class NORMAL(private val originalMode: Mode? = null) : Mode {
+    override val returnTo: Mode
+      get() = originalMode ?: this
+  }
+
+  data class OP_PENDING(override val returnTo: Mode) : Mode {
     init {
-      require(returnTo is NORMAL || returnTo is OP_PENDING || returnTo is VISUAL || returnTo is INSERT) {
-        "CMD_LINE mode can be active only in NORMAL, OP_PENDING, VISUAL or INSERT modes"
+      // OP_PENDING will normally return to NORMAL, but can return to INSERT or REPLACE if i_CTRL-O is followed by an
+      // operator such as `d`. I.e. "Insert Normal mode" and "Replace Normal mode"
+      require(returnTo is NORMAL || returnTo is INSERT || returnTo is REPLACE) {
+        "OP_PENDING mode can be active only in NORMAL, INSERT or REPLACE modes, not ${returnTo.javaClass.simpleName}"
       }
     }
   }
-}
 
-sealed interface ReturnTo {
-  object INSERT : ReturnTo
-  object REPLACE : ReturnTo
+  data class VISUAL(val selectionType: SelectionType, override val returnTo: Mode = NORMAL()) : Mode {
+    init {
+      // VISUAL will normally return to NORMAL, but can return to INSERT or REPLACE if i_CTRL-O is followed by `v`
+      // I.e. "Insert Visual mode" and "Replace Visual mode"
+      require(returnTo is NORMAL || returnTo is INSERT || returnTo is REPLACE) {
+        "VISUAL mode can be active only in NORMAL, INSERT or REPLACE modes, not ${returnTo.javaClass.simpleName}"
+      }
+    }
+  }
+
+  data class SELECT(val selectionType: SelectionType, override val returnTo: Mode = NORMAL()) : Mode {
+    init {
+      // SELECT will normally return to NORMAL, but can return to INSERT or REPLACE if v_CTRL-O is followed by a command
+      // that deletes the selection, e.g. `d`, or if "Insert Select mode" removes selection (`i`, `<C-O>`, `ve`, `x`)
+      // SELECT can also be changed to VISUAL with v_CTRL-O
+      require(returnTo is NORMAL || returnTo is INSERT || returnTo is REPLACE) {
+        "SELECT mode can be active only in NORMAL, INSERT or REPLACE modes, not ${returnTo.javaClass.simpleName}"
+      }
+    }
+  }
+
+  object INSERT : Mode {
+    override val returnTo: Mode = NORMAL()
+  }
+
+  object REPLACE : Mode {
+    override val returnTo: Mode = NORMAL()
+  }
+
+  data class CMD_LINE(override val returnTo: Mode) : Mode {
+    init {
+      require(returnTo is NORMAL || returnTo is OP_PENDING || returnTo is VISUAL || returnTo is INSERT) {
+        "CMD_LINE mode can be active only in NORMAL, OP_PENDING, VISUAL or INSERT modes, not ${returnTo.javaClass.simpleName}"
+      }
+    }
+  }
 }
 
 enum class SelectionType {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
@@ -20,31 +20,32 @@ import com.maddyhome.idea.vim.state.VimStateMachine
  *
  * Modes with selection have [selectionType] variable representing if the selection is character-, line-, or block-wise.
  *
- * To update the current mode, use [VimStateMachine.setMode]. To get the current mode use [VimStateMachine.mode].
+ * To update the current mode, use [VimStateMachine.mode]. To get the current mode use [VimStateMachine.mode].
  *
  * [Mode] also has a bunch of extension functions like [Mode.isSingleModeActive].
  *
  * Also read about how modes work in Vim: https://github.com/JetBrains/ideavim/wiki/how-many-modes-does-vim-have
  */
 sealed interface Mode {
-  data class NORMAL(val returnTo: ReturnTo? = null) : Mode, ReturnableFromCmd
-  data class OP_PENDING(val returnTo: ReturnTo? = null, val forcedVisual: SelectionType? = null) :
-    Mode, ReturnableFromCmd
-  data class VISUAL(val selectionType: SelectionType, val returnTo: ReturnTo? = null) : Mode,
-    ReturnableFromCmd
+  data class NORMAL(val returnTo: ReturnTo? = null) : Mode
+  data class OP_PENDING(val returnTo: ReturnTo? = null, val forcedVisual: SelectionType? = null) : Mode
+  data class VISUAL(val selectionType: SelectionType, val returnTo: ReturnTo? = null) : Mode
   data class SELECT(val selectionType: SelectionType, val returnTo: ReturnTo? = null) : Mode
-  object INSERT : Mode, ReturnableFromCmd
+  object INSERT : Mode
   object REPLACE : Mode
-  data class CMD_LINE(val returnTo: ReturnableFromCmd) : Mode
+  data class CMD_LINE(val returnTo: Mode) : Mode {
+    init {
+      require(returnTo is NORMAL || returnTo is OP_PENDING || returnTo is VISUAL || returnTo is INSERT) {
+        "CMD_LINE mode can be active only in NORMAL, OP_PENDING, VISUAL or INSERT modes"
+      }
+    }
+  }
 }
 
 sealed interface ReturnTo {
   object INSERT : ReturnTo
   object REPLACE : ReturnTo
 }
-
-// Marks modes that can we return from CMD_LINE mode
-sealed interface ReturnableFromCmd
 
 enum class SelectionType {
   LINE_WISE,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/mode/Mode.kt
@@ -57,6 +57,20 @@ sealed interface Mode {
   data class NORMAL(private val originalMode: Mode? = null) : Mode {
     override val returnTo: Mode
       get() = originalMode ?: this
+
+    /**
+     * Returns true if Insert mode is pending, after the completion of the current Normal command. AKA "Insert Normal"
+     *
+     * When in Insert mode the `<C-O>` keystroke will temporarily switch to Normal for the duration of a single command.
+     */
+    val isInsertPending = originalMode is INSERT
+
+    /**
+     * Returns true if Replace mode is pending, after the completion of the current Normal command.
+     *
+     * Like "Insert Normal", but with `<C-O>` used in Replace mode.
+     */
+    val isReplacePending = originalMode is REPLACE
   }
 
   data class OP_PENDING(override val returnTo: Mode) : Mode {
@@ -77,6 +91,21 @@ sealed interface Mode {
         "VISUAL mode can be active only in NORMAL, INSERT or REPLACE modes, not ${returnTo.javaClass.simpleName}"
       }
     }
+
+    /**
+     * Returns true if Insert mode is pending, after the completion of the current Visual command. AKA "Insert Visual"
+     *
+     * Vim can enter Visual mode from Insert mode, either using shifted keys (based on `'keymodel'` and `'selectmode'`
+     * values) or via "Insert Normal" (`i<C-O>v`).
+     */
+    val isInsertPending = returnTo is INSERT
+
+    /**
+     * Returns true if Replace mode is pending, after the completion of the current Visual command.
+     *
+     * Like "Insert Visual", but starting from (and returning to) Replace (`R<C-O>v`).
+     */
+    val isReplacePending = returnTo is REPLACE
   }
 
   data class SELECT(val selectionType: SelectionType, override val returnTo: Mode = NORMAL()) : Mode {
@@ -88,6 +117,21 @@ sealed interface Mode {
         "SELECT mode can be active only in NORMAL, INSERT or REPLACE modes, not ${returnTo.javaClass.simpleName}"
       }
     }
+
+    /**
+     * Returns true if Insert mode is pending, after the completion of the current Visual command. AKA "Insert Visual"
+     *
+     * Vim can enter Select mode from Insert mode, either using shifted keys (based on `'keymodel'` and `'selectmode'`
+     * values) or via "Insert Normal" (`i<C-O>gh`).
+     */
+    val isInsertPending = returnTo is INSERT
+
+    /**
+     * Returns true if Replace mode is pending, after the completion of the current Visual command.
+     *
+     * Like "Insert Select", but starting from (and returning to) Replace (e.g., `R<C-O>gh`).
+     */
+    val isReplacePending = returnTo is REPLACE
   }
 
   object INSERT : Mode {

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -345,6 +345,11 @@
         "modes": "N"
     },
     {
+        "keys": "<C-O>",
+        "class": "com.maddyhome.idea.vim.action.motion.select.SelectToggleSingleVisualCommandAction",
+        "modes": "SX"
+    },
+    {
         "keys": "<C-P>",
         "class": "com.maddyhome.idea.vim.action.ex.HistoryUpAction",
         "modes": "C"


### PR DESCRIPTION
This PR implements `v_CTRL-O`. That is, pressing `<C-O>` in Select mode will switch to Visual for the duration of a single command. This can be a motion, in which case we switch back to Select, or an operator, which usually removes the selection and so switches to Normal.

The implementation led to refactoring `Mode`, specifically how to represent the mode to return to. Adding a `ReturnTo.SELECT` singleton object would require updates to various `when` statements that need to convert `ReturnTo` to a `Mode`, and there are some transitions to Select that don't make sense, and would either require guessing the selection type, or throwing a runtime error. It is simpler and cleaner to just use `Mode` as the "return to" type.

This PR also updates the text in the "show mode" widget to show the pending modes, e.g. "(insert) NORMAL", "(replace) VISUAL" and so on.