### PR TITLE
VIM-4195 Remove legacy $APP_CONFIG$ macro from @Storage annotations

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/main/java/com/maddyhome/idea/vim/VimPlugin.java
@@ -46,7 +46,7 @@ import org.jetbrains.annotations.Nullable;
  * This is an application level plugin meaning that all open projects will share a common instance of the plugin.
  * Registers and marks are shared across open projects so you can copy and paste between files of different projects.
  */
-@State(name = "VimSettings", storages = {@Storage("$APP_CONFIG$/vim_settings.xml")})
+@State(name = "VimSettings", storages = {@Storage("vim_settings.xml")})
 public class VimPlugin implements PersistentStateComponent<Element>, Disposable {
 
   public static final int STATE_VERSION = 7;

--- a/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/EditorGroup.java
@@ -55,7 +55,7 @@ import static com.maddyhome.idea.vim.newapi.IjVimInjectorKt.ijOptions;
 /**
  * @author vlan
  */
-@State(name = "VimEditorSettings", storages = {@Storage(value = "$APP_CONFIG$/vim_settings.xml")})
+@State(name = "VimEditorSettings", storages = {@Storage(value = "vim_settings.xml")})
 public class EditorGroup implements PersistentStateComponent<Element>, VimEditorGroup {
   public static final @NonNls String EDITOR_STORE_ELEMENT = "editor";
   private final CaretListener myLineNumbersCaretListener = new CaretListener() {

--- a/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -53,7 +53,7 @@ import static java.util.stream.Collectors.toList;
 /**
  * @author vlan
  */
-@State(name = "VimKeySettings", storages = {@Storage(value = "$APP_CONFIG$/vim_settings.xml")})
+@State(name = "VimKeySettings", storages = {@Storage(value = "vim_settings.xml")})
 public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponent<Element> {
   public static final @NonNls String SHORTCUT_CONFLICTS_ELEMENT = "shortcut-conflicts";
   private static final @NonNls String SHORTCUT_CONFLICT_ELEMENT = "shortcut-conflict";


### PR DESCRIPTION
## Summary

- Remove the legacy `$APP_CONFIG$/` prefix from `@Storage` annotations in `VimPlugin.java`, `EditorGroup.java`, and `KeyGroup.java`
- The `$APP_CONFIG$` path macro is rejected by `SecurityHelper.validateSettingsFile` in remote dev / split mode, causing a `Throwable: Path isn't allowed in settings file name`
- The IntelliJ platform resolves app-level storage to the config directory automatically, so the bare filename `vim_settings.xml` is sufficient and correct

## Test plan

- [ ] Verify IdeaVim settings persist correctly after restart (enable/disable plugin, change settings, restart IDE)
- [ ] Verify no `Path isn't allowed in settings file name` error in remote dev / split mode
- [ ] Verify existing `vim_settings.xml` is still picked up after the change (no settings migration needed since the resolved path is the same)

🤖 Generated with [Claude Code](https://claude.com/claude-code)