### PR TITLE
Fix(VIM-3266): Set `FileSaveCloseAction` to `OTHER_SELF_SYNCHRONIZED`

### DIFF
--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/file/FileSaveCloseAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/file/FileSaveCloseAction.kt
@@ -18,7 +18,7 @@ import com.maddyhome.idea.vim.handler.VimActionHandler
 
 @CommandOrMotion(keys = ["ZZ"], modes = [Mode.NORMAL])
 class FileSaveCloseAction : VimActionHandler.SingleExecution() {
-  override val type: Command.Type = Command.Type.OTHER_WRITABLE
+  override val type: Command.Type = Command.Type.OTHER_SELF_SYNCHRONIZED
 
   override fun execute(
     editor: VimEditor,


### PR DESCRIPTION
As discussed in <https://github.com/JetBrains/ideavim/pull/1227#discussion_r2182963443>.