### PR TITLE
VIM-186 Add comment aware wrapping logic

### DIFF
--- a/ThirdPartyLicenses.md
+++ b/ThirdPartyLicenses.md
@@ -2,6 +2,8 @@ IdeaVim project is licensed under MIT license except the following parts of it:
 
 * File [ScrollViewHelper.kt](com/maddyhome/idea/vim/helper/ScrollViewHelper.kt) is licensed under Vim License.
 * File [Tutor.kt](src/main/java/com/maddyhome/idea/vim/ui/Tutor.kt) is licensed under Vim License.
+* File [CodeWrapper.kt](vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CodeWrapper.kt) is licensed under Vim
+  License.
 
 ```
 VIM LICENSE

--- a/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.kt
@@ -23,6 +23,7 @@ import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.psi.util.PsiUtilBase
 import com.maddyhome.idea.vim.EventFacade
 import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.Options
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimChangeGroupBase
 import com.maddyhome.idea.vim.api.VimEditor
@@ -31,11 +32,15 @@ import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.group.change.ChangeRemoteApi
 import com.maddyhome.idea.vim.group.format.FormatRemoteApi
 import com.maddyhome.idea.vim.handler.commandContinuation
+import com.maddyhome.idea.vim.helper.CodeWrapper
+import com.maddyhome.idea.vim.helper.CommentLeaderParser
 import com.maddyhome.idea.vim.helper.inInsertMode
 import com.maddyhome.idea.vim.key.KeyHandlerKeeper
 import com.maddyhome.idea.vim.listener.VimInsertListener
 import com.maddyhome.idea.vim.newapi.IjVimEditor
 import com.maddyhome.idea.vim.newapi.ij
+import com.maddyhome.idea.vim.newapi.ijOptions
+import com.maddyhome.idea.vim.options.OptionAccessScope
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.undo.VimKeyBasedUndoService
 import com.maddyhome.idea.vim.undo.VimTimestampBasedUndoService
@@ -153,6 +158,39 @@ class ChangeGroup : VimChangeGroupBase() {
     val textRange = com.intellij.openapi.util.TextRange.create(start, end)
     injector.application.runWriteAction {
       CodeStyleManager.getInstance(project).reformatText(file, listOf(textRange))
+    }
+    wrapText(editor, start, end)
+  }
+
+  private fun wrapText(editor: IjVimEditor, start: Int, end: Int) {
+    val textwidth = injector.ijOptions(editor).textwidth
+    if (textwidth <= 0) {
+      return
+    }
+    wrapTextToWidth(editor, start, end, textwidth)
+  }
+
+  private fun wrapTextToWidth(editor: IjVimEditor, start: Int, end: Int, width: Int) {
+    val ijEditor = editor.editor
+    val document = ijEditor.document
+
+    val text = document.getText(com.intellij.openapi.util.TextRange.create(start, end))
+    val commentsValue = injector.optionGroup
+      .getOptionValue(Options.comments, OptionAccessScope.LOCAL(editor))
+      .value
+    val wrapper = CodeWrapper(
+      width = width,
+      tabWidth = ijEditor.settings.getTabSize(ijEditor.project),
+      leaders = CommentLeaderParser.parse(commentsValue),
+    )
+    val wrapped = wrapper.wrap(text)
+
+    if (wrapped == text) {
+      return
+    }
+
+    injector.application.runWriteAction {
+      document.replaceString(start, end, wrapped)
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/group/CommentsOptionInitializer.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/CommentsOptionInitializer.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.group
+
+import com.intellij.lang.LanguageCommenters
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiDocumentManager
+import com.maddyhome.idea.vim.api.Options
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.autocmd.IjFileTypeMapping
+import com.maddyhome.idea.vim.helper.CommenterMarkers
+import com.maddyhome.idea.vim.helper.CommenterToComments
+import com.maddyhome.idea.vim.helper.FiletypePresets
+import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
+
+/**
+ * Resolves a buffer-local `'comments'` value when an editor is created.
+ *
+ * Delegates to [OptionGroup.setBufferLocalDefaultIfUntouched], which preserves
+ * any value the user explicitly set via `.ideavimrc` or interactive `:set`.
+ */
+object CommentsOptionInitializer {
+  fun initializeForEditor(editor: Editor) {
+    val optionGroup = injector.optionGroup as? OptionGroup ?: return
+    val resolved = resolveComments(editor) ?: return
+    optionGroup.setBufferLocalDefaultIfUntouched(
+      Options.comments,
+      editor.vim,
+      VimString(resolved),
+    )
+  }
+
+  private fun resolveComments(editor: Editor): String? {
+    val filetypeName = filetypeOf(editor) ?: return null
+    return FiletypePresets.presetFor(filetypeName) ?: deriveFromCommenter(editor)
+  }
+
+  private fun filetypeOf(editor: Editor): String? {
+    val virtualFile: VirtualFile = FileDocumentManager.getInstance().getFile(editor.document) ?: return null
+    return IjFileTypeMapping.toVimFileType(virtualFile)
+  }
+
+  private fun deriveFromCommenter(editor: Editor): String? {
+    val project = editor.project ?: return null
+    val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return null
+    val commenter = LanguageCommenters.INSTANCE.forLanguage(psiFile.language) ?: return null
+    return CommenterToComments.derive(
+      CommenterMarkers(
+        linePrefix = commenter.lineCommentPrefix,
+        blockPrefix = commenter.blockCommentPrefix,
+        blockSuffix = commenter.blockCommentSuffix,
+      ),
+    )
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/group/OptionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/OptionGroup.kt
@@ -146,6 +146,22 @@ class OptionGroup : VimOptionGroupBase(), IjVimOptionGroup, InternalOptionValueA
     super.setOptionValueInternal(option, scope, value)
   }
 
+  /**
+   * Sets the buffer-local value of [option] as a Vim default — but only if the
+   * current value is still a [OptionValue.Default]. Preserves any value the user
+   * explicitly set via `.ideavimrc` or interactive `:set`/`:setlocal`.
+   */
+  fun <T : VimDataType> setBufferLocalDefaultIfUntouched(
+    option: Option<T>,
+    editor: VimEditor,
+    value: T,
+  ) {
+    val scope = OptionAccessScope.LOCAL(editor)
+    val current = getOptionValueInternal(option, scope)
+    if (current !is OptionValue.Default) return
+    setOptionValueInternal(option, scope, OptionValue.Default(value))
+  }
+
   companion object {
     fun editorReleased(editor: Editor) {
       // Vim always has at least one window; it's not possible to close it. Editing a new file will open a new buffer in

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -80,6 +80,7 @@ import com.maddyhome.idea.vim.autocmd.IjFileTypeMapping
 import com.maddyhome.idea.vim.common.ModeChangeListener
 import com.maddyhome.idea.vim.common.ModeWillChangeListener
 import com.maddyhome.idea.vim.group.ChangeGroup
+import com.maddyhome.idea.vim.group.CommentsOptionInitializer
 import com.maddyhome.idea.vim.group.FileGroupHelper
 import com.maddyhome.idea.vim.group.IjOptions
 import com.maddyhome.idea.vim.group.IjVimRedrawService
@@ -347,6 +348,7 @@ object VimListenerManager {
 
       injector.editorGroup.editorCreated(IjVimEditor(editor))
       (VimPlugin.getChange() as ChangeGroup).editorCreated(IjVimEditor(editor), perEditorDisposable)
+      CommentsOptionInitializer.initializeForEditor(editor)
 
       (editor as EditorEx).addFocusListener(VimFocusListener, perEditorDisposable)
 

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/VimShortcutKeyActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/VimShortcutKeyActionTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action
+
+import com.maddyhome.idea.vim.action.VimShortcutKeyAction
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import javax.swing.KeyStroke
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class VimShortcutKeyActionTest : VimTestCase() {
+
+  @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
+  @Test
+  fun `plain Tab is a Vim-only editor key`() {
+    val tab = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0)
+    assertTrue(VimShortcutKeyAction.VIM_ONLY_EDITOR_KEYS.contains(tab))
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
+  @Test
+  fun `S-Tab is not a Vim-only editor key so sethandler can release it to the IDE`() {
+    val shiftTab = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.SHIFT_DOWN_MASK)
+    assertFalse(VimShortcutKeyAction.VIM_ONLY_EDITOR_KEYS.contains(shiftTab))
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -195,6 +195,7 @@ class SetCommandTest : VimTestCase() {
       |nohlsearch          nonumber            nosneak               wrap
       |  ide=IntelliJ IDEA   operatorfunc=       startofline         wrapscan
       |  clipboard=ideaput,autoselect
+      |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
       |  fileencoding=utf-8
       |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
       |noideacopypreprocess
@@ -258,6 +259,7 @@ class SetCommandTest : VimTestCase() {
     |  clipboard=ideaput,autoselect
     |  colorcolumn=
     |nocommentary
+    |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |nocursorline
     |nodigraph
     |noexchange

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
@@ -449,6 +449,7 @@ class SetglobalCommandTest : VimTestCase() {
     |nohlsearch            operatorfunc=     nosurround
     |  ide=IntelliJ IDEA norelativenumber    notextobj-entire
     |  clipboard=ideaput,autoselect
+    |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
     |noideacopypreprocess
     |  idearefactormode=select
@@ -512,6 +513,7 @@ class SetglobalCommandTest : VimTestCase() {
     |  clipboard=ideaput,autoselect
     |  colorcolumn=
     |nocommentary
+    |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |nocursorline
     |nodigraph
     |noexchange

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
@@ -500,6 +500,7 @@ class SetlocalCommandTest : VimTestCase() {
     |nohlsearch            nrformats=hex     nosmartcase           wrap
     |  ide=IntelliJ IDEA nonumber            nosneak               wrapscan
     |  clipboard=ideaput,autoselect
+    |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |  fileencoding=utf-8
     |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
     |--ideacopypreprocess
@@ -563,6 +564,7 @@ class SetlocalCommandTest : VimTestCase() {
     |  clipboard=ideaput,autoselect
     |  colorcolumn=
     |nocommentary
+    |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |nocursorline
     |nodigraph
     |noexchange

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/CommentsOptionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/CommentsOptionTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.jetbrains.plugins.ideavim.option
+
+import com.maddyhome.idea.vim.api.Options
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.options.OptionAccessScope
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+@TestWithoutNeovim(reason = SkipNeovimReason.OPTION)
+class CommentsOptionTest : VimTestCase() {
+
+  private val vimDefault = "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-"
+
+  @BeforeEach
+  override fun setUp(testInfo: TestInfo) {
+    super.setUp(testInfo)
+    configureByText("\n")
+  }
+
+  private fun commentsValue(): String =
+    injector.optionGroup.getOptionValue(
+      Options.comments,
+      OptionAccessScope.LOCAL(fixture.editor.vim),
+    ).value
+
+  @Test
+  fun `comments option default value matches Vim`() {
+    assertEquals(vimDefault, commentsValue())
+  }
+
+  @Test
+  fun `set comments changes the value`() {
+    enterCommand("set comments=://,b:#")
+    assertEquals("://,b:#", commentsValue())
+  }
+
+  @Test
+  fun `set comments& resets to default`() {
+    val original = commentsValue()
+    enterCommand("set comments=://")
+    assertNotEquals(original, commentsValue())
+    enterCommand("set comments&")
+    assertEquals(original, commentsValue())
+  }
+
+  @Test
+  fun `comments abbreviation com is accepted`() {
+    enterCommand("set com=://")
+    assertEquals("://", commentsValue())
+  }
+
+  @Test
+  fun `set comments inspect displays name and value`() {
+    assertCommandOutput("set comments?", "  comments=$vimDefault")
+  }
+
+  @Test
+  fun `set comments+= appends a list entry`() {
+    enterCommand("set comments=://")
+    enterCommand("set comments+=b:#")
+    assertEquals("://,b:#", commentsValue())
+  }
+
+  @Test
+  fun `set comments-= removes a list entry`() {
+    enterCommand("set comments=://,b:#")
+    enterCommand("set comments-=://")
+    assertEquals("b:#", commentsValue())
+  }
+}

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/CommentsDrivenReformatTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/CommentsDrivenReformatTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.jetbrains.plugins.ideavim.action
+
+import com.intellij.openapi.fileTypes.PlainTextFileType
+import com.maddyhome.idea.vim.api.injector
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+/**
+ * End-to-end coverage of `gq` honoring the buffer-local `'comments'` value.
+ *
+ * Uses a leader not present in the default `'comments'` string so the assertion
+ * fails if the option value is not read at wrap time.
+ */
+@TestWithoutNeovim(
+  reason = SkipNeovimReason.SEE_DESCRIPTION,
+  description = "IdeaVim wraps via the 'comments' option and its filetype presets.",
+)
+class CommentsDrivenReformatTest : VimTestCase() {
+
+  @Test
+  fun `custom REM marker from setlocal drives wrap continuation`() {
+    configureByText(
+      PlainTextFileType.INSTANCE,
+      "REM ${c}some long custom-marker comment text that must wrap to respect textwidth",
+    )
+    enterCommand("setlocal comments=:REM")
+    enterCommand("set textwidth=30")
+    typeText(injector.parser.parseKeys("gqq"))
+    assertState(
+      """
+      ${c}REM some long custom-marker
+      REM comment text that must
+      REM wrap to respect textwidth
+      """.trimIndent(),
+    )
+  }
+
+}

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/ReformatCodeTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/ReformatCodeTest.kt
@@ -240,5 +240,250 @@ class ReformatCodeTest : VimJavaTestCase() {
       }
       """.trimIndent(),
     )
+    configureByJavaText(
+      """
+      class C {
+      	int a;
+      	int ${c}b;
+      	int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("<C-V>jgq"))
+    assertState(
+      """
+      class C {
+      	int a;
+          ${c}int b;
+          int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwEmpty() {
+    configureByJavaText(c)
+    typeText(injector.parser.parseKeys("gww"))
+    assertState(c)
+  }
+
+  @Test
+  fun testGwWithCount() {
+    configureByJavaText(
+      """
+      class C {
+      	int a;
+      	int ${c}b;
+      	int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("2gww"))
+    assertState(
+      """
+      class C {
+      	int a;
+          int ${c}b;
+          int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwWithUpMotion() {
+    configureByJavaText(
+      """
+      class C {
+      	int a;
+      	int b;
+      	int ${c}c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("gwk"))
+    assertState(
+      """
+      class C {
+      	int a;
+          int b;
+          int ${c}c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwWithRightMotion() {
+    configureByJavaText(
+      """
+      class C {
+      	int a;
+      	int ${c}b;
+      	int c;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("gwl"))
+    assertState(
+      """
+      class C {
+      	int a;
+          int ${c}b;
+      	int c;
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwWithTextObject() {
+    configureByJavaText(
+      """
+      class C {
+      	int a;
+      	int ${c}b;
+      	int c;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("gwi{"))
+    assertState(
+      """
+      class C {
+          int a;
+          int ${c}b;
+          int c;
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwWithCountsAndDownMotion() {
+    configureByJavaText(
+      """
+      class C {
+      	int ${c}a;
+      	int b;
+      	int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("2gwj"))
+    assertState(
+      """
+      class C {
+          int ${c}a;
+          int b;
+          int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwVisual() {
+    configureByJavaText(
+      """
+      class C {
+      	int a;
+      	int ${c}b;
+      	int c;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("vlgw"))
+    assertState(
+      """
+      class C {
+      	int a;
+          int ${c}b;
+      	int c;
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwLinewiseVisual() {
+    configureByJavaText(
+      """
+      class C {
+      	int a;
+      	int ${c}b;
+      	int c;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("Vgw"))
+    assertState(
+      """
+      class C {
+      	int a;
+          int ${c}b;
+      	int c;
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwVisualMultiline() {
+    configureByJavaText(
+      """
+      class C {
+      	int a;
+      	int ${c}b;
+      	int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("vjgw"))
+    assertState(
+      """
+      class C {
+      	int a;
+          int ${c}b;
+          int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwVisualBlock() {
+    configureByJavaText(
+      """
+      class C {
+      	int a;
+      	int ${c}b;
+      	int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
+    typeText(injector.parser.parseKeys("<C-V>jgw"))
+    assertState(
+      """
+      class C {
+      	int a;
+          int ${c}b;
+          int c;
+      	int d;
+      }
+      """.trimIndent(),
+    )
   }
 }

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/ReformatCommentsTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/ReformatCommentsTest.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.jetbrains.plugins.ideavim.action
+
+import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.openapi.fileTypes.PlainTextFileType
+import com.maddyhome.idea.vim.api.injector
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+@TestWithoutNeovim(
+  reason = SkipNeovimReason.SEE_DESCRIPTION,
+  description = "IdeaVim applies IDE code formatting before textwidth-based wrapping. Comment leaders are driven by the 'comments' option (per-filetype preset, Commenter fallback, or Vim default).",
+)
+class ReformatCommentsTest : VimTestCase() {
+
+  @Test
+  fun testGqWrapsLongJavaLineComment() {
+    configureByText(
+      JavaFileType.INSTANCE,
+      """
+      class Test {
+          // ${c}This is a very long comment that should be wrapped
+          void method() {}
+      }
+      """.trimIndent(),
+    )
+    enterCommand("set textwidth=35")
+    typeText(injector.parser.parseKeys("gqq"))
+    assertState(
+      """
+      class Test {
+          ${c}// This is a very long comment
+          // that should be wrapped
+          void method() {}
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGqWrapsLongJavaBlockComment() {
+    configureByText(
+      JavaFileType.INSTANCE,
+      """
+      class Test {
+          /* ${c}This is a very long block comment that should be wrapped by the formatter */
+          void method() {}
+      }
+      """.trimIndent(),
+    )
+    enterCommand("set textwidth=50")
+    typeText(injector.parser.parseKeys("gqq"))
+    assertState(
+      """
+      class Test {
+          ${c}/* This is a very long block comment that
+           * should be wrapped by the formatter */
+          void method() {}
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGqWrapsJavaDocComment() {
+    configureByText(
+      JavaFileType.INSTANCE,
+      """
+      class Test {
+          /**
+           * ${c}This is a very long JavaDoc comment that should be wrapped when it exceeds previously defined textwidth
+           */
+          void method() {}
+      }
+      """.trimIndent(),
+    )
+    enterCommand("set textwidth=50")
+    typeText(injector.parser.parseKeys("gqj"))
+    assertState(
+      """
+      class Test {
+          /**
+           ${c}* This is a very long JavaDoc comment that
+           * should be wrapped when it exceeds
+           * previously defined textwidth
+           */
+          void method() {}
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGqWrapsLongPlainTextLine() {
+    configureByText(
+      PlainTextFileType.INSTANCE,
+      "${c}This is a very long line of plain text that should be wrapped when it exceeds the textwidth setting",
+    )
+    enterCommand("set textwidth=40")
+    typeText(injector.parser.parseKeys("gqq"))
+    assertState(
+      """
+      ${c}This is a very long line of plain text
+      that should be wrapped when it exceeds
+      the textwidth setting
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwWrapsLongPlainTextLinePreservingCursor() {
+    configureByText(
+      PlainTextFileType.INSTANCE,
+      "This is a very long line of ${c}plain text that should be wrapped when it exceeds the textwidth setting",
+    )
+    enterCommand("set textwidth=40")
+    typeText(injector.parser.parseKeys("gww"))
+    assertState(
+      """
+      This is a very long line of ${c}plain text
+      that should be wrapped when it exceeds
+      the textwidth setting
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGqWrapsMultipleLongLines() {
+    configureByText(
+      PlainTextFileType.INSTANCE,
+      """
+      ${c}This is the first very long line that needs wrapping to fit within textwidth.
+      This is the second very long line that also needs wrapping to fit within textwidth.
+      """.trimIndent(),
+    )
+    enterCommand("set textwidth=40")
+    typeText(injector.parser.parseKeys("gqj"))
+    assertState(
+      """
+      ${c}This is the first very long line that
+      needs wrapping to fit within textwidth.
+      This is the second very long line that
+      also needs wrapping to fit within
+      textwidth.
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGqVisualWrapsSelectedText() {
+    configureByText(
+      PlainTextFileType.INSTANCE,
+      """
+      ${c}This is a very long line that should be wrapped when formatted with gq in visual mode.
+      This line should not be affected.
+      """.trimIndent(),
+    )
+    enterCommand("set textwidth=40")
+    typeText(injector.parser.parseKeys("Vgq"))
+    assertState(
+      """
+      ${c}This is a very long line that should be
+      wrapped when formatted with gq in visual
+      mode.
+      This line should not be affected.
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGqWrapsLongMarkdownParagraph() {
+    configureByTextX(
+      "test.md",
+      """
+      # Header
+
+      ${c}This is a very long paragraph in a markdown file that should be wrapped when it exceeds the textwidth setting.
+
+      Another paragraph.
+      """.trimIndent(),
+    )
+    enterCommand("set textwidth=50")
+    typeText(injector.parser.parseKeys("gqq"))
+    assertState(
+      """
+      # Header
+
+      ${c}This is a very long paragraph in a markdown file
+      that should be wrapped when it exceeds the
+      textwidth setting.
+
+      Another paragraph.
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testGwWrapsMarkdownPreservingCursor() {
+    configureByTextX(
+      "test.md",
+      """
+      This is a very long ${c}markdown line that should be wrapped but cursor position should be preserved.
+      """.trimIndent(),
+    )
+    enterCommand("set textwidth=40")
+    typeText(injector.parser.parseKeys("gww"))
+    assertState(
+      """
+      This is a very long ${c}markdown line that
+      should be wrapped but cursor position
+      should be preserved.
+      """.trimIndent(),
+    )
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2023 The IdeaVim authors
+ * Copyright 2003-2026 The IdeaVim authors
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE.txt file or at
@@ -102,6 +102,14 @@ object Options {
    */
 
   // Simple options, sorted by name
+  val comments: StringListOption = addOption(
+    StringListOption(
+      "comments",
+      LOCAL_TO_BUFFER,
+      "com",
+      "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-",
+    )
+  )
   val digraph: ToggleOption = addOption(ToggleOption("digraph", GLOBAL, "dg", false))
 
   // Default differs from Vim (which uses 0). In Vim, foldlevel=0 means all folds are closed on window open.

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CodeWrapper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CodeWrapper.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.helper
+
+/**
+ * Text wrapper for gq/gw.
+ *
+ * Pipeline for each paragraph:
+ *   1. Match the leader on the first line against [leaders].
+ *   2. Grow the paragraph forward as long as `sameLeader` allows and the
+ *      next line is not a paragraph boundary.
+ *   3. Join: first line kept intact; subsequent lines contribute their
+ *      content after their leader is stripped.
+ *   4. Split the joined line at [width], re-inserting a continuation
+ *      prefix derived from the first line's leader (s→m transition,
+ *      f-flag space padding, or verbatim repeat).
+ */
+class CodeWrapper(
+  private val width: Int = 80,
+  private val tabWidth: Int = 4,
+  private val leaders: List<CommentLeader>,
+) {
+  private val leadersLongestFirst = leaders.sortedByDescending { it.text.length }
+  private val middleByStart: Map<CommentLeader, CommentLeader> = pairStartsWithMiddle()
+
+  fun wrap(text: String?): String {
+    if (text.isNullOrEmpty()) return ""
+    val trailingNewline = text.endsWith("\n")
+    val body = if (trailingNewline) text.dropLast(1) else text
+    val formatted = formatLines(body.split("\n")).joinToString("\n")
+    return if (trailingNewline) "$formatted\n" else formatted
+  }
+
+  private fun formatLines(lines: List<String>): List<String> {
+    val out = mutableListOf<String>()
+    var startLineIndex = 0
+    while (startLineIndex < lines.size) {
+      val firstLine = lines[startLineIndex]
+      val firstMatch = matchLeader(firstLine)
+      if (isEndPar(firstLine, firstMatch)) {
+        out.add(firstLine.trimEnd())
+        startLineIndex++
+        continue
+      }
+      val endLineIndex = findParagraphEnd(lines, startLineIndex, firstLine, firstMatch)
+      val joined = joinParagraph(lines, startLineIndex, endLineIndex)
+      val prefix = continuationPrefix(firstLine, firstMatch)
+      out.addAll(splitAtWidth(joined, prefix))
+      startLineIndex = endLineIndex + 1
+    }
+    return out
+  }
+
+  private fun findParagraphEnd(
+    lines: List<String>,
+    start: Int,
+    firstLine: String,
+    firstMatch: MatchedLeader?,
+  ): Int {
+    var end = start
+    while (end + 1 < lines.size) {
+      val nextLine = lines[end + 1]
+      val nextMatch = matchLeader(nextLine)
+      if (isEndPar(nextLine, nextMatch)) break
+      if (!sameLeader(firstLine, firstMatch, nextLine, nextMatch)) break
+      end++
+    }
+    return end
+  }
+
+  private fun joinParagraph(lines: List<String>, from: Int, to: Int): String {
+    if (from == to) return lines[from]
+    val sb = StringBuilder(lines[from].trimEnd())
+    for (lineIndex in (from + 1)..to) {
+      val line = lines[lineIndex]
+      val match = matchLeader(line)
+      val content = (if (match != null) line.substring(match.trailingEnd) else line.trimStart()).trim()
+      if (content.isEmpty()) continue
+      sb.append(' ').append(content)
+    }
+    return sb.toString()
+  }
+
+  private fun matchLeader(line: String): MatchedLeader? {
+    var indentEnd = 0
+    while (indentEnd < line.length && isAsciiWhite(line[indentEnd])) indentEnd++
+    if (indentEnd >= line.length) return null
+    for (leader in leadersLongestFirst) {
+      if (!line.regionMatches(indentEnd, leader.text, 0, leader.text.length)) continue
+      val afterLeader = indentEnd + leader.text.length
+      if (leader.requiresBlank && afterLeader < line.length && !isAsciiWhite(line[afterLeader])) continue
+      var trailingEnd = afterLeader
+      while (trailingEnd < line.length && isAsciiWhite(line[trailingEnd])) trailingEnd++
+      return MatchedLeader(leader, indentEnd, afterLeader, trailingEnd)
+    }
+    return null
+  }
+
+  private fun isEndPar(line: String, match: MatchedLeader?): Boolean {
+    if (match != null && match.leader.isEnd) return true
+    val start = match?.trailingEnd ?: firstNonWhite(line)
+    return start >= line.length
+  }
+
+  private fun sameLeader(
+    line1: String,
+    m1: MatchedLeader?,
+    line2: String,
+    m2: MatchedLeader?,
+  ): Boolean {
+    if (m1 == null) return m2 == null
+    val leader = m1.leader
+    if (leader.hasNoContinuation) return m2 == null
+    if (leader.isEnd) return false
+    if (leader.isStart) return m2 != null && m2.leader.isMiddle
+    if (m2 == null) return false
+    return line1.substring(m1.indentEnd, m1.leaderEnd) == line2.substring(m2.indentEnd, m2.leaderEnd)
+  }
+
+  private fun continuationPrefix(firstLine: String, match: MatchedLeader?): String {
+    if (match == null) return firstLine.substring(0, firstNonWhite(firstLine))
+    val leader = match.leader
+    val leadingWs = firstLine.substring(0, match.indentEnd)
+    if (leader.isStart) {
+      val mid = middleByStart[leader]
+      if (mid != null) return applyOffset(leadingWs, leader.offset) + mid.text + " "
+    }
+    if (leader.hasNoContinuation) return " ".repeat(match.trailingEnd)
+    return firstLine.substring(0, match.trailingEnd)
+  }
+
+  private fun applyOffset(ws: String, offset: Int): String {
+    if (offset >= 0) return ws + " ".repeat(offset)
+    return ws.dropLast(minOf(-offset, ws.length))
+  }
+
+  private fun splitAtWidth(text: String, continuation: String): List<String> {
+    if (width <= 0) return listOf(text.trimEnd())
+    val out = mutableListOf<String>()
+    var rest = text
+    var first = true
+    while (true) {
+      val line = if (first) rest else continuation + rest
+      if (visualWidth(line) <= width) {
+        out.add(line.trimEnd())
+        break
+      }
+      val leaderEnd = if (first) {
+        matchLeader(line)?.trailingEnd ?: firstNonWhite(line)
+      } else {
+        continuation.length
+      }
+      val breakAt = findBreak(line, leaderEnd)
+      if (breakAt < 0) {
+        out.add(line.trimEnd())
+        break
+      }
+      out.add(line.substring(0, breakAt).trimEnd())
+      rest = line.substring(breakAt).trimStart()
+      if (rest.isEmpty()) break
+      first = false
+    }
+    return out
+  }
+
+  private fun findBreak(line: String, leaderEnd: Int): Int {
+    var bestBefore = -1
+    var firstAfter = -1
+    var col = 0
+    for (pos in line.indices) {
+      val ch = line[pos]
+      if (isAsciiWhite(ch) && pos >= leaderEnd) {
+        if (col <= width) bestBefore = pos
+        else if (firstAfter < 0) firstAfter = pos
+      }
+      col += if (ch == '\t') tabWidth - (col % tabWidth) else 1
+    }
+    return if (bestBefore >= 0) bestBefore else firstAfter
+  }
+
+  private fun visualWidth(text: String): Int {
+    var col = 0
+    for (ch in text) col += if (ch == '\t') tabWidth - (col % tabWidth) else 1
+    return col
+  }
+
+  private fun isAsciiWhite(ch: Char): Boolean = ch == ' ' || ch == '\t'
+
+  private fun firstNonWhite(s: String): Int {
+    for (pos in s.indices) if (!isAsciiWhite(s[pos])) return pos
+    return s.length
+  }
+
+  private fun pairStartsWithMiddle(): Map<CommentLeader, CommentLeader> {
+    val out = mutableMapOf<CommentLeader, CommentLeader>()
+    for ((startIndex, leader) in leaders.withIndex()) {
+      if (!leader.isStart) continue
+      for (candidate in (startIndex + 1) until leaders.size) {
+        if (leaders[candidate].isMiddle) { out[leader] = leaders[candidate]; break }
+      }
+    }
+    return out
+  }
+
+  private data class MatchedLeader(
+    val leader: CommentLeader,
+    val indentEnd: Int,
+    val leaderEnd: Int,
+    val trailingEnd: Int,
+  )
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CodeWrapper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CodeWrapper.kt
@@ -5,6 +5,13 @@
  * license that can be found in the LICENSE.txt file or at
  * https://opensource.org/licenses/MIT.
  */
+
+/*
+ * This file is licensed under the Vim license
+ *
+ * Specifically, the comment-aware paragraph wrapping algorithm is based
+ * on Vim's format_lines, internal_format, get_leader_len and same_leader
+ */
 package com.maddyhome.idea.vim.helper
 
 /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CodeWrapper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CodeWrapper.kt
@@ -97,6 +97,21 @@ class CodeWrapper(
     var indentEnd = 0
     while (indentEnd < line.length && isAsciiWhite(line[indentEnd])) indentEnd++
     if (indentEnd >= line.length) return null
+    val first = matchLeaderAt(line, indentEnd) ?: return null
+    if (!first.leader.isNested) return first
+    // Nested: chain while the outer leader permits it and further matches fit.
+    var leaderEnd = first.leaderEnd
+    var trailingEnd = first.trailingEnd
+    while (true) {
+      val next = matchLeaderAt(line, trailingEnd) ?: break
+      leaderEnd = next.leaderEnd
+      trailingEnd = next.trailingEnd
+      if (!next.leader.isNested) break
+    }
+    return MatchedLeader(first.leader, first.indentEnd, leaderEnd, trailingEnd)
+  }
+
+  private fun matchLeaderAt(line: String, indentEnd: Int): MatchedLeader? {
     for (leader in leadersLongestFirst) {
       if (!line.regionMatches(indentEnd, leader.text, 0, leader.text.length)) continue
       val afterLeader = indentEnd + leader.text.length

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CommentLeaderParser.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CommentLeaderParser.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.helper
+
+/** See `:help 'comments'` for the input format. */
+object CommentLeaderParser {
+  private val flagChars: Map<Char, CommentLeader.Flag> = mapOf(
+    'b' to CommentLeader.Flag.BLANK_REQUIRED,
+    'f' to CommentLeader.Flag.NO_CONTINUATION,
+    's' to CommentLeader.Flag.START,
+    'm' to CommentLeader.Flag.MIDDLE,
+    'e' to CommentLeader.Flag.END,
+    'x' to CommentLeader.Flag.END_SHORTCUT,
+    'n' to CommentLeader.Flag.NESTED,
+    'l' to CommentLeader.Flag.LEFT_ALIGN,
+    'r' to CommentLeader.Flag.RIGHT_ALIGN,
+    'O' to CommentLeader.Flag.NO_OPEN_BELOW,
+  )
+
+  private val trailingSignedInt = Regex("-?\\d+$")
+
+  fun parse(input: String): List<CommentLeader> {
+    if (input.isEmpty()) return emptyList()
+    return splitOnUnescapedCommas(input).mapNotNull { parseEntry(it) }
+  }
+
+  private fun splitOnUnescapedCommas(input: String): List<String> {
+    val entries = mutableListOf(StringBuilder())
+    var escaped = false
+    for (c in input) {
+      when {
+        escaped -> {
+          entries.last().append(c)
+          escaped = false
+        }
+
+        c == '\\' -> escaped = true
+        c == ',' -> entries.add(StringBuilder())
+        else -> entries.last().append(c)
+      }
+    }
+    return entries.map { it.toString() }
+  }
+
+  private fun parseEntry(entry: String): CommentLeader? {
+    val colonIndex = entry.indexOf(':')
+    if (colonIndex < 0) return null
+    val flagsStr = entry.substring(0, colonIndex)
+    val text = entry.substring(colonIndex + 1)
+    return CommentLeader(
+      text = text,
+      flags = parseFlags(flagsStr),
+      offset = parseOffset(flagsStr),
+    )
+  }
+
+  private fun parseFlags(flagsStr: String): Set<CommentLeader.Flag> =
+    flagsStr.mapNotNull { flagChars[it] }.toSet()
+
+  private fun parseOffset(flagsStr: String): Int =
+    trailingSignedInt.find(flagsStr)?.value?.toIntOrNull() ?: 0
+}
+
+data class CommentLeader(
+  val text: String,
+  val flags: Set<Flag> = emptySet(),
+  val offset: Int = 0,
+) {
+  val isStart: Boolean get() = Flag.START in flags
+  val isMiddle: Boolean get() = Flag.MIDDLE in flags
+  val isEnd: Boolean get() = Flag.END in flags
+  val requiresBlank: Boolean get() = Flag.BLANK_REQUIRED in flags
+  val hasNoContinuation: Boolean get() = Flag.NO_CONTINUATION in flags
+
+  enum class Flag {
+    BLANK_REQUIRED,
+    NO_CONTINUATION,
+    START,
+    MIDDLE,
+    END,
+    END_SHORTCUT,
+    NESTED,
+    LEFT_ALIGN,
+    RIGHT_ALIGN,
+    NO_OPEN_BELOW,
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CommentLeaderParser.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CommentLeaderParser.kt
@@ -76,6 +76,7 @@ data class CommentLeader(
   val isEnd: Boolean get() = Flag.END in flags
   val requiresBlank: Boolean get() = Flag.BLANK_REQUIRED in flags
   val hasNoContinuation: Boolean get() = Flag.NO_CONTINUATION in flags
+  val isNested: Boolean get() = Flag.NESTED in flags
 
   enum class Flag {
     BLANK_REQUIRED,

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CommenterToComments.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/CommenterToComments.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.helper
+
+/**
+ * Vim-style `'comments'` markers derived from IntelliJ's `com.intellij.lang.Commenter`.
+ *
+ * Plugin-side callers populate [linePrefix], [blockPrefix], [blockSuffix] from the
+ * `Commenter` API and hand the result to [CommenterToComments.derive].
+ */
+data class CommenterMarkers(
+  val linePrefix: String?,
+  val blockPrefix: String?,
+  val blockSuffix: String?,
+)
+
+/**
+ * Derives a Vim-style `'comments'` value from [CommenterMarkers] — the fallback when
+ * [FiletypePresets] has no entry for the buffer's filetype.
+ *
+ * Lossy by design: the output omits Vim-specific flags (notably `b:` BLANK_REQUIRED
+ * and per-language bullet markers), because the IntelliJ `Commenter` API does not
+ * expose them. Use a [FiletypePresets] entry for fidelity on supported languages.
+ */
+object CommenterToComments {
+  fun derive(markers: CommenterMarkers): String? {
+    val line = markers.linePrefix?.trim()?.takeIf { it.isNotEmpty() }
+    val blockPrefix = markers.blockPrefix?.takeIf { it.isNotEmpty() }
+    val blockSuffix = markers.blockSuffix?.takeIf { it.isNotEmpty() }
+
+    val entries = mutableListOf<String>()
+    // Three-piece entries first: Vim parses left-to-right and matches continuation
+    // lines against `mb:` before the line leader.
+    if (blockPrefix != null && blockSuffix != null) {
+      entries += blockEntries(blockPrefix, blockSuffix)
+    }
+    if (line != null) entries += ":$line"
+
+    return entries.joinToString(",").ifEmpty { null }
+  }
+
+  private fun blockEntries(prefix: String, suffix: String): List<String> {
+    // Middle marker is the last char of the prefix when the block is symmetric
+    // (e.g., /* ... */, (* ... *)). For asymmetric block forms like <!-- -->
+    // or --[[ ]], fall back to a space — matches Vim's html.vim convention and
+    // degrades safely on unknown shapes.
+    val symmetric = prefix.length >= 2 && prefix.first() == suffix.last()
+    val middle: Char = if (symmetric) prefix.last() else ' '
+    return listOf("s1:$prefix", "mb:$middle", "ex:$suffix")
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/FiletypePresets.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/FiletypePresets.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.helper
+
+/**
+ * Per-filetype `'comments'` defaults, modelled on Vim's ftplugins.
+ *
+ * Keys are lowercase filetype names (matching Vim's `&filetype`). Plugin-side
+ * adapters translate IntelliJ's `FileType`/`Language` id into one of these keys.
+ */
+object FiletypePresets {
+  private val presets: Map<String, String> = mapOf(
+    // C-family. Three-piece block plus `//` line and `///` doc, matching Vim's c.vim ftplugin.
+    "c" to C_FAMILY,
+    "cpp" to C_FAMILY,
+    "java" to C_FAMILY,
+    "kotlin" to C_FAMILY,
+    "scala" to C_FAMILY,
+    "groovy" to C_FAMILY,
+    "javascript" to C_FAMILY,
+    "typescript" to C_FAMILY,
+    "dart" to C_FAMILY,
+
+    // C-like but without the three-piece bullet continuation.
+    "go" to "s1:/*,mb:*,ex:*/,://",
+    "swift" to "s1:/*,mb:*,ex:*/,:///,://",
+    "rust" to "s1:/*,mb:*,ex:*/,:///,://!,://",
+    "php" to "s1:/*,mb:*,ex:*/,://,:#",
+    "css" to "s1:/*,mb:*,ex:*/",
+    "scss" to "s1:/*,mb:*,ex:*/,://",
+    "less" to "://",
+
+    // Shell/Python family.
+    "python" to "b:#,fb:-",
+    "sh" to "b:#",
+    "bash" to "b:#",
+    "zsh" to ":#",
+    "fish" to ":#",
+    "ruby" to "b:#",
+    "perl" to ":#",
+    "yaml" to ":#",
+    "toml" to ":#",
+    "dockerfile" to ":#",
+    "makefile" to "sO:# -,mO:#  ,b:#",
+    "cmake" to "b:#",
+    "r" to ":#',:###,:##,:#",
+    "julia" to ":#",
+    "nix" to ":#",
+    "terraform" to "://,:#",
+
+    // SQL / Haskell / Lua family.
+    "sql" to "s1:/*,mb:*,ex:*/,:--,://",
+    "lua" to ":---,:--",
+    "haskell" to "s1fl:{-,mb:-,ex:-},:--",
+    "elm" to "s1fl:{-,mb: ,ex:-},:--",
+    "ada" to "O:--,:--  ",
+
+    // Lisp family.
+    "lisp" to ":;;;;,:;;;,:;;,:;,sr:#|,mb:|,ex:|#",
+    "scheme" to ":;;;;,:;;;,:;;,:;,sr:#|,mb:|,ex:|#",
+    "clojure" to "n:;",
+    "racket" to ":;;;;,:;;;,:;;,:;",
+
+    // Markdown.
+    "markdown" to "fb:*,fb:-,fb:+,n:>",
+
+    // Vim script. Deliberate improvement over Vim (which inherits the C default for .vim files).
+    "vim" to "sO:\"\\ -,mO:\"\\ \\ ,:\"",
+
+    // TeX.
+    "tex" to ":%",
+    "latex" to ":%",
+
+    // Erlang/Elixir.
+    "erlang" to ":%%%,:%%,:%",
+    "elixir" to ":#",
+
+    // Other.
+    "nim" to "exO:]#,fs1:#[,mb:*,ex:]#,:#",
+    "crystal" to ":#",
+  )
+
+  fun presetFor(filetype: String): String? = presets[filetype.lowercase()]
+
+  /** All registered presets as `(filetype, commentsValue)` pairs. */
+  fun allPresets(): Map<String, String> = presets
+
+  // Two trailing spaces after `mO:*` are intentional — Vim writes this as `mO:*\ \ `
+  // in its ftplugins; the space-pair is the literal continuation.
+  private const val C_FAMILY = "sO:* -,mO:*  ,exO:*/,s1:/*,mb:*,ex:*/,:///,://"
+}

--- a/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/CodeWrapperTest.kt
+++ b/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/CodeWrapperTest.kt
@@ -1,0 +1,822 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.helper
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+
+data class WrapTestCase(
+  val description: String,
+  private val rawInput: String?,
+  private val rawExpectedOutput: String,
+  val trimIndent: Boolean = true,
+  val width: Int = 80,
+  val tabWidth: Int = 4,
+  val visibleNewlines: Boolean = false,
+  val leaders: String? = null,
+) {
+  val input: String? = rawInput?.let { if (trimIndent) it.trimIndent() else it }
+  val expectedOutput: String = if (trimIndent) rawExpectedOutput.trimIndent() else rawExpectedOutput
+}
+
+class CodeWrapperTest {
+
+  private val testDefaultLeaders =
+    "s1:/**,s1:/*,mb:*,ex:*/,://!,://,b:#,:%,:XCOMM,n:>,fb:-,:;,:--,:."
+
+
+  private val testCases = listOf(
+    WrapTestCase(
+      "Test trimIndent option in tests (false)",
+      """            This text should not be trimmed """,
+      """            This text should not be trimmed""",
+      trimIndent = false
+    ),
+    WrapTestCase(
+      "Test trimIndent option in tests (true)",
+      """            This text should be trimmed """,
+      """            This text should be trimmed""",
+      trimIndent = true
+    ),
+    WrapTestCase(
+      "combines two adjacent single-line comments",
+      """
+            // This is my text.
+            // This is my text.
+            """,
+      """
+            // This is my text. This is my text.
+            """
+    ),
+    WrapTestCase(
+      "Wraps to column width - comment",
+      """
+            // aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            """,
+      """
+            // aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            // a a a a a a a a a a a a a a a a a a a a a a
+            """
+    ),
+    WrapTestCase(
+      "Wraps to column width - C-style opening comment",
+      """
+            /** aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            */
+            """,
+      """
+            /** aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a aa
+             * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            */
+            """
+    ),
+    WrapTestCase(
+      "Wraps to column width - no comment",
+      """
+            aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            """,
+      """
+            aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a a a a a
+            """
+    ),
+    WrapTestCase(
+      "Wraps one long line",
+      """
+            // This is my very long line of text. This is my very long line of text. This is my very long line of text.
+            """,
+      """
+            // This is my very long line of text. This is my very long line of text. This is
+            // my very long line of text.
+            """
+    ),
+    WrapTestCase(
+      "Wrap retains separate paragraphs",
+      """
+            // This is my very long line of text. This is my very long line of text. This is my very long line of text.
+
+            // This is a second paragraph.
+            """,
+      """
+            // This is my very long line of text. This is my very long line of text. This is
+            // my very long line of text.
+
+            // This is a second paragraph.
+            """
+    ),
+    WrapTestCase(
+      "Wrap wraps Python comments",
+      """
+            # This is my very long line of text. This is my very long line of text. This is my very long line of text.
+
+            # This is a second paragraph.
+            """,
+      """
+            # This is my very long line of text. This is my very long line of text. This is
+            # my very long line of text.
+
+            # This is a second paragraph.
+            """
+    ),
+    WrapTestCase(
+      "wraps single-line block comment opener into multiple lines with star continuations",
+      """
+            /** This is my text This is my long multi-line comment opener text. More text please. This is yet another bunch of text in my test comment, so I will get multiple lines in the comment.
+            """,
+      """
+            /** This is my text This is my long multi-line comment opener text. More text
+             * please. This is yet another bunch of text in my test comment, so I will get
+             * multiple lines in the comment.
+            """
+    ),
+    WrapTestCase(
+      "preserves indent before block comment opener when wrapping with star continuations",
+      """
+              /* This is my text This is my long multi-line comment opener text. More text please. This is yet another bunch of text in my test comment, so I will get multiple lines in the comment. */
+            """,
+      """
+              /* This is my text This is my long multi-line comment opener text. More text
+               * please. This is yet another bunch of text in my test comment, so I will get
+               * multiple lines in the comment. */
+            """
+    ),
+    WrapTestCase(
+      "Wrap preserves empty comment lines",
+      """
+            /*
+             * This is my text. This is my long multi-line comment opener text. More text please. This is yet another bunch of text in my test comment, so I will get multiple lines in the comment.
+             *
+             * This is another line of text.
+            */
+            """,
+      """
+            /*
+             * This is my text. This is my long multi-line comment opener text. More text
+             * please. This is yet another bunch of text in my test comment, so I will get
+             * multiple lines in the comment.
+             *
+             * This is another line of text.
+            */
+            """
+    ),
+    WrapTestCase(
+      "Wrap multiple comment paragraphs",
+      """
+            /*
+             * This is my text. This is my long multi-line comment opener text. More text please. This is yet another bunch of text in my test comment, so I will get multiple lines in the comment.
+             *
+             * This is another line of text.
+             *
+             * And yet another long line of text. Text going on and on endlessly, much longer than it really should.
+            */
+            """,
+      """
+            /*
+             * This is my text. This is my long multi-line comment opener text. More text
+             * please. This is yet another bunch of text in my test comment, so I will get
+             * multiple lines in the comment.
+             *
+             * This is another line of text.
+             *
+             * And yet another long line of text. Text going on and on endlessly, much
+             * longer than it really should.
+            */
+            """
+    ),
+    WrapTestCase(
+      "Wrap retains space indent",
+      "    This is my long indented string. It's too long to fit on one line, uh oh! What will happen?",
+      "    This is my long indented string. It's too long to fit on one line, uh oh!\n    What will happen?",
+      trimIndent = false
+    ),
+    WrapTestCase(
+      "Wrap retains tab indent",
+      "\tThis is my long indented string. It's too long to fit on one line, uh oh! What will happen?",
+      "\tThis is my long indented string. It's too long to fit on one line, uh oh!\n\tWhat will happen?",
+      trimIndent = false,
+      tabWidth = 4
+    ),
+    WrapTestCase(
+      "Wrap retains space indent on comment",
+      "    // This is my long indented comment. It's too long to fit on one line, uh oh! What will happen?",
+      "    // This is my long indented comment. It's too long to fit on one line, uh\n    // oh! What will happen?",
+      trimIndent = false
+    ),
+    WrapTestCase(
+      "Wrap retains tab indent on comment",
+      "\t// This is my long indented comment. It's too long to fit on one line, uh oh! What will happen?",
+      "\t// This is my long indented comment. It's too long to fit on one line, uh\n\t// oh! What will happen?",
+      trimIndent = false,
+      tabWidth = 4
+    ),
+    WrapTestCase(
+      "Wrap handles lines within multiline comment",
+      """
+            * This is a long line in a multi-line comment block. Note the star at the beginning.
+            * This is another line in a multi-line comment.
+            """,
+      """
+            * This is a long line in a multi-line comment block. Note the star at the
+            * beginning. This is another line in a multi-line comment.
+            """,
+    ),
+    WrapTestCase(
+      "Wrap preserves leading indent",
+      """
+            . My long bullet line. My long bullet line. My long bullet line. My long bullet line.
+            """,
+      """
+            . My long bullet line. My long bullet line. My long bullet line. My long bullet
+            . line.
+            """
+    ),
+    WrapTestCase(
+      "Ignores trailing spaces",
+      """
+            The quick brown fox
+            jumps over the lazy
+            dog
+            """,
+      """
+            The quick brown fox jumps over the lazy dog
+            """
+    ),
+    WrapTestCase(
+      "Preserves comment symbols within text",
+      """
+            /**
+             * Let's provide a javadoc comment that has a link to some method, e.g. {@link #m()}.
+             */
+            """,
+      """
+            /**
+             * Let's provide a javadoc comment that has a link to some method, e.g. {@link
+             * #m()}.
+             */
+            """
+    ),
+    WrapTestCase(
+      "returns empty string when input is null",
+      null,
+      ""
+    ),
+    WrapTestCase(
+      "returns empty string when input is empty",
+      "",
+      "",
+      trimIndent = false
+    ),
+    WrapTestCase(
+      "does not break a word longer than width",
+      "supercalifragilisticexpialidocious",
+      "supercalifragilisticexpialidocious",
+      trimIndent = false,
+      width = 5
+    ),
+    WrapTestCase(
+      "returns single-line output when width is zero",
+      "hello world foo bar",
+      "hello world foo bar",
+      trimIndent = false,
+      width = 0
+    ),
+    WrapTestCase(
+      "Accounts for tab width",
+      "\t\t\t\tThis is my very long line of text. This is my very long line of text. This is my\t very long line of text.",
+      "\t\t\t\tThis is my very long\n\t\t\t\tline of text. This\n\t\t\t\tis my very long line\n\t\t\t\tof text. This is my\n\t\t\t\tvery long line of\n\t\t\t\ttext.",
+      trimIndent = false,
+      width = 40,
+      tabWidth = 5
+    ),
+    WrapTestCase(
+      "Supports Chinese",
+      """
+            它是如何工作的呢？实际上，每个bundle在定义自己的服务配置都是跟目前为止你看到的是一样的。换句话说，一个bundle使用一个或者多个配置资源文件（通常是XML)来指定bundle所需要的参数和服务。然而，我们不直接在配置文件中使用 imports 命令导入它们，而是仅仅在bundle中调用一个服务容器扩展来为我们做同样的工作。一个服务容器扩展是 bundle 的作者创建的一个PHP类，它主要完成两件事情
+            """,
+      """
+            它是如何工作的呢？实际上，每个bundle在定义自己的服务配置都是跟目前为止你看到的是一样的。换句话说，一个bundle使用一个或者多个配置资源文件（通常是XML)来指定bundle所需要的参数和服务。然而，我们不直接在配置文件中使用
+            imports 命令导入它们，而是仅仅在bundle中调用一个服务容器扩展来为我们做同样的工作。一个服务容器扩展是 bundle
+            的作者创建的一个PHP类，它主要完成两件事情
+            """,
+    ),
+    WrapTestCase(
+      "Wraps SQL comments",
+      """
+            -- This is a SQL comment. It may not be an important comment, but it's mine. My own. My precious.
+            """,
+      """
+            -- This is a SQL comment. It may not be an important comment, but it's mine. My
+            -- own. My precious.
+            """
+    ),
+    WrapTestCase(
+      "Wraps single line Python docstrings",
+      """
+            ''' This is a long docstring comment. It goes on and on to explain how the function works. However, I forgot to add line breaks! '''
+            """,
+      """
+            ''' This is a long docstring comment. It goes on and on to explain how the
+            function works. However, I forgot to add line breaks! '''
+            """
+    ),
+    WrapTestCase(
+      "Wraps Python docstrings that start on the opener line",
+      """
+            ''' This is a long docstring comment. It goes on and on to explain how the function works. However, I forgot to add line breaks!
+            And the comment continues on the next line. '''
+            """,
+      """
+            ''' This is a long docstring comment. It goes on and on to explain how the
+            function works. However, I forgot to add line breaks! And the comment continues
+            on the next line. '''
+            """
+    ),
+    WrapTestCase(
+      "Wraps Markdown block quotes",
+      """
+            > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+            """,
+      """
+            > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            > incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+            > nostrud exercitation
+            """
+    ),
+    WrapTestCase(
+      description = "Wraps Rust parent line comments",
+      rawInput = """
+            //! My foo module
+            //!
+            //! This is the documentation for my foo module. It has some pretty long lines, which I consider a feature and not a bug.
+            """,
+      rawExpectedOutput = """
+            //! My foo module
+            //!
+            //! This is the documentation for my foo module. It has some pretty long lines,
+            //! which I consider a feature and not a bug.
+            """
+    ),
+    WrapTestCase(
+      description = "Wrap preserves newlines",
+      rawInput = "// test line 1 test line 1 test line 1 test line 1 test line 1 test line 1\n\n",
+      rawExpectedOutput = "// test line 1 test line 1 test line 1 test line 1 test line\n// 1 test line 1\n\n",
+      trimIndent = false,
+      width = 60,
+      visibleNewlines = true
+    ),
+    WrapTestCase(
+      description = "uses custom leader list for marker detection",
+      rawInput = "; this is a semicolon comment that should wrap",
+      rawExpectedOutput = "; this is a semicolon\n; comment that should\n; wrap",
+      trimIndent = false,
+      width = 22,
+      leaders = ":;",
+    ),
+    WrapTestCase(
+      description = "marker not in leader list is treated as plain text",
+      rawInput = "# hash comment line",
+      rawExpectedOutput = "# hash comment line",
+      trimIndent = false,
+      width = 80,
+      leaders = ":;",
+    ),
+    WrapTestCase(
+      description = "BLANK_REQUIRED leader skips marker followed by non-whitespace",
+      rawInput = "#include long line that wraps to multiple lines",
+      rawExpectedOutput = "#include long line that wraps to\nmultiple lines",
+      trimIndent = false,
+      width = 40,
+      leaders = "b:#",
+    ),
+    WrapTestCase(
+      description = "NO_CONTINUATION leader omits marker on continuation lines",
+      rawInput = "- bullet point item that should wrap across multiple continuation lines",
+      rawExpectedOutput = "- bullet point item that\n  should wrap across\n  multiple continuation\n  lines",
+      trimIndent = false,
+      width = 25,
+      leaders = "fb:-",
+    ),
+    WrapTestCase(
+      description = "three-piece leaders drive Javadoc continuation prefix",
+      rawInput = "/** long javadoc text that needs wrapping across multiple lines to test the star continuation",
+      rawExpectedOutput = "/** long javadoc text that\n * needs wrapping across\n * multiple lines to test\n * the star continuation",
+      trimIndent = false,
+      width = 26,
+      leaders = "s1:/**,s1:/*,mb:*,ex:*/",
+    ),
+    WrapTestCase(
+      description = "two three-piece groups in one leader list pick the correct MIDDLE",
+      rawInput = "-- long sql style block comment that needs wrapping across several lines here",
+      rawExpectedOutput = "-- long sql style block\n -- comment that needs\n -- wrapping across\n -- several lines here",
+      trimIndent = false,
+      width = 24,
+      leaders = "s1:/*,mb:*,ex:*/,s1:--,mb:--,ex:--",
+    ),
+    WrapTestCase(
+      description = "negative offset on START shifts MIDDLE continuation to the left",
+      rawInput = "  /* long text that wraps",
+      rawExpectedOutput = "  /* long text that\n * wraps",
+      trimIndent = false,
+      width = 19,
+      leaders = "s-1:/*,mb:*,ex:*/",
+    ),
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Neovim format_lines parity cases. Each is tagged with the Neovim
+    // function it encodes:
+    //   [fmt_check_par]   paragraph boundary detection (textformat.c:466)
+    //   [same_leader]     two-line join predicate     (textformat.c:506)
+    //   [get_leader_len]  leader matching vs comments (change.c:1919)
+    //   [join_split]      end-to-end join-then-split  (textformat.c:892)
+    //   [internal_format] width-aware break scan      (textformat.c:70)
+    //   [continuation]    leader emitted on wrap      (change.c:1220)
+    // Some of these may fail today — they document the target behaviour
+    // for the planned rewrite, not the present behaviour.
+    // ─────────────────────────────────────────────────────────────────────
+
+    WrapTestCase(
+      "[fmt_check_par] empty line ends paragraph",
+      """
+        // first paragraph line one
+        // first paragraph line two
+
+        // second paragraph
+      """,
+      """
+        // first paragraph line one first paragraph line two
+
+        // second paragraph
+      """,
+    ),
+    WrapTestCase(
+      "[fmt_check_par] leader-only line (no content after leader) is its own paragraph",
+      """
+        // first
+        //
+        // second
+      """,
+      """
+        // first
+        //
+        // second
+      """,
+    ),
+    WrapTestCase(
+      "[fmt_check_par] line with e-flagged leader is its own paragraph",
+      """
+         * middle one
+         * middle two
+         */
+      """,
+      """
+         * middle one middle two
+         */
+      """,
+    ),
+    WrapTestCase(
+      "[fmt_check_par] empty content after leader on C block marks paragraph end",
+      """
+        /*
+         * first chunk of text
+         * still first chunk
+         *
+         * second chunk of text
+         */
+      """,
+      """
+        /*
+         * first chunk of text still first chunk
+         *
+         * second chunk of text
+         */
+      """,
+    ),
+
+    WrapTestCase(
+      "[same_leader] identical line-comment leaders join",
+      """
+        // part one of the sentence
+        // part two of the sentence
+      """,
+      """
+        // part one of the sentence part two of the sentence
+      """,
+    ),
+    WrapTestCase(
+      "[same_leader] different line-comment leaders (// vs #) do not join",
+      """
+        // slashes style comment
+        # hash style comment
+      """,
+      """
+        // slashes style comment
+        # hash style comment
+      """,
+    ),
+    WrapTestCase(
+      "[same_leader] s-flag + m-flag (/* followed by *) joins",
+      """
+        /* opener text
+         * middle text
+      """,
+      """
+        /* opener text middle text
+      """,
+    ),
+    WrapTestCase(
+      "[same_leader] s-flag + non-m leader does not join",
+      """
+        /* opener text here
+        // different leader line
+      """,
+      """
+        /* opener text here
+        // different leader line
+      """,
+    ),
+    WrapTestCase(
+      "[same_leader] m-flag + m-flag joins",
+      """
+         * middle line one
+         * middle line two
+      """,
+      """
+         * middle line one middle line two
+      """,
+    ),
+    WrapTestCase(
+      "[same_leader] m-flag (*) + e-flag (*/) does not join (string mismatch)",
+      """
+         * middle line
+         */
+      """,
+      """
+         * middle line
+         */
+      """,
+    ),
+    WrapTestCase(
+      "[same_leader] e-flagged line never joins forward",
+      """
+         */
+        // next comment line
+      """,
+      """
+         */
+        // next comment line
+      """,
+    ),
+    WrapTestCase(
+      "[same_leader] f-flag (first-only) + next line with no leader joins",
+      """
+        - bullet item content
+          continuation of the bullet
+      """,
+      """
+        - bullet item content continuation of the bullet
+      """,
+      leaders = "fb:-,://",
+    ),
+    WrapTestCase(
+      "[same_leader] f-flag + next line with same leader does NOT join",
+      """
+        - first bullet item
+        - second bullet item
+      """,
+      """
+        - first bullet item
+        - second bullet item
+      """,
+      leaders = "fb:-,://",
+    ),
+    WrapTestCase(
+      "[same_leader] leaders with different surrounding whitespace still match",
+      """
+         //  one word
+         // two word
+      """,
+      """
+         //  one word two word
+      """,
+    ),
+
+    WrapTestCase(
+      "[get_leader_len] longest leader wins (/** preferred over /*)",
+      """
+        /** javadoc start text
+         * middle text
+      """,
+      """
+        /** javadoc start text middle text
+      """,
+    ),
+    WrapTestCase(
+      "[get_leader_len] b-flag leader rejected when not followed by whitespace",
+      """
+        #include <stdio.h>
+        // plain line
+      """,
+      """
+        #include <stdio.h>
+        // plain line
+      """,
+    ),
+    WrapTestCase(
+      "[get_leader_len] b-flag leader accepted when followed by whitespace",
+      """
+        # python comment one
+        # python comment two
+      """,
+      """
+        # python comment one python comment two
+      """,
+    ),
+    WrapTestCase(
+      "[get_leader_len] leader preceded by tabs still recognised",
+      "\t// tabbed comment one\n\t// tabbed comment two",
+      "\t// tabbed comment one tabbed comment two",
+      trimIndent = false,
+    ),
+
+    WrapTestCase(
+      "[join_split] three short // lines join then re-wrap at width 40",
+      """
+        // aa aa aa aa aa aa aa aa
+        // aa aa aa aa aa aa aa aa
+        // aa aa aa aa aa aa aa aa
+      """,
+      """
+        // aa aa aa aa aa aa aa aa aa aa aa aa
+        // aa aa aa aa aa aa aa aa aa aa aa aa
+      """,
+      width = 40,
+    ),
+    WrapTestCase(
+      "[join_split] s+m block comment joins then wraps with ` * ` continuation",
+      """
+        /* opener text that is long enough to force a wrap
+         * second physical line
+      """,
+      """
+        /* opener text that is long enough to force a
+         * wrap second physical line
+      """,
+      width = 45,
+    ),
+    WrapTestCase(
+      "[join_split] s+m+e block: e-line excluded from join, preserved verbatim",
+      """
+        /* start of comment text that is long enough
+         * middle line text here
+         */
+      """,
+      """
+        /* start of comment text that is long enough
+         * middle line text here
+         */
+      """,
+      width = 50,
+    ),
+    WrapTestCase(
+      "[join_split] mixed leaders with no blank line between split into separate paragraphs",
+      """
+        // part of the first leader group
+        # part of the second leader group
+      """,
+      """
+        // part of the first leader group
+        # part of the second leader group
+      """,
+    ),
+    WrapTestCase(
+      "[join_split] joining strips subsequent leaders, preserves first line's leader",
+      """
+         *    heavily indented middle one
+         *    heavily indented middle two
+      """,
+      """
+         *    heavily indented middle one heavily indented middle two
+      """,
+    ),
+    WrapTestCase(
+      "[join_split] plain-text paragraph joins then re-wraps (no leaders)",
+      """
+        one two three four five
+        six seven eight nine ten
+      """,
+      """
+        one two three four
+        five six seven eight
+        nine ten
+      """,
+      width = 20,
+    ),
+
+    WrapTestCase(
+      "[internal_format] break happens at last whitespace at or before textwidth",
+      "one two three four five",
+      "one two three four\nfive",
+      trimIndent = false,
+      width = 20,
+    ),
+    WrapTestCase(
+      "[internal_format] unbreakable word longer than width stays on one line",
+      "supercalifragilisticexpialidocious",
+      "supercalifragilisticexpialidocious",
+      trimIndent = false,
+      width = 10,
+    ),
+    WrapTestCase(
+      "[internal_format] content fitting inside textwidth is left unwrapped",
+      "// short comment",
+      "// short comment",
+      trimIndent = false,
+      width = 80,
+    ),
+    WrapTestCase(
+      "[internal_format] break point refuses positions inside leader; long word stays with leader",
+      """
+        // aaaaaaaaa bbb
+      """,
+      """
+        // aaaaaaaaa
+        // bbb
+      """,
+      width = 10,
+    ),
+    WrapTestCase(
+      "[internal_format] leader longer than width still wraps at first whitespace past the leader",
+      "          // hello world",
+      "          // hello\n          // world",
+      trimIndent = false,
+      width = 10,
+    ),
+
+    WrapTestCase(
+      "[continuation] s1 offset aligns ` *` under `/*` on wrapped lines",
+      "/* long text that must be wrapped because it exceeds the width",
+      "/* long text that\n * must be wrapped\n * because it\n * exceeds the\n * width",
+      trimIndent = false,
+      width = 18,
+      leaders = "s1:/*,mb:*,ex:*/",
+    ),
+    WrapTestCase(
+      "[continuation] s-1 negative offset shifts continuation one column left",
+      "  /* indented opener text that wraps across lines",
+      "  /* indented opener\n * text that wraps\n * across lines",
+      trimIndent = false,
+      width = 20,
+      leaders = "s-1:/*,mb:*,ex:*/",
+    ),
+    WrapTestCase(
+      "[continuation] f-flag leader produces space-only continuation indent",
+      "- bullet item that wraps across several lines of text here",
+      "- bullet item that wraps\n  across several lines of\n  text here",
+      trimIndent = false,
+      width = 25,
+      leaders = "fb:-",
+    ),
+    WrapTestCase(
+      "[continuation] line-comment leader repeated verbatim on wrapped lines",
+      "// aaa bbb ccc ddd eee fff ggg hhh iii jjj",
+      "// aaa bbb ccc ddd eee\n// fff ggg hhh iii jjj",
+      trimIndent = false,
+      width = 22,
+    ),
+    WrapTestCase(
+      "[continuation] three-piece with two distinct groups picks matching MIDDLE (parity)",
+      "-- sql style block comment that needs wrapping across several lines here",
+      "-- sql style block\n -- comment that needs\n -- wrapping across\n -- several lines here",
+      trimIndent = false,
+      width = 22,
+      leaders = "s1:/*,mb:*,ex:*/,s1:--,mb:--,ex:--",
+    ),
+  )
+
+  @TestFactory
+  fun generateTests(): List<DynamicTest> {
+    return testCases.map { testCase ->
+      DynamicTest.dynamicTest(testCase.description) {
+        val parsedLeaders = CommentLeaderParser.parse(testCase.leaders ?: testDefaultLeaders)
+        val wrapper = CodeWrapper(
+          tabWidth = testCase.tabWidth,
+          width = testCase.width,
+          leaders = parsedLeaders,
+        )
+        val result = wrapper.wrap(testCase.input)
+        val expected = testCase.expectedOutput.maybeVisible(testCase.visibleNewlines)
+        val actual = result.maybeVisible(testCase.visibleNewlines)
+        assertEquals(expected, actual, testCase.description)
+      }
+    }
+  }
+
+  private fun String.maybeVisible(visible: Boolean): String =
+    if (visible) replace("\n", "\\n") else this
+}

--- a/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/CodeWrapperTest.kt
+++ b/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/CodeWrapperTest.kt
@@ -797,6 +797,55 @@ class CodeWrapperTest {
       width = 22,
       leaders = "s1:/*,mb:*,ex:*/,s1:--,mb:--,ex:--",
     ),
+
+    WrapTestCase(
+      "[get_leader_len] n-flag consumes repeated leaders as a single nested leader",
+      """
+        > > quoted reply one
+        > > quoted reply two
+      """,
+      """
+        > > quoted reply one quoted reply two
+      """,
+    ),
+    WrapTestCase(
+      "[get_leader_len] n-flag supports depth-2 nesting",
+      """
+        > > > triple quote one
+        > > > triple quote two
+      """,
+      """
+        > > > triple quote one triple quote two
+      """,
+    ),
+    WrapTestCase(
+      "[same_leader] n-flag: different nesting depth splits paragraph",
+      """
+        > > depth two text
+        > depth one text
+      """,
+      """
+        > > depth two text
+        > depth one text
+      """,
+    ),
+    WrapTestCase(
+      "[get_leader_len] non-nested leader does not chain (plain // stays shallow)",
+      """
+        // // looks like two // but is single leader
+        // second line here
+      """,
+      """
+        // // looks like two // but is single leader second line here
+      """,
+    ),
+
+    WrapTestCase(
+      "[same_leader] same leader text with different leading indent still joins (Vim parity)",
+      "// outer indent\n    // deeper indent",
+      "// outer indent deeper indent",
+      trimIndent = false,
+    ),
   )
 
   @TestFactory

--- a/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/CommentLeaderParserTest.kt
+++ b/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/CommentLeaderParserTest.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.helper
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CommentLeaderParserTest {
+
+  @Test
+  fun `empty string returns empty list`() {
+    assertEquals(emptyList<CommentLeader>(), CommentLeaderParser.parse(""))
+  }
+
+  @Test
+  fun `parses single leader with no flags`() {
+    assertEquals(
+      listOf(CommentLeader(text = "//")),
+      CommentLeaderParser.parse("://"),
+    )
+  }
+
+  @Test
+  fun `parses b flag as BLANK_REQUIRED`() {
+    assertEquals(
+      listOf(CommentLeader(text = "#", flags = setOf(CommentLeader.Flag.BLANK_REQUIRED))),
+      CommentLeaderParser.parse("b:#"),
+    )
+  }
+
+  @Test
+  fun `comma separates multiple entries`() {
+    assertEquals(
+      listOf(
+        CommentLeader(text = "//"),
+        CommentLeader(text = "#", flags = setOf(CommentLeader.Flag.BLANK_REQUIRED)),
+      ),
+      CommentLeaderParser.parse("://,b:#"),
+    )
+  }
+
+  @Test
+  fun `parses fb as NO_CONTINUATION and BLANK_REQUIRED`() {
+    assertEquals(
+      listOf(
+        CommentLeader(
+          text = "-",
+          flags = setOf(CommentLeader.Flag.NO_CONTINUATION, CommentLeader.Flag.BLANK_REQUIRED),
+        ),
+      ),
+      CommentLeaderParser.parse("fb:-"),
+    )
+  }
+
+  @Test
+  fun `parses s flag as START with numeric offset`() {
+    assertEquals(
+      listOf(CommentLeader(text = "/*", flags = setOf(CommentLeader.Flag.START), offset = 1)),
+      CommentLeaderParser.parse("s1:/*"),
+    )
+  }
+
+  @Test
+  fun `parses s flag with negative offset`() {
+    assertEquals(
+      listOf(CommentLeader(text = "/*", flags = setOf(CommentLeader.Flag.START), offset = -1)),
+      CommentLeaderParser.parse("s-1:/*"),
+    )
+  }
+
+  @Test
+  fun `ignores digit before flag when computing offset`() {
+    assertEquals(
+      listOf(CommentLeader(text = "/*", flags = setOf(CommentLeader.Flag.START), offset = 0)),
+      CommentLeaderParser.parse("1s:/*"),
+    )
+  }
+
+  @Test
+  fun `parses m flag as MIDDLE`() {
+    assertEquals(
+      listOf(CommentLeader(text = "*", flags = setOf(CommentLeader.Flag.MIDDLE, CommentLeader.Flag.BLANK_REQUIRED))),
+      CommentLeaderParser.parse("mb:*"),
+    )
+  }
+
+  @Test
+  fun `parses e flag as END`() {
+    assertEquals(
+      listOf(CommentLeader(text = "*/", flags = setOf(CommentLeader.Flag.END))),
+      CommentLeaderParser.parse("e:*/"),
+    )
+  }
+
+  @Test
+  fun `parses x flag as END_SHORTCUT`() {
+    assertEquals(
+      listOf(
+        CommentLeader(
+          text = "*/",
+          flags = setOf(CommentLeader.Flag.END, CommentLeader.Flag.END_SHORTCUT),
+        ),
+      ),
+      CommentLeaderParser.parse("ex:*/"),
+    )
+  }
+
+  @Test
+  fun `parses n flag as NESTED`() {
+    assertEquals(
+      listOf(CommentLeader(text = ">", flags = setOf(CommentLeader.Flag.NESTED))),
+      CommentLeaderParser.parse("n:>"),
+    )
+  }
+
+  @Test
+  fun `parses l flag as LEFT_ALIGN`() {
+    assertEquals(
+      listOf(CommentLeader(text = "*/", flags = setOf(CommentLeader.Flag.LEFT_ALIGN))),
+      CommentLeaderParser.parse("l:*/"),
+    )
+  }
+
+  @Test
+  fun `parses r flag as RIGHT_ALIGN`() {
+    assertEquals(
+      listOf(CommentLeader(text = "*", flags = setOf(CommentLeader.Flag.RIGHT_ALIGN))),
+      CommentLeaderParser.parse("r:*"),
+    )
+  }
+
+  @Test
+  fun `parses O flag as NO_OPEN_BELOW`() {
+    assertEquals(
+      listOf(
+        CommentLeader(
+          text = "* -",
+          flags = setOf(CommentLeader.Flag.START, CommentLeader.Flag.NO_OPEN_BELOW),
+        ),
+      ),
+      CommentLeaderParser.parse("sO:* -"),
+    )
+  }
+
+  @Test
+  fun `parses Vim default comments value into nine entries`() {
+    val vimDefault = "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-"
+    val result = CommentLeaderParser.parse(vimDefault)
+    assertEquals(9, result.size)
+    assertEquals("/*", result[0].text)
+    assertEquals(setOf(CommentLeader.Flag.START), result[0].flags)
+    assertEquals(1, result[0].offset)
+    assertEquals("//", result[3].text)
+    assertEquals(emptySet<CommentLeader.Flag>(), result[3].flags)
+    assertEquals("XCOMM", result[6].text)
+    assertEquals("-", result[8].text)
+  }
+
+  @Test
+  fun `parses realistic Java ftplugin value`() {
+    val java = "sO:* -,mO:*  ,exO:*/,s1:/*,mb:*,ex:*/,://"
+    val result = CommentLeaderParser.parse(java)
+    assertEquals(7, result.size)
+    assertEquals(
+      CommentLeader(
+        text = "* -",
+        flags = setOf(CommentLeader.Flag.START, CommentLeader.Flag.NO_OPEN_BELOW),
+      ),
+      result[0],
+    )
+    assertEquals(
+      CommentLeader(
+        text = "*  ",
+        flags = setOf(CommentLeader.Flag.MIDDLE, CommentLeader.Flag.NO_OPEN_BELOW),
+      ),
+      result[1],
+    )
+    assertEquals(
+      CommentLeader(
+        text = "*/",
+        flags = setOf(
+          CommentLeader.Flag.END,
+          CommentLeader.Flag.END_SHORTCUT,
+          CommentLeader.Flag.NO_OPEN_BELOW,
+        ),
+      ),
+      result[2],
+    )
+    assertEquals(CommentLeader(text = "//"), result[6])
+  }
+
+  @Test
+  fun `backslash escapes a comma inside the text`() {
+    assertEquals(
+      listOf(CommentLeader(text = ",foo")),
+      CommentLeaderParser.parse(":\\,foo"),
+    )
+  }
+
+  @Test
+  fun `backslash escapes a backslash`() {
+    assertEquals(
+      listOf(CommentLeader(text = "foo\\bar")),
+      CommentLeaderParser.parse(":foo\\\\bar"),
+    )
+  }
+
+  @Test
+  fun `trailing backslash at end of input is dropped`() {
+    assertEquals(
+      listOf(CommentLeader(text = "//")),
+      CommentLeaderParser.parse("://\\"),
+    )
+  }
+
+  @Test
+  fun `entry without colon is silently skipped`() {
+    assertEquals(
+      listOf(CommentLeader(text = "//")),
+      CommentLeaderParser.parse("garbage,://,more-garbage"),
+    )
+  }
+}

--- a/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/CommenterToCommentsTest.kt
+++ b/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/CommenterToCommentsTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.helper
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class CommenterToCommentsTest {
+
+  private fun markers(line: String? = null, block: String? = null, suffix: String? = null) =
+    CommenterMarkers(linePrefix = line, blockPrefix = block, blockSuffix = suffix)
+
+  @Test
+  fun `returns null when no markers are present`() {
+    assertNull(CommenterToComments.derive(markers()))
+  }
+
+  @Test
+  fun `line-only commenter maps to colon prefix entry`() {
+    assertEquals(":#", CommenterToComments.derive(markers(line = "#")))
+  }
+
+  @Test
+  fun `symmetric block maps last char of prefix as middle`() {
+    assertEquals("s1:/*,mb:*,ex:*/", CommenterToComments.derive(markers(block = "/*", suffix = "*/")))
+  }
+
+  @Test
+  fun `combined line and block produces both entries with block first`() {
+    assertEquals(
+      "s1:/*,mb:*,ex:*/,://",
+      CommenterToComments.derive(markers(line = "//", block = "/*", suffix = "*/")),
+    )
+  }
+
+  @Test
+  fun `block with only prefix but no suffix is skipped`() {
+    assertEquals(":#", CommenterToComments.derive(markers(line = "#", block = "(*")))
+  }
+
+  @Test
+  fun `block with only suffix but no prefix is skipped`() {
+    assertEquals(":#", CommenterToComments.derive(markers(line = "#", suffix = "-}")))
+  }
+
+  @Test
+  fun `asymmetric block like HTML uses space as middle marker`() {
+    assertEquals(
+      "s1:<!--,mb: ,ex:-->",
+      CommenterToComments.derive(markers(block = "<!--", suffix = "-->")),
+    )
+  }
+
+  @Test
+  fun `asymmetric block like Lua degrades safely to space middle`() {
+    assertEquals(
+      "s1:--[[,mb: ,ex:]]",
+      CommenterToComments.derive(markers(block = "--[[", suffix = "]]")),
+    )
+  }
+
+  @Test
+  fun `empty-string markers are treated as absent`() {
+    assertNull(CommenterToComments.derive(markers(line = "", block = "", suffix = "")))
+  }
+
+  @Test
+  fun `trailing whitespace on line prefix is trimmed`() {
+    assertEquals(":#", CommenterToComments.derive(markers(line = "# ")))
+  }
+}

--- a/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/FiletypePresetsTest.kt
+++ b/vim-engine/src/test/kotlin/com/maddyhome/idea/vim/helper/FiletypePresetsTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.helper
+
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+
+class FiletypePresetsTest {
+
+  @Test
+  fun `java preset matches Vim C-family default`() {
+    assertEquals(
+      "sO:* -,mO:*  ,exO:*/,s1:/*,mb:*,ex:*/,:///,://",
+      FiletypePresets.presetFor("java"),
+    )
+  }
+
+  @Test
+  fun `python preset uses hash and bullet`() {
+    assertEquals("b:#,fb:-", FiletypePresets.presetFor("python"))
+  }
+
+  @Test
+  fun `sql preset uses line and block comments`() {
+    assertEquals("s1:/*,mb:*,ex:*/,:--,://", FiletypePresets.presetFor("sql"))
+  }
+
+  @Test
+  fun `unknown filetype returns null`() {
+    assertNull(FiletypePresets.presetFor("cobol"))
+  }
+
+  @Test
+  fun `lookup is case-insensitive`() {
+    assertEquals(FiletypePresets.presetFor("java"), FiletypePresets.presetFor("JAVA"))
+    assertEquals(FiletypePresets.presetFor("python"), FiletypePresets.presetFor("Python"))
+  }
+
+  @Test
+  fun `every preset parses to a non-empty leader list`() {
+    assertAll(
+      FiletypePresets.allPresets().map { (filetype, preset) ->
+        Executable {
+          val parsed = CommentLeaderParser.parse(preset)
+          assertTrue(parsed.isNotEmpty(), "$filetype: '$preset' parsed to empty list")
+        }
+      },
+    )
+  }
+
+  @Test
+  fun `rust preset includes rustdoc markers`() {
+    val rust = FiletypePresets.presetFor("rust")
+    assertNotNull(rust)
+    assertTrue("://!" in rust!!, "rustdoc inner marker missing")
+    assertTrue(":///" in rust, "rustdoc outer marker missing")
+  }
+
+  @Test
+  fun `markdown preset uses nested blockquote flag`() {
+    assertEquals("fb:*,fb:-,fb:+,n:>", FiletypePresets.presetFor("markdown"))
+  }
+}


### PR DESCRIPTION
Add comment-aware code wrapping for `gq`/`gw`, driven by Vim's `'comments'` option. Paragraph boundaries and join rules follow Vim's `format_lines` algorithm.