### PR TITLE
VIM-4112 collapse restored carets after undo of block-visual edit

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/UndoRedoHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/UndoRedoHelper.kt
@@ -28,6 +28,7 @@ import com.maddyhome.idea.vim.common.InsertSequence
 import com.maddyhome.idea.vim.newapi.IjVimCaret
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.newapi.ij
+import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.undo.VimTimestampBasedUndoService
 
 /**
@@ -51,12 +52,15 @@ class UndoRedoHelper : VimTimestampBasedUndoService {
     val textEditor = getTextEditor(editor.ij)
     val undoManager = UndoManager.getInstance(project)
     if (undoManager.isUndoAvailable(textEditor)) {
+      val caretCountBeforeUndo = editor.ij.caretModel.allCarets.size
       val scrollingModel = editor.getScrollingModel()
       scrollingModel.accumulateViewportChanges()
 
       performUndo(editor, undoManager, textEditor)
 
       scrollingModel.flushViewportChanges()
+
+      collapseRestoredBlockVisualCarets(editor, caretCountBeforeUndo)
 
       return true
     }
@@ -194,6 +198,23 @@ class UndoRedoHelper : VimTimestampBasedUndoService {
         removeSelections(editor)
       }
     }
+  }
+
+  /**
+   * VIM-4112. IntelliJ's undo restores the pre-edit `CaretState`; for a block-visual edit that
+   * means one caret per block row. A 1 → N caret-count jump across undo uniquely identifies
+   * this, since [com.maddyhome.idea.vim.helper.exitVisualMode] is the only flow that collapses
+   * multi-carets to one. The remaining caret is placed at the block's top-left, matching Vim's
+   * convention of cursor-at-start-of-undone-change.
+   */
+  private fun collapseRestoredBlockVisualCarets(editor: VimEditor, caretCountBeforeUndo: Int) {
+    val caretModel = editor.ij.caretModel
+    val restoredExtraCarets = caretCountBeforeUndo == 1 && caretModel.allCarets.size > 1
+    if (!restoredExtraCarets || editor.mode !is Mode.NORMAL) return
+
+    val blockTopOffset = caretModel.allCarets.minOf { it.offset }
+    caretModel.removeSecondaryCarets()
+    caretModel.primaryCaret.moveToOffset(blockTopOffset)
   }
 
   private fun removeSelections(editor: VimEditor) {

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/UndoActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/UndoActionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2023 The IdeaVim authors
+ * Copyright 2003-2026 The IdeaVim authors
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE.txt file or at
@@ -62,6 +62,34 @@ class UndoActionTest : VimTestCase() {
       ApplicationManager.getApplication().runReadAction {
         kotlin.test.assertFalse(hasSelection())
       }
+    }
+  }
+
+  @Test
+  fun `test undo after visual block mode delete clears leftover native carets`() {
+    configureByText(
+      """
+      ${c}1. Item
+      2. Item
+      3. Item
+      """.trimIndent()
+    )
+
+    typeText("<C-V>jjllx")
+
+    typeText("u")
+    assertState(
+      """
+      ${c}1. Item
+      2. Item
+      3. Item
+      """.trimIndent()
+    )
+
+    assertMode(Mode.NORMAL())
+    ApplicationManager.getApplication().runReadAction {
+      kotlin.test.assertFalse(hasSelection())
+      kotlin.test.assertEquals(1, fixture.editor.caretModel.allCarets.size)
     }
   }
 


### PR DESCRIPTION
After undoing a block-visual edit (<C-V>…x, <C-V>…c, <C-V>…I), IntelliJ restored the pre-edit multi-caret CaretState even though Vim is in single-cursor normal mode, leaving stray native carets. UndoRedoHelper now detects the 1 -> N caret jump across undo - a signal unique to block-visual since it's the only flow that collapses multi-carets on exit - and collapses back to a single caret at the block's top-left, matching Vim's convention