### PR TITLE
Improve SpeedSearch and disposal of NERDTree

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/AbstractDispatcher.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/AbstractDispatcher.kt
@@ -25,7 +25,16 @@ internal abstract class AbstractDispatcher(private val mappings: Mappings) : Dum
   private val keys = mutableListOf<KeyStroke>()
 
   override fun update(e: AnActionEvent) {
-    e.presentation.isEnabled = e.getData(PlatformDataKeys.SPEED_SEARCH_TEXT) == null // SpeedSearch is inactive
+    e.presentation.isEnabled = true
+    // If <ESC> is pressed, clear the keys; skip only if there are no keys
+    if ((e.inputEvent as? KeyEvent)?.keyCode == KeyEvent.VK_ESCAPE) {
+      e.presentation.isEnabled = keys.isNotEmpty()
+      keys.clear()
+    }
+    // Skip if SpeedSearch is active
+    if (e.getData(PlatformDataKeys.SPEED_SEARCH_TEXT) != null) {
+      e.presentation.isEnabled = false
+    }
   }
 
   override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/AbstractDispatcher.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/AbstractDispatcher.kt
@@ -8,6 +8,7 @@
 
 package com.maddyhome.idea.vim.extension.nerdtree
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.project.DumbAwareAction
@@ -22,6 +23,12 @@ import javax.swing.KeyStroke
  */
 internal abstract class AbstractDispatcher(private val mappings: Mappings) : DumbAwareAction() {
   private val keys = mutableListOf<KeyStroke>()
+
+  override fun update(e: AnActionEvent) {
+    e.presentation.isEnabled = e.getData(PlatformDataKeys.SPEED_SEARCH_TEXT) == null // SpeedSearch is inactive
+  }
+
+  override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
   override fun actionPerformed(e: AnActionEvent) {
     var keyStroke = getKeyStroke(e) ?: return

--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/Mappings.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/Mappings.kt
@@ -161,5 +161,6 @@ internal class Mappings(name: String) {
     register("NERDTreeMapJumpPrevSibling", "<C-K>", Action.ij("Tree-selectPreviousSibling"))
 
     register("/", Action.ij("SpeedSearch"))
+    register("<ESC>", Action { _, _ -> })
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/Mappings.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/Mappings.kt
@@ -159,5 +159,7 @@ internal class Mappings(name: String) {
     )
     register("NERDTreeMapJumpNextSibling", "<C-J>", Action.ij("Tree-selectNextSibling"))
     register("NERDTreeMapJumpPrevSibling", "<C-K>", Action.ij("Tree-selectPreviousSibling"))
+
+    register("/", Action.ij("SpeedSearch"))
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/Mappings.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/Mappings.kt
@@ -144,8 +144,16 @@ internal class Mappings(name: String) {
       },
     )
 
-    // FIXME The first row is not the root of External Libraries
-    register("NERDTreeMapJumpRoot", "P", Action.ij("Tree-selectFirst"))
+    register("NERDTreeMapJumpRoot", "P", Action { _, tree ->
+      // Note that we should not consider the root simply the first row
+      // It cannot be guaranteed that the tree has a single visible root
+      var path = tree.selectionPath ?: return@Action
+      while (path.parentPath != null && tree.getRowForPath(path.parentPath) >= 0) {
+        path = path.parentPath
+      }
+      tree.selectionPath = path
+      tree.scrollPathToVisible(path)
+    })
     register("NERDTreeMapJumpParent", "p", Action.ij("Tree-selectParentNoCollapse"))
     register(
       "NERDTreeMapJumpFirstChild",
@@ -153,8 +161,7 @@ internal class Mappings(name: String) {
       Action { _, tree ->
         var path = tree.selectionPath ?: return@Action
         while (true) {
-          val previous = TreeUtil.previousVisibleSibling(tree, path)
-          if (previous == null) break
+          val previous = TreeUtil.previousVisibleSibling(tree, path) ?: break
           path = previous
         }
         tree.selectionPath = path

--- a/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTree.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/nerdtree/NerdTree.kt
@@ -11,10 +11,8 @@ package com.maddyhome.idea.vim.extension.nerdtree
 import com.intellij.ide.projectView.ProjectView
 import com.intellij.ide.projectView.impl.ProjectViewImpl
 import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -163,17 +161,6 @@ internal class NerdTree : VimExtension {
 
   @Service(Service.Level.PROJECT)
   class NerdDispatcher : AbstractDispatcher(mappings) {
-    override fun update(e: AnActionEvent) {
-      e.presentation.isEnabled = !speedSearchIsHere(e)
-    }
-
-    override fun getActionUpdateThread() = ActionUpdateThread.BGT
-
-    private fun speedSearchIsHere(e: AnActionEvent): Boolean {
-      val searchText = e.getData(PlatformDataKeys.SPEED_SEARCH_TEXT)
-      return searchText != null
-    }
-
     companion object {
       fun getInstance(project: Project): NerdDispatcher {
         return project.service<NerdDispatcher>()
@@ -284,8 +271,6 @@ internal class NerdTree : VimExtension {
       "A",
       Mappings.Action.ij("MaximizeToolWindow"),
     )
-
-    mappings.register("/", Mappings.Action.ij("SpeedSearch"))
   }
 
   object Util {


### PR DESCRIPTION
- Initiate SpeedSearch right after <kbd>/</kbd> is pressed in NERDTree
- Clear NERDTree's KeyStroke buffer after <kbd>&lt;ESC&gt;</kbd> is pressed
- [VIM-3981](https://youtrack.jetbrains.com/issue/VIM-3981) make `:set noNERDTree` work
- Improve the concurrency of NERDTree mapping registration/disposal lifecycle
- Correct the behavior of <kbd>P</kbd> (`NERDTreeMapJumpRoot`) to jump to the root node
