### PR TITLE
Fix Del and BS not working in Select mode

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -314,7 +314,7 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
       if (c instanceof JComponent) {
         final List<AnAction> actions = ActionUtil.getActions((JComponent)c);
         for (AnAction action : actions) {
-          if (action instanceof VimShortcutKeyAction) {
+          if (action instanceof VimShortcutKeyAction || action == VimShortcutKeyAction.getInstance()) {
             continue;
           }
           final Shortcut[] shortcuts = action.getShortcutSet().getShortcuts();
@@ -334,7 +334,11 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
     final Keymap keymap = KeymapManager.getInstance().getActiveKeymap();
     for (String id : keymap.getActionIds(keyStroke)) {
       final AnAction action = ActionManager.getInstance().getAction(id);
-      if (action != null) {
+
+      // EmptyAction is used to reserve a shortcut, but can't be executed. Code can ask for an action by ID and
+      // use its shortcut(s) to dynamically register a new action on a component in the UI hierarchy. It's not
+      // useful for our needs here - we'll pick up the real action when we get local actions.
+      if (action != null && !(action instanceof EmptyAction)) {
         results.add(action);
       }
     }

--- a/src/main/java/com/maddyhome/idea/vim/helper/ModeExtensions.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/ModeExtensions.kt
@@ -33,7 +33,7 @@ internal fun Editor.exitSelectMode(adjustCaretPosition: Boolean) {
     this.caretModel.allCarets.forEach {
       it.removeSelection()
       it.vim.vimSelectionStartClear()
-      if (adjustCaretPosition) {
+      if (adjustCaretPosition && !vimEditor.isEndAllowed) {
         val lineEnd = IjVimEditor(this).getLineEndForOffset(it.offset)
         val lineStart = IjVimEditor(this).getLineStartForOffset(it.offset)
         if (it.offset == lineEnd && it.offset != lineStart) {
@@ -54,7 +54,7 @@ internal fun VimEditor.exitSelectMode(adjustCaretPosition: Boolean) {
       val caret = (vimCaret as IjVimCaret).caret
       caret.removeSelection()
       caret.vim.vimSelectionStartClear()
-      if (adjustCaretPosition) {
+      if (adjustCaretPosition && !isEndAllowed) {
         val lineEnd = IjVimEditor((this as IjVimEditor).editor).getLineEndForOffset(caret.offset)
         val lineStart = IjVimEditor(editor).getLineStartForOffset(caret.offset)
         if (caret.offset == lineEnd && caret.offset != lineStart) {

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectDeleteActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectDeleteActionTest.kt
@@ -6,6 +6,8 @@
  * https://opensource.org/licenses/MIT.
  */
 
+@file:Suppress("SpellCheckingInspection")
+
 package org.jetbrains.plugins.ideavim.action.motion.select
 
 import com.maddyhome.idea.vim.state.mode.Mode
@@ -160,6 +162,61 @@ class SelectDeleteActionTest : VimTestCase() {
         |Cras id tellus in ex imperdiet egestas.
       """.trimMargin(),
       Mode.REPLACE
+    ) {
+      enterCommand("set selectmode=key keymodel=startsel")
+    }
+  }
+
+  // VIM-3042
+  // We don't need to test Del and BS separately for this
+  @Test
+  fun `test deleting last word of line places caret at correct offset when returning to Normal mode`() {
+    doTest(
+      listOf("ve", "<C-G>", "<Del>"),
+      """
+        |Lorem Ipsum
+        |
+        |I found it in a legendary${c} land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem Ipsum
+        |
+        |I found it in a legendar${c}y
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.NORMAL()
+    )
+  }
+
+  // VIM-3042
+  @Test
+  fun `test deleting last word of line places caret at correct offset when returning to Insert mode`() {
+    // Remember that IdeaVim treats Select mode as exclusive, so we need 5x<S-Right> to select " land" and the caret
+    // will finish up _after_ the word, on the new line char
+    doTest(
+      listOf("i", "<S-Right>".repeat(5), "<Del>"),
+      """
+        |Lorem Ipsum
+        |
+        |I found it in a legendary${c} land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem Ipsum
+        |
+        |I found it in a legendary${c}
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.INSERT
     ) {
       enterCommand("set selectmode=key keymodel=startsel")
     }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectDeleteActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectDeleteActionTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2003-2025 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action.motion.select
+
+import com.maddyhome.idea.vim.state.mode.Mode
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class SelectDeleteActionTest : VimTestCase() {
+  @Test
+  fun `test Delete removes text and returns to Normal mode`() {
+    doTest(
+      listOf("ve", "<C-G>", "<Del>"),
+      """
+        |Lorem Ipsum
+        |
+        |I ${c}found it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem Ipsum
+        |
+        |I $c it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.NORMAL()
+    )
+  }
+
+  @Test
+  fun `test Delete removes text and returns to Insert mode when invoked from Insert Select`() {
+    doTest(
+      listOf("i", "<S-Right>".repeat(5), "<Del>"),
+      """
+        |Lorem Ipsum
+        |
+        |I ${c}found it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem Ipsum
+        |
+        |I $c it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.INSERT
+    ) {
+      enterCommand("set selectmode=key keymodel=startsel")
+    }
+  }
+
+  @Test
+  fun `test Delete removes text and returns to Replace mode when invoked from Select with pending Replace mode`() {
+    doTest(
+      listOf("R", "<S-Right>".repeat(5), "<Del>"),
+      """
+        |Lorem Ipsum
+        |
+        |I ${c}found it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem Ipsum
+        |
+        |I $c it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.REPLACE
+    ) {
+      enterCommand("set selectmode=key keymodel=startsel")
+    }
+  }
+
+  @Test
+  fun `test Backspace deletes text and returns to Normal mode`() {
+    doTest(
+      listOf("ve", "<C-G>", "<Del>"),
+      """
+        |Lorem Ipsum
+        |
+        |I ${c}found it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem Ipsum
+        |
+        |I $c it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.NORMAL()
+    )
+  }
+
+  @Test
+  fun `test Backspace removes text and returns to Insert mode when invoked from Insert Select`() {
+    doTest(
+      listOf("i", "<S-Right>".repeat(5), "<BS>"),
+      """
+        |Lorem Ipsum
+        |
+        |I ${c}found it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem Ipsum
+        |
+        |I $c it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.INSERT
+    ) {
+      enterCommand("set selectmode=key keymodel=startsel")
+    }
+  }
+
+  @Test
+  fun `test Backspace removes text and returns to Replace mode when invoked from Select with pending Replace mode`() {
+    doTest(
+      listOf("R", "<S-Right>".repeat(5), "<BS>"),
+      """
+        |Lorem Ipsum
+        |
+        |I ${c}found it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem Ipsum
+        |
+        |I $c it in a legendary land
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      Mode.REPLACE
+    ) {
+      enterCommand("set selectmode=key keymodel=startsel")
+    }
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectEscapeActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/select/SelectEscapeActionTest.kt
@@ -39,7 +39,6 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -65,12 +64,11 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
   @Test
-  fun `test exit char mode on line end`() {
+  fun `test exit char mode on line end puts caret at correct offset when returning to Normal mode`() {
     this.doTest(
       listOf("gh", "<esc>"),
       """
@@ -91,7 +89,33 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
+  @Test
+  fun `test exit char mode on line end puts caret at correct offset when returning to Insert mode`() {
+    this.doTest(
+      listOf("i", "<S-Right>", "<esc>"),
+      """
+                A Discovery
+
+                I found it in a legendary lan${c}d
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      """
+                A Discovery
+
+                I found it in a legendary land${c}
+                all rocks and lavender and tufted grass,
+                where it was settled on some sodden sand
+                hard by the torrent of a mountain pass.
+      """.trimIndent(),
+      Mode.INSERT,
+    ) {
+      enterCommand("set selectmode=key keymodel=startsel")
+    }
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -117,7 +141,6 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -143,7 +166,6 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -169,7 +191,6 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -195,7 +216,6 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -221,7 +241,6 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -247,7 +266,6 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -273,7 +291,6 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -299,7 +316,6 @@ class SelectEscapeActionTest : VimTestCase() {
       """.trimIndent(),
       Mode.NORMAL(),
     )
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -328,7 +344,6 @@ class SelectEscapeActionTest : VimTestCase() {
     kotlin.test.assertFalse(fixture.editor.caretModel.allCarets.any(Caret::hasSelection))
     kotlin.test.assertEquals(1, fixture.editor.caretModel.caretCount)
     assertCaretsVisualAttributes()
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -357,7 +372,6 @@ class SelectEscapeActionTest : VimTestCase() {
     kotlin.test.assertFalse(fixture.editor.caretModel.allCarets.any(Caret::hasSelection))
     kotlin.test.assertEquals(1, fixture.editor.caretModel.caretCount)
     assertCaretsVisualAttributes()
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -386,7 +400,6 @@ class SelectEscapeActionTest : VimTestCase() {
     kotlin.test.assertFalse(fixture.editor.caretModel.allCarets.any(Caret::hasSelection))
     kotlin.test.assertEquals(1, fixture.editor.caretModel.caretCount)
     assertCaretsVisualAttributes()
-    assertMode(Mode.NORMAL())
   }
 
   @TestWithoutNeovim(SkipNeovimReason.SELECT_MODE)
@@ -415,6 +428,5 @@ class SelectEscapeActionTest : VimTestCase() {
     kotlin.test.assertFalse(fixture.editor.caretModel.allCarets.any(Caret::hasSelection))
     kotlin.test.assertEquals(1, fixture.editor.caretModel.caretCount)
     assertCaretsVisualAttributes()
-    assertMode(Mode.NORMAL())
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectDeleteAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/SelectDeleteAction.kt
@@ -19,14 +19,22 @@ import com.maddyhome.idea.vim.handler.VimActionHandler
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-/**
- * @author Alex Plate
- */
+@CommandOrMotion(keys = ["<DEL>"], modes = [Mode.SELECT])
+class SelectDeleteAction : SelectDeleteBackspaceActionBase() {
+  override val keyStroke: KeyStroke
+    get() = KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0)
+}
 
-@CommandOrMotion(keys = ["<BS>", "<DEL>"], modes = [Mode.SELECT])
-class SelectDeleteAction : VimActionHandler.SingleExecution() {
+@CommandOrMotion(keys = ["<BS>"], modes = [Mode.SELECT])
+class SelectBackspaceAction : SelectDeleteBackspaceActionBase() {
+  override val keyStroke: KeyStroke
+    get() = KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0)
+}
 
+abstract class SelectDeleteBackspaceActionBase : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.INSERT
+
+  abstract val keyStroke: KeyStroke
 
   override fun execute(
     editor: VimEditor,
@@ -34,15 +42,22 @@ class SelectDeleteAction : VimActionHandler.SingleExecution() {
     cmd: Command,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    val enterKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0)
-    val actions = injector.keyGroup.getActions(editor, enterKeyStroke)
+    // TODO: It would be nice to know _why_ we use native actions for Delete/Backspace
+    // If there's some kind of additional native editor action bound to Delete or Backspace (e.g. cancelling something,
+    // etc.) then we should of course invoke it, like we do with Escape or Enter. But if we do, we should reconsider
+    // unconditionally exiting Select mode. If the additional native editor action doesn't delete the text, then we're
+    // exiting Select mode incorrectly. If there isn't an additional native editor action, then would it just be simpler
+    // to delete the selected text using editor APIs?
+    val actions = injector.keyGroup.getActions(editor, keyStroke)
     for (action in actions) {
       if (injector.actionExecutor.executeAction(editor, action, context)) {
         break
       }
     }
+
+    // Note that Vim returns to the pending mode. I.e., when starting Select from Normal/Visual, it will return to
+    // Normal. When returning from Insert or Replace pending Select (via shifted keys), it will return to Insert/Replace
     editor.exitSelectModeNative(true)
-    injector.changeGroup.insertBeforeCursor(editor, context)
     return true
   }
 }

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -126,7 +126,7 @@
     },
     {
         "keys": "<BS>",
-        "class": "com.maddyhome.idea.vim.action.motion.select.SelectDeleteAction",
+        "class": "com.maddyhome.idea.vim.action.motion.select.SelectBackspaceAction",
         "modes": "S"
     },
     {


### PR DESCRIPTION
This PR fixes an issue when hitting `<Del>` or `<BS>` to delete selected text in Select mode would fail to delete anything. The implementation would try to invoke native actions to delete but had two problems. Firstly, it would fail to filter out the IdeaVim action bound to the keystroke and would recurse (but fail to invoke anything). Secondly, it would also try to invoke instances of `EmptyAction`, which are placeholder actions that are used to reserve a shortcut. Code will use look for these actions by ID to look up the shortcut to use when dynamically registering the real action locally in a `Component`. We gather these locally registered actions, so it's safe to ignore the empty action.

It also correctly transitions from Select mode to Normal or Insert/Replace, depending on context. If Select mode was started from Normal (via `gh` or `v<C-G>`), then it will return to Normal. If started in Insert/Replace mode via shifted keys, then it will return to Insert/Replace. As part of this, it correctly positions the caret, especially when deleting the last text character in a line.

Fixes [VIM-3618](https://youtrack.jetbrains.com/issue/VIM-3618/Del-Backspace-in-select-Mode-not-working) and [VIM-3042](https://youtrack.jetbrains.com/issue/VIM-3042/Select-and-delete-from-insert-mode-moves-cursor-position).

~~This PR depends on #1078, specifically to handle the correct mode transitions. As such, it lists a load of unnecessary commits from that branch. Once #1078 is merged, I'll rebase, force push and mark this PR as no longer draft. Here is the list of commits in this PR: [272bea0...5275057](https://github.com/JetBrains/ideavim/compare/272bea02f2d40a9d259298f955c11fa46c477856...52750570d0459f24ecf5a9a7b3d58fcea3e08132)~~