### PR TITLE
Implement pumvisible() function

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/PopupMenuVisibleFunctionHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/functions/handlers/PopupMenuVisibleFunctionHandler.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2003-2023 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.functions.handlers
+
+import com.intellij.codeInsight.completion.CompletionService
+import com.intellij.vim.annotations.VimscriptFunction
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDataType
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
+import com.maddyhome.idea.vim.vimscript.model.expressions.Expression
+import com.maddyhome.idea.vim.vimscript.model.functions.FunctionHandler
+
+@VimscriptFunction(name = "pumvisible")
+internal class PopupMenuVisibleFunctionHandler : FunctionHandler() {
+  override val minimumNumberOfArguments = 0
+  override val maximumNumberOfArguments = 0
+
+  override fun doFunction(
+    argumentValues: List<Expression>,
+    editor: VimEditor,
+    context: ExecutionContext,
+    vimContext: VimLContext,
+  ): VimDataType {
+    return if (CompletionService.getCompletionService().currentCompletion == null)
+      VimInt.ZERO
+    else
+      VimInt.ONE
+  }
+}

--- a/src/main/resources/ksp-generated/intellij_vimscript_functions.json
+++ b/src/main/resources/ksp-generated/intellij_vimscript_functions.json
@@ -1,3 +1,4 @@
 {
-    "has": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.HasFunctionHandler"
+    "has": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.HasFunctionHandler",
+    "pumvisible": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.PopupMenuVisibleFunctionHandler"
 }


### PR DESCRIPTION
Adds the [pumvisible()](https://vimdoc.sourceforge.net/htmldoc/eval.html#pumvisible\(\)) function that returns whether a code completion popup is visible. It allows, for example:

```
sethandler <A-J> a:vim
sethandler <A-K> a:vim

" Use A-J/K to navigate code completion popups, or clone carets in the editor

map <expr> <A-j> pumvisible() ? '<Action>(EditorDown)' : '<Action>(EditorCloneCaretBelow)'
map <expr> <A-k> pumvisible() ? '<Action>(EditorUp)' : '<Action>(EditorCloneCaretAbove)'

imap <expr> <A-j> pumvisible() ? '<Action>(EditorDown)' : '<Action>(EditorCloneCaretBelow)'
imap <expr> <A-k> pumvisible() ? '<Action>(EditorUp)' : '<Action>(EditorCloneCaretAbove)'

" When pressing '&', accept selected suggestion and follow it with '&&'

imap <expr> & pumvisible() ? '<Action>(EditorChooseLookupItem) && ' : '&'
```
