### PR TITLE
Fix initialising non-default colorcolumn option

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/OptionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/OptionGroup.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.editor.ScrollPositionCalculator
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.ex.EditorSettingsExternalizable
 import com.intellij.openapi.editor.impl.softwrap.SoftWrapAppliancePlaces
+import com.intellij.openapi.editor.textarea.TextComponentEditor
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.impl.LoadTextUtil
 import com.intellij.openapi.fileEditor.impl.text.TextEditorImpl
@@ -490,6 +491,14 @@ private class ColorColumnOptionValueProvider(private val colorColumnOption: Stri
     // If isRightMarginShown is disabled, then we don't show any visual guides, including the right margin
     if (!editor.ij.settings.isRightMarginShown) {
       return VimString.EMPTY
+    }
+
+    // The fallback editor always has an uninitialised value for softMargins, rather than falling back to the global
+    // default. If the global value has been set, the empty value looks like it's been set and we treat it as External.
+    // By returning the global value, we treat it as Default, so we don't reset the value when initialising a new
+    // window/editor's options
+    if (editor.ij is TextComponentEditor) {
+      return getGlobalExternalValue(editor)
     }
 
     val softMargins = editor.ij.settings.softMargins


### PR DESCRIPTION
When initialising a new window, we copy options from the current window. Because there might not be an initial window when loading options from `~/.ideavimrc`, we initialise a hidden "fallback" window. This isn't a real IntelliJ `Editor`, and so it's local settings for "visual guides" is hard coded as an empty list. If there is a global value set in the IDE, this empty list looks like we've edited it, and this value gets copied to any new window, and hides the visual guides there. This fix will return the global value for the fallback window, and since the local value matches the global value, it's treated as default and doesn't update the new window.

Fixes [VIM-3984](https://youtrack.jetbrains.com/issue/VIM-3984/The-IDE-shows-visual-guides-incorrectly-with-IdeaVim-enabled)