### PR TITLE
VIM-3798 Replace with register empty text objects

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/replacewithregister/ReplaceWithRegister.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/replacewithregister/ReplaceWithRegister.kt
@@ -15,6 +15,7 @@ import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.ImmutableVimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.getLineEndOffset
+import com.maddyhome.idea.vim.api.getText
 import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.MappingMode
@@ -148,6 +149,22 @@ private fun doReplace(editor: Editor, context: DataContext, caret: ImmutableVimC
 
   var usedType = savedRegister.type
   var usedText = savedRegister.text
+
+  val selection = visualSelection.caretsAndSelections.values.first()
+  val startOffset: Int = selection.vimStart
+  val endOffset: Int = selection.vimEnd + 1
+
+  val isEmptySelection: Boolean = startOffset == endOffset
+
+  if (isEmptySelection) {
+    val editor: VimEditor = editor.vim
+
+    val beforeChar: String = editor.getText(startOffset - 1, startOffset)
+    val afterChar: String = editor.getText(endOffset, endOffset + 1)
+
+    usedText = beforeChar + usedText + afterChar
+  }
+
   if (usedType.isLine && usedText?.endsWith('\n') == true) {
     // Code from original plugin implementation. Correct text for linewise selected text
     usedText = usedText.dropLast(1)

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterTest.kt
@@ -784,4 +784,47 @@ class ReplaceWithRegisterTest : VimTestCase() {
     assertState(expected)
   }
 
+  @TestFor(issues = ["VIM-3798"])
+  @Test
+  fun `test for performing replace with register on empty text object (empty parentheses), from default register`() {
+    val before = """
+      ${c}text
+      function()
+    """.trimIndent()
+
+    configureByText(before)
+
+    typeText("yiw")
+    typeText("j")
+    typeText("grib")
+
+    val expected = """
+      text
+      function(tex${c}t)
+    """.trimIndent()
+
+    assertState(expected)
+  }
+
+  @TestFor(issues = ["VIM-3798"])
+  @Test
+  fun `test for performing replace with register on empty text object (empty quotation marks), from default register`() {
+    val before = """
+      ${c}text
+      function("")
+    """.trimIndent()
+
+    configureByText(before)
+
+    typeText("yiw")
+    typeText("j")
+    typeText("gri\"")
+
+    val expected = """
+      text
+      function("tex${c}t")
+    """.trimIndent()
+
+    assertState(expected)
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterTest.kt
@@ -800,7 +800,7 @@ class ReplaceWithRegisterTest : VimTestCase() {
 
     val expected = """
       text
-      function(tex${c}t)
+      function(text${c})
     """.trimIndent()
 
     assertState(expected)
@@ -822,9 +822,50 @@ class ReplaceWithRegisterTest : VimTestCase() {
 
     val expected = """
       text
-      function("tex${c}t")
+      function("text${c}")
     """.trimIndent()
 
     assertState(expected)
   }
+
+  @TestFor(issues = ["VIM-3798"])
+  @Test
+  fun `test for performing replace with register on empty text object (empty parentheses), with empty register`() {
+    VimPlugin.getRegister().resetRegisters()
+
+    val before = """
+      ${c}function()
+    """.trimIndent()
+
+    configureByText(before)
+
+    typeText("grib")
+
+    val expected = """
+      ${c}function()
+    """.trimIndent()
+
+    assertState(expected)
+  }
+
+  @TestFor(issues = ["VIM-3798"])
+  @Test
+  fun `test for performing replace with register on empty text object (empty quotation marks), with empty register`() {
+    VimPlugin.getRegister().resetRegisters()
+
+    val before = """
+      ${c}function("")
+    """.trimIndent()
+
+    configureByText(before)
+
+    typeText("gri\"")
+
+    val expected = """
+      ${c}function("")
+    """.trimIndent()
+
+    assertState(expected)
+  }
+
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterTest.kt
@@ -868,4 +868,48 @@ class ReplaceWithRegisterTest : VimTestCase() {
     assertState(expected)
   }
 
+  @TestFor(issues = ["VIM-3798"])
+  @Test
+  fun `test for performing replace with register on empty text object (empty parentheses), with text from register a`() {
+    val before = """
+      ${c}text
+      function()
+    """.trimIndent()
+
+    configureByText(before)
+
+    typeText("\"ayiw")
+    typeText("j")
+    typeText("\"agrib")
+
+    val expected = """
+      text
+      function(text${c})
+    """.trimIndent()
+
+    assertState(expected)
+  }
+
+  @TestFor(issues = ["VIM-3798"])
+  @Test
+  fun `test for performing replace with register on empty text object (empty quotation marks), with text from register a`() {
+    val before = """
+      ${c}text
+      function("")
+    """.trimIndent()
+
+    configureByText(before)
+
+    typeText("\"ayiw")
+    typeText("j")
+    typeText("\"agri\"")
+
+    val expected = """
+      text
+      function("text${c}")
+    """.trimIndent()
+
+    assertState(expected)
+  }
+
 }


### PR DESCRIPTION
Link to the YouTrack issue: [VIM-3798](https://youtrack.jetbrains.com/issue/VIM-3798)