### PR TITLE
Wrap split mode tests with xvfb-run

### DIFF
--- a/.teamcity/_Self/buildTypes/SplitModeTests.kt
+++ b/.teamcity/_Self/buildTypes/SplitModeTests.kt
@@ -28,7 +28,6 @@ object SplitModeTests : IdeaVimBuildType({
   params {
     param("env.ORG_GRADLE_PROJECT_downloadIdeaSources", "false")
     param("env.ORG_GRADLE_PROJECT_instrumentPluginCode", "false")
-    param("env.DISPLAY", ":99")
   }
 
   vcs {
@@ -41,7 +40,7 @@ object SplitModeTests : IdeaVimBuildType({
   steps {
     script {
       name = "Run split mode tests"
-      scriptContent = "./gradlew :tests:split-mode-tests:testSplitMode --console=plain --build-cache --configuration-cache --stacktrace"
+      scriptContent = "xvfb-run -a -s '-screen 0 1920x1080x24' ./gradlew :tests:split-mode-tests:testSplitMode --console=plain --build-cache --configuration-cache --stacktrace"
     }
   }
 


### PR DESCRIPTION
## Summary
- Build #8 of `Split mode tests` failed with `java.awt.AWTError: Can't connect to X11 window server using ':99'` — the agent has Xvfb installed but no server actually running on `:99`. The frontend IDE crashed at startup with exit code 3, which is what the misleading "driver has already exited" / `closeIde` errors were a symptom of.
- Wrap the Gradle invocation in `xvfb-run -a -s '-screen 0 1920x1080x24'`. `-a` picks a free display, `xvfb-run` exports `DISPLAY` for the wrapped process and tears down the server when it exits — no manual start/wait/kill needed.
- Drop the static `env.DISPLAY=:99` param since `xvfb-run` manages it.
- Follow-up to #1723.

## Test plan
- [ ] Next triggered run on master goes green; no `Can't connect to X11 window server` in `ide-BookmarkSplitTest-err`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)