### PR TITLE
VIM-3727 Fix Python console Enter and arrow keys in split mode 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -225,7 +225,7 @@ tasks {
 
   val runPycharm by intellijPlatformTesting.runIde.registering {
     type = IntelliJPlatformType.PyCharmProfessional
-    version = "2025.3.2"
+    version = "2026.1"
     task {
       systemProperty("octopus.handler", System.getProperty("octopus.handler") ?: true)
     }
@@ -310,7 +310,7 @@ tasks {
   }
   val runPycharmSplitMode by intellijPlatformTesting.runIde.registering {
     type = IntelliJPlatformType.PyCharmProfessional
-    version = "2025.3.2"
+    version = "2026.1"
     splitMode = true
     splitModeTarget = SplitModeAware.SplitModeTarget.BOTH
 
@@ -353,6 +353,45 @@ tasks {
           logger.warn(
             "Could not find jetbrains_client64.vmoptions in sandbox. " +
                     "Run `./gradlew runIdeSplitMode` once first to populate the sandbox, then use this task."
+          )
+        }
+      }
+    }
+  }
+
+  val runPycharmSplitModeDebugFrontend by intellijPlatformTesting.runIde.registering {
+    type = IntelliJPlatformType.PyCharmProfessional
+    version = "2026.1"
+    splitMode = true
+    splitModeTarget = SplitModeAware.SplitModeTarget.BOTH
+
+    plugins {
+      plugin("AceJump", "3.8.22")
+      plugin("org.jetbrains.IdeaVim-EasyMotion", "1.16")
+    }
+
+    prepareSandboxTask {
+      val sandboxDir = project.layout.buildDirectory.dir("idea-sandbox").map { it.asFile }
+      doLast {
+        val debugLine = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006"
+        val vmoptions = sandboxDir.get().walkTopDown()
+          .filter { it.name == "jetbrains_client64.vmoptions" && it.path.contains("runPycharmSplitModeDebugFrontend") }
+          .firstOrNull()
+          ?: sandboxDir.get().walkTopDown()
+            .filter { it.name == "jetbrains_client64.vmoptions" }
+            .firstOrNull()
+
+        if (vmoptions != null) {
+          val content = vmoptions.readText()
+          if (debugLine !in content) {
+            vmoptions.appendText("\n$debugLine\n")
+            logger.lifecycle("Patched frontend vmoptions with JDWP debug agent: ${vmoptions.absolutePath}")
+          }
+          logger.lifecycle("Connect a Remote JVM Debug configuration to localhost:5006")
+        } else {
+          logger.warn(
+            "Could not find jetbrains_client64.vmoptions in sandbox. " +
+                    "Run `./gradlew runPycharmSplitMode` once first to populate the sandbox, then use this task."
           )
         }
       }

--- a/src/main/java/com/maddyhome/idea/vim/extension/windownavigation/ToolWindowNavEverywhere.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/windownavigation/ToolWindowNavEverywhere.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ToolWindowType
 import com.maddyhome.idea.vim.extension.VimExtension
+import com.maddyhome.idea.vim.helper.EditorHelper
 import java.awt.Component
 import java.awt.KeyboardFocusManager
 import java.beans.PropertyChangeListener
@@ -31,7 +32,7 @@ internal class ToolWindowNavEverywhere : VimExtension {
     val oldFocusOwner = evt.oldValue as? JComponent
     val dispatcher = service<ToolWindowNavDispatcher>()
 
-    if (newFocusOwner != null && isInsideToolWindow(newFocusOwner)) {
+    if (newFocusOwner != null && isInsideToolWindow(newFocusOwner) && !isPythonConsoleComponent(newFocusOwner)) {
       dispatcher.register(newFocusOwner)
     }
 
@@ -49,6 +50,18 @@ internal class ToolWindowNavEverywhere : VimExtension {
     KeyboardFocusManager.getCurrentKeyboardFocusManager()
       .removePropertyChangeListener("focusOwner", focusListener)
     super.dispose()
+  }
+
+  private fun isPythonConsoleComponent(component: Component): Boolean {
+    for (project in ProjectManager.getInstance().openProjects) {
+      if (project.isDisposed) continue
+      val toolWindowManager = ToolWindowManager.getInstance(project)
+      val tw = toolWindowManager.getToolWindow(EditorHelper.PYTHON_CONSOLE_TOOL_WINDOW_ID) ?: continue
+      if (SwingUtilities.isDescendingFrom(component, tw.component)) {
+        return true
+      }
+    }
+    return false
   }
 
   private fun isInsideToolWindow(component: Component): Boolean {

--- a/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -28,6 +28,8 @@ import com.maddyhome.idea.vim.action.change.LazyVimCommand;
 import com.maddyhome.idea.vim.api.*;
 import com.maddyhome.idea.vim.command.MappingMode;
 import com.maddyhome.idea.vim.extension.VimExtensionFacade;
+import com.maddyhome.idea.vim.helper.EditorHelper;
+import com.maddyhome.idea.vim.helper.EditorHelperRt;
 import com.maddyhome.idea.vim.helper.ShortcutHelper;
 import com.maddyhome.idea.vim.key.*;
 import com.maddyhome.idea.vim.newapi.IjNativeAction;
@@ -180,9 +182,15 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
 
   @Override
   public void registerRequiredShortcutKeys(@NotNull VimEditor editor) {
+    Editor ijEditor = ((IjVimEditor)editor).getEditor();
+    if (EditorHelperRt.isIdeaVimDisabledHere(ijEditor)) return;
+
+    var vf = editor.getVirtualFile();
+    if (vf != null && vf.getPath().contains(EditorHelper.PYTHON_CONSOLE_FILE_NAME)) return;
+
     EventFacade.getInstance().registerCustomShortcutSet(VimShortcutKeyAction.getInstance(),
                                                         ShortcutHelper.toShortcutSet(getRequiredShortcutKeys()),
-                                                        ((IjVimEditor)editor).getEditor().getContentComponent());
+                                                        ijEditor.getContentComponent());
   }
 
   @Override

--- a/src/main/java/com/maddyhome/idea/vim/handler/VimEnterHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/handler/VimEnterHandler.kt
@@ -21,7 +21,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import com.intellij.openapi.editor.actions.SplitLineAction
 import com.intellij.openapi.editor.impl.CaretModelImpl
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.UserDataHolder
 import com.intellij.openapi.util.removeUserData
@@ -119,11 +118,7 @@ internal abstract class OctopusHandler(private val nextHandler: EditorActionHand
 
   private fun executeInInvokeLater(editor: Editor): Boolean {
     // Currently we have a workaround for the PY console VIM-3157
-    val fileName = FileDocumentManager.getInstance().getFile(editor.document)?.name
-    if (
-      fileName == "Python Console.py" || // This is the name in 232+
-      fileName == "Python Console" // This is the name in 231
-    ) return false
+    if (EditorHelper.isPythonConsole(editor)) return false
     return (editor.caretModel as? CaretModelImpl)?.isIteratingOverCarets ?: true
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -45,6 +45,9 @@ public class EditorHelper {
   // mitigates the visible area bouncing around too much and even pushing the cursor line off screen with large
   // multiline rendered doc comments, while still providing some visibility of the block inlay (e.g. Rider's single line
   // Code Vision)
+  public static final String PYTHON_CONSOLE_FILE_NAME = "Python Console.py";
+  public static final String PYTHON_CONSOLE_TOOL_WINDOW_ID = "Python Console";
+
   private static final int BLOCK_INLAY_MAX_LINE_HEIGHT = 3;
 
   public static @NotNull Rectangle getVisibleArea(final @NotNull Editor editor) {
@@ -694,5 +697,13 @@ public class EditorHelper {
     }
 
     return false;
+  }
+
+  public static boolean isPythonConsole(@NotNull Editor editor) {
+    if (editor.getVirtualFile() == null) return false;
+    // In split mode, the projected VirtualFile may have a different getName() result,
+    // so we also check getPath() to reliably detect the Python console.
+    return editor.getVirtualFile().getName().contains(PYTHON_CONSOLE_FILE_NAME)
+           || editor.getVirtualFile().getPath().contains(PYTHON_CONSOLE_FILE_NAME);
   }
 }


### PR DESCRIPTION
In split mode, VimShortcutKeyAction and ToolWindowNavDispatcher claimed Enter/arrow key shortcuts on the Python console editor component, preventing the thin client from creating backend delegating actions for Console.Execute and history navigation