### PR TITLE
Fix casting error in `KeyStrokeTrie.getEntries`

### DIFF
--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyStrokeTrie.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyStrokeTrie.kt
@@ -144,7 +144,7 @@ class KeyStrokeTrie<T>(private val name: String) {
       }
     }
 
-    val node = prefix?.let { getTrieNode(it) as TrieNodeImpl<T> } ?: root
+    val node = prefix?.let { (getTrieNode(it) ?: return emptySequence()) as TrieNodeImpl<T> } ?: root
     return sequence { yieldTrieNode(node) }
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyStrokeTrie.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyStrokeTrie.kt
@@ -107,12 +107,7 @@ class KeyStrokeTrie<T>(private val name: String) {
    * @return Returns null if the key sequence does not exist, or if the data at the node is empty
    */
   fun getData(keyStrokes: List<KeyStroke>): T? {
-    var current = root
-    keyStrokes.forEach {
-      if (!current.children.isInitialized()) return null
-      current = current.children.value[it] ?: return null
-    }
-    return current.data
+    return getTrieNode(keyStrokes)?.data
   }
 
   /**


### PR DESCRIPTION
Return an empty sequence if the prefix node is not found in `KeyStrokeTrie`.
Passing a non-existent prefix previously would result in a casting error.

I had intended to add unit tests for it, but `KeyStrokeTrie.add` uses `injector`, which isn't initialized in the tests for vim-engine.