### PR TITLE
Fix VIM-3819 Arrow keys in macros are broken

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/RegistersCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/RegistersCommandTest.kt
@@ -110,7 +110,7 @@ class RegistersCommandTest : VimTestCase() {
     assertExOutput(
       """
         |Type Name Content
-        |  c  "a   ^IHello World^M^[
+        |  c  "a   ^IHello World^J^[
       """.trimMargin(),
     )
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/register/RegisterMacroTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/register/RegisterMacroTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2003-2025 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.register
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class RegisterMacroTest : VimTestCase() {
+
+  @Test
+  fun `test that macros work correctly with arrows`() {
+    doTest(
+      "qa\$as<esc><down>as<esc>q<down>@a", // Register a macro that adds s at the end of two lines and reruns it
+      """
+        1
+        2
+        3
+        4
+      """.trimMargin(),
+      """
+        1s
+        2s
+        3s
+        4s
+      """.trimMargin()
+    )
+  }
+}


### PR DESCRIPTION
This PR fixes https://youtrack.jetbrains.com/issue/VIM-3819/Arrow-keys-in-macros-are-broken that was caused when the `Register` that was refactored to be immutable in f1f86b5c .

It makes the register based on `KeyStroke` instead of the copied text.
