### PR TITLE
Fix(VIM-2375): do not save file with `ZQ`

### DIFF
--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/file/FileCloseAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/file/FileCloseAction.kt
@@ -16,9 +16,9 @@ import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.VimActionHandler
 
-@CommandOrMotion(keys = ["ZZ"], modes = [Mode.NORMAL])
-class FileSaveCloseAction : VimActionHandler.SingleExecution() {
-  override val type: Command.Type = Command.Type.OTHER_WRITABLE
+@CommandOrMotion(keys = ["ZQ"], modes = [Mode.NORMAL])
+class FileCloseAction : VimActionHandler.SingleExecution() {
+  override val type: Command.Type = Command.Type.OTHER_SELF_SYNCHRONIZED
 
   override fun execute(
     editor: VimEditor,
@@ -26,7 +26,6 @@ class FileSaveCloseAction : VimActionHandler.SingleExecution() {
     cmd: Command,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    injector.file.saveFile(editor, context)
     injector.file.closeFile(editor, context)
     return true
   }

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -1211,7 +1211,7 @@
     },
     {
         "keys": "ZQ",
-        "class": "com.maddyhome.idea.vim.action.file.FileSaveCloseAction",
+        "class": "com.maddyhome.idea.vim.action.file.FileCloseAction",
         "modes": "N"
     },
     {


### PR DESCRIPTION
ZQ is defined to `Quit without checking for changes (same as ":q!").`