### PR TITLE
[VIM-3541]Can't escape out of insert mode in read-only files

### DIFF
--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -18,6 +18,7 @@ import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.diagnostic.VimLogger
 import com.maddyhome.idea.vim.diagnostic.trace
 import com.maddyhome.idea.vim.diagnostic.vimLogger
+import com.maddyhome.idea.vim.handler.ChangeEditorActionHandler
 import com.maddyhome.idea.vim.impl.state.toMappingMode
 import com.maddyhome.idea.vim.key.KeyConsumer
 import com.maddyhome.idea.vim.key.KeyStack
@@ -260,14 +261,12 @@ class KeyHandler {
 
     // Save off the command we are about to execute
     editorState.executingCommand = command
-    val type = command.type
-    if (type.isWrite) {
-      if (!editor.isWritable()) {
+    // If it is a command that modifies the file content but the file is read-only, we should not execute it
+    if (command.action is ChangeEditorActionHandler && !editor.isWritable()){
         injector.messages.indicateError()
         reset(keyState, editorState.mode)
         logger.warn("File is not writable")
         return
-      }
     }
 
     val action: Runnable = ActionRunner(editor, context, command, keyState, operatorArguments)


### PR DESCRIPTION
# Bug description
## Steps to reproduce

- Use **Help | Find Action**, search for `"http request"`, hit **Enter**  
- Provide a name, hit **Enter**  
- Go into insert mode (type `i`)  
- Select **"Requests with Tests and Scripts"** from the **"Examples"** drop-down near the top right corner of the editor window  
- (Verify you're still in insert mode)  
- Hit **Esc** to exit insert mode  
- (Verify this action had no effect)  

---

### Expected result (correct behavior)

If you navigate to a read-only file while in insert mode, you should either:  
- be put into normal mode, **OR**  
- be allowed to press **Esc** to exit insert mode.  

---

### Actual result (faulty behavior)

If you navigate to a read-only file while in insert mode, you **remain in insert mode**.  
You cannot escape into normal mode. To get around this, you must:  

1. Return to an editable editor  
2. Escape into normal mode  
3. Then return to the read-only editor in order to use normal-mode commands.  

# Solution
I have opted for limiting the command actions in read-only files to the ones that do not change, or allow to change its contents. I have noticed that this bug was actually happening in more situations that the one described. What I did is a simply one-line change that blocks the execution of any command that extends from ChangeEditorActionHandler class when the editor is not writable.
