### PR TITLE
Drop Xvfb startup from split mode tests script

### DIFF
--- a/.teamcity/_Self/buildTypes/SplitModeTests.kt
+++ b/.teamcity/_Self/buildTypes/SplitModeTests.kt
@@ -40,34 +40,8 @@ object SplitModeTests : IdeaVimBuildType({
 
   steps {
     script {
-      name = "Start Xvfb and run split mode tests"
-      scriptContent = """
-              # Kill any leftover Xvfb from previous runs
-              pkill -f 'Xvfb :99' || true
-
-              Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp &
-              XVFB_PID=${'$'}!
-
-              # Wait until the display is ready
-              for i in $(seq 1 30); do
-                if xdpyinfo -display :99 >/dev/null 2>&1; then
-                  echo "Xvfb is ready on :99"
-                  break
-                fi
-                sleep 1
-              done
-
-              if ! xdpyinfo -display :99 >/dev/null 2>&1; then
-                echo "ERROR: Xvfb failed to start on :99"
-                exit 1
-              fi
-
-              ./gradlew :tests:split-mode-tests:testSplitMode --console=plain --build-cache --configuration-cache --stacktrace
-              TEST_EXIT=${'$'}?
-
-              kill ${'$'}XVFB_PID 2>/dev/null || true
-              exit ${'$'}TEST_EXIT
-          """.trimIndent()
+      name = "Run split mode tests"
+      scriptContent = "./gradlew :tests:split-mode-tests:testSplitMode --console=plain --build-cache --configuration-cache --stacktrace"
     }
   }
 


### PR DESCRIPTION
## Summary
- The agent already runs Xvfb on `:99`, so the build step doesn't need to start it. The startup/wait/kill scaffolding only adds noise and a failure mode (`xdpyinfo` not on PATH, leftover Xvfb across runs, etc.).
- Reduces the step to just the Gradle invocation. `env.DISPLAY=:99` stays, since the tests still need a display.
- Follow-up to #1722.

## Test plan
- [ ] Next triggered run on master goes green without the Xvfb scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)