### PR TITLE
Fix unhandled key stroke after surround operation

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/surround/VimSurroundExtension.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimCaret
@@ -139,6 +140,10 @@ internal class VimSurroundExtension : VimExtension {
         // Leave visual mode
         editor.exitVisualMode()
         editor.ij.caretModel.moveToOffset(selectionStart)
+
+        // Reset the key handler so that the command trie is updated for the new mode (Normal)
+        // TODO: This should probably be handled by ToHandlerMapping.execute
+        KeyHandler.getInstance().reset(editor)
       }
     }
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/surround/VimSurroundExtensionTest.kt
@@ -633,6 +633,17 @@ class VimSurroundExtensionTest : VimTestCase() {
     doTest(listOf(motion), before, after, Mode.NORMAL())
   }
 
+  // VIM-3841
+  @Test
+  fun `test return to Normal mode after surround in Visual mode`() {
+    doTest(
+      listOf("veS\"", "i"),
+      "lorem ${c}ipsum dolor sit amet",
+      "lorem ${c}\"ipsum\" dolor sit amet",
+      Mode.INSERT,
+    )
+  }
+
   companion object {
     @JvmStatic
     fun removeWhiteSpaceWithClosingBracketParams() = listOf(


### PR DESCRIPTION
Fixes [VIM-3841](https://youtrack.jetbrains.com/issue/VIM-3841/Unhandled-key-press-after-surround-operation).

Given a command such as `veS"`, IdeaVim will enter Visual mode, surround the selection with `"` and exit Visual. A subsequent keystroke such as `i` has no effect.

This is because the key handler is not reset when leaving Visual mode, and continues to try and process keystrokes as Visual. This PR resets the key handler.

See discussion at #1124.