### PR TITLE
Remove obsolete internal options

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/IjOptionProperties.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjOptionProperties.kt
@@ -31,10 +31,8 @@ open class GlobalIjOptions(scope: OptionAccessScope) : OptionsPropertiesBase(sco
 
   // Temporary options to control work-in-progress behaviour
   var closenotebooks: Boolean by optionProperty(IjOptions.closenotebooks)
-  var commandOrMotionAnnotation: Boolean by optionProperty(IjOptions.commandOrMotionAnnotation)
   var oldundo: Boolean by optionProperty(IjOptions.oldundo)
   var unifyjumps: Boolean by optionProperty(IjOptions.unifyjumps)
-  var vimscriptFunctionAnnotation: Boolean by optionProperty(IjOptions.vimscriptFunctionAnnotation)
 }
 
 /**

--- a/src/main/java/com/maddyhome/idea/vim/group/IjOptions.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjOptions.kt
@@ -141,12 +141,8 @@ object IjOptions {
   // Temporary feature flags during development, not really intended for external use
   val closenotebooks: ToggleOption =
     addOption(ToggleOption("closenotebooks", GLOBAL, "closenotebooks", true, isHidden = true))
-  val commandOrMotionAnnotation: ToggleOption =
-    addOption(ToggleOption("commandormotionannotation", GLOBAL, "commandormotionannotation", true, isHidden = true))
   val oldundo: ToggleOption = addOption(ToggleOption("oldundo", GLOBAL, "oldundo", false, isHidden = true))
   val unifyjumps: ToggleOption = addOption(ToggleOption("unifyjumps", GLOBAL, "unifyjumps", true, isHidden = true))
-  val vimscriptFunctionAnnotation: ToggleOption =
-    addOption(ToggleOption("vimscriptfunctionannotation", GLOBAL, "vimscriptfunctionannotation", true, isHidden = true))
 
   // This needs to be Option<out VimDataType> so that it can work with derived option types, such as NumberOption, which
   // derives from Option<VimInt>


### PR DESCRIPTION
Removes the `'commandormotionannotation'` and `'vimscriptfunctionannotation'` internal options that were used as feature flags, but there's no longer a switch on behaviour.