### PR TITLE
Prevent daily failure alerts from forks for Update Changelog workflow

### DIFF
--- a/.github/workflows/updateChangelogClaude.yml
+++ b/.github/workflows/updateChangelogClaude.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
+    if: github.repository == 'JetBrains/ideavim'
+
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- `.github/workflows/updateFormatting.yml` uses a safeguard `if: github.repository == 'JetBrains/ideavim'`, so scheduled runs are skipped on forks.
- `.github/workflows/updateChangelogClaude.yml` lacks the same check, so on forks the scheduled run fails due to missing secrets and sends daily alerts.
- Apply the same repository guard to `updateChangelogClaude` to stop failure notifications for all fork users (myself included).

## Problem
- Fork users receive daily workflow failure alerts.
- Wastes CI resources and creates notification noise for forks.

## Proposed Change
Add the repository condition to `jobs.build` in `updateChangelogClaude`:

```yaml
jobs:
  build:
    runs-on: ubuntu-latest
    if: github.repository == 'JetBrains/ideavim'
```

This pattern can be applied to other scheduled workflows if needed.