### PR TITLE
Refactor mapping to better handle replaying failed mappings

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimApplication.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimApplication.kt
@@ -32,7 +32,7 @@ internal class IjVimApplication : VimApplicationBase() {
     return ApplicationManager.getApplication().isDispatchThread
   }
 
-  override fun invokeLater(action: () -> Unit, editor: VimEditor) {
+  override fun invokeLater(editor: VimEditor, action: () -> Unit) {
     ApplicationManager.getApplication()
       .invokeLater(action, ModalityState.stateForComponent((editor as IjVimEditor).editor.component))
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/NormalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/NormalCommandTest.kt
@@ -8,6 +8,7 @@
 
 package org.jetbrains.plugins.ideavim.ex.implementation.commands
 
+import com.maddyhome.idea.vim.state.mode.Mode
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.Test
 
@@ -20,6 +21,11 @@ class NormalCommandTest : VimTestCase() {
   @Test
   fun `test short command`() {
     doTest(exCommand("norm x"), "123<caret>456", "123<caret>56")
+  }
+
+  @Test
+  fun `test normal command automatically exits Insert mode`() {
+    doTest(exCommand("normal iFoo"), "123<caret>456", "123Fo<caret>o456", Mode.NORMAL())
   }
 
   @Test
@@ -54,7 +60,7 @@ class NormalCommandTest : VimTestCase() {
   }
 
   @Test
-  fun `test with mapping`() {
+  fun `test normal command with single letter mapping`() {
     configureByText(
       """
             <caret>123456
@@ -73,7 +79,28 @@ class NormalCommandTest : VimTestCase() {
   }
 
   @Test
-  fun `test with disabled mapping`() {
+  fun `test normal command with multi-letter mapping`() {
+    doTest(
+      exCommand("normal dd"),
+      """
+        |${c}Lorem ipsum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+      """
+        |Lorem ipsum dolor sit amet,
+        |consectetur adipiscing elit
+        |Sed in orci mauris.
+        |${c}Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+    ) {
+      enterCommand("map dd G")
+    }
+  }
+
+  @Test
+  fun `test normal command with disabled mapping`() {
     configureByText(
       """
             <caret>123456

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/NormalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/NormalCommandTest.kt
@@ -8,33 +8,35 @@
 
 package org.jetbrains.plugins.ideavim.ex.implementation.commands
 
-/*
-class NormalCommandTest : VimTestCase() {
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 
+class NormalCommandTest : VimTestCase() {
   @Test
   fun `test simple execution`() {
-    doTest("normal x", "123<caret>456", "123<caret>56")
+    doTest(exCommand("normal x"), "123<caret>456", "123<caret>56")
   }
 
   @Test
   fun `test short command`() {
-    doTest("norm x", "123<caret>456", "123<caret>56")
+    doTest(exCommand("norm x"), "123<caret>456", "123<caret>56")
   }
 
   @Test
   fun `test multiple commands`() {
-    doTest("normal xiNewText", "123<caret>456", "123NewTex<caret>t56")
+    doTest(exCommand("normal xiNewText"), "123<caret>456", "123NewTex<caret>t56")
   }
 
   @Test
   fun `test range single stroke`() {
-    doTest(".norm x", "123<caret>456", "<caret>23456")
+    doTest(exCommand(".norm x"), "123<caret>456", "<caret>23456")
   }
 
   @Test
   fun `test range multiple strokes`() {
     doTest(
-      "1,3norm x",
+      exCommand("1,3norm x"),
       """
          123456
          123456
@@ -61,8 +63,8 @@ class NormalCommandTest : VimTestCase() {
             123456
       """.trimIndent()
     )
-    typeText(commandToKeys("map G dd"))
-    typeText(commandToKeys("normal G"))
+    enterCommand("map G dd")
+    enterCommand("normal G")
     assertState(
       """
       <caret>123456
@@ -80,8 +82,8 @@ class NormalCommandTest : VimTestCase() {
             123456
       """.trimIndent()
     )
-    typeText(commandToKeys("map G dd"))
-    typeText(commandToKeys("normal! G"))
+    enterCommand("map G dd")
+    enterCommand("normal! G")
     assertState(
       """
             123456
@@ -102,8 +104,8 @@ class NormalCommandTest : VimTestCase() {
             123456
       """.trimIndent()
     )
-    typeText(parseKeys("Vjj"))
-    typeText(commandToKeys("normal x"))
+    typeText("Vjj")
+    enterCommand("normal x")
     assertState(
       """
             23456
@@ -126,8 +128,8 @@ class NormalCommandTest : VimTestCase() {
         123456
       """.trimIndent()
     )
-    typeText(commandToKeys("normal Vjj"))
-    typeText(parseKeys("x"))
+    enterCommand("normal Vjj")
+    typeText("x")
     assertState(
       """
           <caret>123456
@@ -148,8 +150,8 @@ class NormalCommandTest : VimTestCase() {
       123456
       """.trimIndent()
     )
-    typeText(parseKeys("qqxq", "jVjjj"))
-    typeText(commandToKeys("norm @q"))
+    typeText("qqxq", "jVjjj")
+    enterCommand("norm @q")
     assertState(
       """
       23456
@@ -162,32 +164,26 @@ class NormalCommandTest : VimTestCase() {
     )
   }
 
+  @Disabled("Not working. NormalCommand is not correctly handling Visual and selection")
   @Test
   fun `test command executes at selection start`() {
     configureByText("hello <caret>world !")
-    typeText(parseKeys("vw"))
-    typeText(parseKeys(":<C-u>norm x<CR>"))
+    typeText("vw")
+    enterCommand("<C-u>norm x")
     assertState("hello <caret>orld !")
   }
 
   @Test
   fun `test false escape`() {
     configureByText("hello <caret>world !")
-    typeText(commandToKeys("norm i<Esc>"))
+    enterCommand("norm i<Esc>")
     assertState("hello <Esc<caret>>world !")
   }
 
   @Test
   fun `test C-R`() {
-    configureByText("myprop: \"my value\"")
-    typeText(commandToKeys("exe \"norm ^dei-\\<C-R>\\\"-\""))
-    assertState("-myprop-: \"my value\"")
-  }
-
-  private fun doTest(command: String, before: String, after: String) {
-    myFixture.configureByText("a.java", before)
-    typeText(commandToKeys(command))
-    myFixture.checkResult(after)
+    configureByText("""myprop: "my value"""")
+    enterCommand("""exe "norm ^dei-\<C-R>\"-"""")
+    assertState("""-myprop-: "my value"""")
   }
 }
-*/

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/NormalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/NormalCommandTest.kt
@@ -9,7 +9,6 @@
 package org.jetbrains.plugins.ideavim.ex.implementation.commands
 
 import org.jetbrains.plugins.ideavim.VimTestCase
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class NormalCommandTest : VimTestCase() {
@@ -29,12 +28,12 @@ class NormalCommandTest : VimTestCase() {
   }
 
   @Test
-  fun `test range single stroke`() {
+  fun `test normal command with current line range moves caret to start of line before executing command`() {
     doTest(exCommand(".norm x"), "123<caret>456", "<caret>23456")
   }
 
   @Test
-  fun `test range multiple strokes`() {
+  fun `test normal command with multi-line range`() {
     doTest(
       exCommand("1,3norm x"),
       """
@@ -94,7 +93,7 @@ class NormalCommandTest : VimTestCase() {
   }
 
   @Test
-  fun `test from visual mode`() {
+  fun `test normal from Visual mode runs command on start of each line in range`() {
     configureByText(
       """
             <caret>123456
@@ -105,7 +104,7 @@ class NormalCommandTest : VimTestCase() {
       """.trimIndent()
     )
     typeText("Vjj")
-    enterCommand("normal x")
+    enterCommand("normal x")  // Will give `:'<,'>normal x`
     assertState(
       """
             23456
@@ -118,7 +117,7 @@ class NormalCommandTest : VimTestCase() {
   }
 
   @Test
-  fun `test execute visual mode`() {
+  fun `test normal command switches to Visual mode`() {
     configureByText(
       """
         <caret>123456
@@ -164,7 +163,6 @@ class NormalCommandTest : VimTestCase() {
     )
   }
 
-  @Disabled("Not working. NormalCommand is not correctly handling Visual and selection")
   @Test
   fun `test command executes at selection start`() {
     configureByText("hello <caret>world !")

--- a/src/test/java/org/jetbrains/plugins/ideavim/ui/ShowCmdTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ui/ShowCmdTest.kt
@@ -8,6 +8,7 @@
 
 package org.jetbrains.plugins.ideavim.ui
 
+import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.ui.ShowCmd
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
@@ -16,7 +17,6 @@ import org.jetbrains.plugins.ideavim.VimBehaviorDiffers
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.jetbrains.plugins.ideavim.waitAndAssert
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import kotlin.test.assertEquals
@@ -87,15 +87,12 @@ class ShowCmdTest : VimTestCase() {
     assertEquals("32d", getShowCmdText())
   }
 
-  // TODO: This test fails because IdeaVim's mapping handler doesn't correctly expand unhandled keys on timeout
   @Test
-  @Disabled
   fun `test showcmd expands ambiguous mapped keys on timeout`() {
-//     `rrr` should timeout and replay `rr` which is mapped to `42`
     enterCommand("nmap rr 42")
     enterCommand("nmap rrr 55")
     typeText(injector.parser.parseKeys("12rr"))
-    waitAndAssert { "1242" == getShowCmdText() }
+    waitAndAssert(injector.globalOptions().timeoutlen + 100) { "1242" == getShowCmdText() }
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.SHOW_CMD)

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -1087,7 +1087,7 @@ abstract class VimTestCase {
       var startIndex = if (command.startsWith(":")) 1 else 0
 
       // Special case support for <C-U>
-      startIndex = if (command.substring(startIndex).startsWith("<C-U>")) {
+      startIndex = if (command.substring(startIndex).startsWith("<C-U>", ignoreCase = true)) {
         keys.addAll(injector.parser.parseKeys("<C-U>"))
         startIndex + 5
       }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimApplication.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimApplication.kt
@@ -12,7 +12,7 @@ import javax.swing.KeyStroke
 
 interface VimApplication {
   fun isMainThread(): Boolean
-  fun invokeLater(action: () -> Unit, editor: VimEditor)
+  fun invokeLater(editor: VimEditor, action: () -> Unit)
   fun invokeLater(action: () -> Unit)
   fun isUnitTest(): Boolean
   fun isInternal(): Boolean

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroup.kt
@@ -336,6 +336,7 @@ interface VimChangeGroup {
   )
 
   fun type(vimEditor: VimEditor, context: ExecutionContext, key: Char)
+  fun type(vimEditor: VimEditor, context: ExecutionContext, string: String)
   fun replaceText(editor: VimEditor, caret: VimCaret, start: Int, end: Int, str: String)
 
   enum class ChangeCaseType {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimApplicationStub.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/stubs/VimApplicationStub.kt
@@ -22,7 +22,7 @@ class VimApplicationStub : VimApplicationBase() {
     TODO("Not yet implemented")
   }
 
-  override fun invokeLater(action: () -> Unit, editor: VimEditor) {
+  override fun invokeLater(editor: VimEditor, action: () -> Unit) {
     TODO("Not yet implemented")
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/MappingProcessor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/MappingProcessor.kt
@@ -61,16 +61,12 @@ object MappingProcessor : KeyConsumer {
     log.trace { "Get keys for mapping mode. mode = $mappingMode" }
     val mapping = injector.keyGroup.getKeyMappingLayer(mappingMode)
 
-    // Returns true if any of these methods handle the key. False means that the key is unrelated to mapping and should
-    // be processed as normal.
-    // TODO: This pipeline is confusing - each function has knowledge of where it is in the pipeline
-    // E.g. handleCompleteMappingSequence assumes it's not a prefix because it's called after handleUnfinishedMappingSeq
-    // Perhaps this should be simplified to `if (isUnfinishedMappingSequence) process() else if (isComplete...)`?
-    // The benefit of the existing functions is that we always fall through to handleAbandoned, which sorts everything
+    // Try to handle the key as part of an unfinished mapping sequence, completing a sequence or a key that terminates
+    // an in-progress sequence
     val mappingProcessed =
-      handleUnfinishedMappingSequence(editor, keyProcessResultBuilder, mapping, mappingCompleted)
-        || handleCompleteMappingSequence(keyProcessResultBuilder, mapping, key)
-        || handleAbandonedMappingSequence(keyProcessResultBuilder)
+      tryHandleUnfinishedMappingSequence(editor, keyProcessResultBuilder, mapping)
+        || tryHandleCompletedMappingSequence(keyProcessResultBuilder, mapping)
+        || tryHandleAbandonedMappingSequence(keyProcessResultBuilder)
     log.debug { "Finish mapping processing. Return $mappingProcessed" }
 
     return mappingProcessed
@@ -101,31 +97,18 @@ object MappingProcessor : KeyConsumer {
    * unfinished sequence. We wait for the next keystroke or, if `'timeout'` is set, start a timer to abandon the mapping
    * if no other keys are pressed.
    */
-  private fun handleUnfinishedMappingSequence(
+  private fun tryHandleUnfinishedMappingSequence(
     editor: VimEditor,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
     mapping: KeyMappingLayer,
-    mappingCompleted: Boolean,
   ): Boolean {
-    log.trace("Processing unfinished mappings...")
-
-    // This is set when we need to replay an unhandled key sequence. That sequence was a prefix to a mapping that wasn't
-    // completed, either due to a timeout or a key that wasn't part of the mapping. The unhandled keys are passed
-    // through the key handler again, with this flag set to prevent us trying to map them again.
-    // TODO: Try to remove this, so we don't have to pass yet more state around
-    // When replaying, we should find the longest viable mapping and invoke it, then pass the remaining keys back to key
-    // handler without any flags set - they can be mapped. If there is no mapping in the previous sequence, then pass
-    // all the keys back to key handler with the allowKeyMappings flag set to false.
-    if (mappingCompleted) {
-      log.trace("Mapping is already completed. Returning false.")
-      return false
-    }
+    log.trace("Try processing unfinished mappings...")
 
     // If the current sequence, with the current key, is a prefix to one or more mappings, then it's unfinished. A
     // completed sequence is not a prefix to itself - this function will return false unless it's also a prefix for
     // other mappings.
     if (!mapping.isPrefix(keyProcessResultBuilder.state.mappingState.keys)) {
-      log.debug("There are no mappings that start with the current sequence. Returning false.")
+      log.debug("There are no mappings that start with the current sequence. Mapping processor will not handle further.")
       return false
     }
 
@@ -152,7 +135,7 @@ object MappingProcessor : KeyConsumer {
     context: ExecutionContext,
   ) {
       injector.application.invokeLater(editor) {
-        log.debug("Delayed mapping timer call")
+        log.debug("Callback for 'timeout'. Replaying unhandled keys")
 
         val unhandledKeys = keyState.mappingState.detachKeys()
 
@@ -166,104 +149,47 @@ object MappingProcessor : KeyConsumer {
           return@invokeLater
         }
 
-        log.trace("Replaying unhandled keys...")
-
-        // TODO: Centralise replaying unhandled keys
-        // Find the longest sequence that's a mapping and execute it. Then replay the remaining keys, allowing
-        // mapping. This will remove the need for mappingComplete.
-        for ((index, keyStroke) in unhandledKeys.withIndex()) {
-          // TODO: There is a bug if the previous longest sequence is not the last char
-          // Related issue: VIM-2315
-          // If we have two mappings: for `abc` and for `ab`, after typing `ab` we should wait a bit and execute
-          //   `ab` mapping
-          // So, we rerun all keys with mappings with "mappingsCompleted" for the last char to avoid infinite loop
-          //  of waiting for `abc` mapping.
-          val lastKeyInSequence = index == unhandledKeys.lastIndex
-
-          val keyHandler = KeyHandler.getInstance()
-          keyHandler.handleKey(
-            editor,
-            keyStroke,
-            context,
-            allowKeyMappings = true,
-            mappingCompleted = lastKeyInSequence,
-            keyState,
-          )
-        }
+        replayUnhandledKeys(unhandledKeys, editor, context, keyState)
       }
   }
 
   /**
-   * Handles a complete key sequence, if applicable
+   * Handles a completed key sequence, if applicable
    *
    * If the current sequence completes a mapping, then execute it. If not, do nothing.
-   *
-   * TODO: This documentation doesn't match current implementation.
    */
-  private fun handleCompleteMappingSequence(
-    processBuilder: KeyProcessResult.KeyProcessResultBuilder,
+  private fun tryHandleCompletedMappingSequence(
+    keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
     mapping: KeyMappingLayer,
-    key: KeyStroke,
   ): Boolean {
-    log.trace("Processing complete mapping sequence...")
+    log.trace("Try processing complete mapping sequence...")
 
-    // The current sequence isn't a prefix, check to see if it's a completed sequence.
-    // TODO: The current sequence might be a prefix
-    // If an unfinished sequence times out, we replay with mapping enabled, and set mappingComplete for the last char,
-    // which skips the unfinished check. In this case, it is a prefix, but we try to complete it, or complete a mapping
-    // for the sequence that ends the character before.
-    // If we simplify the replay mechanism, we don't need to worry about this.
-    val mappingState = processBuilder.state.mappingState
-    val mappingInfoForCurrentSequence = mapping.getLayer(mappingState.keys)
-    var mappingInfo = mappingInfoForCurrentSequence
+    val mappingState = keyProcessResultBuilder.state.mappingState
+    val mappingInfo = mapping.getLayer(mappingState.keys)
     if (mappingInfo == null) {
-      log.trace("Haven't found any mapping info for the given sequence. Trying to apply mapping to a subsequence.")
-
-      // It's an abandoned sequence, check to see if the previous sequence was a complete sequence.
-      // TODO: This is incorrect behaviour
-      // What about sequences that were completed N keys ago?
-      // I.e. if we have `imap ab AB` and `imap abcde ABCDE`, this will try to handle `abcd`, which isn't a map
-      // This will likely drop us into handleAbandonedMappingSequence, which will start replaying key strokes, but
-      // crucially without mapping and without invoking any earlier complete sequences, so we end up with `abcd` instead
-      // of `ABcd`.
-      // This should really be handled as part of an abandoned key sequence. We should also consolidate the replay
-      // of cached keys - this happens in timeout, here and also in abandoned sequences.
-      // Extract most of this method into handleMappingInfo. If we have a complete sequence, call it and we're done.
-      // If it's not a complete sequence, handleAbandonedMappingSequence should do something like call
-      // mappingState.detachKeys and look for the longest complete sequence in the returned list, evaluate it, and then
-      // replay any keys not yet handled. NB: The actual implementation should be compared to Vim behaviour to see what
-      // should actually happen.
-      val previouslyUnhandledKeySequence = ArrayList<KeyStroke>()
-      mappingState.keys.forEach { e: KeyStroke -> previouslyUnhandledKeySequence.add(e) }
-      if (previouslyUnhandledKeySequence.size > 1) {
-        previouslyUnhandledKeySequence.removeAt(previouslyUnhandledKeySequence.size - 1)
-        mappingInfo = mapping.getLayer(previouslyUnhandledKeySequence)
-      }
-    }
-
-    if (mappingInfo == null) {
-      log.trace("Cannot find any mapping info for the sequence. Return false.")
+      log.trace("Cannot find any mapping info for the sequence. Mapping processor will not handle further.")
       return false
     }
 
-    processBuilder.addExecutionStep { ks, e, c ->
-      processCompleteMappingSequence(key, ks, e, c, mappingInfo, mappingInfoForCurrentSequence)
+    keyProcessResultBuilder.addExecutionStep { ks, e, c ->
+      log.trace("Executing mapping")
+
+      val mappingState = ks.mappingState
+      mappingState.resetMappingSequence()
+      executeMappingInfo(mappingInfo, e, c, ks)
+
+      log.trace("Completed mapping sequence processed. Returning true.")
     }
     return true
   }
 
-  private fun processCompleteMappingSequence(
-    key: KeyStroke,
-    keyState: KeyHandlerState,
+  private fun executeMappingInfo(
+    mappingInfo: MappingInfoLayer,
     editor: VimEditor,
     context: ExecutionContext,
-    mappingInfo: MappingInfoLayer,
-    mappingInfoForCurrentSequence: MappingInfoLayer?,
+    keyState: KeyHandlerState,
   ) {
     val mappingState = keyState.mappingState
-    mappingState.resetMappingSequence()
-
-    log.trace("Executing mapping info")
 
     // Catch any exception, but also NotImplementedError. Don't just catch Throwable, as this will catch exceptions
     // thrown by log.error, which can include TestLoggerAssertionError
@@ -275,9 +201,9 @@ object MappingProcessor : KeyConsumer {
       injector.messages.indicateError()
       log.error(
         """
-                Caught exception during ${mappingInfo.getPresentableString()}
-                ${e.message}
-        """.trimIndent(),
+                  Caught exception during ${mappingInfo.getPresentableString()}
+                  ${e.message}
+          """.trimIndent(),
         e
       )
     } catch (e: NotImplementedError) {
@@ -285,21 +211,14 @@ object MappingProcessor : KeyConsumer {
       injector.messages.indicateError()
       log.error(
         """
-                Caught exception during ${mappingInfo.getPresentableString()}
-                ${e.message}
-        """.trimIndent(),
+                  Caught exception during ${mappingInfo.getPresentableString()}
+                  ${e.message}
+          """.trimIndent(),
         e
       )
     } finally {
       mappingState.stopMapExecution()
     }
-
-    // If we've just evaluated the previous key sequence, make sure to also handle the current key
-    if (mappingInfo !== mappingInfoForCurrentSequence) {
-      log.trace("Evaluating the current key")
-      KeyHandler.getInstance().handleKey(editor, key, context, allowKeyMappings = true, false, keyState)
-    }
-    log.trace("Completed mapping sequence")
   }
 
   /**
@@ -308,84 +227,110 @@ object MappingProcessor : KeyConsumer {
    * If the user enters a key that is not part of a prefix and doesn't complete a mapping, then replay the unhandled
    * keys so that they get processed.
    */
-  private fun handleAbandonedMappingSequence(processBuilder: KeyProcessResult.KeyProcessResultBuilder): Boolean {
-    log.debug("Processing abandoned mapping sequence")
+  private fun tryHandleAbandonedMappingSequence(keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder): Boolean {
+    log.debug("Trying to process abandoned mapping sequence...")
 
-    // The user has terminated a mapping sequence with an unexpected key
-    // E.g. if there is a mapping for "hello" and user enters command "help" the processing of "h", "e" and "l" will be
-    //   prevented by this handler. Make sure the currently unhandled keys are processed as normal.
-    val unhandledKeyStrokes = processBuilder.state.mappingState.detachKeys()
+    // The user has terminated a mapping sequence with an unexpected key. Detach and replay the batched unhandled keys.
+    val unhandledKeyStrokes = keyProcessResultBuilder.state.mappingState.detachKeys()
 
-    // If there is only the current key to handle, do nothing
+    // If there is only the current key to handle, return false. The mapping processor will not handle this, and the
+    // other key consumers can have a go.
     if (unhandledKeyStrokes.size == 1) {
-      log.trace("There is only one key in mapping. Return false.")
+      log.trace("There is only one key in abandoned mapping sequence. Mapping processor will not handle further.")
       return false
     }
 
-    processBuilder.addExecutionStep { lambdaKeyState, lambdaEditor, lambdaContext ->
-      processAbandonedMappingSequence(unhandledKeyStrokes, lambdaEditor, lambdaContext, lambdaKeyState)
+    keyProcessResultBuilder.addExecutionStep { ks, e, c ->
+      log.trace("Replaying abandoned keys")
+      replayUnhandledKeys(unhandledKeyStrokes, e, c, ks)
+      log.trace("Abandoned keys processed. Returning true.")
     }
     return true
   }
 
-  private fun processAbandonedMappingSequence(
-    unhandledKeyStrokes: List<KeyStroke>,
+  /**
+   * Replays unhandled keys through the key handler
+   *
+   * If a key sequence is not a mapping, the keys we've batched up need to be replayed through the key handler and
+   * properly processed.
+   *
+   * Firstly, we look for the next longest subsequence that is a mapping. If found, execute it and then replay the
+   * remaining keys, with mapping enabled, as though they were typed.
+   *
+   * If there are no subsequences matching a mapping, replay all the keys. The first key should not allow mappings, or
+   * we'll try to map the same prefix again, and fail again. Subsequent keys should allow mapping, also as though they
+   * were typed.
+   */
+  private fun replayUnhandledKeys(
+    unhandledKeys: List<KeyStroke>,
     editor: VimEditor,
     context: ExecutionContext,
     keyState: KeyHandlerState,
   ) {
-    if (isPluginMapping(unhandledKeyStrokes)) {
+    log.trace("Replaying unhandled keys. Looking for mapping in subsequence")
+    val mappingLayer = injector.keyGroup.getKeyMappingLayer(editor.mode.toMappingMode())
+
+    val subsequence = unhandledKeys.toMutableList()
+    while (subsequence.isNotEmpty()) {
+      val mappingInfo = mappingLayer.getLayer(subsequence)
+      if (mappingInfo != null) {
+        log.trace("Found mapping. Executing it and replaying the rest of the keys")
+
+        executeMappingInfo(mappingInfo, editor, context, keyState)
+
+        // Replay the rest of the keys, with mapping applied, as though they were typed
+        unhandledKeys.subList(subsequence.size, unhandledKeys.size).forEach {
+          KeyHandler.getInstance().handleKey(editor, it, context, allowKeyMappings = true, mappingCompleted = false, keyState)
+        }
+        return
+      }
+
+      subsequence.removeLast()
+    }
+
+    // TODO: I don't understand the reasoning behind this code
+    // Why do we throw away a `<Plug>...` prefix sequence? Normal Vim behaviour is to replay the failed sequence, so I
+    // would expect us to do the same here. The only reason I can think of is that `<Plug>` is converted into a custom
+    // keystroke that wouldn't be processed properly, especially because the first replayed keystroke is not mapped.
+    // If this is why we skip it, maybe we should expand it to normal keystrokes (allowing mapping)?
+    // Also, if we do this for `<Plug>`, why do we not do it for `<Action>`?
+    if (isPluginMapping(unhandledKeys)) {
+      // TODO: Original comment, but we're not processing the plugin mapping?!
       log.trace("This is a plugin mapping, process it")
 
-      // We've typed a key that causes us to abandon the sequence. If it's an (unfinished) <Plug> sequence, ignore the
-      // plugin sequence and only replay the last character?
-      // TODO: Why do we skip this <Plug> prefix? Why not push it through without mapping? Surely that's the expected behaviour
+      // If the user types a key that ends a `<Plug>...` prefix sequence, we ignore the prefix and replay just the key,
+      // with mappings enabled, as though the user typed it.
+      // Note that we have logic in the 'timeout' function to ignore `<Plug>` mappings completely there. That sequence
+      // only contains valid keystrokes, so there's nothing to replay.
       KeyHandler.getInstance().handleKey(
         editor,
-        unhandledKeyStrokes[unhandledKeyStrokes.size - 1],
+        unhandledKeys.last(),
         context,
         allowKeyMappings = true,
         mappingCompleted = false,
         keyState,
       )
-    } else {
-      log.trace("Process abandoned keys.")
+    }
+    else {
+      log.trace("Replaying unhandled keys. There is no mapping in subsequence. Replaying all keys")
 
-      // Okay, look at the code below. Why is the first key handled separately?
-      // Let's assume the next mappings:
-      //   - map ds j
-      //   - map I 2l
-      // If user enters `dI`, the first `d` will be caught be this handler because it's a prefix for `ds` command.
-      //  After the user enters `I`, the caught `d` should be processed without mapping, and the rest of keys
-      //  should be processed with mappings (to make I work)
-      KeyHandler.getInstance()
-        .handleKey(
-          editor,
-          unhandledKeyStrokes[0],
-          context,
-          allowKeyMappings = false,
-          mappingCompleted = false,
-          keyState
-        )
-      for (keyStroke in unhandledKeyStrokes.subList(1, unhandledKeyStrokes.size)) {
-        KeyHandler.getInstance()
-          .handleKey(editor, keyStroke, context, allowKeyMappings = true, mappingCompleted = false, keyState)
+      // There wasn't a complete sequence in the unhandled keys, so replay all of them. Do not allow mappings for the
+      // first key, or we'll start to build the same prefix that just failed. Subsequent keys should allow mappings, as
+      // though they were typed.
+      val keyHandler = KeyHandler.getInstance()
+      unhandledKeys.forEachIndexed { index, it ->
+        keyHandler.handleKey(editor, it, context, allowKeyMappings = index != 0, mappingCompleted = false, keyState)
       }
     }
-    log.trace("Return true from abandoned keys processing.")
   }
 
+  // TODO: WHY?
   // The <Plug>mappings are not executed if they fail to map to something.
   //   E.g.
   //   - map <Plug>iA someAction
   //   - map I <Plug>i
   //   For `IA` someAction should be executed.
   //   But if the user types `Ib`, `<Plug>i` won't be executed again. Only `b` will be passed to keyHandler.
-  // TODO: If we change how we replay keys, this logic needs to be revisited
-  // User types `I`, which is a complete sequence. Since it's a recursive mapping, `<Plug>i` is pushed through the key
-  // handler. It's an unfinished sequence. The user types `b` and we've now got an abandoned sequence. I would expect
-  // Vim to replay everything (`<Plug>ib`) with no mapping, but we seem to skip the `<Plug>` prefix completely.
-  // I still don't understand why
   private fun isPluginMapping(unhandledKeyStrokes: List<KeyStroke>): Boolean {
     return unhandledKeyStrokes.isNotEmpty() && unhandledKeyStrokes[0] == injector.parser.plugKeyStroke
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/MappingProcessor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/MappingProcessor.kt
@@ -26,7 +26,7 @@ import com.maddyhome.idea.vim.key.isPrefix
 import com.maddyhome.idea.vim.state.KeyHandlerState
 import javax.swing.KeyStroke
 
-object MappingProcessor : KeyConsumer {
+internal object MappingProcessor : KeyConsumer {
 
   private val log = vimLogger<MappingProcessor>()
 
@@ -34,7 +34,6 @@ object MappingProcessor : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     log.trace { "Entered MappingProcessor with key $key" }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyConsumer.kt
@@ -12,7 +12,7 @@ import com.maddyhome.idea.vim.KeyProcessResult
 import com.maddyhome.idea.vim.api.VimEditor
 import javax.swing.KeyStroke
 
-interface KeyConsumer {
+internal interface KeyConsumer {
   /**
    * @return true if consumed key and could do something meaningful wit it
    */
@@ -20,7 +20,6 @@ interface KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyMapping.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyMapping.kt
@@ -173,7 +173,10 @@ class KeyMapping(private val mode: MappingMode) : Iterable<List<KeyStroke>>, Key
     if (keysTrie.isPrefix(keys)) return true
 
     // Is this an incomplete RHS on-demand <Action>(...)?
-    return keys.first().keyCode == injector.parser.actionKeyStroke.keyCode && keys.last().keyChar != ')'
+    return keys.first().keyCode == injector.parser.actionKeyStroke.keyCode
+      && (keys.size < 2 || keys[1].keyChar == '(')
+      && (keys.size < 3 || !Character.isWhitespace(keys[2].keyChar))
+      && keys.last().keyChar != ')'
   }
 
   /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CharArgumentConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CharArgumentConsumer.kt
@@ -20,7 +20,7 @@ import com.maddyhome.idea.vim.key.KeyConsumer
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-class CharArgumentConsumer : KeyConsumer {
+internal class CharArgumentConsumer : KeyConsumer {
   private companion object {
     private val logger = vimLogger<CharArgumentConsumer>()
   }
@@ -29,7 +29,6 @@ class CharArgumentConsumer : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     logger.trace { "Entered CharArgumentConsumer" }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandConsumer.kt
@@ -26,7 +26,7 @@ import com.maddyhome.idea.vim.state.VimStateMachine
 import com.maddyhome.idea.vim.state.mode.Mode
 import javax.swing.KeyStroke
 
-class CommandConsumer : KeyConsumer {
+internal class CommandConsumer : KeyConsumer {
   private companion object {
     private val logger = vimLogger<CommandConsumer>()
   }
@@ -35,7 +35,6 @@ class CommandConsumer : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     logger.trace("Entered CommandConsumer")

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandCountConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandCountConsumer.kt
@@ -19,7 +19,7 @@ import com.maddyhome.idea.vim.state.mode.Mode
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-class CommandCountConsumer : KeyConsumer {
+internal class CommandCountConsumer : KeyConsumer {
   private companion object {
     private val logger = vimLogger<CommandCountConsumer>()
   }
@@ -28,7 +28,6 @@ class CommandCountConsumer : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     logger.trace { "Entered CommandCountConsumer" }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DeleteCommandConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DeleteCommandConsumer.kt
@@ -18,7 +18,7 @@ import com.maddyhome.idea.vim.state.mode.Mode
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-class DeleteCommandConsumer : KeyConsumer {
+internal class DeleteCommandConsumer : KeyConsumer {
   private companion object {
     private val logger = vimLogger<DeleteCommandConsumer>()
   }
@@ -27,7 +27,6 @@ class DeleteCommandConsumer : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     logger.trace { "Entered DeleteCommandConsumer" }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DigraphConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/DigraphConsumer.kt
@@ -21,7 +21,7 @@ import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-class DigraphConsumer : KeyConsumer {
+internal class DigraphConsumer : KeyConsumer {
   private companion object {
     private val logger = vimLogger<DigraphConsumer>()
   }
@@ -30,7 +30,6 @@ class DigraphConsumer : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     logger.trace { "Entered DigraphConsumer" }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/EditorResetConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/EditorResetConsumer.kt
@@ -23,7 +23,7 @@ import com.maddyhome.idea.vim.state.mode.Mode
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-class EditorResetConsumer : KeyConsumer {
+internal class EditorResetConsumer : KeyConsumer {
   private companion object {
     private val logger = vimLogger<EditorResetConsumer>()
   }
@@ -32,7 +32,6 @@ class EditorResetConsumer : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     logger.trace { "Entered EditorResetConsumer" }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModalInputConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModalInputConsumer.kt
@@ -14,12 +14,11 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.key.KeyConsumer
 import javax.swing.KeyStroke
 
-class ModalInputConsumer : KeyConsumer {
+internal class ModalInputConsumer : KeyConsumer {
   override fun consumeKey(
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     val modalInput = injector.modalInput.getCurrentModalInput() ?: return false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModeInputConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/ModeInputConsumer.kt
@@ -18,7 +18,7 @@ import com.maddyhome.idea.vim.key.KeyConsumer
 import com.maddyhome.idea.vim.state.mode.Mode
 import javax.swing.KeyStroke
 
-class ModeInputConsumer : KeyConsumer {
+internal class ModeInputConsumer : KeyConsumer {
   private companion object {
     private val logger = vimLogger<ModeInputConsumer>()
   }
@@ -27,7 +27,6 @@ class ModeInputConsumer : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     logger.trace { "Entered ModeInputConsumer" }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/RegisterConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/RegisterConsumer.kt
@@ -18,7 +18,7 @@ import com.maddyhome.idea.vim.key.KeyConsumer
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-class RegisterConsumer : KeyConsumer {
+internal class RegisterConsumer : KeyConsumer {
   private companion object {
     private val logger = vimLogger<CharArgumentConsumer>()
   }
@@ -27,7 +27,6 @@ class RegisterConsumer : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     logger.trace { "Entered RegisterConsumer" }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/SelectRegisterConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/SelectRegisterConsumer.kt
@@ -18,7 +18,7 @@ import com.maddyhome.idea.vim.state.KeyHandlerState
 import com.maddyhome.idea.vim.state.mode.Mode
 import javax.swing.KeyStroke
 
-class SelectRegisterConsumer : KeyConsumer {
+internal class SelectRegisterConsumer : KeyConsumer {
   private companion object {
     private val logger = vimLogger<SelectRegisterConsumer>()
   }
@@ -27,7 +27,6 @@ class SelectRegisterConsumer : KeyConsumer {
     key: KeyStroke,
     editor: VimEditor,
     allowKeyMappings: Boolean,
-    mappingCompleted: Boolean,
     keyProcessResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
     logger.trace { "Entered SelectRegisterConsumer" }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/ActionCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/ActionCommand.kt
@@ -29,7 +29,7 @@ data class ActionCommand(val range: Range, val modifier: CommandModifier, val ar
     RangeFlag.RANGE_OPTIONAL,
     ArgumentFlag.ARGUMENT_OPTIONAL,
     Access.READ_ONLY,
-    Flag.SAVE_VISUAL,
+    Flag.SAVE_SELECTION,
   )
 
   override fun processCommand(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/Command.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/Command.kt
@@ -81,7 +81,7 @@ sealed class Command(
     // Unless the command needs us to keep visual (e.g. :action), remove the secondary carets that are an implementation
     // detail for block selection, but leave all other carets. If any other caret has a selection, move the caret to the
     // start offset of the selection, copying Vim's behaviour (with its only caret)
-    if (Flag.SAVE_VISUAL !in argFlags.flags) {
+    if (Flag.SAVE_SELECTION !in argFlags.flags) {
       // Editor.inBlockSelection is not available, because we're not in Visual mode anymore. Check if the primary caret
       // currently has a selection and if (when we still in Visual) it was a block selection.
       injector.application.runReadAction {
@@ -240,12 +240,14 @@ sealed class Command(
 
   enum class Flag {
     /**
-     * This command should not exit visual mode.
+     * The current selection should not be reset before executing this command
      *
-     * Vim exits visual mode before command execution, but in this case :action will work incorrect.
-     *   With this flag visual mode will not be exited while command execution.
+     * Vim and IdeaVim always exit Visual mode, removing selection, and return to Normal before a command is executed.
+     * However, IdeaVim has some commands that require the current selection, especially commands like `:action` that
+     * interact with IDE functions. If this flag is specified, IdeaVim will still leave Visual and return to Normal, but
+     * the current selection is not removed. It is up to the command to handle and either remove/update the selection.
      */
-    SAVE_VISUAL,
+    SAVE_SELECTION,
   }
 
   data class CommandHandlerFlags(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/NormalCommand.kt
@@ -54,7 +54,7 @@ data class NormalCommand(val range: Range, val modifier: CommandModifier, val ar
       val keyHandler = KeyHandler.getInstance()
       keyHandler.reset(editor)
       for (key in keys) {
-        keyHandler.handleKey(editor, key, context, useMappings, true, keyHandler.keyHandlerState)
+        keyHandler.handleKey(editor, key, context, useMappings, false, keyHandler.keyHandlerState)
       }
 
       // Exit if state leaves as insert or cmd_line


### PR DESCRIPTION
This PR refactors `MappingProcessor`, primarily to remove the need for the `mappingComplete` parameter, which is required for a forthcoming PR. However, a bigger impact is on the way unhandled keys are processed after a mapping fails.

- [x] Extract and centralise a single implementation to replay unhandled keys when a mapping sequence no longer matches a prefix or the `'timeout'` expires
- [x] Fix the implementation of replaying unhandled keys to find the longest mapping LHS in the abandoned sequence, instead of just looking at the sequence up to the previous character. E.g. given `map ab foo`, `map abcde bar` and an input of `abcdz`, the mapping processor will now execute the `ab` mapping (producing `foo`) and then try to handle `cdz` separately.
- [x] Remove the `mappingComplete` parameter from `KeyConsumer`. Because of the above change, it is no longer necessary to identify the last character in a sequence to stop further mapping. 
- [x] Remove the special case handling of `<Plug>` when processing unhandled mappings. Previously, we would discard all characters for a sequence that began with `<Plug>`. It's unclear why this was done, possibly because replaying the keys in Normal mode would rarely result in what the user expected. However, this is Vim behaviour, and IdeaVim has been updated to match.
- [x] Output `"<Plug>"` and `"<Action>"` as text when replaying unhandled `<Plug>` and `<Action>` maps in Insert mode. Like in Vim, the `<Plug>` key is a special keystroke that can't be typed (`<Action>` is the same). When replaying a `<Plug>` or `<Action>` mapping prefix in Insert mode, the special keystroke is converted to plain text, again following Vim behaviour.
- [x] Uncomment tests for the `:normal` command. Not sure why they were commented, but they work
- [x] Removed special case handling of modes in the `:normal` command implementation, as well as removing the `SAVE_VISUAL` command flag. This fixes an issue with an incorrect caret location when invoking `:normal` from Visual. IdeaVim (like Vim) always switches to Normal before executing a command, but the `SAVE_VISUAL` flag would maintain the selection. Because the command handler was expecting Visual mode, the selection was never removed and the caret was in the wrong place. Removing all of this means the default behaviour works as expected.
- [x] Fix an issue with the `:normal` command and multi-character mappings. Because `:normal` was setting `mappingComplete` to `true`, it wasn't processing the last character correctly.
- [x] Rename the `SAVE_VISUAL` flag to `SAVE_SELECTION` to better indicate what's actually happening. IdeaVim always leaves Visual and returns to Normal before calling a command handler. The flag keeps the selection, not the Visual mode.

With regard to the `mappingComplete` parameter, this has been removed from `KeyConsumer`, but not from `KeyHandler.handleKey`. This function is used by external plugins, so will need to remain. It hasn't been marked as deprecated because there isn't an alternative yet. That will be taken care of in a forthcoming PR.