### PR TITLE
Restore manual Xvfb startup for split mode tests

### DIFF
--- a/.teamcity/_Self/buildTypes/SplitModeTests.kt
+++ b/.teamcity/_Self/buildTypes/SplitModeTests.kt
@@ -28,6 +28,7 @@ object SplitModeTests : IdeaVimBuildType({
   params {
     param("env.ORG_GRADLE_PROJECT_downloadIdeaSources", "false")
     param("env.ORG_GRADLE_PROJECT_instrumentPluginCode", "false")
+    param("env.DISPLAY", ":99")
   }
 
   vcs {
@@ -39,8 +40,34 @@ object SplitModeTests : IdeaVimBuildType({
 
   steps {
     script {
-      name = "Run split mode tests"
-      scriptContent = "xvfb-run -a -s '-screen 0 1920x1080x24' ./gradlew :tests:split-mode-tests:testSplitMode --console=plain --build-cache --configuration-cache --stacktrace"
+      name = "Start Xvfb and run split mode tests"
+      scriptContent = """
+              # Kill any leftover Xvfb from previous runs
+              pkill -f 'Xvfb :99' || true
+
+              Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp &
+              XVFB_PID=${'$'}!
+
+              # Wait until the display is ready
+              for i in $(seq 1 30); do
+                if xdpyinfo -display :99 >/dev/null 2>&1; then
+                  echo "Xvfb is ready on :99"
+                  break
+                fi
+                sleep 1
+              done
+
+              if ! xdpyinfo -display :99 >/dev/null 2>&1; then
+                echo "ERROR: Xvfb failed to start on :99"
+                exit 1
+              fi
+
+              ./gradlew :tests:split-mode-tests:testSplitMode --console=plain --build-cache --configuration-cache --stacktrace
+              TEST_EXIT=${'$'}?
+
+              kill ${'$'}XVFB_PID 2>/dev/null || true
+              exit ${'$'}TEST_EXIT
+          """.trimIndent()
     }
   }
 


### PR DESCRIPTION
## Summary
- Build #10 (with PR #1725 finally synced) failed at `xvfb-run: not found` (exit 127). The agent has the `Xvfb` binary on PATH but not the `xvfb-run` wrapper, so #1725's approach can't work without an agent-side install.
- Restore the explicit Xvfb start/wait/kill block (matches the version that worked before #1723) and put `env.DISPLAY=:99` back.
- Apt-get install step is intentionally not restored — `Xvfb` is already on the agent.

## Test plan
- [ ] Force `Load project settings from VCS` in TeamCity once this is merged.
- [ ] Re-run the build; expect the script to start Xvfb on `:99`, see `Xvfb is ready on :99` in the log, then go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)