### PR TITLE
Always print float numbers using period as a decimal separator, VIM-3894

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/datatypes/VimFloatTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/expressions/datatypes/VimFloatTest.kt
@@ -10,6 +10,7 @@ package org.jetbrains.plugins.ideavim.ex.implementation.expressions.datatypes
 
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimFloat
 import org.junit.jupiter.api.Test
+import java.util.Locale
 import kotlin.test.assertEquals
 
 class VimFloatTest {
@@ -22,5 +23,16 @@ class VimFloatTest {
   @Test
   fun `round 7 digits`() {
     assertEquals("1.0", VimFloat(0.9999999).toString())
+  }
+
+  @Test
+  fun `use point as decimal separator always`() {
+    val oldLocale = Locale.getDefault()
+    Locale.setDefault(Locale.GERMANY) // In Germany, they use a comma as a decimal separator, i.e., "3,14".
+    try {
+      assertEquals("3.14", VimFloat(3.14).toString())
+    } finally {
+      Locale.setDefault(oldLocale)
+    }
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/datatypes/VimFloat.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/datatypes/VimFloat.kt
@@ -10,6 +10,8 @@ package com.maddyhome.idea.vim.vimscript.model.datatypes
 
 import com.maddyhome.idea.vim.ex.exExceptionMessage
 import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.Locale
 import kotlin.math.abs
 
 data class VimFloat(val value: Double) : VimDataType() {
@@ -32,14 +34,12 @@ data class VimFloat(val value: Double) : VimDataType() {
 
   override fun toString(): String {
     if (value.isNaN()) return "nan"
-    return if (abs(value) >= 1e6 || (abs(value) < 1e-3 && value != 0.0)) {
-      val formatter = DecimalFormat("0.0#####E0")
-      formatter.decimalFormatSymbols = formatter.decimalFormatSymbols.apply { exponentSeparator = "e" }
-      formatter.format(value)
+    val tooBigOrTooSmall = abs(value) >= 1e6 || (abs(value) < 1e-3 && value != 0.0)
+    val pattern = if (tooBigOrTooSmall) "0.0#####E0" else "0.0#####"
+    val symbols = DecimalFormatSymbols.getInstance(Locale.ROOT).apply {
+      exponentSeparator = "e"
     }
-    else {
-      DecimalFormat("0.0#####").format(value)
-    }
+    return DecimalFormat(pattern, symbols).format(value)
   }
 
   override fun deepCopy(level: Int): VimFloat {


### PR DESCRIPTION
[VIM-3894](https://youtrack.jetbrains.com/issue/VIM-3894/Unit-tests-fail-on-host-with-German-locale)
