### PR TITLE
fix: distanceTo to works with nested quotes and brackets (mini.ai) plugin

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/miniai/MiniAI.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/miniai/MiniAI.kt
@@ -220,11 +220,16 @@ private fun findClosestQuoteRange(
 }
 
 private fun TextRange.distanceTo(caretOffset: Int): Int {
-  return if (caretOffset < startOffset) {
-    startOffset - caretOffset
-  } else if (caretOffset > endOffset) {
-    caretOffset - endOffset
-  } else {
-    0 // Caret is inside the range
+  val rangeLength = endOffset - startOffset
+
+  // If caret is inside the range
+  if (caretOffset in startOffset..endOffset) {
+    // Return the length of the range - smaller ranges get priority
+    return rangeLength
   }
+
+  // If caret is outside, make the distance much larger
+  val startDistance = kotlin.math.abs(caretOffset - startOffset)
+  val endDistance = kotlin.math.abs(caretOffset - endOffset)
+  return (startDistance + endDistance) * 1000 + rangeLength
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/miniai/MiniAIExtensionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/miniai/MiniAIExtensionTest.kt
@@ -10,17 +10,58 @@ package org.jetbrains.plugins.ideavim.extension.miniai
 
 import com.intellij.ide.highlighter.JavaFileType
 import com.maddyhome.idea.vim.state.mode.Mode
-import org.jetbrains.plugins.ideavim.VimJavaTestCase
+import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 
 @Suppress("SpellCheckingInspection")
-class MiniAIExtensionTest : VimJavaTestCase() {
+class MiniAIExtensionTest : VimTestCase() {
   @BeforeEach
   override fun setUp(testInfo: TestInfo) {
     super.setUp(testInfo)
     enableExtensions("mini-ai")
+  }
+
+
+  @Test
+  fun testFromAlex() {
+    doTest(
+      "ciq",
+      "<caret>This is a \"'simple'\" test",
+      "This is a \"<caret>\" test",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+
+  // To make sure the order in list is not relevant
+  @Test
+  fun testChangeInsideBackQuoteWithNestedSingleQuote() {
+    doTest(
+      "ciq",
+      "<caret>This is a `'simple'` test",
+      "This is a `<caret>` test",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+
+  // To make sure the order in list is not relevant
+  @Test
+  fun testChangeInsideSingleQuoteWithNestedDoubleQuote() {
+    doTest(
+      "ciq",
+      "<caret>This is a '\"simple\"' test",
+      "This is a '<caret>' test",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
   }
 
   @Test

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/extension/miniai/MiniAIExtensionTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/extension/miniai/MiniAIExtensionTest.kt
@@ -24,6 +24,200 @@ class MiniAIExtensionTest : VimJavaTestCase() {
   }
 
   @Test
+  fun testChangeInsideNestedQuotes() {
+    doTest(
+      "ciq",
+      "this 'simple<caret> \"test\"'",
+      "this '<caret>'",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testDeleteInsideNestedQuotes() {
+    doTest(
+      "diq",
+      "this 'simple<caret> \"test\"'",
+      "this '<caret>'",
+      Mode.NORMAL(),
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testChangeInsideNestedQuotesDoubleInner() {
+    doTest(
+      "ciq",
+      "this \"simple<caret> 'test'\"",
+      "this \"<caret>\"",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testDeleteInsideNestedQuotesDoubleInner() {
+    doTest(
+      "diq",
+      "this \"simple<caret> 'test'\"",
+      "this \"<caret>\"",
+      Mode.NORMAL(),
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testChangeInsideNestedQuotesBackQuote() {
+    doTest(
+      "ciq",
+      "this `simple<caret> \"test\"`",
+      "this `<caret>`",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testDeleteInsideNestedQuotesBackQuote() {
+    doTest(
+      "diq",
+      "this `simple<caret> \"test\"`",
+      "this `<caret>`",
+      Mode.NORMAL(),
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testChangeAroundNestedSingleQuotes() {
+    doTest(
+      "caq",
+      "this 'simple<caret> \"test\"'",
+      "this <caret>",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testDeleteAroundNestedSingleQuotes() {
+    doTest(
+      "daq",
+      "this 'simple<caret> \"test\"' test",
+      "this <caret> test",
+      Mode.NORMAL(),
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testChangeAroundNestedDoubleQuotes() {
+    doTest(
+      "caq",
+      "this \"simple<caret> 'test'\"",
+      "this <caret>",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testDeleteAroundNestedDoubleQuotes() {
+    doTest(
+      "daq",
+      "this \"simple<caret> 'test'\" test",
+      "this <caret> test",
+      Mode.NORMAL(),
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testChangeAroundNestedBackQuotes() {
+    doTest(
+      "caq",
+      "this `simple<caret> \"test\"`",
+      "this <caret>",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testDeleteAroundNestedBackQuotes() {
+    doTest(
+      "daq",
+      "this `simple<caret> \"test\"` test",
+      "this <caret> test",
+      Mode.NORMAL(),
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  // Additional edge cases with cursor on different positions
+  @Test
+  fun testChangeAroundNestedQuotesOnInnerQuote() {
+    doTest(
+      "caq",
+      "this 'simple \"<caret>test\"'",
+      "this 'simple <caret>'",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testDeleteAroundNestedQuotesOnInnerQuote() {
+    doTest(
+      "daq",
+      "this 'simple \"<caret>test\"'",
+      "this 'simple '",
+      Mode.NORMAL(),
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  // Test with multiple levels of nesting
+  @Test
+  fun testChangeAroundTripleNestedQuotes() {
+    doTest(
+      "caq",
+      "this 'simple \"nested `<caret>test`\"'",
+      "this 'simple \"nested <caret>\"'",
+      Mode.INSERT,
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
+  fun testDeleteAroundTripleNestedQuotes() {
+    doTest(
+      "daq",
+      "this 'simple \"nested `<caret>test`\"'",
+      "this 'simple \"nested <caret>\"'",
+      Mode.NORMAL(),
+      JavaFileType.INSTANCE,
+    )
+    assertSelection(null)
+  }
+
+  @Test
   fun testChangeInsideSingleQuote() {
     doTest(
       "ciq",


### PR DESCRIPTION
### Why?
The mini.ai extension had an issue with nested quotes or brackets selection.

### The Problem
When dealing with nested quotes, the extension should select the innermost quotes containing the cursor. However, it was incorrectly selecting outer quotes due to the distance calculation logic.

### Example:

current state: This is a "simple '|example'" that works

After pressing ciq it should produce the following result:

expected: This is a "simple '|'" that works

However it is behaving like this:

actual: This is a "|" that works

### The Solution
The distanceTo function has been refactored to prioritize:

- Ranges that contain the cursor
- Smaller ranges over larger ones
- Heavily penalize ranges where the cursor is outside

I noticed that the distanceTo function was wrong, this pr fixes it.

Please take a look at the new tests to understand the problem.





