### PR TITLE
VIM-4197 Fix missing Vim features in Java files decompiled from Kotlin class files

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,6 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.editor.*;
 import com.intellij.openapi.editor.ex.util.EditorUtil;
 import com.intellij.openapi.editor.impl.EditorImpl;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -683,6 +684,48 @@ public class EditorHelper {
   }
 
   /**
+   * Checks if the editor is the Python console, so we can disable Vim features
+   */
+  public static boolean isPythonConsole(@NotNull Editor editor) {
+    if (editor.getVirtualFile() == null) return false;
+    // In split mode, the projected VirtualFile may have a different getName() result,
+    // so we also check getPath() to reliably detect the Python console.
+    return editor.getVirtualFile().getName().contains(PYTHON_CONSOLE_FILE_NAME)
+           || editor.getVirtualFile().getPath().contains(PYTHON_CONSOLE_FILE_NAME);
+  }
+
+  /**
+   * Checks if the editor is hosted in the Commit tool window, so we can enable Vim features
+   */
+  public static boolean isCommitWindowEditor(@NotNull Editor editor) {
+    // The best heuristic we have is the file name, which is Dummy.txt
+    var file = editor.getVirtualFile();
+    return file != null && file.getName().contains("Dummy.txt");
+  }
+
+  /**
+   * Checks if the editor is a Kotlin class file decompiled to a Java file, so we can enable Vim features
+   * <p>
+   *   The platform changed the implementation of decompiling a Kotlin .class file to Java in 2026.2. Previously, it
+   *   used a dummy virtual file implementation. Now it uses an instance of {@link LightVirtualFile}. Typically, this
+   *   means an in-memory file that we don't want to have Vim features for, but in this case, we do.
+   * </p>
+   * <p>
+   *   To test, open a .class file generated from a Kotlin file. Then use the "Decompile to Java" action to create a
+   *   separate (in-memory) `.decompiled.java` file. Java-based .class files are decompiled directly in the document for
+   *   the .class file, so the editor is always backed by a valid file.
+   * </p>
+   * <p>
+   *   Perhaps a future implementation would have an allow-list for {@link VirtualFile#getFileType()} and allow "JAVA"?
+   * </p>
+   */
+  public static boolean isKotlinClassDecompiledToJavaFile(@NotNull Editor editor) {
+    @SuppressWarnings("deprecation") @Nullable Key<?> key = Key.findKeyByName("IS_KOTLIN_DECOMPILED_FILE");
+    var file = editor.getVirtualFile();
+    return file != null && key != null && editor.getVirtualFile().getUserData(key) == Boolean.TRUE;
+  }
+
+  /**
    * Checks if the document in the editor is modified.
    */
   public static boolean hasUnsavedChanges(@NotNull Editor editor) {
@@ -697,13 +740,5 @@ public class EditorHelper {
     }
 
     return false;
-  }
-
-  public static boolean isPythonConsole(@NotNull Editor editor) {
-    if (editor.getVirtualFile() == null) return false;
-    // In split mode, the projected VirtualFile may have a different getName() result,
-    // so we also check getPath() to reliably detect the Python console.
-    return editor.getVirtualFile().getName().contains(PYTHON_CONSOLE_FILE_NAME)
-           || editor.getVirtualFile().getPath().contains(PYTHON_CONSOLE_FILE_NAME);
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
@@ -49,7 +49,7 @@ internal val Editor.isIdeaVimDisabledHere: Boolean
       !ClientId.isCurrentlyUnderLocalId || // CWM-927
       (ideaVimDisabledForSingleLine(ideaVimSupportValue) && isSingleLine()) ||
       IdeaVimDisablerExtensionPoint.isDisabledForEditor(this) ||
-      isNotFileEditorExceptAllowed() || EditorHelper.isPythonConsole(this)
+      !isAllowedFileEditor()
   }
 
 /**
@@ -61,18 +61,18 @@ internal val Editor.isIdeaVimDisabledHere: Boolean
  * Here are issues when non-file editors were supported:
  * AI Chat – VIM-3786
  * Debug evaluate console – VIM-3929
+ * Python console - VIM-4172
  *
- * However, we still support IdeaVim in a commit window because it works fine there, and removing vim from this place will
- *   be quite a visible change for users.
- * We detect the commit window by the name of the editor (Dummy.txt). If this causes issues, let's disable IdeaVim
- *   in the commit window as well.
- *
- * Also, we support IdeaVim in diff viewers.
+ * We do want to support Vim actions in some windows, such as the commit window, diff windows, and decompiled Java
+ * files. We don't support the Python console.
  */
-private fun Editor.isNotFileEditorExceptAllowed(): Boolean {
-  if (EditorHelper.getVirtualFile(this)?.name?.contains("Dummy.txt") == true) return false
-  if (EditorHelper.isDiffEditor(this)) return false
-  return !EditorHelper.isFileEditor(this)
+private fun Editor.isAllowedFileEditor(): Boolean {
+  if (EditorHelper.isPythonConsole(this)) return false
+
+  return EditorHelper.isCommitWindowEditor(this)
+    || EditorHelper.isKotlinClassDecompiledToJavaFile(this)
+    || EditorHelper.isDiffEditor(this)
+    || EditorHelper.isFileEditor(this)
 }
 
 private fun ideaVimDisabledInDialog(ideaVimSupportValue: StringListOptionValue): Boolean {


### PR DESCRIPTION
This PR will fix missing Vim features in Java files that have been decompiled from Kotlin-based `.class` files. This appears to be a change in the 2026.2 platform.

To test: Open a `.class` file that has been generated from a Kotlin source file, then invoke the "Decompile to Java" action. This will open a new (in-memory) `.decompiled.java` file. Previously, this was using a full `VirtualFile` implementation. In 262, it appears to be an instance of `LightVirtualFile` - used to handle in-memory files.

IdeaVim will disable Vim features in any file backed with `LightVirtualFile`, as these in-memory files cannot be assumed to be simple editable text files. This PR will check for the presence of the `IS_KOTLIN_DECOMPILED_FILE` user data in the virtual file to indicate that it is an in-memory file based on a Kotlin class file.

This does not affect decompiled Java files, as these are decompiled directly in the document for the `.class` file, so it is always a disk-backed virtual file, rather than in-memory, and Vim features are already active.

It also updates the checks to avoid the double negative. Instead of `isNotFileEditorExceptAllowed` we now have `isAllowedFileEditor`, which is easier to reason about.

It also updates `gradle.xml` so that Gradle will default to the project SDK, rather than the explicit `JAVA_HOME` value that might not be set on a user's machine.

Fixes [VIM-4197](https://youtrack.jetbrains.com/issue/VIM-4197/IdeaVim-no-longer-active-in-decompiled-Java-file)