### PR TITLE
fix CommandParserTest after removing octopus

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -89,8 +89,8 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
         // Control-flow exceptions (like ProcessCanceledException) should never be logged and should be rethrown
         // See {@link com.intellij.openapi.diagnostic.Logger.checkException}
         throw e
-      } catch (throwable: Throwable) {
-        LOG.error(throwable)
+      } catch (e: Exception) {
+        LOG.error(e)
       }
     }
   }

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -1014,7 +1014,14 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
             ActionManager.getInstance(),
             0,
           )
-          if (ActionUtil.lastUpdateAndCheckDumb(VimShortcutKeyAction.instance, e, true)) {
+          if (!VimPlugin.isEnabled()) {
+            // VimShortcutKeyAction is a no-op when the plugin is disabled, so deliver
+            // Enter/Escape to the IDE directly.
+            when {
+              key.keyCode == KeyEvent.VK_ENTER && key.modifiers == 0 -> fixture.type('\n')
+              key.keyCode == KeyEvent.VK_ESCAPE -> fixture.performEditorAction("EditorEscape")
+            }
+          } else if (ActionUtil.lastUpdateAndCheckDumb(VimShortcutKeyAction.instance, e, true)) {
             ActionUtil.performActionDumbAwareWithCallbacks(VimShortcutKeyAction.instance, e)
           }
         }
@@ -1026,10 +1033,6 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
 
   private fun KeyStroke.getChar(editor: Editor): CharType {
     if (keyChar != KeyEvent.CHAR_UNDEFINED) return CharType.CharDetected(keyChar)
-    if (editor.vim.mode !is Mode.CMD_LINE) {
-      if (keyCode == KeyEvent.VK_ENTER && modifiers == 0) return CharType.CharDetected(keyCode.toChar())
-      if (keyCode == KeyEvent.VK_ESCAPE) return CharType.EditorAction("EditorEscape")
-    }
     return CharType.UNDEFINED
   }
 

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -71,11 +71,11 @@ import com.maddyhome.idea.vim.group.visual.VimVisualTimer.swingTimer
 import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.TestInputModel
 import com.maddyhome.idea.vim.helper.getGuiCursorMode
-import com.maddyhome.idea.vim.mark.Mark
 import com.maddyhome.idea.vim.key.MappingOwner
 import com.maddyhome.idea.vim.key.ToKeysMappingInfo
 import com.maddyhome.idea.vim.listener.SelectionVimListenerSuppressor
 import com.maddyhome.idea.vim.listener.VimListenerManager
+import com.maddyhome.idea.vim.mark.Mark
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.newapi.ijOptions
 import com.maddyhome.idea.vim.newapi.vim
@@ -1026,6 +1026,10 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
 
   private fun KeyStroke.getChar(editor: Editor): CharType {
     if (keyChar != KeyEvent.CHAR_UNDEFINED) return CharType.CharDetected(keyChar)
+    if (editor.vim.mode !is Mode.CMD_LINE) {
+      if (keyCode == KeyEvent.VK_ENTER && modifiers == 0) return CharType.CharDetected(keyCode.toChar())
+      if (keyCode == KeyEvent.VK_ESCAPE) return CharType.EditorAction("EditorEscape")
+    }
     return CharType.UNDEFINED
   }
 

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/ChangeActionJavaTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/ChangeActionJavaTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2024 The IdeaVim authors
+ * Copyright 2003-2026 The IdeaVim authors
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE.txt file or at
@@ -14,7 +14,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.maddyhome.idea.vim.api.injector
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
-import org.jetbrains.plugins.ideavim.VimBehaviorDiffers
 import org.jetbrains.plugins.ideavim.VimJavaTestCase
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -65,25 +64,12 @@ class ChangeActionJavaTest : VimJavaTestCase() {
   // VIM-511 |.|
   @TestWithoutNeovim(SkipNeovimReason.DIFFERENT)
   @Test
-  @VimBehaviorDiffers(
-    originalVimAfter = """
-    class C {
-      C(int i) {
-          i = 3;
-      }
-      C(int i) {
-          i = 3;
-      }
-    }
-  """, description = """The bracket should be on the new line.
-    |This behaviour was explicitely broken as we migrate to the new handlers and I can't support it"""
-  )
   fun testAutoCompleteCurlyBraceWithEnterWithinFunctionBody() {
     configureByJavaText(
       """
   class C $c{
   }
-  
+
       """.trimIndent(),
     )
     typeText(injector.parser.parseKeys("o" + "C(" + "<BS>" + "(int i) {" + "<Enter>" + "i = 3;" + "<Esc>" + "<Down>" + "."))
@@ -93,7 +79,8 @@ class ChangeActionJavaTest : VimJavaTestCase() {
         i = 3;
     }
     C(int i) {
-    i = 3;}
+        i = 3;
+    }
 }
 """,
     )


### PR DESCRIPTION
in VimTestCase there was check for octopus to pass enter/esc directly do editor but it was removed so we check now if we are in cmd line mode