### PR TITLE
Fix count accepted as valid in text object

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/CommandCountTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/CommandCountTest.kt
@@ -8,6 +8,7 @@
 
 package org.jetbrains.plugins.ideavim.action
 
+import com.intellij.idea.TestFor
 import com.maddyhome.idea.vim.api.injector
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
@@ -57,5 +58,15 @@ class CommandCountTest : VimTestCase() {
     configureByText("${c}12345678901234567890123456789012345678901234567890")
     typeText(injector.parser.parseKeys("2\"a2\"b2\"b2d2l")) // Delete 32 characters
     assertState("345678901234567890")
+  }
+
+  @TestFor(issues = ["VIM-3960"])
+  @Test
+  fun `test count not accepted in multicharacter text object`() {
+    doTest(
+      "di3w",
+      "Lorem ipsum do${c}lor sit amet",
+      "Lorem ipsum dolor ${c}sit amet"
+    )
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/CommandBuilder.kt
@@ -141,10 +141,11 @@ class CommandBuilder private constructor(
 
   val isExpectingCount: Boolean
     get() {
-      return commandState == CurrentCommandState.NEW_COMMAND &&
-        !isRegisterPending &&
-        expectedArgumentType != Argument.Type.CHARACTER &&
-        expectedArgumentType != Argument.Type.DIGRAPH
+      return commandState == CurrentCommandState.NEW_COMMAND
+        && !isRegisterPending
+        && expectedArgumentType != Argument.Type.CHARACTER
+        && expectedArgumentType != Argument.Type.DIGRAPH
+        && commandKeyStrokes.isEmpty()
     }
 
   /**


### PR DESCRIPTION
This PR fixes command builder incorrectly accepting a count inside a text object, such as `di3w`. This is not a valid Vim command and should result in the delete command failing, and only the `w` succeeding.

Fixes [VIM-3960](https://youtrack.jetbrains.com/issue/VIM-3960)