### PR TITLE
VIM-4202 Add space after c langauges comments

### DIFF
--- a/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/comment/CommentaryRemoteApiImpl.kt
+++ b/modules/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/comment/CommentaryRemoteApiImpl.kt
@@ -8,6 +8,7 @@
 
 package com.maddyhome.idea.vim.group.comment
 
+import com.intellij.application.options.CodeStyle
 import com.intellij.codeInsight.actions.MultiCaretCodeInsightActionHandler
 import com.intellij.codeInsight.generation.CommentByBlockCommentHandler
 import com.intellij.codeInsight.generation.CommentByLineCommentHandler
@@ -55,22 +56,41 @@ internal class CommentaryRemoteApiImpl : CommentaryRemoteApi {
     val project = editor.project ?: return
     val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return
 
-    CommandProcessor.getInstance().executeCommand(project, {
-      ApplicationManager.getApplication().runWriteAction {
-        val caret = editor.caretModel.primaryCaret
-        caret.setSelection(startOffset, endOffset)
-        try {
-          val handler = pickHandler(psiFile, lineWise)
-          handler.invoke(project, editor, caret, psiFile)
-          handler.postInvoke()
-        } finally {
-          caret.removeSelection()
-          if (caretOffset >= 0) {
-            caret.moveToOffset(caretOffset)
+    val invokeHandler = {
+      CommandProcessor.getInstance().executeCommand(project, {
+        ApplicationManager.getApplication().runWriteAction {
+          val caret = editor.caretModel.primaryCaret
+          caret.setSelection(startOffset, endOffset)
+          try {
+            val handler = pickHandler(psiFile, lineWise)
+            handler.invoke(project, editor, caret, psiFile)
+            handler.postInvoke()
+          } finally {
+            caret.removeSelection()
+            if (caretOffset >= 0) {
+              caret.moveToOffset(caretOffset)
+            }
           }
         }
+      }, "Commentary", null)
+    }
+
+    // normally comment action goes through rider backend comment action running on .net nto jvm so we cannot call it directly.
+    // But we still want to apply space after comment as it's default bahavior there so we overrite this flag for intelij comment handler
+    if (isCFamily(psiFile)) {
+      val baseSettings = CodeStyle.getSettings(psiFile)
+      CodeStyle.runWithLocalSettings(project, baseSettings) { localSettings ->
+        localSettings.getCommonSettings(psiFile.language).LINE_COMMENT_ADD_SPACE = true
+        invokeHandler()
       }
-    }, "Commentary", null)
+    } else {
+      invokeHandler()
+    }
+  }
+
+  private fun isCFamily(psiFile: PsiFile): Boolean {
+    val fileTypeName = psiFile.fileType.name
+    return fileTypeName == "C++" || fileTypeName == "C#" || fileTypeName == "ObjectiveC"
   }
 
   private fun pickHandler(psiFile: PsiFile, lineWise: Boolean): MultiCaretCodeInsightActionHandler {

--- a/tests/java-tests/build.gradle.kts
+++ b/tests/java-tests/build.gradle.kts
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 /*
@@ -46,7 +54,7 @@ dependencies {
     create(ideaType, ideaVersion) { this.useInstaller = useInstaller }
     testFramework(TestFrameworkType.Platform)
     testFramework(TestFrameworkType.JUnit5)
-    bundledPlugins("com.intellij.java", "org.jetbrains.plugins.yaml")
+    bundledPlugins("com.intellij.java", "org.jetbrains.plugins.yaml", "org.jetbrains.plugins.textmate")
   }
 }
 

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/extension/commentary/CommentaryExtensionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2024 The IdeaVim authors
+ * Copyright 2003-2026 The IdeaVim authors
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE.txt file or at
@@ -91,6 +91,28 @@ class CommentaryExtensionTest : VimJavaTestCase() {
         "//}\n",
       Mode.NORMAL(),
       JavaFileType.INSTANCE,
+    )
+  }
+
+  @Test
+  fun testLineCommentCppSingleLine() {
+    doTest(
+      keys = "gcc",
+      before = "<caret>#include <cstdint>\n",
+      after = "<caret>// #include <cstdint>\n",
+      modeAfter = Mode.NORMAL(),
+      fileName = "test.cpp",
+    )
+  }
+
+  @Test
+  fun testLineCommentCppMultipleLines() {
+    doTest(
+      keys = "2gcc",
+      before = "<caret>#include <cstdint>\n#include <cstdio>\n",
+      after = "<caret>// #include <cstdint>\n// #include <cstdio>\n",
+      modeAfter = Mode.NORMAL(),
+      fileName = "test.cpp",
     )
   }
 


### PR DESCRIPTION
normally space is added by rider/clion backend which we cannot directlly execute as it is not running on JVM. Workaround is to specify space flag for comment handler