### PR TITLE
VIM-4202 Don't intercept all <S-Tab>

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -274,7 +274,6 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
       ImmutableSet.builder<KeyStroke>().addAll(getKeyStrokes(KeyEvent.VK_ENTER, 0))
         .addAll(getKeyStrokes(KeyEvent.VK_ESCAPE, 0))
         .addAll(getKeyStrokes(KeyEvent.VK_TAB, 0))
-        .addAll(getKeyStrokes(KeyEvent.VK_TAB, InputEvent.SHIFT_DOWN_MASK))
         .addAll(getKeyStrokes(KeyEvent.VK_BACK_SPACE, 0, InputEvent.CTRL_DOWN_MASK))
         .addAll(getKeyStrokes(KeyEvent.VK_INSERT, 0))
         .addAll(getKeyStrokes(KeyEvent.VK_DELETE, 0, InputEvent.CTRL_DOWN_MASK))


### PR DESCRIPTION
When <S-Tab> was in VIM_ONLY_EDITOR_KEYS users couldn't override it for other intelij actions