### PR TITLE
fix(VIM-4226): check if editor is disposed on focus

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
@@ -172,6 +172,7 @@ class CaretVisualAttributesListener : IsReplaceCharListener, ModeChangeListener,
   @RequiresEdt
   private fun updateCaretsVisual(editor: VimEditor) {
     val ijEditor = (editor as IjVimEditor).editor
+    if (ijEditor.isDisposed) return
     ijEditor.updateCaretsVisualAttributes()
     ijEditor.updateCaretsVisualPosition()
   }

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -384,11 +384,13 @@ object VimListenerManager {
    */
   private object VimFocusListener : FocusChangeListener {
     override fun focusGained(editor: Editor) {
+      if (editor.isDisposed) return
       if (vimDisabled(editor)) return
       injector.listenersNotifier.notifyEditorFocusGained(editor.vim)
     }
 
     override fun focusLost(editor: Editor) {
+      if (editor.isDisposed) return
       if (vimDisabled(editor)) return
       injector.listenersNotifier.notifyEditorFocusLost(editor.vim)
     }


### PR DESCRIPTION
There were race condition when user opened ex panel and after closing editor might be disposed for some reason which resulted in unhandled exception and complete loss of focus