### PR TITLE
Extend NERDTree support to Tree components other than Project

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTree.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTree.kt
@@ -21,7 +21,6 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.wm.ToolWindowId
 import com.intellij.openapi.wm.ex.ToolWindowManagerEx
-import com.intellij.ui.treeStructure.Tree
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.common.CommandAliasHandler
@@ -34,7 +33,6 @@ import com.maddyhome.idea.vim.key.MappingOwner
 import com.maddyhome.idea.vim.key.RequiredShortcut
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.newapi.vim
-import java.awt.KeyboardFocusManager
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import javax.swing.SwingConstants
 import kotlin.concurrent.read
@@ -113,23 +111,6 @@ internal class NerdTree : VimExtension {
       VimExtensionFacade.addCommand("NERDTreeClose", CloseHandler())
       VimExtensionFacade.addCommand("NERDTreeFind", IjCommandHandler("SelectInProjectView"))
       VimExtensionFacade.addCommand("NERDTreeRefreshRoot", IjCommandHandler("Synchronize"))
-
-      // NERDTree Everywhere
-      KeyboardFocusManager.getCurrentKeyboardFocusManager().addPropertyChangeListener("focusOwner") {
-        val newFocusOwner = it.newValue
-        val oldFocusOwner = it.oldValue
-        val dispatcher = service<NerdTreeEverywhere.Dispatcher>()
-        if (newFocusOwner is Tree) {
-          val shortcuts =
-            NerdTreeEverywhere.mappings.keyStrokes.map { RequiredShortcut(it, MappingOwner.Plugin.get(PLUGIN_NAME)) }
-          // It's okay to have `register` called multiple times, as its internal implementation prevents duplicate registrations
-          dispatcher.registerCustomShortcutSet(KeyGroup.toShortcutSet(shortcuts), newFocusOwner)
-        }
-        // Note that we do not have to unregister the shortcut in fact
-        if (oldFocusOwner is Tree) {
-          dispatcher.unregisterCustomShortcutSet(oldFocusOwner)
-        }
-      }
     }
     ProjectManager.getInstance().openProjects.forEach(::installDispatcher)
   }

--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTreeEverywhere.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTreeEverywhere.kt
@@ -9,11 +9,48 @@
 package com.maddyhome.idea.vim.extension.nerdtree
 
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.ui.treeStructure.Tree
+import com.maddyhome.idea.vim.extension.VimExtension
+import com.maddyhome.idea.vim.group.KeyGroup
+import com.maddyhome.idea.vim.key.MappingOwner
+import com.maddyhome.idea.vim.key.RequiredShortcut
+import java.awt.KeyboardFocusManager
 import java.awt.event.ActionEvent
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
-internal class NerdTreeEverywhere {
+/**
+ * This plugin extends NERDTree support to components other than the Project Tool Window.
+ *
+ * TODO:
+ * It should be considered a "sub-plugin" of NERDTree and cannot be enabled independently,
+ * i.e., should not function after the NERDTree plugin is turned off.
+ */
+internal class NerdTreeEverywhere : VimExtension {
+  companion object {
+    const val PLUGIN_NAME = "NERDTreeEverywhere" // This is a temporary name
+  }
+
+  override fun getName() = PLUGIN_NAME
+
+  override fun init() {
+    KeyboardFocusManager.getCurrentKeyboardFocusManager().addPropertyChangeListener("focusOwner") {
+      val newFocusOwner = it.newValue
+      val oldFocusOwner = it.oldValue
+      val dispatcher = service<Dispatcher>()
+      if (newFocusOwner is Tree) {
+        val shortcuts = mappings.keyStrokes.map { RequiredShortcut(it, MappingOwner.Plugin.get(PLUGIN_NAME)) }
+        // It's okay to have `register` called multiple times, as its internal implementation prevents duplicate registrations
+        dispatcher.registerCustomShortcutSet(KeyGroup.toShortcutSet(shortcuts), newFocusOwner)
+      }
+      // Note that we do not have to unregister the shortcut in fact
+      if (oldFocusOwner is Tree) {
+        dispatcher.unregisterCustomShortcutSet(oldFocusOwner)
+      }
+    }
+  }
+
   @Service
   class Dispatcher : AbstractDispatcher(mappings) {
     init {
@@ -27,8 +64,6 @@ internal class NerdTreeEverywhere {
       })
     }
   }
-
-  companion object {
-    val mappings = Mappings("NerdTreeEverywhere")
-  }
 }
+
+private val mappings = Mappings(NerdTreeEverywhere.PLUGIN_NAME)

--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTreeEverywhere.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTreeEverywhere.kt
@@ -9,6 +9,9 @@
 package com.maddyhome.idea.vim.extension.nerdtree
 
 import com.intellij.openapi.components.Service
+import java.awt.event.ActionEvent
+import java.awt.event.KeyEvent
+import javax.swing.KeyStroke
 
 internal class NerdTreeEverywhere {
   @Service
@@ -17,6 +20,11 @@ internal class NerdTreeEverywhere {
       templatePresentation.isEnabledInModalContext = true
 
       mappings.registerNavigationMappings()
+      mappings.register("NERDTreeMapActivateNode", "o", Mappings.Action { _, tree ->
+        // TODO a more reliable way of invocation (such as double-clicking?)
+        val listener = tree.getActionForKeyStroke(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0))
+        listener.actionPerformed(ActionEvent(tree, ActionEvent.ACTION_PERFORMED, null))
+      })
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTreeEverywhere.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTreeEverywhere.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2003-2025 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.extension.nerdtree
+
+import com.intellij.openapi.components.Service
+
+internal class NerdTreeEverywhere {
+  @Service
+  class Dispatcher : AbstractDispatcher(mappings) {
+    init {
+      templatePresentation.isEnabledInModalContext = true
+
+      mappings.registerNavigationMappings()
+    }
+  }
+
+  companion object {
+    val mappings = Mappings("NerdTreeEverywhere")
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -351,6 +351,9 @@
       </aliases>
     </vimExtension>
 
+    <vimExtension implementation="com.maddyhome.idea.vim.extension.nerdtree.NerdTreeEverywhere"
+                  name="NERDTreeEverywhere"/>
+
     <vimExtension implementation="com.maddyhome.idea.vim.extension.paragraphmotion.ParagraphMotion"
                   name="vim-paragraph-motion">
       <aliases>

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -210,6 +210,7 @@ class SetCommandTest : VimTestCase() {
         |  keymodel=continueselect,stopselect
         |  lookupkeys=<Tab>,<Down>,<Up>,<Enter>,<Left>,<Right>,<C-Down>,<C-Up>,<PageUp>,<PageDown>,<C-J>,<C-Q>
         |  matchpairs=(:),{:},[:]
+        |noNERDTreeEverywhere
         |noReplaceWithRegister
         |  selection=inclusive
         |  shell=/dummy/path/to/bash
@@ -293,6 +294,7 @@ class SetCommandTest : VimTestCase() {
       |  more
       |nomultiple-cursors
       |noNERDTree
+      |noNERDTreeEverywhere
       |  nrformats=hex
       |nonumber
       |  operatorfunc=

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
@@ -458,6 +458,7 @@ class SetglobalCommandTest : VimTestCase() {
       |  keymodel=continueselect,stopselect
       |  lookupkeys=<Tab>,<Down>,<Up>,<Enter>,<Left>,<Right>,<C-Down>,<C-Up>,<PageUp>,<PageDown>,<C-J>,<C-Q>
       |  matchpairs=(:),{:},[:]
+      |noNERDTreeEverywhere
       |noReplaceWithRegister
       |  selection=inclusive
       |  shell=/dummy/path/to/bash
@@ -543,6 +544,7 @@ class SetglobalCommandTest : VimTestCase() {
       |  more
       |nomultiple-cursors
       |noNERDTree
+      |noNERDTreeEverywhere
       |  nrformats=hex
       |nonumber
       |  operatorfunc=

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
@@ -509,6 +509,7 @@ class SetlocalCommandTest : VimTestCase() {
       |  keymodel=continueselect,stopselect
       |  lookupkeys=<Tab>,<Down>,<Up>,<Enter>,<Left>,<Right>,<C-Down>,<C-Up>,<PageUp>,<PageDown>,<C-J>,<C-Q>
       |  matchpairs=(:),{:},[:]
+      |noNERDTreeEverywhere
       |noReplaceWithRegister
       |  selection=inclusive
       |  shell=/dummy/path/to/bash
@@ -593,6 +594,7 @@ class SetlocalCommandTest : VimTestCase() {
       |  more
       |nomultiple-cursors
       |noNERDTree
+      |noNERDTreeEverywhere
       |  nrformats=hex
       |nonumber
       |  operatorfunc=


### PR DESCRIPTION
Related issue: [VIM-3253](https://youtrack.jetbrains.com/issue/VIM-3253/Support-j-k-to-move-in-all-list-related-UI)

### Supported operations

- [x] Navigation
- [x] ActivateNode
- [x] SpeedSearch (via #1280)

Currently can be enabled via `:set NERDTreeEverywhere`

### Limitations

Enabling extended NERDTree will make some mappings available only in Project NERDTree (e.g. `gi`, `go`) inoperable.
