### PR TITLE
Fix(VIM-2413): correct the range of line-wise case change commands

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/change/ChangeCaseToggleCharacterActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/change/ChangeCaseToggleCharacterActionTest.kt
@@ -320,4 +320,61 @@ class ChangeCaseToggleCharacterActionTest : VimTestCase() {
       enterCommand("set nooldundo")
     }
   }
+
+  @Test
+  fun `test toggle case line caret position`() {
+    configureByText("  Hello ${c}World")
+    typeText("g~~")
+    assertState("  ${c}hELLO wORLD")
+    typeText("u")
+    assertState("  Hello ${c}World")
+
+    typeText("^g~~")
+    assertState("  ${c}hELLO wORLD")
+    typeText("u")
+    assertState("  ${c}Hello World")
+
+    typeText("hg~~")
+    assertState(" $c hELLO wORLD")
+    typeText("u")
+    assertState(" $c Hello World")
+  }
+
+  @Test
+  fun `test uppercase line caret position`() {
+    configureByText("  Hello ${c}World")
+    typeText("gUU")
+    assertState("  ${c}HELLO WORLD")
+    typeText("u")
+    assertState("  Hello ${c}World")
+
+    typeText("^gUU")
+    assertState("  ${c}HELLO WORLD")
+    typeText("u")
+    assertState("  ${c}Hello World")
+
+    typeText("hgUU")
+    assertState(" $c HELLO WORLD")
+    typeText("u")
+    assertState(" $c Hello World")
+  }
+
+  @Test
+  fun `test lowercase line caret position`() {
+    configureByText("  Hello ${c}World")
+    typeText("guu")
+    assertState("  ${c}hello world")
+    typeText("u")
+    assertState("  Hello ${c}World")
+
+    typeText("^guu")
+    assertState("  ${c}hello world")
+    typeText("u")
+    assertState("  ${c}Hello World")
+
+    typeText("hguu")
+    assertState(" $c hello world")
+    typeText("u")
+    assertState(" $c Hello World")
+  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseLowerMotionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseLowerMotionAction.kt
@@ -18,10 +18,13 @@ import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.DuplicableOperatorAction
 import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
 
 @CommandOrMotion(keys = ["gu"], modes = [Mode.NORMAL])
 class ChangeCaseLowerMotionAction : ChangeEditorActionHandler.ForEachCaret(), DuplicableOperatorAction {
+  private val logger = vimLogger<ChangeCaseLowerMotionAction>()
+
   override val type: Command.Type = Command.Type.CHANGE
 
   override val argumentType: Argument.Type = Argument.Type.MOTION
@@ -35,15 +38,18 @@ class ChangeCaseLowerMotionAction : ChangeEditorActionHandler.ForEachCaret(), Du
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    return argument != null &&
-      injector.changeGroup
-        .changeCaseMotion(
-          editor,
-          caret,
-          context,
-          VimChangeGroup.ChangeCaseType.LOWER,
-          argument,
-          operatorArguments,
-        )
+    if (argument == null || argument !is Argument.Motion) {
+      logger.error("Argument is null or not Argument.Motion. argument=$argument")
+      return false
+    }
+
+    return injector.changeGroup.changeCaseMotion(
+        editor,
+        caret,
+        context,
+        VimChangeGroup.ChangeCaseType.LOWER,
+        argument,
+        operatorArguments,
+      )
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseToggleMotionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseToggleMotionAction.kt
@@ -18,10 +18,13 @@ import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.DuplicableOperatorAction
 import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
 
 @CommandOrMotion(keys = ["g~"], modes = [Mode.NORMAL])
 class ChangeCaseToggleMotionAction : ChangeEditorActionHandler.ForEachCaret(), DuplicableOperatorAction {
+  private val logger = vimLogger<ChangeCaseToggleMotionAction>()
+
   override val type: Command.Type = Command.Type.CHANGE
 
   override val argumentType: Argument.Type = Argument.Type.MOTION
@@ -35,15 +38,18 @@ class ChangeCaseToggleMotionAction : ChangeEditorActionHandler.ForEachCaret(), D
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    return argument != null &&
-      injector.changeGroup
-        .changeCaseMotion(
-          editor,
-          caret,
-          context,
-          VimChangeGroup.ChangeCaseType.TOGGLE,
-          argument,
-          operatorArguments,
-        )
+    if (argument == null || argument !is Argument.Motion) {
+      logger.error("Argument is null or not Argument.Motion. argument=$argument")
+      return false
+    }
+
+    return injector.changeGroup.changeCaseMotion(
+        editor,
+        caret,
+        context,
+        VimChangeGroup.ChangeCaseType.TOGGLE,
+        argument,
+        operatorArguments,
+      )
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseUpperMotionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeCaseUpperMotionAction.kt
@@ -18,10 +18,13 @@ import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.DuplicableOperatorAction
 import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
 
 @CommandOrMotion(keys = ["gU"], modes = [Mode.NORMAL])
 class ChangeCaseUpperMotionAction : ChangeEditorActionHandler.ForEachCaret(), DuplicableOperatorAction {
+  private val logger = vimLogger<ChangeCaseUpperMotionAction>()
+
   override val type: Command.Type = Command.Type.CHANGE
 
   override val argumentType: Argument.Type = Argument.Type.MOTION
@@ -35,15 +38,18 @@ class ChangeCaseUpperMotionAction : ChangeEditorActionHandler.ForEachCaret(), Du
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    return argument != null &&
-      injector.changeGroup
-        .changeCaseMotion(
-          editor,
-          caret,
-          context,
-          VimChangeGroup.ChangeCaseType.UPPER,
-          argument,
-          operatorArguments,
-        )
+    if (argument == null || argument !is Argument.Motion) {
+      logger.error("Argument is null or not Argument.Motion. argument=$argument")
+      return false
+    }
+
+    return injector.changeGroup.changeCaseMotion(
+        editor,
+        caret,
+        context,
+        VimChangeGroup.ChangeCaseType.UPPER,
+        argument,
+        operatorArguments,
+      )
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroup.kt
@@ -198,7 +198,7 @@ interface VimChangeGroup {
     caret: VimCaret,
     context: ExecutionContext?,
     type: ChangeCaseType,
-    argument: Argument,
+    argument: Argument.Motion,
     operatorArguments: OperatorArguments,
   ): Boolean
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -1857,16 +1857,11 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     caret: VimCaret,
     context: ExecutionContext?,
     type: VimChangeGroup.ChangeCaseType,
-    argument: Argument,
+    argument: Argument.Motion,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    if (argument !is Argument.Motion) {
-      throw RuntimeException("changeCaseMotion requires a Motion argument, but got $argument")
-    }
-
     var range = injector.motion.getMotionRange(
-      editor, caret, context!!, argument,
-      operatorArguments
+      editor, caret, context!!, argument, operatorArguments
     )
     if (range == null) return false
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
@@ -396,12 +396,11 @@ abstract class VimMotionGroupBase : VimMotionGroup {
     // If we are a linewise motion we need to normalize the start and stop then move the start to the beginning
     // of the line and move the end to the end of the line.
     if (argument.isLinewiseMotion()) {
-      if (caret.getBufferPosition().line != editor.lineCount() - 1) {
-        start = editor.getLineStartForOffset(start)
-        end = min((editor.getLineEndForOffset(end) + 1).toLong(), editor.fileSize()).toInt()
+      start = editor.getLineStartForOffset(start)
+      end = if (caret.getBufferPosition().line != editor.lineCount() - 1) {
+        min((editor.getLineEndForOffset(end) + 1).toLong(), editor.fileSize()).toInt()
       } else {
-        start = editor.getLineStartForOffset(start)
-        end = editor.getLineEndForOffset(end)
+        editor.getLineEndForOffset(end)
       }
     }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/Argument.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/Argument.kt
@@ -53,15 +53,11 @@ sealed class Argument {
 
     fun getMotionType() = if (isLinewiseMotion()) SelectionType.LINE_WISE else SelectionType.CHARACTER_WISE
 
-    fun isLinewiseMotion(): Boolean {
-      return motion.let {
-        when (it) {
-          is TextObjectActionHandler -> it.visualType == TextObjectVisualType.LINE_WISE
-          is MotionActionHandler -> it.motionType == MotionType.LINE_WISE
-          is ExternalActionHandler -> it.isLinewiseMotion
-          else -> error("Command is not a motion: $motion")
-        }
-      }
+    fun isLinewiseMotion(): Boolean = when (motion) {
+      is TextObjectActionHandler -> motion.visualType == TextObjectVisualType.LINE_WISE
+      is MotionActionHandler -> motion.motionType == MotionType.LINE_WISE
+      is ExternalActionHandler -> motion.isLinewiseMotion
+      else -> error("Command is not a motion: $motion")
     }
 
     fun withArgument(argument: Argument) = Motion(motion, argument)


### PR DESCRIPTION
We observed that the start of the range is the leftmost non-whitespace character OR the current position, whichever is closer to the left.