### PR TITLE
Add support for `:=` to print line number

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/PrintLineNumberTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/PrintLineNumberTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2003-2025 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.commands
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class PrintLineNumberTest : VimTestCase() {
+  @Test
+  fun `test print last line number`() {
+    configureByLines(10, "Lorem ipsum dolor sit amet")
+    enterCommand("=")
+    assertStatusLineMessageContains("10")
+  }
+
+  @Test
+  fun `test print current line number`() {
+    configureByLines(10, "Lorem ipsum dolor sit amet")
+    typeText("4j")
+    enterCommand(".=")
+    assertStatusLineMessageContains("5")
+  }
+
+  @Test
+  fun `test print specific line number`() {
+    configureByLines(10, "Lorem ipsum dolor sit amet")
+    enterCommand("7=")
+    assertStatusLineMessageContains("7")
+  }
+
+  @Test
+  fun `test print line number of last part of range`() {
+    configureByLines(10, "Lorem ipsum dolor sit amet")
+    enterCommand("1,5=")
+    assertStatusLineMessageContains("5")
+  }
+
+  @Test
+  fun `test trailing characters raises an error`() {
+    configureByLines(10, "Lorem ipsum dolor sit amet")
+    enterCommand("=foo")
+    assertPluginError(true)
+    assertPluginErrorMessageContains("E488: Trailing characters: foo")
+  }
+
+  @Test
+  fun `test # flag prints line content and number`() {
+    configureByText("""
+      |Lorem ipsum dolor sit amet
+      |...consectetur adipiscing elit
+      |Maecenas efficitur nec odio vel malesuada
+    """.trimMargin().dotToTab())
+    enterCommand("2=#")
+    assertStatusLineMessageContains("2 \t\t\tconsectetur adipiscing elit")
+  }
+
+  @Test
+  fun `test l flag prints line content as printable string and number`() {
+    configureByText("""
+      |Lorem ipsum dolor sit amet
+      |...consectetur adipiscing elit
+      |Maecenas efficitur nec odio vel malesuada
+    """.trimMargin().dotToTab())
+    enterCommand("2=l")
+    assertStatusLineMessageContains("2 ^I^I^Iconsectetur adipiscing elit")
+  }
+
+  @Test
+  fun `test l and p flags print line content as printable string and number`() {
+    configureByText("""
+      |Lorem ipsum dolor sit amet
+      |...consectetur adipiscing elit
+      |Maecenas efficitur nec odio vel malesuada
+    """.trimMargin().dotToTab())
+    enterCommand("2=lp")
+    assertStatusLineMessageContains("2 ^I^I^Iconsectetur adipiscing elit")
+  }
+
+  @Test
+  fun `test p flag prints line content and number`() {
+    configureByText("""
+      |Lorem ipsum dolor sit amet
+      |...consectetur adipiscing elit
+      |Maecenas efficitur nec odio vel malesuada
+    """.trimMargin().dotToTab())
+    enterCommand("2=p")
+    assertStatusLineMessageContains("2 \t\t\tconsectetur adipiscing elit")
+  }
+
+  @Test
+  fun `test p and # flag prints line content and number`() {
+    configureByText("""
+      |Lorem ipsum dolor sit amet
+      |...consectetur adipiscing elit
+      |Maecenas efficitur nec odio vel malesuada
+    """.trimMargin().dotToTab())
+    enterCommand("2=p#")
+    assertStatusLineMessageContains("2 \t\t\tconsectetur adipiscing elit")
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/parser/ExecutableTextRangesTests.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/parser/ExecutableTextRangesTests.kt
@@ -39,7 +39,7 @@ class ExecutableTextRangesTests : VimTestCase() {
     val scriptString = """
       set rnu
       if 1
-        -0=a " some line that parser cannot recognize (it should be ignored)
+        -0§a " some line that parser cannot recognize (it should be ignored)
         let y = 76
       endif
     """.trimIndent()
@@ -61,7 +61,7 @@ class ExecutableTextRangesTests : VimTestCase() {
       oh, hi Mark
       "        ideavim ignore end
       if 1
-        -0=a " some line that parser cannot recognize (it should be ignored)
+        -0§a " some line that parser cannot recognize (it should be ignored)
         let y = 76
       endif
     """.trimIndent()

--- a/vim-engine/src/main/antlr/Vimscript.g4
+++ b/vim-engine/src/main/antlr/Vimscript.g4
@@ -123,6 +123,7 @@ command:
         | FILE | EXIT | E_LOWERCASE | EDIT_FILE | DUMP_LINE | DIGRAPH | DEL_MARKS | D_LOWERCASE | DEL_LINES | DELCMD
         | T_LOWERCASE | COPY | CMD_CLEAR | BUFFER_LIST | BUFFER_CLOSE | B_LOWERCASE | BUFFER | ASCII
         | ACTIONLIST | ACTION | LOCKVAR | UNLOCKVAR | PACKADD | TABMOVE
+        | ASSIGN    // `:=` print last line number
       )
       bangModifier = BANG?
     WS* ((commandArgumentWithoutBars? inline_comment NEW_LINE) | (commandArgumentWithoutBars? NEW_LINE) | (commandArgumentWithoutBars? BAR)) (NEW_LINE | BAR)*

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/PrintLineNumberCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/PrintLineNumberCommand.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2003-2025 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.commands
+
+import com.intellij.vim.annotations.ExCommand
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.ex.exExceptionMessage
+import com.maddyhome.idea.vim.ex.ranges.Range
+import com.maddyhome.idea.vim.helper.EngineStringHelper
+import com.maddyhome.idea.vim.vimscript.model.ExecutionResult
+
+@ExCommand(command = "=")
+data class PrintLineNumberCommand(val range: Range, val modifier: CommandModifier, val argument: String) :
+  Command.SingleExecution(range, modifier, argument) {
+
+  init {
+    defaultRange = "$"
+  }
+
+  override val argFlags: CommandHandlerFlags =
+    flags(RangeFlag.RANGE_OPTIONAL, ArgumentFlag.ARGUMENT_OPTIONAL, Access.READ_ONLY)
+
+  override fun processCommand(
+    editor: VimEditor,
+    context: ExecutionContext,
+    operatorArguments: OperatorArguments,
+  ): ExecutionResult {
+    if (argument.isNotEmpty() && argument[0] !in "l#p") {
+      throw exExceptionMessage("E488", argument)  // E488: Trailing characters: $argument
+    }
+
+    val line1 = range.getLineRange(editor, editor.currentCaret()).endLine1
+
+    // `l` means output the line like `:list` - show unprintable chars, and include `^` and `$`
+    // `#` means output the line with the line number
+    // `p` means output the line like `:print`
+    // The flags can be combined, so `l#` means line number and `:list`. Normally, Vim displays this over two lines.
+    // Since we're outputting to the single line status bar, if any flags are specified, we treat it like `#` was
+    // specified - we always show line number.
+    val content = if (argument.isNotEmpty()) {
+      val text = editor.getLineText(line1 - 1)
+      if (argument.contains("l")) {
+        val keys = injector.parser.stringToKeys(text)
+        EngineStringHelper.toPrintableCharacters(keys)
+      }
+      else text
+    }
+    else ""
+
+    injector.messages.showStatusBarMessage(editor, "$line1 $content")
+    return ExecutionResult.Success
+  }
+}

--- a/vim-engine/src/main/resources/ksp-generated/engine_ex_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_ex_commands.json
@@ -1,6 +1,7 @@
 {
     "&": "com.maddyhome.idea.vim.vimscript.model.commands.SubstituteCommand",
     "<": "com.maddyhome.idea.vim.vimscript.model.commands.ShiftLeftCommand",
+    "=": "com.maddyhome.idea.vim.vimscript.model.commands.PrintLineNumberCommand",
     ">": "com.maddyhome.idea.vim.vimscript.model.commands.ShiftRightCommand",
     "@": "com.maddyhome.idea.vim.vimscript.model.commands.RepeatCommand",
     "N[ext]": "com.maddyhome.idea.vim.vimscript.model.commands.PreviousFileCommand",


### PR DESCRIPTION
Supports `:{range}= [flags]` to output the line number for the given range. If there is no range, the default is `$`, which prints the last line number. If there's a range such as `3,6`, the last line is printed.

The `[flags]` can be any value in `l#p`. In Vim, this prints out the line number and the contents of the line over two separate lines. `#` shows the line with a line number prefix, `l` shows the content like `:list` with non-printable characters made visible and `p` outputs like `:print` (so just the text, no line number prefix). The flags can be combined, although if `l` is specified, it wins and the non-printable characters are displayed.

IdeaVim only has the status bar to show output, so can only show one line of output. If a flag is specied, the output is different to Vim - the single line output includes the line number and the text (very similar to the last line of output in Vim with `=#`).

Fixes [VIM-3921](https://youtrack.jetbrains.com/issue/VIM-3921)