### PR TITLE
FIX(VIM-4184): clipboad=unnamed paste bugs on wayland

### DIFF
--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/copy/PutVisualTextAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/copy/PutVisualTextAction.kt
@@ -19,6 +19,7 @@ import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.group.visual.VimSelection
 import com.maddyhome.idea.vim.handler.VisualOperatorActionHandler
 import com.maddyhome.idea.vim.put.PutData
+import com.maddyhome.idea.vim.register.Register
 
 /**
  * @author vlan
@@ -59,11 +60,31 @@ sealed class PutVisualTextBaseAction(
     count: Int,
   ): PutData {
     val lastRegisterChar = injector.registerGroup.lastRegisterChar
-    val register = caret.registerStorage.getRegister(editor, context, lastRegisterChar)
-    val textData = register?.let { PutData.TextData(register) }
+    val register = resolveRegisterForVisualPaste(lastRegisterChar, caret, editor, context)
+    val textData = register?.let { PutData.TextData(it) }
     val visualSelection = selection?.let { PutData.VisualSelection(mapOf(caret to it), it.type) }
     return PutData(textData, visualSelection, count, insertTextBeforeCaret, indent, caretAfterInsertedText)
   }
+
+  private fun resolveRegisterForVisualPaste(
+    lastRegisterChar: Char,
+    caret: VimCaret,
+    editor: VimEditor,
+    context: ExecutionContext,
+  ): Register? {
+    // IntelliJ updates X11 PRIMARY on visual selection; use the last explicitly-yanked value.
+    return if (isDefaultSystemClipboard(lastRegisterChar)) {
+      injector.registerGroup.getLastExplicitlyWrittenRegister(lastRegisterChar)
+        ?: caret.registerStorage.getRegister(editor, context, lastRegisterChar)
+    } else {
+      caret.registerStorage.getRegister(editor, context, lastRegisterChar)
+    }
+  }
+
+  private fun isDefaultSystemClipboard(registerChar: Char) =
+    !injector.registerGroup.isRegisterSpecifiedExplicitly &&
+      injector.registerGroup.isSystemClipboard(registerChar) &&
+      injector.registerGroup.isPrimaryRegisterSupported()
 }
 
 @CommandOrMotion(keys = ["P"], modes = [Mode.VISUAL])

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroup.kt
@@ -90,4 +90,6 @@ interface VimRegisterGroup {
   fun getCurrentRegisterForMulticaret(): Char // `set clipbaard+=unnamedplus` should not make system register the default one when working with multiple carets VIM-2804
   fun isSystemClipboard(register: Char): Boolean
   fun isPrimaryRegisterSupported(): Boolean
+
+  fun getLastExplicitlyWrittenRegister(r: Char): Register?
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
@@ -401,6 +401,11 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
     return System.getenv("DISPLAY") != null && injector.systemInfoService.isXWindow
   }
 
+  override fun getLastExplicitlyWrittenRegister(r: Char): Register? {
+    require(CLIPBOARD_REGISTERS.contains(r.lowercaseChar())) { "Only clipboard registers are supported: got '$r'" }
+    return myRegisters[r.lowercaseChar()]
+  }
+
   private fun setSystemPrimaryRegisterText(editor: VimEditor, context: ExecutionContext, copiedText: VimCopiedText) {
     logger.trace("Setting text: $copiedText to primary selection...")
     if (isPrimaryRegisterSupported()) {
@@ -428,7 +433,13 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
       return refreshClipboardRegister(editor, context)
     }
     try {
-      val clipboardData = injector.clipboardManager.getPrimaryContent(editor, context) ?: return null
+      val clipboardData = injector.clipboardManager.getPrimaryContent(editor, context)
+      if (clipboardData == null || clipboardData.text.isEmpty()) {
+        // Wayland/XWayland clears PRIMARY on focus change; prefer the last IdeaVim-written value over
+        // an empty result. Differs from Vim only when the user deliberately clears PRIMARY externally.
+        logger.trace("PRIMARY selection is unavailable or empty; falling back to in-memory register value")
+        return myRegisters[PRIMARY_REGISTER]
+      }
       val currentRegister = myRegisters[PRIMARY_REGISTER]
       if (currentRegister != null && clipboardData.text == currentRegister.text) {
         return currentRegister


### PR DESCRIPTION
Use in-memory register when PRIMARY is unavailable due to wayland focus loss and bypass the live PRIMARY read during cisual paste to avoid automatic selection tracking overwriiting the yanked text