### PR TITLE
Fix issues with new islands theme

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ExOutputPanel.java
@@ -13,6 +13,9 @@ import com.intellij.ide.ui.LafManagerListener;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.impl.IdeBackgroundUtil;
+import com.intellij.ui.ClientProperty;
+import com.intellij.ui.components.JBPanel;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.IJSwingUtilities;
 import com.maddyhome.idea.vim.KeyHandler;
@@ -44,7 +47,7 @@ import static com.maddyhome.idea.vim.api.VimInjectorKt.injector;
 /**
  * This panel displays text in a <code>more</code> like window.
  */
-public class ExOutputPanel extends JPanel {
+public class ExOutputPanel extends JBPanel<ExOutputPanel> {
   private final @NotNull Editor myEditor;
 
   public final @NotNull JLabel myLabel = new JLabel("more");
@@ -86,6 +89,11 @@ public class ExOutputPanel extends JPanel {
     MoreKeyListener moreKeyListener = new MoreKeyListener(this);
     addKeyListener(moreKeyListener);
     myText.addKeyListener(moreKeyListener);
+
+    // Suppress the fancy frame background used in the Islands theme, which comes from a custom Graphics implementation
+    // applied to the IdeRoot, and used to paint all children, including this panel. This client property is checked by
+    // JBPanel.getComponentGraphics to give us the original Graphics, opting out of the fancy painting.
+    ClientProperty.putRecursive(this, IdeBackgroundUtil.NO_BACKGROUND, true);
 
     updateUI();
   }

--- a/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/VimModeWidget.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/VimModeWidget.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.CustomStatusBarWidget
 import com.intellij.openapi.wm.StatusBarWidgetFactory
 import com.intellij.openapi.wm.WindowManager
+import com.intellij.openapi.wm.impl.IdeBackgroundUtil
 import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.ui.components.JBLabel
@@ -24,6 +25,7 @@ import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import java.awt.Dimension
+import java.awt.Graphics
 import java.awt.Point
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
@@ -181,6 +183,14 @@ class VimModeWidget(val project: Project) : CustomStatusBarWidget, VimStatusBarW
     override fun getMaximumSize(): Dimension {
       val maximumSize = super.getMaximumSize()
       return Dimension(max(maximumSize.width, wordWidth + insets.width), maximumSize.height)
+    }
+
+    override fun getComponentGraphics(g: Graphics): Graphics {
+      // Opt out of the fancy frame background painting that is part of the Islands theme. This is implemented with a
+      // custom Graphics implementation that paints the nice background _after_ invoking any fill-like paint request
+      // (fillRect, etc.) Since we're part of the frame, we get the modified Graphics. Get the original Graphics so our
+      // background isn't overwritten.
+      return IdeBackgroundUtil.getOriginalGraphics(g)
     }
   }
 }


### PR DESCRIPTION
The [recent UI refresh](https://blog.jetbrains.com/platform/2025/06/testing-a-fresh-look-for-jetbrains-ides/) draws the IDE frame with a nice gradient fill. Any buttons drawn on the frame, like the main toolbar, or the tool window "strips" are drawn as though their background is transparent, while the opaque tool windows and editor look like "islands" on the frame.

This breaks the colour highlighting of the mode status bar widget, so it no longer shows a different colour per mode, only the new gradient fill. The implementation also affects the output panel (because it's drawn with `IdeRoot` too), so the output of e.g. `:map` is also drawn with a gradient background.

The implementation of islands is done by wrapping the `Graphics` instance used to draw the `IdeRoot`, including all of its children. This wrapped `Graphics` object will draw the fancy background whenever it's asked invoked for a fill-like command.

There are several ways to avoid this. If there's a `JBPanel` instance in the parent hierarchy, the `IdeBackgroundUtil.NO_BACKGROUND` client property will opt out a component and its children. This is because `JBPanel.getComponentGraphics` is set up to either return a wrapped `Graphics` or check for the property and return the original instance. Alternatively, the `IdeBackgroundUtil.getOriginalGraphics` will unwrap the `Graphics` instance if it's wrapped. Both approaches are used here to make the output panel and status bar widget work.

This has been tested with islands enabled in 2025.2, and with the current 2025.1.

Interestingly, `ExEntryPanel` is implemented in essentially the same way as `ExOutputPanel`, so one would expect this to also be broken. However, it works just fine. I'm not entirely sure why. I _think_ it's because it sets the panel's parent to the editor component, and the editor has already opted out of the new frame background.