### PR TITLE
Re-enable split mode tests in TeamCity

### DIFF
--- a/.teamcity/_Self/buildTypes/SplitModeTests.kt
+++ b/.teamcity/_Self/buildTypes/SplitModeTests.kt
@@ -13,6 +13,7 @@ import _Self.IdeaVimBuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object SplitModeTests : IdeaVimBuildType({
   name = "Split mode tests"
@@ -70,12 +71,11 @@ object SplitModeTests : IdeaVimBuildType({
     }
   }
 
-  // VCS trigger disabled until Xvfb is installed on the TeamCity agent
-  // triggers {
-  //   vcs {
-  //     branchFilter = "+:<default>"
-  //   }
-  // }
+  triggers {
+    vcs {
+      branchFilter = "+:<default>"
+    }
+  }
 
   requirements {
     // Use a larger agent for split-mode tests — they launch two full IDE instances


### PR DESCRIPTION
## Summary
- Re-enable the VCS trigger for the Split Mode Tests build configuration in TeamCity.
- Reverts the disable from 34196bc0d (the agent now has Xvfb available, which was the original blocker).

## Test plan
- [ ] TeamCity picks up the trigger and runs Split Mode Tests on the next push to the default branch.
- [ ] First triggered run succeeds (Xvfb starts, tests execute against the XLARGE Linux agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)