### PR TITLE
Report cannot track intention action

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
@@ -182,8 +182,8 @@ internal class NotificationService(private val project: Project?) {
     ).notify(project)
   }
 
-  fun notifyActionId(id: String?, candidates: List<String>? = null) {
-    ActionIdNotifier.notifyActionId(id, project, candidates)
+  fun notifyActionId(id: String?, candidates: List<String>? = null, intentionName: String?) {
+    ActionIdNotifier.notifyActionId(id, project, candidates, intentionName)
   }
 
   fun notifyKeymapIssues(issues: ArrayList<KeyMapIssue>) {
@@ -261,12 +261,15 @@ internal class NotificationService(private val project: Project?) {
   object ActionIdNotifier {
     private var notification: Notification? = null
 
-    fun notifyActionId(id: String?, project: Project?, candidates: List<String>? = null) {
+    fun notifyActionId(id: String?, project: Project?, candidates: List<String>? = null, intentionName: String? = null) {
       notification?.expire()
 
       val possibleIDs = candidates?.distinct()?.sorted()
       val content = when {
         id != null -> "Action ID: <code>$id</code><br><br>"
+        possibleIDs.isNullOrEmpty() && !intentionName.isNullOrEmpty() -> {
+          "Intention \"$intentionName\" does not have an action ID.<br><br>"
+        }
         possibleIDs.isNullOrEmpty() -> "<i>Cannot detect action ID</i><br><br>"
         possibleIDs.size == 1 -> "Possible action ID: <code>${possibleIDs[0]}</code><br><br>"
         else -> {

--- a/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
@@ -18,6 +18,7 @@ import com.intellij.codeInsight.template.TemplateEditingAdapter
 import com.intellij.codeInsight.template.TemplateManagerListener
 import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.find.FindModelListener
+import com.intellij.ide.actions.ApplyIntentionAction
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
@@ -94,10 +95,14 @@ internal object IdeaSpecifics {
           } else {
             emptyList()
           }
+         val intentionName = if (action is ApplyIntentionAction) {
+            action.name
+          }
+          else null
 
           // We can still get empty ID and empty candidates. Notably, for the tool window toggle buttons on the new UI.
           // We could filter out action events with `place == ActionPlaces.TOOLWINDOW_TOOLBAR_BAR`
-          VimPlugin.getNotifications(event.dataContext.getData(CommonDataKeys.PROJECT)).notifyActionId(id, candidates)
+          VimPlugin.getNotifications(event.dataContext.getData(CommonDataKeys.PROJECT)).notifyActionId(id, candidates, intentionName)
         }
       }
 


### PR DESCRIPTION
If an alt+enter intention is invoked from Search Everywhere, IdeaVim's Track Action ID shows "Cannot detect action ID" instead of explaining that there is no action ID.

Relates to [VIM-2541](https://youtrack.jetbrains.com/issue/VIM-2541).