### PR TITLE
Reorder and add information to plugins doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Here are some examples of supported vim features and commands:
 * highlightedyank
 * indent-object
 * matchit.vim
-* Mini.ai: Extend and create a/i textobjects (IMPORTANT: The plugin is not related with artificial intelligence)
+* Mini.ai
 * multiple-cursors
 * NERDTree
 * paragraph-motion

--- a/README.md
+++ b/README.md
@@ -98,18 +98,18 @@ Here are some examples of supported vim features and commands:
 * exchange
 * FunctionTextObj
 * highlightedyank
-* IdeaVim-Quickscope
+* indent-object
 * matchit.vim
 * Mini.ai: Extend and create a/i textobjects (IMPORTANT: The plugin is not related with artificial intelligence)
 * multiple-cursors
 * NERDTree
+* paragraph-motion
+* Peekaboo
+* quick-scope
 * ReplaceWithRegister
 * surround
 * Switch
 * textobj-entire
-* Vim Peekaboo
-* vim-indent-object
-* vim-paragraph-motion
 * Which-Key
 
 See also:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Here are some examples of supported vim features and commands:
 * Peekaboo
 * quick-scope
 * ReplaceWithRegister
+* sneak
 * surround
 * Switch
 * textobj-entire

--- a/README.md
+++ b/README.md
@@ -92,20 +92,25 @@ Here are some examples of supported vim features and commands:
 
 [IdeaVim plugins](https://github.com/JetBrains/ideavim/wiki/IdeaVim-Plugins):
 
-* vim-easymotion
+* argtextobj
+* commentary
+* easymotion
+* exchange
+* FunctionTextObj
+* highlightedyank
+* IdeaVim-Quickscope
+* matchit.vim
+* Mini.ai: Extend and create a/i textobjects (IMPORTANT: The plugin is not related with artificial intelligence)
+* multiple-cursors
 * NERDTree
-* vim-surround
-* vim-multiple-cursors
-* vim-commentary
-* argtextobj.vim
-* vim-textobj-entire
 * ReplaceWithRegister
-* vim-exchange
-* vim-highlightedyank
-* vim-paragraph-motion
+* surround
+* Switch
+* textobj-entire
+* Vim Peekaboo
 * vim-indent-object
-* match.it  
-etc
+* vim-paragraph-motion
+* Which-Key
 
 See also:
 

--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -16,11 +16,11 @@ in `~/.ideavimrc`. E.g. `set nosurround`.
 Available plugins:
 
 <details>
-<summary><h2>argtextobj</h2></summary>
+<summary><h2>argtextobj: Provides a text-object 'a' argument</h2></summary>
 
 Original plugin: [argtextobj.vim](https://www.vim.org/scripts/script.php?script_id=2699).
 
-### About:
+### Summary:
 This plugin provides a text-object 'a' (argument). 
 You can d(elete), c(hange), v(select)... an argument or inner argument in familiar ways.
 
@@ -60,12 +60,12 @@ https://www.vim.org/scripts/script.php?script_id=2699
 </details>
 
 <details>
-<summary><h2>commentary</h2></summary>
+<summary><h2>commentary: Adds mapping for quickly commenting stuff out</h2></summary>
 
 By [Daniel Leong](https://github.com/dhleong)  
 Original plugin: [commentary.vim](https://github.com/tpope/vim-commentary).
 
-### About:
+### Summary:
 Comment stuff out. 
 Use gcc to comment out a line (takes a count), gc to comment out the target of a motion 
 (for example, gcap to comment out a paragraph), gc in visual mode to comment out the selection, 
@@ -96,11 +96,11 @@ https://github.com/tpope/vim-commentary/blob/master/doc/commentary.txt
 </details>
 
 <details>
-<summary><h2>easymotion</h2></summary>
+<summary><h2>easymotion: Simplifies some motions</h2></summary>
    
 Original plugin: [vim-easymotion](https://github.com/easymotion/vim-easymotion).
 
-### About:
+### Summary:
 EasyMotion provides a much simpler way to use some motions in vim. 
 It takes the \<number> out of \<number>w or \<number>f{char} by highlighting all possible choices 
 and allowing you to press one key to jump directly to the target.
@@ -127,12 +127,12 @@ All commands with the mappings are supported. See the [full list of supported co
 </details>
 
 <details>
-<summary><h2>exchange</h2></summary>
+<summary><h2>exchange: Easy text exchange operator</h2></summary>
 
 By [fan-tom](https://github.com/fan-tom)  
 Original plugin: [vim-exchange](https://github.com/tommcdo/vim-exchange).
 
-### About:
+### Summary:
 Easy text exchange operator for Vim.
 
 ### Setup:
@@ -155,11 +155,11 @@ https://github.com/tommcdo/vim-exchange/blob/master/doc/exchange.txt
 </details>
 
 <details>
-<summary><h2>FunctionTextObj</h2></summary>
+<summary><h2>FunctionTextObj: Adds text objects for manipulating functions/methods</h2></summary>
 
 By Julien Phalip
 
-### About:
+### Summary:
 An extension for IdeaVim that adds text objects for manipulating functions/methods in your code. 
 Similar to how iw operates on words or i" operates on quoted strings, 
 this plugin provides if and af to operate on functions
@@ -175,12 +175,12 @@ https://plugins.jetbrains.com/plugin/25897-vim-functiontextobj
 </details>
 
 <details>
-<summary><h2>highlightedyank</h2></summary>
+<summary><h2>highlightedyank: Highlights the yanked region</h2></summary>
 
 By [KostkaBrukowa](https://github.com/KostkaBrukowa)  
 Original plugin: [vim-highlightedyank](https://github.com/machakann/vim-highlightedyank).
 
-### About:
+### Summary:
 Make the yanked region apparent!
 
 ### Setup:
@@ -213,12 +213,12 @@ https://github.com/machakann/vim-highlightedyank/blob/master/doc/highlightedyank
 </details>
 
 <details>
-<summary><h2>indent-object</h2></summary>
+<summary><h2>indent-object: Adds text objects for manipulating sentences/paragraphs/etc...</h2></summary>
 
 By [Shrikant Sharat Kandula](https://github.com/sharat87)  
 Original plugin: [vim-indent-object](https://github.com/michaeljsmith/vim-indent-object).
 
-### About:
+### Summary:
 Vim text objects provide a convenient way to select and operate on various types of objects. 
 These objects include regions surrounded by various types of brackets and various parts of language 
 (ie sentences, paragraphs, etc).
@@ -243,12 +243,12 @@ https://github.com/michaeljsmith/vim-indent-object/blob/master/doc/indent-object
 </details>
 
 <details>
-<summary><h2>matchit.vim</h2></summary>
+<summary><h2>matchit.vim: Extends the % key functionality</h2></summary>
 
 By [Martin Yzeiri](https://github.com/myzeiri)
 Original plugin: [matchit.vim](https://github.com/chrisbra/matchit).
 
-### About:
+### Summary:
 In Vim, as in plain vi, the percent key, |%|, jumps the cursor from a brace, bracket, or paren to its match. 
 This can be configured with the 'matchpairs' option. 
 The matchit plugin extends this in several ways...
@@ -273,7 +273,7 @@ https://github.com/adelarsq/vim-matchit/blob/master/doc/matchit.txt
 <details>
 <summary><h2>Mini.ai: Extend and create a/i textobjects (IMPORTANT: The plugin is not related with artificial intelligence)</h2></summary>
 
-### About:
+### Summary:
 Extend and create a/i textobjects
 
 ### Features:
@@ -292,7 +292,7 @@ Original plugin: [mini.ai](https://github.com/echasnovski/mini.ai).
 </details>
 
 <details>
-<summary><h2>multiple-cursors</h2></summary>
+<summary><h2>multiple-cursors: Extends multicursor support</h2></summary>
 
 Original plugin: [vim-multiple-cursors](https://github.com/terryma/vim-multiple-cursors).
 
@@ -334,9 +334,12 @@ xmap <leader>g<C-n> <Plug>AllOccurrences
 </details>
 
 <details>
-<summary><h2>NERDTree</h2></summary>
+<summary><h2>NERDTree: Adds NERDTree navigation to the project panel</h2></summary>
    
 Original plugin: [NERDTree](https://github.com/preservim/nerdtree).
+
+### Summary:
+Adds NERDTree navigation to the project panel. 
    
 ### Setup:
 - Add the following command to `~/.ideavimrc`: `Plug 'preservim/nerdtree'`
@@ -358,12 +361,68 @@ Original plugin: [NERDTree](https://github.com/preservim/nerdtree).
 </details>
 
 <details>
-<summary><h2>quick-scope</h2></summary>
+<summary><h2>paragraph-motion: Extends the { and } motions to ignore whitespace on otherwise empty lines</h2></summary>
+
+Original plugin: [vim-paragraph-motion](https://github.com/dbakker/vim-paragraph-motion).
+
+### Summary:
+Normally the { and } motions only match completely empty lines. 
+With this plugin lines that only contain whitespace are also matched.
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'dbakker/vim-paragraph-motion'`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plugin 'dbakker/vim-paragraph-motion'</code>
+      <br/>
+      <code>Plug 'https://github.com/dbakker/vim-paragraph-motion'</code>
+      <br/>
+      <code>Plug 'vim-paragraph-motion'</code>
+      <br/>
+      <code>Plug 'https://github.com/vim-scripts/Improved-paragraph-motion'</code>
+      <br/>
+      <code>Plug 'vim-scripts/Improved-paragraph-motion'</code>
+      <br/>
+      <code>Plug 'Improved-paragraph-motion'</code>
+      <br/>
+      <code>set vim-paragraph-motion</code>
+      </details>
+
+### Instructions
+
+https://github.com/dbakker/vim-paragraph-motion#vim-paragraph-motion
+
+</details>
+
+<details>
+<summary><h2>Peekaboo: Extends " @ CTRL-r to show a popup of the register contents</h2></summary>
+
+By Julien Phalip  
+Original plugin: [vim-peekaboo](https://github.com/junegunn/vim-peekaboo).
+
+### Summary:
+Peekaboo extends " and @ in normal mode and <CTRL-R> in insert mode so you can see the contents of the registers.
+
+### Setup
+
+Add `set peekaboo` to your `~/.ideavimrc` file, then run `:source ~/.ideavimrc`
+or restart the IDE.
+
+### Instructions
+
+https://plugins.jetbrains.com/plugin/25776-vim-peekaboo
+</details>
+
+<details>
+<summary><h2>quick-scope: Always-on highlight for a unique character in every word on a line to help use f, F, etc.</h2></summary>
 
 Original plugin: [quick-scope](https://github.com/unblevable/quick-scope).
 
-### About:
+### Summary:
 An always-on highlight for a unique character in every word on a line to help you use f, F and family.
+
+This plugin should help you get to any word on a line in two or three keystrokes with Vim's built-in f<char> 
+(which moves your cursor to <char>).
 
 ### Setup:
 - Install [IdeaVim-Quickscope](https://plugins.jetbrains.com/plugin/19417-ideavim-quickscope) plugin.
@@ -374,11 +433,76 @@ An always-on highlight for a unique character in every word on a line to help yo
 https://plugins.jetbrains.com/plugin/19417-ideavim-quickscope
 
 </details>
+
 <details>
-<summary><h2>surround</h2></summary>
+<summary><h2>ReplaceWithRegister: Adds two-in-one command that replaces text with the contents of a register.</h2></summary>
+
+By [igrekster](https://github.com/igrekster)  
+Original plugin: [ReplaceWithRegister](https://github.com/vim-scripts/ReplaceWithRegister).
+
+### Summary:
+This plugin offers a two-in-one command that replaces text covered by a
+{motion}, entire line(s) or the current selection with the contents of a
+register; the old text is deleted into the black-hole register, i.e. it's
+gone. (But of course, the command can be easily undone.)
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'vim-scripts/ReplaceWithRegister'`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plugin 'vim-scripts/ReplaceWithRegister'</code>
+      <br/>
+      <code>Plug 'ReplaceWithRegister'</code>
+      <br/>
+      <code>Plug 'https://github.com/inkarkat/vim-ReplaceWithRegister'</code>
+      <br/>
+      <code>Plug 'inkarkat/vim-ReplaceWithRegister'</code>
+      <br/>
+      <code>Plug 'vim-ReplaceWithRegister'</code>
+      <br/>
+      <code>Plug 'https://www.vim.org/scripts/script.php?script_id=2703'</code>
+      <br/>
+      <code>set ReplaceWithRegister</code>
+      </details>
+
+### Instructions
+
+https://github.com/vim-scripts/ReplaceWithRegister/blob/master/doc/ReplaceWithRegister.txt
+
+</details>
+
+<details>
+<summary><h2>sneak: Jump to any location specified by two characters</h2></summary>
+
+<img src="images/sneakIcon.svg" width="80" height="80" alt="icon"/>  
+
+By [Mikhail Levchenko](https://github.com/Mishkun)  
+Original repository with the plugin: https://github.com/Mishkun/ideavim-sneak  
+Original plugin: [vim-sneak](https://github.com/justinmk/vim-sneak).
+
+### Summary:
+Jump to any location specified by two characters.
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'justinmk/vim-sneak'`
+
+### Instructions
+
+* Type `s` and two chars to start sneaking in forward direction
+* Type `S` and two chars to start sneaking in backward direction
+* Type `;` or `,` to proceed with sneaking just as if you were using `f` or `t` commands
+
+</details>
+
+<details>
+<summary><h2>surround: Adds provides mappings to easily delete, change, and add surroundings in pairs</h2></summary>
    
 Original plugin: [vim-surround](https://github.com/tpope/vim-surround).
    
+### Summary:
+Surround.vim is all about "surroundings": parentheses, brackets, quotes, XML tags, and more. 
+The plugin provides mappings to easily delete, change and add such surroundings in pairs.
+
 ### Setup:
 - Add the following command to `~/.ideavimrc`: `Plug 'tpope/vim-surround'`
     <details>
@@ -398,49 +522,41 @@ https://github.com/tpope/vim-surround/blob/master/doc/surround.txt
 
 </details>
 
-
-
 <details>
-<summary><h2>ReplaceWithRegister</h2></summary>
-   
-By [igrekster](https://github.com/igrekster)  
-Original plugin: [ReplaceWithRegister](https://github.com/vim-scripts/ReplaceWithRegister).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'vim-scripts/ReplaceWithRegister'`
-    <details>
-      <summary>Alternative syntax</summary>
-      <code>Plugin 'vim-scripts/ReplaceWithRegister'</code>
-      <br/>
-      <code>Plug 'ReplaceWithRegister'</code>
-      <br/>
-      <code>Plug 'https://github.com/inkarkat/vim-ReplaceWithRegister'</code>
-      <br/>
-      <code>Plug 'inkarkat/vim-ReplaceWithRegister'</code>
-      <br/>
-      <code>Plug 'vim-ReplaceWithRegister'</code>
-      <br/>
-      <code>Plug 'https://www.vim.org/scripts/script.php?script_id=2703'</code>
-      <br/>
-      <code>set ReplaceWithRegister</code>
-      </details>
-   
+<summary><h2>Switch: Switch some text under the cursor based on regex patterns</h2></summary>
+
+By Julien Phalip  
+Original plugin: [switch.vim](https://github.com/AndrewRadev/switch.vim).
+
+### Summary:
+The purpose of the plugin is to switch some text under the cursor based on regex patterns. 
+The main entry point is a single command, :Switch. 
+When the command is executed, 
+the plugin looks for one of a few specific patterns under the cursor and performs a substitution depending on it. 
+
+### Setup
+
+Add `set switch` to your `~/.ideavimrc` file, then run `:source ~/.ideavimrc`
+or restart the IDE.
+
 ### Instructions
-   
-https://github.com/vim-scripts/ReplaceWithRegister/blob/master/doc/ReplaceWithRegister.txt
+
+https://plugins.jetbrains.com/plugin/25899-vim-switch
 
 </details>
 
-
-   
-
-   
 <details>
-<summary><h2>textobj-entire</h2></summary>
+<summary><h2>textobj-entire: Adds mapping for selecting entire contents of file regardless of cursor position</h2></summary>
 
 By [Alexandre Grison](https://github.com/agrison)  
 Original plugin: [vim-textobj-entire](https://github.com/kana/vim-textobj-entire).
    
+### Summary:
+vim-textobj-entire is a Vim plugin to provide text objects 
+(ae and ie by default) to select the entire content of a buffer. 
+Though these are trivial operations (e.g. ggVG), text object versions are more handy, 
+because you do not have to be conscious of the cursor position (e.g. vae).
+
 ### Setup:
 - Add the following command to `~/.ideavimrc`: `Plug 'kana/vim-textobj-entire'`
     <details>
@@ -460,71 +576,13 @@ https://github.com/kana/vim-textobj-entire/blob/master/doc/textobj-entire.txt
 
 </details>
    
-
 <details>
-<summary><h2>vim-paragraph-motion</h2></summary>
-
-Original plugin: [vim-paragraph-motion](https://github.com/dbakker/vim-paragraph-motion).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'dbakker/vim-paragraph-motion'`
-    <details>
-      <summary>Alternative syntax</summary>
-      <code>Plugin 'dbakker/vim-paragraph-motion'</code>
-      <br/>
-      <code>Plug 'https://github.com/dbakker/vim-paragraph-motion'</code>
-      <br/>
-      <code>Plug 'vim-paragraph-motion'</code>
-      <br/>
-      <code>Plug 'https://github.com/vim-scripts/Improved-paragraph-motion'</code>
-      <br/>
-      <code>Plug 'vim-scripts/Improved-paragraph-motion'</code>
-      <br/>
-      <code>Plug 'Improved-paragraph-motion'</code>
-      <br/>
-      <code>set vim-paragraph-motion</code>
-      </details>
-   
-### Instructions
-   
-https://github.com/dbakker/vim-paragraph-motion#vim-paragraph-motion
-
-</details>
-   
-<details>
-<summary><h2>vim-indent-object</h2></summary>
-
-By [Shrikant Sharat Kandula](https://github.com/sharat87)  
-Original plugin: [vim-indent-object](https://github.com/michaeljsmith/vim-indent-object).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'michaeljsmith/vim-indent-object'`
-    <details>
-      <summary>Alternative syntax</summary>
-      <code>Plugin 'michaeljsmith/vim-indent-object'</code>
-      <br/>
-      <code>Plug 'https://github.com/michaeljsmith/vim-indent-object'</code>
-      <br/>
-      <code>Plug 'vim-indent-object'</code>
-      <br/>
-      <code>set textobj-indent</code>
-      </details>
-   
-### Instructions
-   
-https://github.com/michaeljsmith/vim-indent-object/blob/master/doc/indent-object.txt
-
-</details>
-   
-   
-
-
-
-
-<details>
-<summary><h2>Which-Key</h2></summary>
+<summary><h2>Which-Key: Displays available keybindings in popup</h2></summary>
 
 Original plugin: [vim-which-key](https://github.com/liuchengxu/vim-which-key).
+
+### Summary:
+vim-which-key is vim port of emacs-which-key that displays available keybindings in popup.
 
 ### Setup:
 - Install [Which-Key](https://plugins.jetbrains.com/plugin/15976-which-key) plugin.
@@ -535,63 +593,3 @@ Original plugin: [vim-which-key](https://github.com/liuchengxu/vim-which-key).
 https://github.com/TheBlob42/idea-which-key?tab=readme-ov-file#installation
 
 </details>
-<details>
-<summary><h2>Vim Peekaboo</h2></summary>
-
-By Julien Phalip  
-Original plugin: [vim-peekaboo](https://github.com/junegunn/vim-peekaboo).
-
-### Setup
-
-Add `set peekaboo` to your `~/.ideavimrc` file, then run `:source ~/.ideavimrc`
-or restart the IDE.
-
-### Instructions
-
-https://plugins.jetbrains.com/plugin/25776-vim-peekaboo
-</details>
-
-
-<details>
-<summary><h2>Switch</h2></summary>
-
-By Julien Phalip  
-Original plugin: [switch.vim](https://github.com/AndrewRadev/switch.vim).
-
-### Setup
-
-Add `set switch` to your `~/.ideavimrc` file, then run `:source ~/.ideavimrc`
-or restart the IDE.
-
-### Instructions
-
-https://plugins.jetbrains.com/plugin/25899-vim-switch
-
-</details>
-
-## Archived
-
-<details>
-<summary><h2>sneak</h2></summary>
-
-<img src="images/sneakIcon.svg" width="80" height="80" alt="icon"/>  
-
-By [Mikhail Levchenko](https://github.com/Mishkun)  
-Original repository with the plugin: https://github.com/Mishkun/ideavim-sneak  
-Original plugin: [vim-sneak](https://github.com/justinmk/vim-sneak).
-
-### About:
-Now built in to Ideavim! 
-See [this](https://github.com/JetBrains/ideavim/discussions/818) GitHub discussion for more details. 
-
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'justinmk/vim-sneak'`
-
-### Instructions
-
-* Type `s` and two chars to start sneaking in forward direction
-* Type `S` and two chars to start sneaking in backward direction
-* Type `;` or `,` to proceed with sneaking just as if you were using `f` or `t` commands
-
-</details>
-

--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -16,10 +16,95 @@ in `~/.ideavimrc`. E.g. `set nosurround`.
 Available plugins:
 
 <details>
+<summary><h2>argtextobj</h2></summary>
+
+Original plugin: [argtextobj.vim](https://www.vim.org/scripts/script.php?script_id=2699).
+
+### About:
+This plugin provides a text-object 'a' (argument). 
+You can d(elete), c(hange), v(select)... an argument or inner argument in familiar ways.
+
+That is, such as 'daa'(delete-an-argument) 'cia'(change-inner-argument) 'via'(select-inner-argument).
+What this script does is more than just typing
+
+F,dt,
+
+because it recognizes inclusion relationship of parentheses.
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'vim-scripts/argtextobj.vim'`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plugin 'vim-scripts/argtextobj.vim'</code>
+      <br/>
+      <code>Plug 'https://github.com/vim-scripts/argtextobj.vim'</code>
+      <br/>
+      <code>Plug 'argtextobj.vim'</code>
+      <br/>
+      <code>Plug 'https://www.vim.org/scripts/script.php?script_id=2699'</code>
+      <br/>
+      <code>set argtextobj</code>
+      </details>
+
+### Instructions
+
+By default, only the arguments inside parenthesis are considered. To extend the functionality
+to other types of brackets, set `g:argtextobj_pairs` variable to a comma-separated
+list of colon-separated pairs (same as VIM's `matchpairs` option), like
+`let g:argtextobj_pairs="(:),{:},<:>"`. The order of pairs matters when
+handling symbols that can also be operators: `func(x << 5, 20) >> 17`. To handle
+this syntax parenthesis, must come before angle brackets in the list.
+
+https://www.vim.org/scripts/script.php?script_id=2699
+
+</details>
+
+<details>
+<summary><h2>commentary</h2></summary>
+
+By [Daniel Leong](https://github.com/dhleong)  
+Original plugin: [commentary.vim](https://github.com/tpope/vim-commentary).
+
+### About:
+Comment stuff out. 
+Use gcc to comment out a line (takes a count), gc to comment out the target of a motion 
+(for example, gcap to comment out a paragraph), gc in visual mode to comment out the selection, 
+and gc in operator pending mode to target a comment. 
+You can also use it as a command, either with a range like :7,17Commentary, 
+or as part of a :global invocation like with :g/TODO/Commentary. 
+That's it.
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'tpope/vim-commentary'`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plugin 'tpope/vim-commentary'</code>
+      <br/>
+      <code>Plug 'https://github.com/tpope/vim-commentary'</code>
+      <br/>
+      <code>Plug 'vim-commentary'</code>
+      <br/>
+      <code>Plug 'tcomment_vim'</code>
+      <br/>
+      <code>set commentary</code>
+      </details>
+
+### Instructions
+
+https://github.com/tpope/vim-commentary/blob/master/doc/commentary.txt
+
+</details>
+
+<details>
 <summary><h2>easymotion</h2></summary>
    
 Original plugin: [vim-easymotion](https://github.com/easymotion/vim-easymotion).
-   
+
+### About:
+EasyMotion provides a much simpler way to use some motions in vim. 
+It takes the \<number> out of \<number>w or \<number>f{char} by highlighting all possible choices 
+and allowing you to press one key to jump directly to the target.
+
 ### Setup:
 - Install [IdeaVim-EasyMotion](https://plugins.jetbrains.com/plugin/13360-ideavim-easymotion/)
       and [AceJump](https://plugins.jetbrains.com/plugin/7086-acejump/) plugins.
@@ -38,27 +123,6 @@ Original plugin: [vim-easymotion](https://github.com/easymotion/vim-easymotion).
 ### Instructions
    
 All commands with the mappings are supported. See the [full list of supported commands](https://github.com/AlexPl292/IdeaVim-EasyMotion#supported-commands).
-
-</details>
-
-
-<details>
-<summary><h2>sneak</h2></summary>
-
-<img src="images/sneakIcon.svg" width="80" height="80" alt="icon"/>  
-
-By [Mikhail Levchenko](https://github.com/Mishkun)  
-Original repository with the plugin: https://github.com/Mishkun/ideavim-sneak  
-Original plugin: [vim-sneak](https://github.com/justinmk/vim-sneak).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'justinmk/vim-sneak'`
-   
-### Instructions
-
-* Type `s` and two chars to start sneaking in forward direction
-* Type `S` and two chars to start sneaking in backward direction
-* Type `;` or `,` to proceed with sneaking just as if you were using `f` or `t` commands
 
 </details>
 
@@ -152,32 +216,6 @@ xmap <leader>g<C-n> <Plug>AllOccurrences
 
 </details>
 
-<details>
-<summary><h2>commentary</h2></summary>
-
-By [Daniel Leong](https://github.com/dhleong)  
-Original plugin: [commentary.vim](https://github.com/tpope/vim-commentary).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'tpope/vim-commentary'`
-    <details>
-      <summary>Alternative syntax</summary>
-      <code>Plugin 'tpope/vim-commentary'</code>
-      <br/>
-      <code>Plug 'https://github.com/tpope/vim-commentary'</code>
-      <br/>
-      <code>Plug 'vim-commentary'</code>
-      <br/>
-      <code>Plug 'tcomment_vim'</code>
-      <br/>
-      <code>set commentary</code>
-      </details>
-   
-### Instructions
-   
-https://github.com/tpope/vim-commentary/blob/master/doc/commentary.txt
-
-</details>
 
 <details>
 <summary><h2>ReplaceWithRegister</h2></summary>
@@ -210,38 +248,7 @@ https://github.com/vim-scripts/ReplaceWithRegister/blob/master/doc/ReplaceWithRe
 
 </details>
 
-<details>
-<summary><h2>argtextobj</h2></summary>
 
-Original plugin: [argtextobj.vim](https://www.vim.org/scripts/script.php?script_id=2699).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'vim-scripts/argtextobj.vim'`
-    <details>
-      <summary>Alternative syntax</summary>
-      <code>Plugin 'vim-scripts/argtextobj.vim'</code>
-      <br/>
-      <code>Plug 'https://github.com/vim-scripts/argtextobj.vim'</code>
-      <br/>
-      <code>Plug 'argtextobj.vim'</code>
-      <br/>
-      <code>Plug 'https://www.vim.org/scripts/script.php?script_id=2699'</code>
-      <br/>
-      <code>set argtextobj</code>
-      </details>
-   
-### Instructions
-   
-By default, only the arguments inside parenthesis are considered. To extend the functionality
-      to other types of brackets, set `g:argtextobj_pairs` variable to a comma-separated
-      list of colon-separated pairs (same as VIM's `matchpairs` option), like
-      `let g:argtextobj_pairs="(:),{:},<:>"`. The order of pairs matters when
-      handling symbols that can also be operators: `func(x << 5, 20) >> 17`. To handle
-      this syntax parenthesis, must come before angle brackets in the list.
-   
-https://www.vim.org/scripts/script.php?script_id=2699
-
-</details>
    
 
 <details>
@@ -501,4 +508,30 @@ or restart the IDE.
 ### Instructions
 
 https://plugins.jetbrains.com/plugin/25899-vim-switch
+
+## Archived
+
+<details>
+<summary><h2>sneak</h2></summary>
+
+<img src="images/sneakIcon.svg" width="80" height="80" alt="icon"/>  
+
+By [Mikhail Levchenko](https://github.com/Mishkun)  
+Original repository with the plugin: https://github.com/Mishkun/ideavim-sneak  
+Original plugin: [vim-sneak](https://github.com/justinmk/vim-sneak).
+
+### About:
+Now built in to Ideavim! 
+See [this](https://github.com/JetBrains/ideavim/discussions/818) GitHub discussion for more details. 
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'justinmk/vim-sneak'`
+
+### Instructions
+
+* Type `s` and two chars to start sneaking in forward direction
+* Type `S` and two chars to start sneaking in backward direction
+* Type `;` or `,` to proceed with sneaking just as if you were using `f` or `t` commands
+
+</details>
 

--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -127,6 +127,213 @@ All commands with the mappings are supported. See the [full list of supported co
 </details>
 
 <details>
+<summary><h2>exchange</h2></summary>
+
+By [fan-tom](https://github.com/fan-tom)  
+Original plugin: [vim-exchange](https://github.com/tommcdo/vim-exchange).
+
+### About:
+Easy text exchange operator for Vim.
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'tommcdo/vim-exchange'`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plugin 'tommcdo/vim-exchange'</code>
+      <br/>
+      <code>Plug 'https://github.com/tommcdo/vim-exchange'</code>
+      <br/>
+      <code>Plug 'vim-exchange'</code>
+      <br/>
+      <code>set exchange</code>
+      </details>
+
+### Instructions
+
+https://github.com/tommcdo/vim-exchange/blob/master/doc/exchange.txt
+
+</details>
+
+<details>
+<summary><h2>FunctionTextObj</h2></summary>
+
+By Julien Phalip
+
+### About:
+An extension for IdeaVim that adds text objects for manipulating functions/methods in your code. 
+Similar to how iw operates on words or i" operates on quoted strings, 
+this plugin provides if and af to operate on functions
+
+### Setup
+
+Add `set functiontextobj` to your `~/.ideavimrc` file, then run `:source ~/.ideavimrc`
+or restart the IDE.
+
+### Instructions
+
+https://plugins.jetbrains.com/plugin/25897-vim-functiontextobj
+</details>
+
+<details>
+<summary><h2>highlightedyank</h2></summary>
+
+By [KostkaBrukowa](https://github.com/KostkaBrukowa)  
+Original plugin: [vim-highlightedyank](https://github.com/machakann/vim-highlightedyank).
+
+### About:
+Make the yanked region apparent!
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'machakann/vim-highlightedyank'`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plugin 'machakann/vim-highlightedyank'</code>
+      <br/>
+      <code>Plug 'https://github.com/machakann/vim-highlightedyank'</code>
+      <br/>
+      <code>Plug 'vim-highlightedyank'</code>
+      <br/>
+      <code>set highlightedyank</code>
+      </details>
+
+### Instructions
+
+If you want to optimize highlight duration, assign a time in milliseconds:  
+`let g:highlightedyank_highlight_duration = "1000"`  
+A negative number makes the highlight persistent.
+
+If you want to change background color of highlight you can provide the rgba of the color you want e.g.  
+`let g:highlightedyank_highlight_color = "rgba(160, 160, 160, 155)"`
+
+If you want to change text color of highlight you can provide the rgba of the color you want e.g.  
+`let g:highlightedyank_highlight_foreground_color = "rgba(0, 0, 0, 255)"`
+
+https://github.com/machakann/vim-highlightedyank/blob/master/doc/highlightedyank.txt
+
+</details>
+
+<details>
+<summary><h2>indent-object</h2></summary>
+
+By [Shrikant Sharat Kandula](https://github.com/sharat87)  
+Original plugin: [vim-indent-object](https://github.com/michaeljsmith/vim-indent-object).
+
+### About:
+Vim text objects provide a convenient way to select and operate on various types of objects. 
+These objects include regions surrounded by various types of brackets and various parts of language 
+(ie sentences, paragraphs, etc).
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'michaeljsmith/vim-indent-object'`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plugin 'michaeljsmith/vim-indent-object'</code>
+      <br/>
+      <code>Plug 'https://github.com/michaeljsmith/vim-indent-object'</code>
+      <br/>
+      <code>Plug 'vim-indent-object'</code>
+      <br/>
+      <code>set textobj-indent</code>
+      </details>
+
+### Instructions
+
+https://github.com/michaeljsmith/vim-indent-object/blob/master/doc/indent-object.txt
+
+</details>
+
+<details>
+<summary><h2>matchit.vim</h2></summary>
+
+By [Martin Yzeiri](https://github.com/myzeiri)
+Original plugin: [matchit.vim](https://github.com/chrisbra/matchit).
+
+### About:
+In Vim, as in plain vi, the percent key, |%|, jumps the cursor from a brace, bracket, or paren to its match. 
+This can be configured with the 'matchpairs' option. 
+The matchit plugin extends this in several ways...
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `packadd matchit`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plug 'vim-matchit'</code>
+      <br/>
+      <code>Plug 'chrisbra/matchit'</code>
+      <br/>
+      <code>set matchit</code>
+      </details>
+
+### Instructions
+
+https://github.com/adelarsq/vim-matchit/blob/master/doc/matchit.txt
+
+</details>
+
+<details>
+<summary><h2>Mini.ai: Extend and create a/i textobjects (IMPORTANT: The plugin is not related with artificial intelligence)</h2></summary>
+
+### About:
+Extend and create a/i textobjects
+
+### Features:
+Provides additional text object motions for handling quotes and brackets. The following motions are included:
+
+- aq: Around any quotes.
+- iq: Inside any quotes.
+- ab: Around any parentheses, curly braces, and square brackets.
+- ib: Inside any parentheses, curly braces, and square brackets.
+
+Original plugin: [mini.ai](https://github.com/echasnovski/mini.ai).
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `set mini-ai`
+
+</details>
+
+<details>
+<summary><h2>multiple-cursors</h2></summary>
+
+Original plugin: [vim-multiple-cursors](https://github.com/terryma/vim-multiple-cursors).
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'terryma/vim-multiple-cursors'`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plugin 'terryma/vim-multiple-cursors'</code>
+      <br/>
+      <code>Plug 'https://github.com/terryma/vim-multiple-cursors'</code>
+      <br/>
+      <code>Plug 'vim-multiple-cursors'</code>
+      <br/>
+      <code>set multiple-cursors</code>
+      </details>
+
+### Instructions
+
+At the moment, the default key binds for this plugin do not get mapped correctly in IdeaVim (see [VIM-2178](https://youtrack.jetbrains.com/issue/VIM-2178)). To enable the default key binds, add the following to your `.ideavimrc` file...
+
+```
+" Remap multiple-cursors shortcuts to match terryma/vim-multiple-cursors
+nmap <C-n> <Plug>NextWholeOccurrence
+xmap <C-n> <Plug>NextWholeOccurrence
+nmap g<C-n> <Plug>NextOccurrence
+xmap g<C-n> <Plug>NextOccurrence
+xmap <C-x> <Plug>SkipOccurrence
+xmap <C-p> <Plug>RemoveOccurrence
+
+" Note that the default <A-n> and g<A-n> shortcuts don't work on Mac due to dead keys.
+" <A-n> is used to enter accented text e.g. ñ
+" Feel free to pick your own mappings that are not affected. I like to use <leader>
+nmap <leader><C-n> <Plug>AllWholeOccurrences
+xmap <leader><C-n> <Plug>AllWholeOccurrences
+nmap <leader>g<C-n> <Plug>AllOccurrences
+xmap <leader>g<C-n> <Plug>AllOccurrences
+```
+
+</details>
+
+<details>
 <summary><h2>NERDTree</h2></summary>
    
 Original plugin: [NERDTree](https://github.com/preservim/nerdtree).
@@ -151,6 +358,23 @@ Original plugin: [NERDTree](https://github.com/preservim/nerdtree).
 </details>
 
 <details>
+<summary><h2>quick-scope</h2></summary>
+
+Original plugin: [quick-scope](https://github.com/unblevable/quick-scope).
+
+### About:
+An always-on highlight for a unique character in every word on a line to help you use f, F and family.
+
+### Setup:
+- Install [IdeaVim-Quickscope](https://plugins.jetbrains.com/plugin/19417-ideavim-quickscope) plugin.
+- Add the following command to `~/.ideavimrc`: `set quickscope`
+
+### Instructions
+
+https://plugins.jetbrains.com/plugin/19417-ideavim-quickscope
+
+</details>
+<details>
 <summary><h2>surround</h2></summary>
    
 Original plugin: [vim-surround](https://github.com/tpope/vim-surround).
@@ -174,47 +398,6 @@ https://github.com/tpope/vim-surround/blob/master/doc/surround.txt
 
 </details>
 
-<details>
-<summary><h2>multiple-cursors</h2></summary>
-   
-Original plugin: [vim-multiple-cursors](https://github.com/terryma/vim-multiple-cursors).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'terryma/vim-multiple-cursors'`
-    <details>
-      <summary>Alternative syntax</summary>
-      <code>Plugin 'terryma/vim-multiple-cursors'</code>
-      <br/>
-      <code>Plug 'https://github.com/terryma/vim-multiple-cursors'</code>
-      <br/>
-      <code>Plug 'vim-multiple-cursors'</code>
-      <br/>
-      <code>set multiple-cursors</code>
-      </details>
-   
-### Instructions
-
-At the moment, the default key binds for this plugin do not get mapped correctly in IdeaVim (see [VIM-2178](https://youtrack.jetbrains.com/issue/VIM-2178)). To enable the default key binds, add the following to your `.ideavimrc` file...
-
-```
-" Remap multiple-cursors shortcuts to match terryma/vim-multiple-cursors
-nmap <C-n> <Plug>NextWholeOccurrence
-xmap <C-n> <Plug>NextWholeOccurrence
-nmap g<C-n> <Plug>NextOccurrence
-xmap g<C-n> <Plug>NextOccurrence
-xmap <C-x> <Plug>SkipOccurrence
-xmap <C-p> <Plug>RemoveOccurrence
-
-" Note that the default <A-n> and g<A-n> shortcuts don't work on Mac due to dead keys.
-" <A-n> is used to enter accented text e.g. ñ
-" Feel free to pick your own mappings that are not affected. I like to use <leader>
-nmap <leader><C-n> <Plug>AllWholeOccurrences
-xmap <leader><C-n> <Plug>AllWholeOccurrences
-nmap <leader>g<C-n> <Plug>AllOccurrences
-xmap <leader>g<C-n> <Plug>AllOccurrences
-```
-
-</details>
 
 
 <details>
@@ -251,30 +434,6 @@ https://github.com/vim-scripts/ReplaceWithRegister/blob/master/doc/ReplaceWithRe
 
    
 
-<details>
-<summary><h2>exchange</h2></summary>
-
-By [fan-tom](https://github.com/fan-tom)  
-Original plugin: [vim-exchange](https://github.com/tommcdo/vim-exchange).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'tommcdo/vim-exchange'`
-    <details>
-      <summary>Alternative syntax</summary>
-      <code>Plugin 'tommcdo/vim-exchange'</code>
-      <br/>
-      <code>Plug 'https://github.com/tommcdo/vim-exchange'</code>
-      <br/>
-      <code>Plug 'vim-exchange'</code>
-      <br/>
-      <code>set exchange</code>
-      </details>
-   
-### Instructions
-   
-https://github.com/tommcdo/vim-exchange/blob/master/doc/exchange.txt
-
-</details>
    
 <details>
 <summary><h2>textobj-entire</h2></summary>
@@ -301,40 +460,6 @@ https://github.com/kana/vim-textobj-entire/blob/master/doc/textobj-entire.txt
 
 </details>
    
-<details>
-<summary><h2>highlightedyank</h2></summary>
-
-By [KostkaBrukowa](https://github.com/KostkaBrukowa)  
-Original plugin: [vim-highlightedyank](https://github.com/machakann/vim-highlightedyank).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `Plug 'machakann/vim-highlightedyank'`
-    <details>
-      <summary>Alternative syntax</summary>
-      <code>Plugin 'machakann/vim-highlightedyank'</code>
-      <br/>
-      <code>Plug 'https://github.com/machakann/vim-highlightedyank'</code>
-      <br/>
-      <code>Plug 'vim-highlightedyank'</code>
-      <br/>
-      <code>set highlightedyank</code>
-      </details>
-   
-### Instructions
-   
-If you want to optimize highlight duration, assign a time in milliseconds:  
-      `let g:highlightedyank_highlight_duration = "1000"`  
-      A negative number makes the highlight persistent.  
-   
-If you want to change background color of highlight you can provide the rgba of the color you want e.g.  
-      `let g:highlightedyank_highlight_color = "rgba(160, 160, 160, 155)"`
-
-If you want to change text color of highlight you can provide the rgba of the color you want e.g.  
-`let g:highlightedyank_highlight_foreground_color = "rgba(0, 0, 0, 255)"`
-
-https://github.com/machakann/vim-highlightedyank/blob/master/doc/highlightedyank.txt
-
-</details>
 
 <details>
 <summary><h2>vim-paragraph-motion</h2></summary>
@@ -392,61 +517,8 @@ https://github.com/michaeljsmith/vim-indent-object/blob/master/doc/indent-object
 </details>
    
    
-<details>
-<summary><h2>matchit.vim</h2></summary>
 
-By [Martin Yzeiri](https://github.com/myzeiri)
-Original plugin: [matchit.vim](https://github.com/chrisbra/matchit).
-   
-### Setup:
-- Add the following command to `~/.ideavimrc`: `packadd matchit`
-    <details>
-      <summary>Alternative syntax</summary>
-      <code>Plug 'vim-matchit'</code>
-      <br/>
-      <code>Plug 'chrisbra/matchit'</code>
-      <br/>
-      <code>set matchit</code>
-      </details>
-   
-### Instructions
-   
-https://github.com/adelarsq/vim-matchit/blob/master/doc/matchit.txt
 
-</details>
-
-<details>
-<summary><h2>IdeaVim-Quickscope</h2></summary>
-
-Original plugin: [quick-scope](https://github.com/unblevable/quick-scope).
-
-### Setup:
-- Install [IdeaVim-Quickscope](https://plugins.jetbrains.com/plugin/19417-ideavim-quickscope) plugin.
-- Add the following command to `~/.ideavimrc`: `set quickscope`
-
-### Instructions
-
-https://plugins.jetbrains.com/plugin/19417-ideavim-quickscope
-
-</details>
-
-<details>
-<summary><h2>Mini.ai: Extend and create a/i textobjects (IMPORTANT: The plugin is not related with artificial intelligence)</h2></summary>
-
-### Features: 
-Provides additional text object motions for handling quotes and brackets. The following motions are included:
-
-- aq: Around any quotes.
-- iq: Inside any quotes.
-- ab: Around any parentheses, curly braces, and square brackets.
-- ib: Inside any parentheses, curly braces, and square brackets.
-
-Original plugin: [mini.ai](https://github.com/echasnovski/mini.ai).
-
-### Setup:
-- Add the following command to `~/.ideavimrc`: `set mini-ai`
-
-</details>
 
 
 <details>
@@ -479,20 +551,6 @@ or restart the IDE.
 https://plugins.jetbrains.com/plugin/25776-vim-peekaboo
 </details>
 
-<details>
-<summary><h2>FunctionTextObj</h2></summary>
-
-By Julien Phalip  
-
-### Setup
-
-Add `set functiontextobj` to your `~/.ideavimrc` file, then run `:source ~/.ideavimrc`
-or restart the IDE.
-
-### Instructions
-
-https://plugins.jetbrains.com/plugin/25897-vim-functiontextobj
-</details>
 
 <details>
 <summary><h2>Switch</h2></summary>

--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -509,6 +509,8 @@ or restart the IDE.
 
 https://plugins.jetbrains.com/plugin/25899-vim-switch
 
+</details>
+
 ## Archived
 
 <details>


### PR DESCRIPTION
When I was first getting my IdeaVim setup it was hard to know what each plugin did on the `IdeaVim Plugins` page without going to every link and reading through the repos. 

I added small inline summaries to each title (like what Mini.ai already had), and added a larger summary to each plugins details. 

I also made both the plugin list on the main README, and in the IdeaVim Plugins.md alphabetical. 