### PR TITLE
Handle `:k{mark}` without separating whitespace

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MarkCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MarkCommandTest.kt
@@ -70,6 +70,23 @@ class MarkCommandTest : VimTestCase() {
   }
 
   @Test
+  fun `test k mark with no whitespace`() {
+    configureByText(
+      """Lorem ipsum dolor sit amet,
+                         |consectetur adipiscing elit
+                         |where it$c was settled on some sodden sand
+                         |Cras id tellus in ex imperdiet egestas.
+      """.trimMargin(),
+    )
+    typeText(commandToKeys("ka"))
+    val vimEditor = fixture.editor.vim
+    injector.markService.getMark(vimEditor.primaryCaret(), 'a')?.let {
+      kotlin.test.assertEquals(2, it.line)
+      kotlin.test.assertEquals(0, it.col)
+    } ?: fail("Mark is null")
+  }
+
+  @Test
   fun `test mark in range`() {
     configureByText(
       """Lorem ipsum dolor sit amet,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/parser/visitors/CommandVisitor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/parser/visitors/CommandVisitor.kt
@@ -279,25 +279,6 @@ object CommandVisitor : VimscriptBaseVisitor<Command>() {
     val modifier = if (ctx.bangModifier == null) CommandModifier.NONE else CommandModifier.BANG
     val argument = ctx.commandArgumentWithBars()?.text ?: ""
 
-    val alphabeticPart = name.split(Regex("\\P{Alpha}"))[0]
-    if (setOf(
-        "s",
-        "su",
-        "sub",
-        "subs",
-        "subst",
-        "substi",
-        "substit",
-        "substitu",
-        "substitut",
-        "substitut",
-        "substitute"
-      ).contains(alphabeticPart)
-    ) {
-      val command = SubstituteCommand(range, name.replaceFirst(alphabeticPart, "") + argument, alphabeticPart)
-      command.rangeInScript = ctx.getTextRange()
-      return command
-    }
     val commandConstructor = getCommandByName(name).constructors
       .filter { it.parameters.size == 3 }
       .firstOrNull {


### PR DESCRIPTION
Vim allows `:k{mark}` to set a mark without requiring whitespace between the command `k` and the mark. While IdeaVim supports optional whitespace between a command and its argument, the catch-all "other" parser rule is greedier than the "command with comment" rule, and something like `:ka` is matched as an "other" command. This PR adds special handling for this case.

Fixes [VIM-3915](https://youtrack.jetbrains.com/issue/VIM-3915/k-shorter-mark-is-missing)