### PR TITLE
Fix(VIM-3044): correct the behavior of `I` in (linewise) Visual mode

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/visual/IdeaSelectionControl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/visual/IdeaSelectionControl.kt
@@ -134,7 +134,7 @@ internal object IdeaSelectionControl {
       is Mode.VISUAL -> VimPlugin.getVisualMotion().enterVisualMode(editor.vim, mode.selectionType)
       is Mode.SELECT -> VimPlugin.getVisualMotion().enterSelectMode(editor.vim, mode.selectionType)
       is Mode.INSERT -> VimPlugin.getChange()
-        .insertBeforeCursor(editor.vim, injector.executionContextManager.getEditorExecutionContext(editor.vim))
+        .insertBeforeCaret(editor.vim, injector.executionContextManager.getEditorExecutionContext(editor.vim))
 
       is Mode.NORMAL -> Unit
       else -> error("Unexpected mode: $mode")

--- a/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
@@ -61,7 +61,7 @@ class IJEditorFocusListener : EditorListener {
 
     val switchToInsertMode = Runnable {
       val context: ExecutionContext = injector.executionContextManager.getEditorExecutionContext(editor)
-      VimPlugin.getChange().insertBeforeCursor(editor, context)
+      VimPlugin.getChange().insertBeforeCaret(editor, context)
       KeyHandler.getInstance().lastUsedEditorInfo = LastUsedEditorInfo(currentEditorHashCode, true)
     }
     if (isCurrentEditorTerminal && !ijEditor.inInsertMode) {

--- a/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
@@ -163,7 +163,7 @@ internal object IdeaSpecifics {
       ) {
         editor?.let {
           it.vim.mode = Mode.NORMAL()
-          VimPlugin.getChange().insertBeforeCursor(it.vim, event.dataContext.vim)
+          VimPlugin.getChange().insertBeforeCaret(it.vim, event.dataContext.vim)
           KeyHandler.getInstance().reset(it.vim)
         }
       }
@@ -199,7 +199,7 @@ internal object IdeaSpecifics {
           // Enable insert mode if there is no selection in template
           // Template with selection is handled by [com.maddyhome.idea.vim.group.visual.VisualMotionGroup.controlNonVimSelectionChange]
           if (editor.vim.inNormalMode) {
-            VimPlugin.getChange().insertBeforeCursor(
+            VimPlugin.getChange().insertBeforeCaret(
               editor.vim,
               injector.executionContextManager.getEditorExecutionContext(editor.vim),
             )

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/VisualInsertActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/VisualInsertActionTest.kt
@@ -17,7 +17,7 @@ import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.Test
 
-class VisualBlockInsertActionTest : VimTestCase() {
+class VisualInsertActionTest : VimTestCase() {
   // VIM-1379 |CTRL-V| |j| |v_b_I|
   @TestWithoutNeovim(SkipNeovimReason.VISUAL_BLOCK_MODE)
   @Test
@@ -101,28 +101,70 @@ class VisualBlockInsertActionTest : VimTestCase() {
     )
   }
 
-  @TestWithoutNeovim(SkipNeovimReason.VISUAL_BLOCK_MODE)
   @Test
-  fun `test insert in non block mode`() {
-    doTest(
-      listOf("vwIHello<esc>"),
-      """
-                ${c}A Discovery
+  fun `test insert in non-block visual within single line`() {
+    val before = """
+      |  A ${c}Discovery
 
-                ${c}I found it in a legendary land
-                all rocks and ${c}lavender and tufted grass,
-                where it was settled on some sodden sand
-                hard by the torrent of a mountain pass.
-      """.trimIndent(),
-      """
-                Hell${c}oA Discovery
+      |  I ${c}found it in a legendary land
+      |  all rocks and lavender and tufted grass,
+      |  where it was settled on some sodden sand
+      |  hard by the torrent of a mountain pass.
+    """.trimMargin()
+    val after = """
+      |Hell${c}o  A Discovery
 
-                Hell${c}oI found it in a legendary land
-                Hell${c}oall rocks and lavender and tufted grass,
-                where it was settled on some sodden sand
-                hard by the torrent of a mountain pass.
-      """.trimIndent(),
-    )
+      |Hell${c}o  I found it in a legendary land
+      |  all rocks and lavender and tufted grass,
+      |  where it was settled on some sodden sand
+      |  hard by the torrent of a mountain pass.
+    """.trimMargin()
+    doTest(listOf($$"v$IHello<esc>"), before, after)
+    doTest(listOf("VIHello<esc>"), before, after)
+  }
+
+  @Test
+  fun `test insert in non-block visual spanning multiple lines down`() {
+    val before = """
+      |  A ${c}Discovery
+
+      |  I ${c}found it in a legendary land
+      |  all rocks and lavender and tufted grass,
+      |  where it was settled on some sodden sand
+      |  hard by the torrent of a mountain pass.
+    """.trimMargin()
+    val after = """
+      |Hell${c}o  A Discovery
+
+      |Hell${c}o  I found it in a legendary land
+      |  all rocks and lavender and tufted grass,
+      |  where it was settled on some sodden sand
+      |  hard by the torrent of a mountain pass.
+    """.trimMargin()
+    doTest(listOf("vjIHello<esc>"), before, after)
+    doTest(listOf("VjIHello<esc>"), before, after)
+  }
+
+  @Test
+  fun `test insert in non-block visual spanning multiple lines up`() {
+    val before = """
+      |  A Discovery
+
+      |  I found it in a legendary land
+      |  all rocks and lavender and tufted grass${c},
+      |  where it was settled on some sodden sand
+      |  hard ${c}by the torrent of a mountain pass.
+    """.trimMargin()
+    val after = """
+      |  A Discovery
+
+      |  I found it in a legendary landHell${c}o
+      |  all rocks and lavender and tufted grass,
+      |  whereHell${c}o it was settled on some sodden sand
+      |  hard by the torrent of a mountain pass.
+    """.trimMargin()
+    doTest(listOf("vkIHello<esc>"), before, after)
+    doTest(listOf("VkIHello<esc>"), before, after)
   }
 
   @TestWithoutNeovim(SkipNeovimReason.VISUAL_BLOCK_MODE)

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/change/insert/VisualInsertActionJavaTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/change/insert/VisualInsertActionJavaTest.kt
@@ -17,7 +17,7 @@ import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimJavaTestCase
 import org.junit.jupiter.api.Test
 
-class VisualBlockInsertActionJavaTest : VimJavaTestCase() {
+class VisualInsertActionJavaTest : VimJavaTestCase() {
   // VIM-1110 |CTRL-V| |v_b_i| |zc|
   @TestWithoutNeovim(SkipNeovimReason.FOLDING)
   @Test

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAfterCursorAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAfterCursorAction.kt
@@ -27,7 +27,7 @@ class InsertAfterCursorAction : ChangeEditorActionHandler.SingleExecution() {
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    injector.changeGroup.insertAfterCursor(editor, context)
+    injector.changeGroup.insertAfterCaret(editor, context)
     return true
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAtPreviousInsertAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertAtPreviousInsertAction.kt
@@ -47,5 +47,5 @@ private fun insertAtPreviousInsert(editor: VimEditor, context: ExecutionContext)
   if (motion is Motion.AbsoluteOffset) {
     caret.moveToOffset(motion.offset)
   }
-  injector.changeGroup.insertBeforeCursor(editor, context)
+  injector.changeGroup.insertBeforeCaret(editor, context)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBeforeCursorAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBeforeCursorAction.kt
@@ -29,7 +29,7 @@ class InsertBeforeCursorAction : ChangeEditorActionHandler.SingleExecution() {
     argument: Argument?,
     operatorArguments: OperatorArguments,
   ): Boolean {
-    injector.changeGroup.insertBeforeCursor(editor, context)
+    injector.changeGroup.insertBeforeCaret(editor, context)
     return true
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/motion/SelectMotionArrowLeftAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/motion/SelectMotionArrowLeftAction.kt
@@ -48,7 +48,7 @@ class SelectMotionArrowLeftAction : MotionActionHandler.ForEachCaret() {
       editor.exitSelectModeNative(false)
       if (editor.isTemplateActive()) {
         logger.debug("Template is active. Activate insert mode")
-        injector.changeGroup.insertBeforeCursor(editor, context)
+        injector.changeGroup.insertBeforeCaret(editor, context)
         if (caret.offset in startSelection..endSelection) {
           return startSelection.toMotion()
         }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/motion/SelectMotionArrowRightAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/select/motion/SelectMotionArrowRightAction.kt
@@ -48,7 +48,7 @@ class SelectMotionArrowRightAction : MotionActionHandler.ForEachCaret() {
       editor.exitSelectModeNative(false)
       if (editor.isTemplateActive()) {
         logger.debug("Template is active. Activate insert mode")
-        injector.changeGroup.insertBeforeCursor(editor, context)
+        injector.changeGroup.insertBeforeCaret(editor, context)
         if (caret.offset in startSelection..endSelection) {
           return endSelection.toMotion()
         }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroup.kt
@@ -23,13 +23,13 @@ import javax.swing.KeyStroke
 interface VimChangeGroup {
   fun setInsertRepeat(lines: Int, column: Int, append: Boolean)
 
-  fun insertBeforeCursor(editor: VimEditor, context: ExecutionContext)
+  fun insertBeforeCaret(editor: VimEditor, context: ExecutionContext)
 
   fun insertBeforeFirstNonBlank(editor: VimEditor, context: ExecutionContext)
 
   fun insertLineStart(editor: VimEditor, context: ExecutionContext)
 
-  fun insertAfterCursor(editor: VimEditor, context: ExecutionContext)
+  fun insertAfterCaret(editor: VimEditor, context: ExecutionContext)
 
   fun insertAfterLineEnd(editor: VimEditor, context: ExecutionContext)
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -391,7 +391,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
    * @param editor  The editor to insert into
    * @param context The data context
    */
-  override fun insertBeforeCursor(editor: VimEditor, context: ExecutionContext) {
+  override fun insertBeforeCaret(editor: VimEditor, context: ExecutionContext) {
     initInsert(editor, context, Mode.INSERT)
   }
 
@@ -407,7 +407,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
    * @param editor  The editor to insert into
    * @param context The data context
    */
-  override fun insertAfterCursor(editor: VimEditor, context: ExecutionContext) {
+  override fun insertAfterCaret(editor: VimEditor, context: ExecutionContext) {
     for (caret in editor.nativeCarets()) {
       caret.moveToMotion(injector.motion.getHorizontalMotion(editor, caret, 1, true))
     }
@@ -771,7 +771,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
         lambdaEditor.exitSelectModeNative(false)
         KeyHandler.getInstance().reset(lambdaEditor)
         if (isPrintableChar(key.keyChar) || activeTemplateWithLeftRightMotion(lambdaEditor, key)) {
-          injector.changeGroup.insertBeforeCursor(lambdaEditor, lambdaContext)
+          injector.changeGroup.insertBeforeCaret(lambdaEditor, lambdaContext)
         }
       }
     }
@@ -1292,7 +1292,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
       if (type === SelectionType.LINE_WISE) {
         // Please don't use `getDocument().getText().isEmpty()` because it converts CharSequence into String
         if (editor.fileSize() == 0L) {
-          insertBeforeCursor(editor, context)
+          insertBeforeCaret(editor, context)
         } else if (after && !editor.endsWithNewLine()) {
           insertNewLineBelow(editor, updatedCaret, lp.column)
         } else {
@@ -1305,7 +1305,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
         editor.vimChangeActionSwitchMode = Mode.INSERT
       }
     } else {
-      insertBeforeCursor(editor, context)
+      insertBeforeCaret(editor, context)
     }
     return true
   }
@@ -2030,7 +2030,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
       caret.moveToInlayAwareOffset(editor.bufferPositionToOffset(BufferPosition(line, column)))
       setInsertRepeat(lines, column, append)
     }
-    insertBeforeCursor(editor, context)
+    insertBeforeCaret(editor, context)
     return true
   }
 

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -1106,7 +1106,7 @@
     },
     {
         "keys": "I",
-        "class": "com.maddyhome.idea.vim.action.change.insert.VisualBlockInsertAction",
+        "class": "com.maddyhome.idea.vim.action.change.insert.VisualInsertAction",
         "modes": "X"
     },
     {


### PR DESCRIPTION
The bahavior seems undocumented. Based on my observation in Vim:

- For visual selections spanning multiple lines, keep caret position if it's on the first line.
- Otherwise move the caret to the start of the first selected line.
