### PR TITLE
Fix :edit to create file if it does not exist (VIM-266)

### DIFF
--- a/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
+++ b/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
@@ -12,6 +12,7 @@ import com.intellij.ide.vfs.VirtualFileId
 import com.intellij.ide.vfs.virtualFile
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.readAction
+import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.editor.Editor
@@ -53,21 +54,35 @@ internal class FileRemoteApiImpl : FileRemoteApi {
     findFile(filename, project)?.path
   }
 
-  override suspend fun openFile(filename: String, projectId: ProjectId?, focusEditor: Boolean): String? =
-    onEdt {
-      val project = projectId?.findProjectOrNull() ?: return@onEdt "No project found"
-      val found = findFile(filename, project)
-      if (found != null) {
-        logger.debug { "found file: $found" }
-        val type = FileTypeManager.getInstance().getKnownFileTypeOrAssociate(found, project)
-        if (type != null) {
-          FileEditorManager.getInstance(project).openFile(found, focusEditor)
+  override suspend fun openFile(filename: String, projectId: ProjectId?, focusEditor: Boolean): String? = onEdt {
+    val project = projectId?.findProjectOrNull() ?: return@onEdt "No project found"
+    var file = findFile(filename, project)
+
+    if (file == null) {
+
+      val ioFile = resolveIoFile(filename, project)
+        ?: return@onEdt EngineMessageHelper.message(
+          "message.open.file.not.found",
+          filename
+        )
+      WriteCommandAction.runWriteCommandAction(project) {
+        ioFile.parentFile?.mkdirs()
+        if (!ioFile.exists()) {
+          ioFile.createNewFile()
         }
-        null // success
-      } else {
-        EngineMessageHelper.message("message.open.file.not.found", filename)
       }
+      file = LocalFileSystem.getInstance()
+        .refreshAndFindFileByIoFile(ioFile)
     }
+
+    if (file != null) {
+      FileEditorManager.getInstance(project)
+        .openFile(file, focusEditor)
+      null
+    } else {
+      EngineMessageHelper.message("message.open.file.not.found", filename)
+    }
+  }
 
   override suspend fun closeCurrentFile(projectId: ProjectId?, virtualFileId: VirtualFileId?) =
     onEdt {
@@ -164,6 +179,25 @@ internal class FileRemoteApiImpl : FileRemoteApi {
 
   // ======================== Private helpers ========================
 
+  private fun resolveIoFile(filename: String, project: Project): java.io.File? {
+
+    // ~/path support
+    if (filename.startsWith("~/") || filename.startsWith("~\\")) {
+      val home = System.getProperty("user.home")
+      return java.io.File(home, filename.substring(2))
+    }
+
+    val file = java.io.File(filename)
+
+    // absolute path
+    if (file.isAbsolute) {
+      return file
+    }
+
+    // relative → project root
+    val basePath = project.basePath ?: return null
+    return java.io.File(basePath, filename)
+  }
   private fun findFile(filename: String, project: Project): VirtualFile? {
     if (filename.startsWith("~/") || filename.startsWith("~\\")) {
       val relativePath = filename.substring(2)

--- a/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
+++ b/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
@@ -12,6 +12,7 @@ import com.intellij.ide.vfs.VirtualFileId
 import com.intellij.ide.vfs.virtualFile
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.readAction
+import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.editor.Editor
@@ -53,21 +54,35 @@ internal class FileRemoteApiImpl : FileRemoteApi {
     findFile(filename, project)?.path
   }
 
-  override suspend fun openFile(filename: String, projectId: ProjectId?, focusEditor: Boolean): String? =
-    onEdt {
-      val project = projectId?.findProjectOrNull() ?: return@onEdt "No project found"
-      val found = findFile(filename, project)
-      if (found != null) {
-        logger.debug { "found file: $found" }
-        val type = FileTypeManager.getInstance().getKnownFileTypeOrAssociate(found, project)
-        if (type != null) {
-          FileEditorManager.getInstance(project).openFile(found, focusEditor)
+  override suspend fun openFile(filename: String, projectId: ProjectId?, focusEditor: Boolean): String? = onEdt {
+    val project = projectId?.findProjectOrNull() ?: return@onEdt "No project found"
+    var file = findFile(filename, project)
+
+    if (file == null) {
+
+      val ioFile = resolveIoFile(filename, project)
+        ?: return@onEdt EngineMessageHelper.message(
+          "message.open.file.not.found",
+          filename
+        )
+      WriteCommandAction.runWriteCommandAction(project) {
+        ioFile.parentFile?.mkdirs()
+        if (!ioFile.exists()) {
+          ioFile.createNewFile()
         }
-        null // success
-      } else {
-        EngineMessageHelper.message("message.open.file.not.found", filename)
       }
+      file = LocalFileSystem.getInstance()
+        .refreshAndFindFileByIoFile(ioFile)
     }
+
+    if (file != null) {
+      FileEditorManager.getInstance(project)
+        .openFile(file, focusEditor)
+      null
+    } else {
+      EngineMessageHelper.message("message.open.file.not.found", filename)
+    }
+  }
 
   override suspend fun closeCurrentFile(projectId: ProjectId?, virtualFileId: VirtualFileId?) =
     onEdt {
@@ -169,6 +184,25 @@ internal class FileRemoteApiImpl : FileRemoteApi {
 
   // ======================== Private helpers ========================
 
+  private fun resolveIoFile(filename: String, project: Project): java.io.File? {
+
+    // ~/path support
+    if (filename.startsWith("~/") || filename.startsWith("~\\")) {
+      val home = System.getProperty("user.home")
+      return java.io.File(home, filename.substring(2))
+    }
+
+    val file = java.io.File(filename)
+
+    // absolute path
+    if (file.isAbsolute) {
+      return file
+    }
+
+    // relative → project root
+    val basePath = project.basePath ?: return null
+    return java.io.File(basePath, filename)
+  }
   private fun findFile(filename: String, project: Project): VirtualFile? {
     if (filename.startsWith("~/") || filename.startsWith("~\\")) {
       val relativePath = filename.substring(2)

--- a/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
+++ b/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
@@ -11,6 +11,7 @@ package com.maddyhome.idea.vim.group.file
 import com.intellij.ide.vfs.VirtualFileId
 import com.intellij.ide.vfs.virtualFile
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
@@ -27,6 +28,7 @@ import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.platform.project.ProjectId
@@ -56,24 +58,7 @@ internal class FileRemoteApiImpl : FileRemoteApi {
 
   override suspend fun openFile(filename: String, projectId: ProjectId?, focusEditor: Boolean): String? = onEdt {
     val project = projectId?.findProjectOrNull() ?: return@onEdt "No project found"
-    var file = findFile(filename, project)
-
-    if (file == null) {
-
-      val ioFile = resolveIoFile(filename, project)
-        ?: return@onEdt EngineMessageHelper.message(
-          "message.open.file.not.found",
-          filename
-        )
-      WriteCommandAction.runWriteCommandAction(project) {
-        ioFile.parentFile?.mkdirs()
-        if (!ioFile.exists()) {
-          ioFile.createNewFile()
-        }
-      }
-      file = LocalFileSystem.getInstance()
-        .refreshAndFindFileByIoFile(ioFile)
-    }
+    var file = findFile(filename, project) ?: createFile(filename, project)
 
     if (file != null) {
       FileEditorManager.getInstance(project)
@@ -183,26 +168,6 @@ internal class FileRemoteApiImpl : FileRemoteApi {
   }
 
   // ======================== Private helpers ========================
-
-  private fun resolveIoFile(filename: String, project: Project): java.io.File? {
-
-    // ~/path support
-    if (filename.startsWith("~/") || filename.startsWith("~\\")) {
-      val home = System.getProperty("user.home")
-      return java.io.File(home, filename.substring(2))
-    }
-
-    val file = java.io.File(filename)
-
-    // absolute path
-    if (file.isAbsolute) {
-      return file
-    }
-
-    // relative → project root
-    val basePath = project.basePath ?: return null
-    return java.io.File(basePath, filename)
-  }
   private fun findFile(filename: String, project: Project): VirtualFile? {
     if (filename.startsWith("~/") || filename.startsWith("~\\")) {
       val relativePath = filename.substring(2)
@@ -284,6 +249,31 @@ internal class FileRemoteApiImpl : FileRemoteApi {
     val projectScope = ProjectScope.getProjectScope(project)
     val names = FilenameIndex.getVirtualFilesByName(filename, projectScope)
     return names.firstOrNull()
+  }
+
+  private fun createFile(filename: String, project: Project): VirtualFile? {
+    val path = when {
+      filename.startsWith("~/") || filename.startsWith("~\\") -> {
+        val home = System.getProperty("user.home")
+        Path(home, filename.substring(2))
+      }
+      Path(filename).isAbsolute -> Path(filename)
+      else -> {
+        val basePath = project.basePath ?: return null
+        Path(basePath, filename)
+      }
+    }
+
+    return try {
+      WriteAction.compute<VirtualFile?, Exception> {
+        val parentDir = VfsUtil.createDirectoryIfMissing(path.parent.toString()) ?: return@compute null
+        logger.debug { "creating new file: $path" }
+        parentDir.createChildData(this, path.fileName.toString())
+      }
+    } catch (e: Exception) {
+      logger.warn("Failed to create file '$filename': ${e.message}")
+      null
+    }
   }
 
   companion object {

--- a/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
+++ b/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
@@ -265,11 +265,14 @@ internal class FileRemoteApiImpl : FileRemoteApi {
     }
 
     return try {
-      WriteAction.compute<VirtualFile?, Exception> {
-        val parentDir = VfsUtil.createDirectoryIfMissing(path.parent.toString()) ?: return@compute null
-        logger.debug { "creating new file: $path" }
-        parentDir.createChildData(this, path.fileName.toString())
-      }
+      WriteCommandAction.writeCommandAction(project)
+        .withName("Create File")
+        .compute<VirtualFile?, Exception> {
+          val parentDir = VfsUtil.createDirectoryIfMissing(path.parent.toString())
+            ?: return@compute null
+          logger.debug { "creating new file: $path" }
+          parentDir.createChildData(this, path.fileName.toString())
+        }
     } catch (e: Exception) {
       logger.warn("Failed to create file '$filename': ${e.message}")
       null

--- a/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
+++ b/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
@@ -11,6 +11,7 @@ package com.maddyhome.idea.vim.group.file
 import com.intellij.ide.vfs.VirtualFileId
 import com.intellij.ide.vfs.virtualFile
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
@@ -27,6 +28,7 @@ import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.platform.project.ProjectId
@@ -56,24 +58,7 @@ internal class FileRemoteApiImpl : FileRemoteApi {
 
   override suspend fun openFile(filename: String, projectId: ProjectId?, focusEditor: Boolean): String? = onEdt {
     val project = projectId?.findProjectOrNull() ?: return@onEdt "No project found"
-    var file = findFile(filename, project)
-
-    if (file == null) {
-
-      val ioFile = resolveIoFile(filename, project)
-        ?: return@onEdt EngineMessageHelper.message(
-          "message.open.file.not.found",
-          filename
-        )
-      WriteCommandAction.runWriteCommandAction(project) {
-        ioFile.parentFile?.mkdirs()
-        if (!ioFile.exists()) {
-          ioFile.createNewFile()
-        }
-      }
-      file = LocalFileSystem.getInstance()
-        .refreshAndFindFileByIoFile(ioFile)
-    }
+    var file = findFile(filename, project) ?: createFile(filename, project)
 
     if (file != null) {
       FileEditorManager.getInstance(project)
@@ -178,26 +163,6 @@ internal class FileRemoteApiImpl : FileRemoteApi {
     }
 
   // ======================== Private helpers ========================
-
-  private fun resolveIoFile(filename: String, project: Project): java.io.File? {
-
-    // ~/path support
-    if (filename.startsWith("~/") || filename.startsWith("~\\")) {
-      val home = System.getProperty("user.home")
-      return java.io.File(home, filename.substring(2))
-    }
-
-    val file = java.io.File(filename)
-
-    // absolute path
-    if (file.isAbsolute) {
-      return file
-    }
-
-    // relative → project root
-    val basePath = project.basePath ?: return null
-    return java.io.File(basePath, filename)
-  }
   private fun findFile(filename: String, project: Project): VirtualFile? {
     if (filename.startsWith("~/") || filename.startsWith("~\\")) {
       val relativePath = filename.substring(2)
@@ -279,6 +244,31 @@ internal class FileRemoteApiImpl : FileRemoteApi {
     val projectScope = ProjectScope.getProjectScope(project)
     val names = FilenameIndex.getVirtualFilesByName(filename, projectScope)
     return names.firstOrNull()
+  }
+
+  private fun createFile(filename: String, project: Project): VirtualFile? {
+    val path = when {
+      filename.startsWith("~/") || filename.startsWith("~\\") -> {
+        val home = System.getProperty("user.home")
+        Path(home, filename.substring(2))
+      }
+      Path(filename).isAbsolute -> Path(filename)
+      else -> {
+        val basePath = project.basePath ?: return null
+        Path(basePath, filename)
+      }
+    }
+
+    return try {
+      WriteAction.compute<VirtualFile?, Exception> {
+        val parentDir = VfsUtil.createDirectoryIfMissing(path.parent.toString()) ?: return@compute null
+        logger.debug { "creating new file: $path" }
+        parentDir.createChildData(this, path.fileName.toString())
+      }
+    } catch (e: Exception) {
+      logger.warn("Failed to create file '$filename': ${e.message}")
+      null
+    }
   }
 
   companion object {

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/EditFileCreateTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/EditFileCreateTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.commands
+
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.vfs.LocalFileSystem
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class EditFileCreateTest : VimTestCase() {
+
+  @Test
+  fun `test edit creates file if it does not exist`() {
+    configureByText("\n")
+
+    val fileName = "vim266_new_${System.currentTimeMillis()}.txt"
+
+    typeText(commandToKeys("edit $fileName"))
+
+    val currentFile = FileEditorManager.getInstance(fixture.project).selectedFiles.firstOrNull()
+
+    assertNotNull(currentFile, "No file is currently selected/open")
+    assertEquals(fileName, currentFile.name, "The editor should have switched to the new file")
+
+    val foundOnDisk = LocalFileSystem.getInstance().refreshAndFindFileByPath(currentFile.path)
+    assertNotNull(foundOnDisk, "File should physically exist in the test VFS")
+  }
+}

--- a/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/EditFileCreateSplitTest.kt
+++ b/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/EditFileCreateSplitTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ */
+
+package com.maddyhome.idea.vim.split
+
+import org.junit.jupiter.api.Test
+
+class EditFileCreateSplitTest : IdeaVimStarterTestBase() {
+
+  @Test
+  fun `test edit non-existent file creates it and opens it in the editor`() {
+    openFile("src/placeholder.txt")
+    pause(2_000)
+
+    exCommand("e src/brand_new_file.txt")
+    pause(3_000)
+
+    typeVimAndEscape("ihello from IdeaVim")
+    pause(1_000)
+
+    assertEditorContains("hello from IdeaVim")
+
+    val file = projectDir.resolve("src/brand_new_file.txt")
+    assert(file.toFile().exists()) {
+      "File should exist at: ${file.toAbsolutePath()}. projectDir=$projectDir"
+    }
+  }
+}


### PR DESCRIPTION
This change makes :edit behave like Vim by creating a new file
when the specified file does not exist.

Previously, :edit returned an error if the file was missing.

Changes:
- Create file inside project base path if not found
- Create parent directories when needed
- Refresh VirtualFileSystem after creation
- Open created file in editor