### PR TITLE
Replacement string fixes

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SubstituteCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SubstituteCommandTest.kt
@@ -197,6 +197,19 @@ class SubstituteCommandTest : VimTestCase() {
     VimOption(TestOptionConstants.ignorecase, doesntAffectTest = true),
   )
   @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
+  fun `test missing group`() {
+    doTest(
+      exCommand("s/b/<\\7>/"),
+      "${c}abc",
+      "a<>c",
+    )
+  }
+
+  @OptionTest(
+    VimOption(TestOptionConstants.smartcase, doesntAffectTest = true),
+    VimOption(TestOptionConstants.ignorecase, doesntAffectTest = true),
+  )
+  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
   fun `test to nl`() {
     doTest(
       exCommand("s/\\./\\r/g"),

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SubstituteCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SubstituteCommandTest.kt
@@ -197,6 +197,19 @@ class SubstituteCommandTest : VimTestCase() {
     VimOption(TestOptionConstants.ignorecase, doesntAffectTest = true),
   )
   @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
+  fun `test ampersand group`() {
+    doTest(
+      exCommand("s/a\\|b/z&/g"),
+      "${c}abcdefg",
+      "zazbcdefg",
+    )
+  }
+
+  @OptionTest(
+    VimOption(TestOptionConstants.smartcase, doesntAffectTest = true),
+    VimOption(TestOptionConstants.ignorecase, doesntAffectTest = true),
+  )
+  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
   fun `test missing group`() {
     doTest(
       exCommand("s/b/<\\7>/"),
@@ -1339,6 +1352,62 @@ class SubstituteCommandTest : VimTestCase() {
       exCommand("%s/[*/]//g"),
       "/* comment */",
       " comment ",
+    )
+  }
+
+  // VIM-3510
+  @OptionTest(
+    VimOption(TestOptionConstants.smartcase, doesntAffectTest = true),
+    VimOption(TestOptionConstants.ignorecase, doesntAffectTest = true),
+  )
+  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
+  fun `test replace action U`() {
+    doTest(
+      exCommand("s/\\(foo\\)/\\U\\1bar/"),
+      "${c}a foo",
+      "a FOOBAR",
+    )
+  }
+
+  // VIM-3510
+  @OptionTest(
+    VimOption(TestOptionConstants.smartcase, doesntAffectTest = true),
+    VimOption(TestOptionConstants.ignorecase, doesntAffectTest = true),
+  )
+  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
+  fun `test replace action U and E`() {
+    doTest(
+      exCommand("s/\\(foo\\)/\\U\\1\\ebar/"),
+      "${c}a foo",
+      "a FOObar",
+    )
+  }
+
+  // VIM-3510
+  @OptionTest(
+    VimOption(TestOptionConstants.smartcase, doesntAffectTest = true),
+    VimOption(TestOptionConstants.ignorecase, doesntAffectTest = true),
+  )
+  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
+  fun `test replace action u`() {
+    doTest(
+      exCommand("s/\\(foo\\)/\\u\\1bar/"),
+      "${c}a foo",
+      "a Foobar",
+    )
+  }
+
+  // VIM-3510
+  @OptionTest(
+    VimOption(TestOptionConstants.smartcase, doesntAffectTest = true),
+    VimOption(TestOptionConstants.ignorecase, doesntAffectTest = true),
+  )
+  @TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
+  fun `test replace action u and empty group`() {
+    doTest(
+      exCommand("s/a foo\\(\\)/a foo\\u\\1bar/"),
+      "${c}a foo",
+      "a fooBar",
     )
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/regexp/VimRegex.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/regexp/VimRegex.kt
@@ -389,16 +389,15 @@ class VimRegex(pattern: String) {
           '&' -> result.append(if (magic) '&' else matchResult.value)
           '~' -> result.append(if (magic) '~' else buildSubstituteString(matchResult, lastSubstituteString, "", false))
           '0' -> result.append(matchResult.value)
-          // TODO: check for illegal back references
-          '1' -> result.append(matchResult.groups.get(1)?.value)
-          '2' -> result.append(matchResult.groups.get(2)?.value)
-          '3' -> result.append(matchResult.groups.get(3)?.value)
-          '4' -> result.append(matchResult.groups.get(4)?.value)
-          '5' -> result.append(matchResult.groups.get(5)?.value)
-          '6' -> result.append(matchResult.groups.get(6)?.value)
-          '7' -> result.append(matchResult.groups.get(7)?.value)
-          '8' -> result.append(matchResult.groups.get(8)?.value)
-          '9' -> result.append(matchResult.groups.get(9)?.value)
+          '1' -> result.append(matchResult.groups.get(1)?.value ?: "")
+          '2' -> result.append(matchResult.groups.get(2)?.value ?: "")
+          '3' -> result.append(matchResult.groups.get(3)?.value ?: "")
+          '4' -> result.append(matchResult.groups.get(4)?.value ?: "")
+          '5' -> result.append(matchResult.groups.get(5)?.value ?: "")
+          '6' -> result.append(matchResult.groups.get(6)?.value ?: "")
+          '7' -> result.append(matchResult.groups.get(7)?.value ?: "")
+          '8' -> result.append(matchResult.groups.get(8)?.value ?: "")
+          '9' -> result.append(matchResult.groups.get(9)?.value ?: "")
           'u' -> caseSettings = SubstituteCase.UPPER
           'U' -> caseSettings = SubstituteCase.UPPER_PERSISTENT
           'l' -> caseSettings = SubstituteCase.LOWER


### PR DESCRIPTION
Fixes
* [VIM-3510](https://youtrack.jetbrains.com/issue/VIM-3510) IdeaVim fails switching case within backreferences,
* [VIM-3895](https://youtrack.jetbrains.com/issue/VIM-3895) Missing backreference should be substituted by empty string.