### PR TITLE
VIM-4202 Fix state after commentary action

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -241,7 +241,7 @@ tasks {
 
   val runClion by intellijPlatformTesting.runIde.registering {
     type = IntelliJPlatformType.CLion
-    version = "2025.3.2"
+    version = "2026.1"
     task {
       systemProperty("octopus.handler", System.getProperty("octopus.handler") ?: true)
     }

--- a/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/comment/CommentaryRemoteApiImpl.kt
+++ b/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/comment/CommentaryRemoteApiImpl.kt
@@ -8,23 +8,24 @@
 
 package com.maddyhome.idea.vim.group.comment
 
-import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.codeInsight.actions.MultiCaretCodeInsightActionHandler
+import com.intellij.codeInsight.generation.CommentByBlockCommentHandler
+import com.intellij.codeInsight.generation.CommentByLineCommentHandler
+import com.intellij.lang.LanguageCommenters
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.impl.EditorId
 import com.intellij.openapi.editor.impl.findEditorOrNull
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
 import com.maddyhome.idea.vim.group.onEdt
 
 /**
- * RPC handler for [CommentaryRemoteApi].
- *
- * Sets selection on the backend editor and executes the platform's comment action.
- * Because this runs on the backend, [com.intellij.openapi.command.CommandProcessor]
- * groups all document modifications as a single undo step.
- *
- * The selection is set on the backend editor only — it doesn't affect the frontend
- * editor's visual state, and is cleaned up immediately after the action executes.
+ * Handlers are invoked directly rather than via `ActionManager.tryToExecute` because in
+ * Rider / CLion Nova the action dispatch is async — `ActionCallback` signals `done` at
+ * dispatch, not completion — so the action's selection survived `removeSelection()` and
+ * the selection listener dropped IdeaVim into Visual-Line mode.
  */
 internal class CommentaryRemoteApiImpl : CommentaryRemoteApi {
 
@@ -35,40 +36,47 @@ internal class CommentaryRemoteApiImpl : CommentaryRemoteApi {
     val startOffset = document.getLineStartOffset(startLine)
     val endOffset = document.getLineEndOffset(endLine)
 
-    executeCommentAction(editor, startOffset, endOffset, caretOffset, IdeActions.ACTION_COMMENT_LINE)
+    runCommenter(editor, startOffset, endOffset, caretOffset, lineWise = true)
   }
 
   override suspend fun toggleBlockComment(editorId: EditorId, startOffset: Int, endOffset: Int, caretOffset: Int) =
     onEdt {
       val editor = editorId.findEditorOrNull() ?: return@onEdt
-      // Try block comment first, fall back to line comment
-      if (!executeCommentAction(editor, startOffset, endOffset, caretOffset, IdeActions.ACTION_COMMENT_BLOCK)) {
-        executeCommentAction(editor, startOffset, endOffset, caretOffset, IdeActions.ACTION_COMMENT_LINE)
-      }
+      runCommenter(editor, startOffset, endOffset, caretOffset, lineWise = false)
     }
 
-  private fun executeCommentAction(
+  private fun runCommenter(
     editor: Editor,
     startOffset: Int,
     endOffset: Int,
     caretOffset: Int,
-    actionId: String,
-  ): Boolean {
-    var result = false
-    // Wrap selection + action + caret reset + cleanup in a single command so everything
-    // is a single undo step. In remdev, undo restores pre-command editor state — if
-    // selection is set before the command, undo would restore it. The nested tryToExecute
-    // command merges into this outer command.
-    CommandProcessor.getInstance().executeCommand(editor.project, {
-      editor.selectionModel.setSelection(startOffset, endOffset)
-      val action = ActionManager.getInstance().getAction(actionId)
-      result = ActionManager.getInstance().tryToExecute(action, null, editor.contentComponent, "IdeaVim", true)
-        .let { it.waitFor(5_000); it.isDone }
-      editor.selectionModel.removeSelection()
-      if (caretOffset >= 0) {
-        editor.caretModel.moveToOffset(caretOffset)
+    lineWise: Boolean,
+  ) {
+    val project = editor.project ?: return
+    val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return
+
+    CommandProcessor.getInstance().executeCommand(project, {
+      ApplicationManager.getApplication().runWriteAction {
+        val caret = editor.caretModel.primaryCaret
+        caret.setSelection(startOffset, endOffset)
+        try {
+          val handler = pickHandler(psiFile, lineWise)
+          handler.invoke(project, editor, caret, psiFile)
+          handler.postInvoke()
+        } finally {
+          caret.removeSelection()
+          if (caretOffset >= 0) {
+            caret.moveToOffset(caretOffset)
+          }
+        }
       }
     }, "Commentary", null)
-    return result
+  }
+
+  private fun pickHandler(psiFile: PsiFile, lineWise: Boolean): MultiCaretCodeInsightActionHandler {
+    if (lineWise) return CommentByLineCommentHandler()
+    val commenter = LanguageCommenters.INSTANCE.forLanguage(psiFile.language)
+    val hasBlock = commenter?.blockCommentPrefix != null && commenter.blockCommentSuffix != null
+    return if (hasBlock) CommentByBlockCommentHandler() else CommentByLineCommentHandler()
   }
 }

--- a/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/CommentarySplitTest.kt
+++ b/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/CommentarySplitTest.kt
@@ -79,4 +79,37 @@ class CommentarySplitTest : IdeaVimStarterTestBase() {
     val line2 = editorText().lines().getOrNull(1) ?: ""
     assertTrue(!line2.contains("//")) { "Line should be uncommented. Line: $line2" }
   }
+
+  @Test
+  fun `gcc returns to Normal mode after commenting`() {
+    openFile(javaFile("Comment4"))
+    setUpCommentary()
+    goToLine(2)
+    typeVim("gcc")
+
+    assertEditorContains("//", "Line should be commented")
+
+    typeVimAndEscape("Ohello")
+
+    assertEditorContains("hello", "Ohello<Esc> should insert 'hello' — proves mode is Normal")
+  }
+
+  @Test
+  fun `gcc then undo returns to Normal mode`() {
+    openFile(javaFile("Comment5"))
+    setUpCommentary()
+    goToLine(2)
+    typeVim("gcc")
+
+    assertEditorContains("//", "Line should be commented")
+
+    typeVim("u")
+
+    assertEditorNotContains("//", "Undo should remove comment completely")
+
+    typeVimAndEscape("Ohello")
+
+    assertEditorContains("hello", "Ohello<Esc> should insert 'hello' after undo — proves mode is Normal")
+    assertEditorNotContains("//", "Undo must not have left a lingering comment")
+  }
 }


### PR DESCRIPTION
in split mode/clion/ rider, after the comment action runs on rpc, it happens after removing selection. To fix that, we execute handler directly in synchronous way