### PR TITLE
Stop switching fragment editors to Insert mode

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -8,6 +8,7 @@
 
 package com.maddyhome.idea.vim.helper;
 
+import com.intellij.injected.editor.VirtualFileWindow;
 import com.intellij.openapi.editor.*;
 import com.intellij.openapi.editor.ex.util.EditorUtil;
 import com.intellij.openapi.editor.impl.EditorImpl;
@@ -15,6 +16,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileUtil;
 import com.intellij.testFramework.LightVirtualFile;
 import com.maddyhome.idea.vim.api.EngineEditorHelperKt;
 import com.maddyhome.idea.vim.api.VimEditor;
@@ -652,7 +654,21 @@ public class EditorHelper {
    */
   public static boolean isFileEditor(@NotNull Editor editor) {
     final VirtualFile virtualFile = getVirtualFile(editor);
-    return virtualFile != null && !(virtualFile instanceof LightVirtualFile);
+    if (virtualFile == null) return false;
+    if (virtualFile instanceof LightVirtualFile) {
+      var hostVirtualFile = getHostFileFromInjectedFile(virtualFile);
+      if (hostVirtualFile == null) return false;
+      return !(hostVirtualFile instanceof LightVirtualFile);
+    }
+    return true;
+  }
+
+  private static @Nullable VirtualFile getHostFileFromInjectedFile(@NotNull VirtualFile virtualFile) {
+    final var vf = VirtualFileUtil.originalFileOrSelf(virtualFile);
+    if (vf instanceof VirtualFileWindow) {
+      return ((VirtualFileWindow)vf).getDelegate();
+    }
+    return null;
   }
 
   /**

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
@@ -68,6 +68,20 @@ internal fun Editor.isPrimaryEditor(): Boolean {
   return fileEditorManager.allEditors.any { fileEditor -> this == EditorUtil.getEditorEx(fileEditor) }
 }
 
+/**
+ * Checks if the editor should be treated like a terminal. I.e. switch to Insert mode automatically
+ *
+ * A "terminal" editor is an editor used for purposes other than mainstream editing, such as a terminal, console, log
+ * viewer, etc. In this instance, the editor is writable, the document is writable, but it's not backed by a real file
+ * and it's not the diff viewer. We also check that if it's an injected language fragment backed by a real file.
+ */
+internal fun Editor.isTerminalEditor(): Boolean {
+  return !isViewer
+    && document.isWritable
+    && !EditorHelper.isFileEditor(this)
+    && !EditorHelper.isDiffEditor(this)
+}
+
 // Optimized clone of com.intellij.ide.ui.laf.darcula.DarculaUIUtil.isTableCellEditor
 private fun isTableCellEditor(c: Component): Boolean {
   return (java.lang.Boolean.TRUE == (c as JComponent).getClientProperty("JComboBox.isTableCellEditor")) ||

--- a/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
@@ -10,8 +10,6 @@ package com.maddyhome.idea.vim.listener
 
 import com.intellij.execution.impl.ConsoleViewImpl
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.EditorKind
 import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.LastUsedEditorInfo
 import com.maddyhome.idea.vim.VimPlugin
@@ -19,8 +17,8 @@ import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.common.EditorListener
-import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.inInsertMode
+import com.maddyhome.idea.vim.helper.isTerminalEditor
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.state.mode.Mode
 
@@ -57,7 +55,7 @@ class IJEditorFocusListener : EditorListener {
     // to know that a read-only editor that is hosting a console view with a running process can be treated as writable.
 
     val ijEditor = editor.ij
-    val isCurrentEditorTerminal = isTerminal(ijEditor)
+    val isCurrentEditorTerminal = ijEditor.isTerminalEditor()
 
     KeyHandler.getInstance().lastUsedEditorInfo = LastUsedEditorInfo(currentEditorHashCode, false)
 
@@ -86,13 +84,5 @@ class IJEditorFocusListener : EditorListener {
       }
     }
     KeyHandler.getInstance().reset(editor)
-  }
-
-  // By "terminal" we refer to some editor that should switch to INSERT mode on focus
-  private fun isTerminal(ijEditor: Editor): Boolean {
-    return !ijEditor.isViewer &&
-      !EditorHelper.isFileEditor(ijEditor) &&
-      ijEditor.document.isWritable &&
-      ijEditor.editorKind != EditorKind.DIFF
   }
 }


### PR DESCRIPTION
Fixes [VIM-1217](https://youtrack.jetbrains.com/issue/VIM-1217/Enable-for-Code-Fragments-Webstorm). This ticket was to enable IdeaVim in injected code fragments. This already worked, but the fragment editor started in Insert mode because IdeaVim would see it as an editor that was not backed by a real file. With this change, IdeaVim will check if the fragment editor's virtual file is an injected code fragment file, backed with a real file.