### PR TITLE
Improve compatibility with Next Edit Suggestions

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -35,11 +35,9 @@ import com.maddyhome.idea.vim.handler.enableOctopus
 import com.maddyhome.idea.vim.handler.isOctopusEnabled
 import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.HandlerInjector
-import com.maddyhome.idea.vim.helper.inInsertMode
 import com.maddyhome.idea.vim.helper.inNormalMode
 import com.maddyhome.idea.vim.helper.isIdeaVimDisabledHere
 import com.maddyhome.idea.vim.helper.isPrimaryEditor
-import com.maddyhome.idea.vim.helper.isTemplateActive
 import com.maddyhome.idea.vim.helper.updateCaretsVisualAttributes
 import com.maddyhome.idea.vim.key.ShortcutOwner
 import com.maddyhome.idea.vim.key.ShortcutOwnerInfo
@@ -172,29 +170,6 @@ internal class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatib
         ActionEnableStatus.yes("Is enabled for Esc", LogLevel.INFO)
       } else {
         ActionEnableStatus.no("Is disabled for Esc", LogLevel.INFO)
-      }
-    }
-
-    if (keyCode == KeyEvent.VK_TAB && editor.isTemplateActive()) {
-      return ActionEnableStatus.no("The key is tab and the template is active", LogLevel.INFO)
-    }
-
-    if (editor.inInsertMode) {
-      if (keyCode == KeyEvent.VK_TAB) {
-        // TODO: This stops VimEditorTab seeing <Tab> in insert mode and correctly scrolling the view
-        // There are multiple actions registered for VK_TAB. The important items, in order, are this, the Live
-        // Templates action and TabAction. Returning false in insert mode means that the Live Template action gets to
-        // execute, and this allows Emmet to work (VIM-674). But it also means that the VimEditorTab handle is never
-        // called, so we can't scroll the caret into view correctly.
-        // If we do return true, VimEditorTab handles the Vim side of things and then invokes
-        // IdeActions.ACTION_EDITOR_TAB, which inserts the tab. It also bypasses the Live Template action, and Emmet
-        // no longer works.
-        // This flag is used when recording text entry/keystrokes for repeated insertion. Because we return false and
-        // don't execute the VimEditorTab handler, we don't record tab as an action. Instead, we see an incoming text
-        // change of multiple whitespace characters, which is normally ignored because it's auto-indent content from
-        // hitting <Enter>. When this flag is set, we record the whitespace as the output of the <Tab>
-        VimPlugin.getChange().tabAction = true
-        return ActionEnableStatus.no("Tab action in insert mode", LogLevel.INFO)
       }
     }
 

--- a/src/main/java/com/maddyhome/idea/vim/helper/IjActionExecutor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/IjActionExecutor.kt
@@ -150,8 +150,7 @@ internal class IjActionExecutor : VimActionExecutor {
   }
 
   override fun executeEsc(editor: VimEditor, context: ExecutionContext): Boolean {
-    executeAction(editor, IdeActions.ACTION_EDITOR_ESCAPE, context)
-    return true
+    return executeAction(editor, IdeActions.ACTION_EDITOR_ESCAPE, context)
   }
 
   override fun executeVimAction(

--- a/src/main/java/com/maddyhome/idea/vim/key/VimActionsPromoter.kt
+++ b/src/main/java/com/maddyhome/idea/vim/key/VimActionsPromoter.kt
@@ -12,6 +12,7 @@ import com.intellij.codeInsight.template.impl.editorActions.ExpandLiveTemplateBy
 import com.intellij.openapi.actionSystem.ActionPromoter
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionWrapper
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import com.intellij.openapi.editor.actions.TabAction
@@ -19,7 +20,6 @@ import com.maddyhome.idea.vim.action.VimShortcutKeyAction
 import com.maddyhome.idea.vim.helper.isIdeaVimDisabledHere
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.state.mode.Mode
-import org.jetbrains.plugins.terminal.block.util.TerminalDataContextUtils.editor
 
 /**
  * Provides ordering and prioritisation for actions mapped to Vim shortcuts
@@ -55,7 +55,7 @@ internal class VimActionsPromoter : ActionPromoter {
 
     val tabIndex = actions.indexOfFirst { it is TabAction }
     if (tabIndex != -1) {
-      val editor = context.editor ?: return null
+      val editor = CommonDataKeys.EDITOR.getData(context) ?: return null
       if (editor.isIdeaVimDisabledHere) return null
       val mode = editor.vim.mode
       val vimAction = actions[vimIndex]

--- a/src/main/java/com/maddyhome/idea/vim/key/VimActionsPromoter.kt
+++ b/src/main/java/com/maddyhome/idea/vim/key/VimActionsPromoter.kt
@@ -8,17 +8,81 @@
 
 package com.maddyhome.idea.vim.key
 
+import com.intellij.codeInsight.template.impl.editorActions.ExpandLiveTemplateByTabAction
 import com.intellij.openapi.actionSystem.ActionPromoter
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionWrapper
 import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import com.intellij.openapi.editor.actions.TabAction
 import com.maddyhome.idea.vim.action.VimShortcutKeyAction
+import com.maddyhome.idea.vim.helper.isIdeaVimDisabledHere
+import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.state.mode.Mode
+import org.jetbrains.plugins.terminal.block.util.TerminalDataContextUtils.editor
 
-// VIM-2218
+/**
+ * Provides ordering and prioritisation for actions mapped to Vim shortcuts
+ *
+ * We register [VimShortcutKeyAction] for any modifier-based shortcuts used in Vim mappings (e.g. `<C-V>` but not `V`).
+ * If the IDE has multiple actions registered for the same shortcut, we typically want to promote [VimShortcutKeyAction]
+ * so that it takes precedence over IDE actions. The action can also decide to disable itself, for example if the user
+ * has chosen to use the IDE action instead of Vim, and then the next action in the now ordered list will be invoked.
+ * This promoter is registered as "last", so we have a good chance or ensuring that our action is head of the list.
+ *
+ * This usually works fine (see VIM-2218) but things are a little more complex with Enter, Escape and Tab, which often
+ * have multiple contextual actions, such as Escape removing Find Usage highlights as well as changing Vim mode.
+ * Fortunately, actions for Escape and Enter are mostly implemented as [EditorActionHandler] instances, and IdeaVim can
+ * control the order of IdeaVim's implementation in the `plugin.xml` registration.
+ *
+ * Tab doesn't seem to use the [EditorActionHandler] route, for some reason, and instead has multiple actions registered
+ * to the `Tab` shortcut, such as expanding Live Templates (and Emmet patterns, see VIM-674). If we put
+ * [VimShortcutKeyAction] before these actions, then we don't get these contextual actions. So we make sure to order
+ * the list of actions such that [VimShortcutKeyAction] is after everything apart from [TabAction], which is responsible
+ * for inserting the tab character.
+ *
+ * Most of the contextual actions are safe to call in all modes, apart from expanding Live Templates. This should only
+ * be called in Insert/Select mode. We don't want to be modifying the document in Normal mode, unless the action is in
+ * response to a visible prompt.
+ *
+ * We also need to make sure that we don't call [VimShortcutKeyAction] if the editor is in Insert mode, as it would
+ * interfere with the normal behavior of the Tab key. The exception is if the user has remapped `Tab`.
+ */
 internal class VimActionsPromoter : ActionPromoter {
-  override fun promote(actions: MutableList<out AnAction>, context: DataContext): List<AnAction> {
-    return actions.filter {
-      it is AnActionWrapper && it.delegate is VimShortcutKeyAction
+  override fun promote(actions: List<AnAction>, context: DataContext): List<AnAction>? {
+    val vimIndex = actions.indexOfFirst { it is AnActionWrapper && it.delegate is VimShortcutKeyAction }
+    if (vimIndex == -1) return null
+
+    val tabIndex = actions.indexOfFirst { it is TabAction }
+    if (tabIndex != -1) {
+      val editor = context.editor ?: return null
+      if (editor.isIdeaVimDisabledHere) return null
+      val mode = editor.vim.mode
+      val vimAction = actions[vimIndex]
+
+      val ordered = mutableListOf<AnAction>()
+      actions.forEach {
+        // Don't add VimShortcutKeyAction, yet
+        if (it == vimAction) {
+          return@forEach
+        }
+
+        // Add VimShortcutKeyAction just before TabAction.
+        // TODO: We shouldn't add VimShortcutKeyAction for Tab in Insert mode
+        // The action has a check for this and disables itself. This means we can't remap i_Tab
+        if (it is TabAction) {
+          ordered.add(vimAction)
+        }
+
+        ordered.add(it)
+      }
+
+      // Returns all actions, in the order we've added them
+      return ordered
+    }
+    else {
+      // Return the action we want to promote
+      return listOf(actions[vimIndex])
     }
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/key/VimActionsPromoter.kt
+++ b/src/main/java/com/maddyhome/idea/vim/key/VimActionsPromoter.kt
@@ -74,6 +74,13 @@ internal class VimActionsPromoter : ActionPromoter {
           ordered.add(vimAction)
         }
 
+        // Unless we're in some kind of editable mode, don't allow ExpandLiveTemplateByTabAction. We don't want to
+        // invoke an action that will edit text while we're in e.g., Normal. This isn't a hard and fast rule - we don't
+        // remove InsertInlineCompletionAction or Next Edit Suggestions. These are ok because there are visible prompts,
+        // so modifying text in Normal is expected.
+        if (it is ExpandLiveTemplateByTabAction && mode != Mode.INSERT && mode != Mode.REPLACE && mode !is Mode.SELECT) {
+          return@forEach
+        }
         ordered.add(it)
       }
 

--- a/src/main/java/com/maddyhome/idea/vim/key/VimActionsPromoter.kt
+++ b/src/main/java/com/maddyhome/idea/vim/key/VimActionsPromoter.kt
@@ -67,9 +67,7 @@ internal class VimActionsPromoter : ActionPromoter {
           return@forEach
         }
 
-        // Add VimShortcutKeyAction just before TabAction.
-        // TODO: We shouldn't add VimShortcutKeyAction for Tab in Insert mode
-        // The action has a check for this and disables itself. This means we can't remap i_Tab
+        // Add VimShortcutKeyAction just before TabAction, and after all of the contextual actions
         if (it is TabAction) {
           ordered.add(vimAction)
         }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MapCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MapCommandTest.kt
@@ -1230,4 +1230,39 @@ class MapCommandTest : VimTestCase() {
       enterCommand("imap b test    ")
     }
   }
+
+  @Test
+  fun `test map Tab in Normal mode`() {
+    doTest(
+      listOf("<Tab>"),
+      "",
+      "hello",
+    ) {
+      enterCommand("nmap <Tab> ihello<Esc>")
+    }
+  }
+
+  @TestFor(issues = ["VIM-2331"])
+  @Test
+  fun `test map Tab in Insert mode`() {
+    doTest(
+      listOf("i", "<Tab>", "<Esc>"),
+      "",
+      "hello",
+    ) {
+      enterCommand("imap <Tab> hello")
+    }
+  }
+
+  @TestFor(issues = ["https://github.com/JetBrains/ideavim/discussions/938"])
+  @Test
+  fun `test map Shift+Tab`() {
+    doTest(
+      listOf("i", "<S-Tab>", "<Esc>"),
+      "",
+      "hello",
+    ) {
+      enterCommand("imap <S-Tab> hello")
+    }
+  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -69,9 +69,6 @@ abstract class VimChangeGroupBase : VimChangeGroup {
   @JvmField
   protected var oldOffset: Int = -1
 
-  // Workaround for VIM-1546. Another solution is highly appreciated.
-  var tabAction: Boolean = false
-
   @JvmField
   protected var vimDocumentListener: ChangesListener? = null
 
@@ -350,10 +347,9 @@ abstract class VimChangeGroupBase : VimChangeGroup {
       }
 
       // Ignore multi-character indents as they should be inserted automatically while repeating <Enter> actions
-      if (!tabAction && newFragmentLength > 1 && newFragment.trim { it <= ' ' }.isEmpty()) {
+      if (newFragmentLength > 1 && newFragment.trim { it <= ' ' }.isEmpty()) {
         return
       }
-      tabAction = false
       strokes.addAll(getAdjustCaretActions(change))
       if (oldFragmentLength > 0) {
         val editorDelete = injector.nativeActionManager.deleteAction

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
@@ -56,7 +56,7 @@ class CommandBuilder private constructor(
   val isEmpty
     get() = commandState == CurrentCommandState.NEW_COMMAND
       && selectedRegister == null
-      && counts.size == 1
+      && counts.size == 1 && counts[0] == 0
       && action == null
       && argument == null
       && fallbackArgumentType == null

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/EditorResetConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/EditorResetConsumer.kt
@@ -89,5 +89,17 @@ internal class EditorResetConsumer : KeyConsumer {
       }
     }
     KeyHandler.getInstance().reset(keyState, editor.mode)
+
+    // Make sure the caret attributes are up to date. If we've just changed the mode, then they will be. But if someone
+    // has changed the caret while we weren't expecting, then this will at least sync the caret when hitting Escape.
+    // This is a small workaround for an issue in the initial implementation of Next Edit Suggestions. It changes the
+    // caret colour when it has a suggestion, capturing the original caret attributes when it does so. When it resets,
+    // it restores the cached attributes. Unfortunately, we might easily have changed mode between times. I've seen it
+    // happen where NES manages to capture the Op-pending heavy underscore caret attributes, and it's very confusing
+    // when they're restored (LLM-19241).
+    // Ideally, NES would modify the current caret attributes' colour, rather than recreate and/or cache. If this
+    // doesn't get fixed by NES, we could reset caret attributes after every command, which should reduce how long the
+    // incorrect caret is shown.
+    injector.editorGroup.updateCaretsVisualAttributes(editor)
   }
 }


### PR DESCRIPTION
This PR fixes a number of compatibility issues with Next Edit Suggestions (AI generated related edits) - see [VIM-4010](https://youtrack.jetbrains.com/issue/VIM-4010). Specifically, `Tab` is now supported in Normal mode to review and accept the suggestions and the purple caret colour used to indicate a suggestion is available is maintained when IdeaVim changes mode. (The NES implementation has some issues with maintaining the current caret shape and overwriting the last shape when resetting - see [LLM-19241](https://youtrack.jetbrains.com/issue/LLM-19241/Maintain-custom-caret-shapes-IdeaVim))

In more detail: this PR changes the way `Tab` is handled in the IdeaVim pipeline. `Tab` is very similar to `Escape` and `Enter` in that it can have multiple contextual actions. E.g. `Escape` can clear highlights, dismiss hints and change Vim mode, while `Tab` can expand live templates, indent selected code, move to next parameter while the parameter hint is visible, etc. `Escape` and `Enter` are implemented as `EditorActionHandler` instances, which has ordering as part of registration. For whatever reason, `Tab` isn't handled like this and has multiple action instances all registered with `Tab`.

To ensure that IdeaVim works with multiple action instances with the same registered keys, we have an `ActionPromoter` that will promote our `VimShortcutKeyAction` to the head of the list of actions to be invoked. This promoter is registered as `"last"` so we can be pretty confident that our action will always be invoked first. This action can choose to be not-enabled under certain circumstances, which is how we implement shortcuts being handled by IDE or Vim.

However, by promoting the action to the head of the list for `Tab`, we ignore the other contextual actions such as expanding Live Templates (and Emmet - see [VIM-674](https://youtrack.jetbrains.com/issue/VIM-674)). So the `VimShortcutKeyAction` will mark itself as not-enabled when `Tab` is used in Insert mode. The next actions in the action list are invoked and Live Templates and Emmet work as expected, and the default `TabAction` at the end of the list inserts the tab character. This has a side effect that `Tab` cannot be remapped in Insert mode ([VIM-2331](https://youtrack.jetbrains.com/issue/VIM-2331)). And `Tab` is handled by IdeaVim in Normal and other modes, so NES doesn't work.

This PR makes the following changes:
* Changes the promoter to always put our action at the head of the list of actions, unless the list of actions contains `TabAction`. In this case, put our action lower down the list, but before `TabAction`. This means that all contextual actions will be tried before the Vim shortcuts are handled.
* Remove the `ExpandLineTemplatesByTabAction` handler when not in Insert, Select or Replace mode. This means that `Tab` will not expand a Live Template when IdeaVim is not in an editable mode - we don't insert if we're not in an insert mode. Note that NES and inline LLM completion will still insert in Normal mode, but this is responding to an on-screen prompt, so it's more intuitive.
* Remove the check for `Tab` in `VimShortcutKeyAction.update`. The Vim action will always handle `Tab`. The contextual actions will already have had their chance, and if it reaches IdeaVim, then `Tab` in Normal mode will move around the jump list, and Insert will invoke the `"EditorTab"` action to insert the tab character, which is the same as the `TabAction` in the action list.
* This change allows mapping `Tab` in Insert mode, as well as mapping `<S-Tab>`
* When changing the caret visual attributes, the current colour is checked. If it's been changed, we use it.
* Reset caret shape whenever IdeaVim handles `Escape`, and not just when changing mode. Gives the user a way to reset caret shape if it gets out of sync (e.g. NES using an out of date cached value)

This PR fixes:
* [VIM-4010](https://youtrack.jetbrains.com/issue/VIM-4010) Does not play well with "Next edit suggestions" (mostly)
* [VIM-2331](https://youtrack.jetbrains.com/issue/VIM-2331) Can't remap Tab key in insert mode (see also [JetBrains/ideavim#280](https://github.com/JetBrains/ideavim/pull/280) and [JetBrains/ideavim#938](https://github.com/JetBrains/ideavim/discussions/938))
* [VIM-3455](https://youtrack.jetbrains.com/issue/VIM-3455) Current caret color are being overwritten which resets the current caret color to the editor default