### PR TITLE
Fix race condition resetting editor on focus gain

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
@@ -80,7 +80,9 @@ class IJEditorFocusListener : EditorListener {
       if (ijEditor.isDisposed) return@invokeLater
       val consoleView: ConsoleViewImpl? = ijEditor.getUserData(ConsoleViewImpl.CONSOLE_VIEW_IN_EDITOR_VIEW)
       if (consoleView != null && consoleView.isRunning && !ijEditor.inInsertMode) {
+        // Switch to Insert mode, but make sure we reset the editor to actually make it apply
         switchToInsertMode.run()
+        KeyHandler.getInstance().reset(editor)
       }
     }
     KeyHandler.getInstance().reset(editor)


### PR DESCRIPTION
When an editable console editor gets focus, IdeaVim automatically enters Insert mode. However, we can't always tell a console editor window is editable when it gains focus, so we do an additional check via `application.invokeLater`. If this switches to Insert mode, it doesn't correctly reset the (newly focused console) editor, so even though the mode is "Insert", it was last reset with "Normal". This PR will reset the editor state (including key handler) so that the new mode is "applied".

Fixes [VIM-3773](https://youtrack.jetbrains.com/issue/VIM-3773)