### PR TITLE
Fix Gradle build deprecation warnings and improve type safety

### DIFF
--- a/tests/java-tests/build.gradle.kts
+++ b/tests/java-tests/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
       useInstaller = false
     }
 
-    create(ideaType, ideaVersion, useInstaller)
+    create(ideaType, ideaVersion) { this.useInstaller = useInstaller }
     testFramework(TestFrameworkType.Platform)
     testFramework(TestFrameworkType.JUnit5)
     bundledPlugins("com.intellij.java", "org.jetbrains.plugins.yaml")

--- a/tests/long-running-tests/build.gradle.kts
+++ b/tests/long-running-tests/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#target-versions-installers
     val useInstaller = "EAP-SNAPSHOT" !in ideaVersion
 
-    create(ideaType, ideaVersion, false)
+    create(ideaType, ideaVersion) { this.useInstaller = false }
     testFramework(TestFrameworkType.Platform)
     testFramework(TestFrameworkType.JUnit5)
   }


### PR DESCRIPTION
## Changes
- Replace deprecated java.net.URL and HttpURLConnection with Ktor HttpClient in slackNotification task
- Fix deprecated intellijPlatform API calls:
  - create(ideaType, ideaVersion, useInstaller) → create(ideaType, ideaVersion) { this.useInstaller = useInstaller }
  - verifyPlugin → pluginVerification
- Add explicit Task type parameters to all tasks.register() calls to resolve Kotlin type inference warnings

## Background
First of all, thank you for creating IdeaVim - I use it extensively and it's been incredibly helpful in my daily workflow.

When I forked the repository and attempted to build it, I noticed numerous deprecation warnings and type interface warnings in the build process. I took the initiative to address these issues to help improve the overall code quality and reduce build noise.

After reading the CONTRIBUTING.md guide, I realized there might be some confusion on my part regarding whether I should have created a discussion or filed an issue before starting this work. I decided to go ahead and submit this PR directly, but I apologize if I didn't follow the proper protocol. Please let me know if there's a preferred process I should have followed for this type of maintenance work.

I hope these changes are helpful. This is my first contribution, so any feedback would be appreciated!