### PR TITLE
fix(VIM-4211): commit window work with conectional commits plugin

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -698,7 +698,8 @@ public class EditorHelper {
    * Checks if the editor is hosted in the Commit tool window, so we can enable Vim features
    */
   public static boolean isCommitWindowEditor(@NotNull Editor editor) {
-    // The best heuristic we have is the file name, which is Dummy.txt
+    @SuppressWarnings("deprecation") Key<?> dataKey = Key.findKeyByName("Vcs.CommitMessage.Panel");
+    if (dataKey != null && editor.getDocument().getUserData(dataKey) != null) return true;
     var file = EditorHelper.getVirtualFile(editor);
     return file != null && file.getName().contains("Dummy.txt");
   }


### PR DESCRIPTION
Conventioal Commits plugin was replacing `Dummy.txt` commit window file with it's own. In this commit we redesign checking if editor is commit window by getting editor key for commit window