### PR TITLE
Show message with :map and no mapping found

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -238,7 +238,10 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
     for (MappingMode mode : modes) {
       final KeyMapping mapping = VimPlugin.getKey().getKeyMapping(mode);
 
-      final Iterator<KeyMappingEntry> iterator = mapping.getAll(prefix).iterator();
+      // Vim includes mappings for each key in the prefix, where appropriate. That is, it doesn't just all mappings that
+      // are descendants of the prefix, but includes the mappings for each key in the prefix as well.
+      // E.g. `foo` will include mappings for `f` and `fo`, as well as any mappings that are descendants of `foo`.
+      final Iterator<KeyMappingEntry> iterator = mapping.getAll(prefix, true).iterator();
       while (iterator.hasNext()) {
         final KeyMappingEntry entry = iterator.next();
         final MappingInfo mappingInfo = entry.getMappingInfo();
@@ -375,6 +378,10 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
       builder.append(" ");  // Should be `@` if it's a buffer-local mapping
       builder.append(mappingInfo.getPresentableString());
       builder.append("\n");
+    }
+
+    if (builder.isEmpty()) {
+      builder.append("No mapping found");
     }
 
     VimOutputPanel outputPanel = injector.getOutputPanel()

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MapCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MapCommandTest.kt
@@ -370,6 +370,28 @@ class MapCommandTest : VimTestCase() {
   }
 
   @Test
+  fun `test map reports when no mappings match prefix`() {
+    configureByText("\n")
+    assertCommandOutput("map foo", "No mapping found")
+  }
+
+  @Test
+  fun `test map outputs mappings that are a prefix to arg and that have arg as a prefix`() {
+    configureByText("\n")
+    // Vim matches mappings that are a prefix to arg (e.g. mapping "f" matches arg "foo"),
+    // and it matches mappings that have arg as a prefix (e.g., mapping "food" matches arg "foo").
+    // I find this surprising
+    enterCommand("map f bar")
+    enterCommand("map food baz")
+    assertCommandOutput("map foo",
+      """
+        |   f             bar
+        |   food          baz
+      """.trimMargin()
+    )
+  }
+
+  @Test
   fun `test map with only trailing spaces treated as no arguments`() {
     configureByText("\n")
     enterCommand("map foo bar")

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyMapping.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyMapping.kt
@@ -88,12 +88,13 @@ class KeyMapping(private val mode: MappingMode) : Iterable<List<KeyStroke>>, Key
     keysTrie.getEntries().map { KeyMappingEntry(it).getPath() }.iterator()
 
   /**
-   * Returns a sequence of all valid key sequences
+   * Returns a sequence of all valid key sequences for the given prefix, optionally including mappings for the prefixes
    *
-   * Does not return any prefixes.
+   * If [prefix] is an empty list, returns all valid key sequences. If [includePrefixMappings] is true, also returns
+   * mapping sequences for each key in the prefix. Otherwise, skips the sequences for the prefixes.
    */
-  fun getAll(prefix: List<KeyStroke>): Sequence<KeyMappingEntry> =
-    keysTrie.getEntries(prefix).map { KeyMappingEntry(it) }
+  fun getAll(prefix: List<KeyStroke>, includePrefixMappings: Boolean = true): Sequence<KeyMappingEntry> =
+    keysTrie.getEntries(prefix, includePrefixNodes = includePrefixMappings).map { KeyMappingEntry(it) }
 
   /**
    * Return a sequence of all valid key sequences belonging to the given owner


### PR DESCRIPTION
This PR adds tests for a scenario found in #1299. When typing `:map foo` and there were no mappings that began with `foo`, and before the change in #1299, IdeaVim would throw an exception instead of reporting "No mapping found".

While adding the tests for this scenario, it became apparent that `:map foo` will display any mappings that are a prefix of the `foo` arg, as well as any mappings that have `foo` as a prefix. So it will show a mapping that has a LHS of `f` or `food`. This PR updates the `KeyStrokeTrie` to handle this scenario, by optionally including nodes that have data (mappings) in the prefix as well as descendants of the prefix. It modifies the fix from #1299.

Note that this modifies `KeyStrokeTrie.getEntries` to add another default parameter. This function is called from external plugins, but without any parameters. AIUI, adding another default parameter is not a breaking change, but we should check this is true before release.