### PR TITLE
Move status bar widgets after dotCover indicator

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -62,7 +62,12 @@
     <applicationConfigurable groupId="editor" instance="com.maddyhome.idea.vim.ui.VimEmulationConfigurable"/>
     <projectService serviceImplementation="com.maddyhome.idea.vim.group.LastTabService"/>
     <statusBarWidgetFactory id="IdeaVimMode" implementation="com.maddyhome.idea.vim.ui.widgets.mode.ModeWidgetFactory" order="last, before Memory"/>
-    <statusBarWidgetFactory id="IdeaVim-Icon" implementation="com.maddyhome.idea.vim.ui.StatusBarIconFactory" order="last, before IdeaVimMode"/>
+    <!-- [VERSION UPDATE: 2025.1+]
+         Rider's dotCover status indicator sets itself as "last" which pushes the IdeaVim widgets out
+         Hopefully this will be fixed in Rider 2025.1. Once this is the minimum supported version, we can remove this
+         https://youtrack.jetbrains.com/issue/DCVR-13021/dotCover-status-bar-indicator-in-Rider-incorrect-position
+    -->
+    <statusBarWidgetFactory id="IdeaVim-Icon" implementation="com.maddyhome.idea.vim.ui.StatusBarIconFactory" order="last, before IdeaVimMode, after dotCoverIndicator"/>
     <statusBarWidgetFactory id="IdeaVimShowCmd" implementation="com.maddyhome.idea.vim.ui.ShowCmdStatusBarWidgetFactory" order="first"/>
     <statusBarWidgetFactory id="IdeaVimMacro" implementation="com.maddyhome.idea.vim.ui.widgets.macro.MacroWidgetFactory" order="first, after IdeaVimShowCmd"/>
 


### PR DESCRIPTION
Rider's dotCover indicator is marked as "last" rather than relative to other dotnet icons. This position pushes out IdeaVim widgets, so make sure we're after "dotCoverIndicator".

See also [DCVR-13021](https://youtrack.jetbrains.com/issue/DCVR-13021/dotCover-status-bar-indicator-in-Rider-incorrect-position)


![Screenshot 2025-03-10 at 6 03 43 pm](https://github.com/user-attachments/assets/1bef2f02-5898-4f29-ac39-c87073c3c603)
![Screenshot 2025-03-10 at 6 00 15 pm](https://github.com/user-attachments/assets/1838b5fc-f514-49c4-b171-f4fea0af1c72)
