### PR TITLE
Fix(VIM-4104): Allow Tab to move to next component

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.impl.EditorComponentImpl
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.DumbAware
@@ -29,10 +30,12 @@ import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.command.MappingMode
 import com.maddyhome.idea.vim.group.IjOptionConstants
 import com.maddyhome.idea.vim.group.IjOptions
 import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.HandlerInjector
+import com.maddyhome.idea.vim.helper.inInsertMode
 import com.maddyhome.idea.vim.helper.inNormalMode
 import com.maddyhome.idea.vim.helper.isIdeaVimDisabledHere
 import com.maddyhome.idea.vim.helper.isPrimaryEditor
@@ -96,7 +99,7 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
   }
 
   // There is a chance that we can use BGT, but we call for isCell inside the update.
-  // Not sure if can can use BGT with this call. Let's use EDT for now.
+  // Not sure if we can use BGT with this call. Let's use EDT for now.
   override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
   override fun update(e: AnActionEvent) {
@@ -162,6 +165,24 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
       }
     }
 
+    if (keyCode == KeyEvent.VK_TAB && editor.inInsertMode) {
+      // IdeaVim will handle Tab, and in Insert mode, will invoke the platform's TabAction to insert the tab character.
+      // (Other Tab features are handled by IDE actions called before VimShortcutKeyAction).
+      // Single line editors or editors hosted in a dialog/tool window do not accept/insert Tab, and TabAction is
+      // disabled. In fact, all actions are disabled and normal Swing handling will move the focus to the next
+      // component. Disable this action in the same circumstances, unless the user explicitly maps Tab.
+      // TODO: Should this also ignore Tab in Normal mode?
+      // This is a valid Vim action (navigating jump list), but unlikely in a single line or embedded editor.
+      if (injector.keyGroup.getKeyMapping(MappingMode.INSERT).get(listOf(keyStroke)) == null) {
+        if (editor.isOneLineMode || (editor as? EditorEx)?.isEmbeddedIntoDialogWrapper == true || editor.isViewer) {
+          return ActionEnableStatus.no(
+            "Tab should be ignored when editor is in one line mode, embedded into a dialog wrapper or is a readonly viewer",
+            LogLevel.INFO
+          )
+        }
+      }
+    }
+
     if (keyStroke in VIM_ONLY_EDITOR_KEYS) {
       return ActionEnableStatus.yes("Vim only editor keys", LogLevel.INFO)
     }
@@ -175,7 +196,7 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
 
       ShortcutOwner.IDE -> {
         if (!isShortcutConflict(keyStroke)) {
-          ActionEnableStatus.yes("Owner is IDE, but no actionve shortcut conflict", LogLevel.DEBUG)
+          ActionEnableStatus.yes("Owner is IDE, but no actions have shortcut conflict", LogLevel.DEBUG)
         } else {
           ActionEnableStatus.no("Owner is IDE", LogLevel.DEBUG)
         }
@@ -241,7 +262,7 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
    *   <C-W> by IdeaVim.
    *
    * The list of keys that should be processed by IDE is stored in the "lookupKeys" option. So, we should search
-   *   if the pressed key is presented in this list. The caches are used to speedup the process.
+   *   if the pressed key is presented in this list. The caches are used to speed up the process.
    */
   private object LookupKeys {
     fun isEnabledForLookup(keyStroke: KeyStroke): Boolean {

--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -28,18 +28,20 @@ import com.intellij.openapi.util.registry.Registry
 import com.intellij.ui.KeyStrokeAdapter
 import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.api.getFirstMappingInfoMatch
 import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.command.MappingMode
 import com.maddyhome.idea.vim.group.IjOptionConstants
 import com.maddyhome.idea.vim.group.IjOptions
 import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.HandlerInjector
+import com.maddyhome.idea.vim.helper.enumSetOf
 import com.maddyhome.idea.vim.helper.inInsertMode
 import com.maddyhome.idea.vim.helper.inNormalMode
 import com.maddyhome.idea.vim.helper.isIdeaVimDisabledHere
 import com.maddyhome.idea.vim.helper.isPrimaryEditor
 import com.maddyhome.idea.vim.helper.updateCaretsVisualAttributes
+import com.maddyhome.idea.vim.impl.state.toMappingMode
 import com.maddyhome.idea.vim.key.ShortcutOwner
 import com.maddyhome.idea.vim.key.ShortcutOwnerInfo
 import com.maddyhome.idea.vim.listener.AceJumpService
@@ -173,13 +175,13 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
       // component. Disable this action in the same circumstances, unless the user explicitly maps Tab.
       // TODO: Should this also ignore Tab in Normal mode?
       // This is a valid Vim action (navigating jump list), but unlikely in a single line or embedded editor.
-      if (injector.keyGroup.getKeyMapping(MappingMode.INSERT).get(listOf(keyStroke)) == null) {
-        if (editor.isOneLineMode || (editor as? EditorEx)?.isEmbeddedIntoDialogWrapper == true || editor.isViewer) {
-          return ActionEnableStatus.no(
-            "Tab should be ignored when editor is in one line mode, embedded into a dialog wrapper or is a readonly viewer",
-            LogLevel.INFO
-          )
-        }
+      if (!hasMapping(listOf(keyStroke), editor)
+        && (editor.isOneLineMode || (editor as? EditorEx)?.isEmbeddedIntoDialogWrapper == true || editor.isViewer)
+      ) {
+        return ActionEnableStatus.no(
+          "Tab should be ignored when editor is in one line mode, embedded into a dialog wrapper or is a readonly viewer",
+          LogLevel.INFO
+        )
       }
     }
 
@@ -209,6 +211,14 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
         ActionEnableStatus.yes("Enable vim for shortcut without owner", LogLevel.DEBUG)
       }
     }
+  }
+
+  /**
+   * Returns true if there is a mapping for the given keys in the current editor mode
+   */
+  private fun hasMapping(keys: List<KeyStroke>, editor: Editor): Boolean {
+    val mode = enumSetOf(editor.vim.mode.toMappingMode())
+    return injector.keyGroup.getFirstMappingInfoMatch(keys, mode) != null
   }
 
   private fun isEnabledForEscape(editor: Editor): Boolean {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimKeyGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimKeyGroup.kt
@@ -81,3 +81,16 @@ interface VimKeyGroup {
   /** Registers a shortcut that is handled directly by KeyHandler, rather than by an action. */
   fun registerShortcutWithoutAction(keyStroke: KeyStroke, owner: MappingOwner) {}
 }
+
+/**
+ * Retrieve the first mapping that is an exact match for the given LHS keystrokes in the given modes
+ *
+ * This function is essentially equivalent to the Vim function `maparg()`.
+ *
+ * Typically, this function will be called with a single mode, in which case there will be a single result, or null.
+ * However, for `maparg()` support, it can also be called with [MappingMode.NVO], which might have the same mapping in
+ * all modes, or a different mapping in any one of the modes. This function, like `maparg()`, will return an arbitrary
+ * (undocumented) mapping in this scenario.
+ */
+fun VimKeyGroup.getFirstMappingInfoMatch(name: List<KeyStroke>, mode: Set<MappingMode>) =
+  mode.map { getKeyMapping(it) }.map { it[name] }.firstOrNull()


### PR DESCRIPTION
When IdeaVim is not active, and the current editor is single line, or hosted in a dialog/tool window, or a readonly viewer (e.g. the Commit tool window editor), then hitting Tab will move focus to the next component rather than inserting a tab character. When IdeaVim is active, Tab does nothing (in Insert mode) because the `VimShortcutKeyAction` handles the keystroke, passing it through the key handler pipeline and then trying to invoke the (disabled) `TabAction` platform action to insert the tab character.

This PR fixes this behaviour by making `VimShortcutKeyAction` disabled if the above conditions are met. Since no actions are enabled, Swing will handle the keystroke. 

IdeaVim will not disable the action if the user has explicitly created an (Insert mode) map for Tab; if the user has explicitly set up a map, we should use it. The IdeaVim action is also only disabled in Insert mode, because Tab is a valid command in Normal. Admittedly, this command is navigating the jump list, and is unlikely in a single line or hosted editor. We could consider allowing this extra behaviour in Normal (or more) modes.

Fixes [VIM-4104](https://youtrack.jetbrains.com/issue/VIM-4104).