### PR TITLE
FIX(VIM-4219) check for in VimPLugin is not null

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/main/java/com/maddyhome/idea/vim/VimPlugin.java
@@ -183,7 +183,8 @@ public class VimPlugin implements PersistentStateComponent<Element>, Disposable 
   }
 
   public static boolean isEnabled() {
-    return getInstance().enabled;
+    final VimPlugin instance = ApplicationManager.getApplication().getService(VimPlugin.class);
+    return instance != null && instance.enabled;
   }
 
   public static void setEnabled(final boolean enabled) {


### PR DESCRIPTION
sometimes where the plugin was being unloaded, getInstance might return null