### PR TITLE
Search fixes/improvements (show match count)

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
@@ -27,6 +27,7 @@ import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.state.mode.inCommandLineModeWithVisual
 import com.maddyhome.idea.vim.state.mode.inVisualMode
+import com.maddyhome.idea.vim.ui.ex.ExEntryPanel
 import org.jetbrains.annotations.Contract
 import java.awt.Font
 import java.util.*
@@ -36,8 +37,9 @@ internal fun updateSearchHighlights(
   shouldIgnoreSmartCase: Boolean,
   showHighlights: Boolean,
   forceUpdate: Boolean,
+  newCaretPosition: Int? = null,
 ) {
-  updateSearchHighlights(null, pattern, 1, shouldIgnoreSmartCase, showHighlights, -1, null, true, forceUpdate)
+  updateSearchHighlights(null, pattern, 1, shouldIgnoreSmartCase, showHighlights, -1, null, true, forceUpdate, newCaretPosition)
 }
 
 internal fun updateIncsearchHighlights(
@@ -63,7 +65,8 @@ internal fun updateIncsearchHighlights(
     searchStartOffset,
     searchRange,
     forwards,
-    false
+    false,
+    null
   )
 }
 
@@ -84,6 +87,12 @@ internal fun addSubstitutionConfirmationHighlight(editor: Editor, start: Int, en
   )
 }
 
+enum class CountMatchesState {
+  NoCountMatches,
+  ShowCount,
+  MaybeClearCount
+}
+
 /**
  * Refreshes current search highlights for all visible editors
  */
@@ -97,6 +106,7 @@ private fun updateSearchHighlights(
   searchRange: LineRange?,
   forwards: Boolean,
   forceUpdate: Boolean,
+  newCaretPosition: Int?
 ): Int {
   var currentEditorCurrentMatchOffset = -1
 
@@ -107,6 +117,18 @@ private fun updateSearchHighlights(
       && (currentEditor == null || it.projectId == currentEditor.projectId)
   }
 
+  val countMatchesSetting = injector.globalOptions().showmatchcount
+  var editorWithSearchMatches = if (countMatchesSetting) { currentEditor?.ij } else { null }
+  if (countMatchesSetting && editorWithSearchMatches == null) {
+    editorWithSearchMatches = injector.editorGroup.getFocusedEditor()?.ij
+  }
+
+  if (!countMatchesSetting) {
+    // In case we were counting matches before clear it, the function
+    //  itself ensures nothing happens if it is cleared already
+    ExEntryPanel.getOrCreatePanelInstance().clearStatusText()
+  }
+
   val shouldIgnoreCase = pattern == null || shouldIgnoreCase(pattern, shouldIgnoreSmartCase)
 
   var maxhlduringincsearch = injector.globalOptions().maxhlduringincsearch
@@ -115,13 +137,17 @@ private fun updateSearchHighlights(
 
   editors.forEach {
     val editor = it.ij
+    val isCurrentEditor = editor == editorWithSearchMatches
+    var countMatches = if (!isCurrentEditor || !countMatchesSetting) CountMatchesState.NoCountMatches else CountMatchesState.ShowCount
+
     var currentMatchOffset = -1
 
     // Try to keep existing highlights if possible. Update if hlsearch has changed or if the pattern has changed.
     // Force update for the situations where the text is the same, but the ignore case values have changed.
     // E.g., Use `*` to search for a word (which ignores smartcase), then use `/<Up>` to search for the same pattern,
     // which will match smartcase. Or changing the smartcase/ignorecase settings
-    if (shouldRemoveSearchHighlights(editor, pattern, showHighlights) || forceUpdate) {
+    val clearHighlights = shouldRemoveSearchHighlights(editor, pattern, showHighlights)
+    if (clearHighlights || forceUpdate) {
       removeSearchHighlights(editor)
     }
 
@@ -131,35 +157,22 @@ private fun updateSearchHighlights(
       // hlsearch (+ incsearch/noincsearch)
       // Make sure the range fits this editor. Note that Vim will use the same range for all windows. E.g., given
       // `:1,5s/foo`, Vim will highlight all occurrences of `foo` in the first five lines of all visible windows
-      val vimEditor = editor.vim
-      val editorLastLine = vimEditor.lineCount() - 1
-      val searchStartLine = searchRange?.startLine ?: 0
-      val searchEndLine = (searchRange?.endLine ?: -1).coerceAtMost(editorLastLine)
-      if (searchStartLine <= editorLastLine) {
-        val results =
-          injector.searchHelper.findAll(
-            vimEditor,
-            pattern,
-            searchStartLine,
-            searchEndLine,
-            shouldIgnoreCase
-          )
-        if (results.isNotEmpty()) {
-          // Only in incsearch is current editor not null, then check result size
-          val showHighlightsInEditor = currentEditor == null || results.size < maxhlduringincsearch
-          if (editor == currentEditor?.ij) {
-            val currentMatchIndex = findClosestMatch(results, initialOffset, count1, forwards)
-            currentMatchOffset = if (currentMatchIndex == -1) -1 else results[currentMatchIndex].startOffset
+      val results = findAllMatches(pattern, editor.vim, searchRange,  shouldIgnoreCase)
+      if (results.isNotEmpty()) {
+        // Only in incsearch is current editor not null, then check result size
+        val showHighlightsInEditor = currentEditor == null || results.size < maxhlduringincsearch
+        if (editor == currentEditor?.ij) {
+          val currentMatchIndex = findClosestMatch(results, initialOffset, count1, forwards)
+          currentMatchOffset = if (currentMatchIndex == -1) -1 else results[currentMatchIndex].startOffset
 
-            if (!showHighlightsInEditor) {
-              // Always highlight at least the "current" match in the active editor
-              highlightSearchResults(editor, pattern, listOf(results[currentMatchIndex]), currentMatchOffset)
-            }
+          if (!showHighlightsInEditor) {
+            // Always highlight at least the "current" match in the active editor
+            highlightSearchResults(editor, pattern, listOf(results[currentMatchIndex]), currentMatchOffset)
           }
+        }
 
-          if (showHighlightsInEditor) {
-            highlightSearchResults(editor, pattern, results, currentMatchOffset)
-          }
+        if (showHighlightsInEditor) {
+          highlightSearchResults(editor, pattern, results, currentMatchOffset)
         }
       }
       editor.vimLastSearch = pattern
@@ -189,11 +202,44 @@ private fun updateSearchHighlights(
       if (offset != null && editor === currentEditor?.ij) {
         currentMatchOffset = offset
       }
+    } else {
+      countMatches = CountMatchesState.MaybeClearCount
     }
 
-    if (editor === currentEditor?.ij) {
+    if (!isCurrentEditor)
+      return@forEach
+
+    var editorCaretOffset = editor.vim.primaryCaret().offset
+    if (currentEditor?.ij != null) {
       currentEditorCurrentMatchOffset = currentMatchOffset
+      editorCaretOffset = currentEditorCurrentMatchOffset
+    } else if (newCaretPosition != null) {
+      editorCaretOffset = newCaretPosition
     }
+
+    if (countMatches == CountMatchesState.NoCountMatches) {
+      return@forEach
+    }
+
+    // If any of the following hold we are still searching:
+    // - We just highlighted some search results (countMatches is not MaybeClear
+    // - We did not clear highlights (
+    // - We are moving towards to a new position
+    if (countMatches == CountMatchesState.MaybeClearCount && clearHighlights && newCaretPosition == null) {
+      ExEntryPanel.getOrCreatePanelInstance().clearStatusText()
+      return@forEach
+    }
+
+    // Search file for pattern, and determine total and position in results
+    val results = findAllMatches(pattern, editor.vim, searchRange,  shouldIgnoreCase)
+    val patternIndex = if (results.isEmpty()) {
+      -1
+    } else {
+      findClosestOrCurrentMatch(results, editorCaretOffset)
+    }
+
+    val countMessage = "[" + (patternIndex + 1) + "/" + results.size + "]"
+    ExEntryPanel.getOrCreatePanelInstance().setStatusText(editor, countMessage)
   }
 
   return currentEditorCurrentMatchOffset
@@ -222,6 +268,23 @@ private fun removeSearchHighlights(editor: Editor) {
 @Contract("_, _, false -> false; _, null, true -> false")
 private fun shouldAddAllSearchHighlights(editor: Editor, newPattern: String?, hlSearch: Boolean): Boolean {
   return hlSearch && newPattern != null && newPattern != editor.vimLastSearch && newPattern != ""
+}
+
+private fun findAllMatches(pattern: String, vimEditor: VimEditor, searchRange: LineRange?, shouldIgnoreCase: Boolean): List<TextRange> {
+  val editorLastLine = vimEditor.lineCount() - 1
+  val searchStartLine = searchRange?.startLine ?: 0
+  val searchEndLine = (searchRange?.endLine ?: -1).coerceAtMost(editorLastLine)
+  if (searchStartLine > editorLastLine) {
+    return listOf()
+  }
+
+  return injector.searchHelper.findAll(
+    vimEditor,
+    pattern,
+    searchStartLine,
+    searchEndLine,
+    shouldIgnoreCase
+  )
 }
 
 private fun findClosestMatch(
@@ -255,6 +318,23 @@ private fun findClosestMatch(
   }
 
   return nextIndex % results.size
+}
+
+private fun findClosestOrCurrentMatch(
+  results: List<TextRange>,
+  initialOffset: Int,
+): Int {
+  if (results.isEmpty() || initialOffset == -1) {
+    return -1
+  }
+
+  val firstMatch = results.filter { it.endOffset >= initialOffset }.minByOrNull { it.endOffset }
+  if (firstMatch == null) {
+    // Results is not empty but there is no match before offset, we must be past the last match
+    return results.size - 1
+  }
+  // Note that wrapping for the count does not make sense
+  return results.indexOfFirst { it.endOffset == firstMatch.endOffset }
 }
 
 internal fun highlightSearchResults(

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimSearchGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimSearchGroup.kt
@@ -81,8 +81,8 @@ open class IjVimSearchGroup : VimSearchGroupBase(), PersistentStateComponent<Ele
     }
   }
 
-  override fun updateSearchHighlights(force: Boolean) {
-    updateSearchHighlights(getLastUsedPattern(), lastIgnoreSmartCase, showSearchHighlight, force)
+  override fun updateSearchHighlights(force: Boolean, newCaretPosition: Int?) {
+    updateSearchHighlights(getLastUsedPattern(), lastIgnoreSmartCase, showSearchHighlight, force, newCaretPosition)
   }
 
   override fun resetIncsearchHighlights() {

--- a/src/main/resources/dictionaries/ideavim.dic
+++ b/src/main/resources/dictionaries/ideavim.dic
@@ -23,6 +23,7 @@ keymodel
 lookupKeys
 mapleader
 matchpairs
+maxhlduringincsearch
 maxmapdepth
 nrformats
 operatorfunc

--- a/src/main/resources/dictionaries/ideavim.dic
+++ b/src/main/resources/dictionaries/ideavim.dic
@@ -35,6 +35,7 @@ shellcmdflag
 shellxescape
 shellxquote
 showcmd
+showmatchcount
 showmode
 sidescroll
 sidescrolloff

--- a/src/test/java/org/jetbrains/plugins/ideavim/helper/SearchHelperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/helper/SearchHelperTest.kt
@@ -90,6 +90,33 @@ class SearchHelperTest : VimTestCase() {
     kotlin.test.assertEquals(previousWordPosition, text.indexOf("second"))
   }
 
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.NOT_VIM_TESTING)
+  @Test
+  fun testFindAllIgnoreCaseOverwritesSmartCase() {
+    val text = "Lorem ipsum lorem ipsum"
+    configureByText(text)
+
+    val capitalMatch = TextRange(0, 5)
+    val lowerMatch = TextRange(12, 17)
+
+    val search = { ignoreCase: Boolean ->
+      injector.searchHelper.findAll(fixture.editor.vim, "\\<Lorem\\>", 0, -1, ignoreCase)
+    }
+
+    // Ensure ignore and smart case are off
+    enterCommand("set noignorecase")
+    enterCommand("set nosmartcase")
+
+    kotlin.test.assertEquals(listOf(capitalMatch), search(false))
+    // Even if both are off, ignore case should still ignore cases
+    kotlin.test.assertEquals(listOf(capitalMatch, lowerMatch), search(true))
+
+    enterCommand("set smartcase")
+    kotlin.test.assertEquals(listOf(capitalMatch), search(false))
+    kotlin.test.assertEquals(listOf(capitalMatch, lowerMatch), search(true))
+  }
+
   @Test
   fun testMotionOuterWordAction() {
     doTest(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
@@ -51,6 +51,7 @@ open class GlobalOptions(scope: OptionAccessScope) : OptionsPropertiesBase(scope
 
   // IdeaVim specific options. Put any editor or IDE specific options in IjOptionProperties
   var maxhlduringincsearch: Int by optionProperty(Options.maxhlduringincsearch)
+  var showmatchcount: Boolean by optionProperty(Options.showmatchcount)
 
   // Temporary flags for work-in-progress behaviour. Hidden from the output of `:set all`
   var ideastrictmode: Boolean by optionProperty(Options.ideastrictmode)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
@@ -50,6 +50,7 @@ open class GlobalOptions(scope: OptionAccessScope) : OptionsPropertiesBase(scope
   var wrapscan: Boolean by optionProperty(Options.wrapscan)
 
   // IdeaVim specific options. Put any editor or IDE specific options in IjOptionProperties
+  var maxhlduringincsearch: Int by optionProperty(Options.maxhlduringincsearch)
 
   // Temporary flags for work-in-progress behaviour. Hidden from the output of `:set all`
   var ideastrictmode: Boolean by optionProperty(Options.ideastrictmode)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -136,6 +136,7 @@ object Options {
       )
     )
   )
+  val maxhlduringincsearch: NumberOption = addOption(NumberOption(name="maxhlduringincsearch", GLOBAL, "maxhld", 100, -1))
   val maxmapdepth: NumberOption = addOption(NumberOption("maxmapdepth", GLOBAL, "mmd", 20))
   val more: ToggleOption = addOption(ToggleOption("more", GLOBAL, "more", true))
   val nrformats: StringListOption = addOption(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -183,6 +183,7 @@ object Options {
     )
   )
   val showcmd: ToggleOption = addOption(ToggleOption("showcmd", GLOBAL, "sc", true))
+  val showmatchcount: ToggleOption = addOption(ToggleOption("showmatchcount", GLOBAL, "smc", false))
   val showmode: ToggleOption = addOption(ToggleOption("showmode", GLOBAL, "smd", true))
   val sidescroll: NumberOption = addOption(UnsignedNumberOption("sidescroll", GLOBAL, "ss", 0))
   val sidescrolloff: NumberOption = addOption(

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
@@ -106,7 +106,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
    *
    * @param force Whether to force this update.
    */
-  protected abstract fun updateSearchHighlights(force: Boolean)
+  protected abstract fun updateSearchHighlights(force: Boolean, newCaretPosition: Int? = null)
 
   /**
    * Reset the search highlights to the last used pattern after highlighting incsearch results.
@@ -441,11 +441,13 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     lastPatternTrailing = ""
     lastDirection = dir
 
-    setShouldShowSearchHighlights()
-    updateSearchHighlights(true)
 
     val offset = findItOffset(editor, range.startOffset, count, lastDirection)?.first ?: -1
-    return if (offset == -1) range.startOffset else offset
+
+    val newOffset = if (offset == -1) range.startOffset else offset
+    setShouldShowSearchHighlights()
+    updateSearchHighlights(true, newOffset)
+    return newOffset
   }
 
   override fun findEndOfPattern(
@@ -518,9 +520,6 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     count: Int,
     dir: Direction,
   ): Int {
-    setShouldShowSearchHighlights()
-    updateSearchHighlights(false)
-
     val startOffset: Int = caret.offset
     var offset = findItOffset(editor, startOffset, count, dir)?.first ?: -1
     if (offset == startOffset) {
@@ -529,6 +528,9 @@ abstract class VimSearchGroupBase : VimSearchGroup {
        * in the buffer: Repeat with count + 1. */
       offset = findItOffset(editor, startOffset, count + 1, dir)?.first ?: -1
     }
+
+    setShouldShowSearchHighlights()
+    updateSearchHighlights(false, offset)
     return offset
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchHelperBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchHelperBase.kt
@@ -385,8 +385,9 @@ abstract class VimSearchHelperBase : VimSearchHelper {
     ignoreCase: Boolean,
   ): List<TextRange> {
     val options = enumSetOf<VimRegexOptions>()
-    if (injector.globalOptions().smartcase) options.add(VimRegexOptions.SMART_CASE)
-    if (injector.globalOptions().ignorecase) options.add(VimRegexOptions.IGNORE_CASE)
+    // If we are explicitly asked to ignore case, assume that smartcase check has already taken place
+    if (injector.globalOptions().smartcase && !ignoreCase) options.add(VimRegexOptions.SMART_CASE)
+    if (injector.globalOptions().ignorecase || ignoreCase) options.add(VimRegexOptions.IGNORE_CASE)
     val regex = try {
       VimRegex(pattern)
     } catch (e: VimRegexException) {


### PR DESCRIPTION
## Content:
This PR fixes one small bug in highlighting and adds two new features.

- Fixes a case where highlighting does not match actual search.
  How to reproduce: Have a word with capital letters and one all lower case, use * on the capitalized word to search for that one. The search correctly ignores case, but if smartcase is enabled the highlighting incorrectly does not highlight the lower case word.
  Maybe related: [VIM-3459](https://youtrack.jetbrains.com/issue/VIM-3459) Regression: 'smartcase' should not affect star command

- Add an option to disable highlighting many matches during incsearch
  This otherwise can massively slow down searching as the IDE tries to highlight all 0s in a csv for example.
  This is protected behind an option ``, but for now I have set the default to 100, WOULD BE CHANGE IN DEFAULT BEHAVIOR (setting it to -1 gets old behavior)
  Related: 
  - [VIM-3581](https://youtrack.jetbrains.com/issue/VIM-3581) Disable search highlight outside editor to avoid search slowdown highlighted in other tool window (e.g. run/debug tool window)
  - [VIM-3093](https://youtrack.jetbrains.com/issue/VIM-3093) hlsearch+incsearch slow in large files

- Add option to show matches to search in file `showmatchcount` this will display a counter and index into the matches while searching, e.g. `[13/159]` means 159 matches and your at or before match 13.
  Related:
  - [VIM-2544](https://youtrack.jetbrains.com/issue/VIM-2544) [Feature Request]Show match count after searching
	 
Example:
<img width="1108" height="434" alt="image" src="https://github.com/user-attachments/assets/b96840f0-7322-4f54-bba2-aa18fbce2395" />
Notice here that I'm searching for "0" in the left editor, the left file show matches because there are only 8 (see right part of command bar). The right file has 1000+ matches so shows nothing, meaning no hiccups while typing "01" for example.
Also visible in the middle bottom is the counter for matches in the files and the current index in the matches for that file.

Once you press enter the "protection" is gone, meaning to only a single slowdown in this case
<img width="1150" height="431" alt="image" src="https://github.com/user-attachments/assets/8ed53deb-efb3-40ca-8e73-ca2ae618001d" />

After that I clicked on the right side and you can see what the search counter looks like when the entry is not active (maybe it should have a border on the left side?)

## Review
Please feel free to school me on anything Kotlin, this is my first time using the languages, just tried to match the patterns I saw in other files.

Also I really tried adding tests for option 2 & 3 but I had to mock so much I gave up, if there is a good/easy way to do it would love to hear it.