### PR TITLE
Fix caret location after :move command

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MoveCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MoveCommandTest.kt
@@ -148,7 +148,7 @@ class MoveCommandTest : VimTestCase() {
     enterCommand("m 0")
     assertState(
       """
-      For example: homewor${c}k, homework, homework, homework, homework, homework, homework, homework, homework.
+      ${c}For example: homework, homework, homework, homework, homework, homework, homework, homework, homework.
       ====
       My mother taught me this trick: if you repeat something over and over again it loses its meaning.
       See, nothing.
@@ -173,8 +173,8 @@ class MoveCommandTest : VimTestCase() {
         |Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
         |Morbi nec luctus tortor, id venenatis lacus.
         |Nunc sit amet tellus vel purus cursus posuere et at purus.
-        |Ut id dapibus augue.
-        |${c}Pellentesque orci dolor, tristique quis rutrum non, scelerisque id dui.
+        |${c}Ut id dapibus augue.
+        |Pellentesque orci dolor, tristique quis rutrum non, scelerisque id dui.
       """.trimMargin()
     )
   }
@@ -194,7 +194,7 @@ class MoveCommandTest : VimTestCase() {
     assertState(
       """
       For example: homework, homework, homework, homework, homework, homework, homework, homework, homework.
-      See, nothing.
+      ${c}See, nothing.
       ====
       My mother taught me this trick: if you repeat something over and over again it loses its meaning.
       """.trimIndent(),
@@ -216,7 +216,7 @@ class MoveCommandTest : VimTestCase() {
       """
       ====
       My mother taught me this trick: if you repeat something over and over again it loses its meaning.
-      See, not${c}hing.
+      ${c}See, nothing.
       For example: homework, homework, homework, homework, homework, homework, homework, homework, homework.
       """.trimIndent(),
     )
@@ -238,8 +238,103 @@ class MoveCommandTest : VimTestCase() {
       ====
       My mother taught me this trick: if you repeat something over and over again it loses its meaning.
       See, nothing.
-      For example: homewor${c}k, homework, homework, homework, homework, homework, homework, homework, homework.
+      ${c}For example: homework, homework, homework, homework, homework, homework, homework, homework, homework.
       """.trimIndent(),
     )
+  }
+
+  // VIM-3837
+  @Test
+  fun `test moving relative line positions caret correctly`() {
+    doTest(
+      exCommand("+2m."), // Move the line 2 lines below, to below the current line
+      """
+        |2
+        |1
+        |${c}3
+        |1
+        |2
+      """.trimMargin(),
+      """
+        |2
+        |1
+        |3
+        |${c}2
+        |1
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test moving relative line positions caret correctly 2`() {
+    doTest(
+      exCommand("+2m."), // Move the line 2 lines below, to below the current line
+      """
+        |Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        |Morbi nec luctus tortor, id venenatis lacus.
+        |Nunc sit amet ${c}tellus vel purus cursus posuere et at purus.
+        |Ut id dapibus augue.
+        |Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        |Pellentesque orci dolor, tristique quis rutrum non, scelerisque id dui.
+      """.trimMargin(),
+      """
+        |Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        |Morbi nec luctus tortor, id venenatis lacus.
+        |Nunc sit amet tellus vel purus cursus posuere et at purus.
+        |${c}Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        |Ut id dapibus augue.
+        |Pellentesque orci dolor, tristique quis rutrum non, scelerisque id dui.
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test moving lines positions caret correctly with nostartofline option`() {
+    doTest(
+      exCommand("+2m."), // Move the line 2 lines below, to below the current line
+      """
+        |Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        |Morbi nec luctus tortor, id venenatis lacus.
+        |Nunc sit amet ${c}tellus vel purus cursus posuere et at purus.
+        |Ut id dapibus augue.
+        |Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        |Pellentesque orci dolor, tristique quis rutrum non, scelerisque id dui.
+      """.trimMargin(),
+      """
+        |Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        |Morbi nec luctus tortor, id venenatis lacus.
+        |Nunc sit amet tellus vel purus cursus posuere et at purus.
+        |Orci varius na${c}toque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        |Ut id dapibus augue.
+        |Pellentesque orci dolor, tristique quis rutrum non, scelerisque id dui.
+      """.trimMargin()
+    ) {
+      enterCommand("set nostartofline")
+    }
+  }
+
+  @Test
+  fun `test moving lines positions caret correctly with nostartofline option on shorter line`() {
+    doTest(
+      exCommand("+2m."), // Move the line 2 lines below, to below the current line
+      """
+        |Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        |Morbi nec luctus tortor, id ${c}venenatis lacus.
+        |Nunc sit amet tellus vel purus cursus posuere et at purus.
+        |Ut id dapibus augue.
+        |Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        |Pellentesque orci dolor, tristique quis rutrum non, scelerisque id dui.
+      """.trimMargin(),
+      """
+        |Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        |Morbi nec luctus tortor, id venenatis lacus.
+        |Ut id dapibus augue${c}.
+        |Nunc sit amet tellus vel purus cursus posuere et at purus.
+        |Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        |Pellentesque orci dolor, tristique quis rutrum non, scelerisque id dui.
+      """.trimMargin()
+    ) {
+      enterCommand("set nostartofline")
+    }
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/cursorFunctions/ColFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/cursorFunctions/ColFunctionTest.kt
@@ -37,8 +37,7 @@ class ColFunctionTest : VimTestCase() {
     // With selection - make sure to delete the '<,'> that is automatically prepended when entering Command-line mode
     // with a selection
     typeText("vll")
-    typeText(":<C-U>echo col(\"v\")<CR>") // enterCommand/assertCommandOutput cannot handle <C-U>!
-    assertExOutput("5")
+    assertCommandOutput("""<C-U>echo col("v")""", "5")
 
     // Remove selection and check again - note that exiting Command-line mode removes selection and switches back to
     // Normal. This <esc> does nothing

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/cursorFunctions/LineFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/cursorFunctions/LineFunctionTest.kt
@@ -32,8 +32,7 @@ class LineFunctionTest : VimTestCase() {
     // With selection - make sure to delete the '<,'> that is automatically prepended when entering Command-line mode
     // with a selection
     typeText("vj")
-    typeText(""":<C-U>echo line("v")<CR>""")  // enterCommand/assertCommandOutput cannot handle <C-U>!
-    assertExOutput("3")
+    assertCommandOutput("""<C-U>echo line("v")""", "3")
 
     // Remove selection and check again - note that exiting Command-line mode removes selection and switches back to
     // Normal. This <esc> does nothing

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/cursorFunctions/LineFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/cursorFunctions/LineFunctionTest.kt
@@ -45,4 +45,50 @@ class LineFunctionTest : VimTestCase() {
       "0 1 5 0 5 0"
     )
   }
+
+  @Test
+  fun `test line with selection`() {
+    doTest(
+      listOf("V2j", "q"),
+      """
+        |1
+        |${c}2
+        |3
+        |4
+        |5
+      """.trimMargin(),
+      """
+        |1
+        |2
+        |3
+        |4 - line(v)==${c}2
+        |5
+      """.trimMargin(),
+    ) {
+      enterCommand("vmap <expr> q '<Esc>a - line(v)=='.line('v').'<Esc>'")
+    }
+  }
+
+  @Test
+  fun `test line with reverse selection`() {
+    doTest(
+      listOf("V2k", "q"),
+      """
+        |1
+        |2
+        |3
+        |${c}4
+        |5
+      """.trimMargin(),
+      """
+        |1
+        |2 - line(v)==${c}4
+        |3
+        |4
+        |5
+      """.trimMargin(),
+    ) {
+      enterCommand("vmap <expr> q '<Esc>a - line(v)=='.line('v').'<Esc>'")
+    }
+  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -225,7 +225,7 @@ class KeyHandler {
     val operatorArguments = OperatorArguments(command.rawCount, editorState.mode)
 
     // If we were in "operator pending" mode, reset back to normal mode.
-    // But opening command line should not reset operator pending mode (e.g. `d/foo`
+    // But opening command line should not reset operator pending mode (e.g. `d/foo`)
     if (!command.flags.contains(CommandFlags.FLAG_START_EX)) {
       editor.resetOpPending()
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/cursorFunctions/ColLineFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/cursorFunctions/ColLineFunctionHandler.kt
@@ -105,7 +105,7 @@ private fun variableToPosition(
   // Current caret line
   if (name[0] == '.') return editor.currentCaret().vimLine.asVimInt() to currentCol(editor)
 
-  // Visual start
+  // The opposite end of the Visual selection, i.e., the start. If there is no selection, return the current line
   if (name == "v") {
     if (!editor.inVisualMode) {
       return editor.currentCaret().vimLine.asVimInt() to currentCol(editor)
@@ -113,10 +113,10 @@ private fun variableToPosition(
 
     val vimStart = editor.currentCaret().vimSelectionStart
     val bufferPosition = editor.offsetToBufferPosition(vimStart)
-    val visualLine = (bufferPosition.line + 1).asVimInt()
-    val visualCol = (bufferPosition.column + 1).asVimInt()
+    val line = (bufferPosition.line + 1).asVimInt()
+    val col = (bufferPosition.column + 1).asVimInt()
 
-    return visualLine to visualCol
+    return line to col
   }
 
   // Mark


### PR DESCRIPTION
Fixes the caret location after the `:move` command, especially with regard to relative addresses, such as `:+2m.`. Fixes [VIM-3837](https://youtrack.jetbrains.com/issue/VIM-3837).

Also makes some minor changes to clarify some behaviour that appeared related but wasn't. Namely, that `line('v')` returns the opposite end of the current selection (related to [VIM-3838](https://youtrack.jetbrains.com/issue/VIM-3838))