### PR TITLE
Add digraph Vim functions

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/mappingFunctions/DigraphGetFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/mappingFunctions/DigraphGetFunctionTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.functions.mappingFunctions
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class DigraphGetFunctionTest : VimTestCase("\n") {
+  @Test
+  fun `test digraph_get returns character for known default digraph`() {
+    assertCommandOutput("echo digraph_get('a:')", "ä")
+  }
+
+  @Test
+  fun `test digraph_get returns character for another known default digraph`() {
+    assertCommandOutput("echo digraph_get('A:')", "Ä")
+  }
+
+  @Test
+  fun `test digraph_get returns second character as fallback for unknown digraph`() {
+    assertCommandOutput("echo digraph_get('xy')", "y")
+  }
+
+  @Test
+  fun `test digraph_get works with reversed character order`() {
+    // getCharacterForDigraph tries both ch1+ch2 and ch2+ch1
+    assertCommandOutput("echo digraph_get(':a')", "ä")
+  }
+
+  @Test
+  fun `test digraph_get returns custom digraph added via digraph command`() {
+    enterCommand("digraph (0 9450")
+    assertCommandOutput("echo digraph_get('(0')", "⓪")
+  }
+
+  @Test
+  fun `test digraph_get returns 32-bit Unicode character`() {
+    // Char is 16 bit. We need to handle 32-bit characters
+    enterCommand("digraph co 128992") // Orange circle. 128,992 > Char.MAX_VALUE
+    assertCommandOutput("echo digraph_get('co')", "🟠")
+  }
+
+  @Test
+  fun `test digraph_get throws E1214 for empty string`() {
+    enterCommand("call digraph_get('')")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1214: Digraph must be just two characters: ")
+  }
+
+  @Test
+  fun `test digraph_get throws E1214 for single character`() {
+    enterCommand("call digraph_get('a')")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1214: Digraph must be just two characters: a")
+  }
+
+  @Test
+  fun `test digraph_get throws E1214 for string longer than two characters`() {
+    enterCommand("call digraph_get('abc')")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1214: Digraph must be just two characters: abc")
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/mappingFunctions/DigraphGetListFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/mappingFunctions/DigraphGetListFunctionTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.functions.mappingFunctions
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class DigraphGetListFunctionTest : VimTestCase("\n") {
+  @Test
+  fun `test digraph_getlist returns empty list when no custom digraphs defined`() {
+    assertCommandOutput("echo digraph_getlist()", "[]")
+  }
+
+  @Test
+  fun `test digraph_getlist returns custom digraph`() {
+    enterCommand("digraph (0 9450")
+    assertCommandOutput("echo digraph_getlist()", "[['(0', '⓪']]")
+  }
+
+
+  @Test
+  fun `test digraph_getlist returns multiple custom digraphs`() {
+    enterCommand("digraph (0 9450")
+    enterCommand("digraph (z 9449")
+    assertCommandOutput("echo digraph_getlist()", "[['(0', '⓪'], ['(z', 'ⓩ']]")
+  }
+
+  @Test
+  fun `test digraph_getlist returns 32-bit unicode digraph`() {
+    enterCommand("digraph co 128992") // Orange circle. 128,992 > Char.MAX_VALUE
+    assertCommandOutput("echo digraph_getlist()", "[['co', '🟠']]")
+  }
+
+  @Test
+  fun `test digraph_getlist with false parameter returns custom digraphs`() {
+    enterCommand("digraph (0 9450")
+    enterCommand("digraph (z 9449")
+    assertCommandOutput("echo digraph_getlist(0)", "[['(0', '⓪'], ['(z', 'ⓩ']]")
+  }
+
+  @Test
+  fun `test digraph_getlist with true parameter returns all builtin digraphs`() {
+    // There are too many digraphs to check the whole output. We know this test will fail if we add more custom digraphs
+    assertCommandOutput("echo len(digraph_getlist(1))", "1363")
+    assertCommandOutput("echo slice(digraph_getlist(1), 0, 5)", "[['!!', '|'], ['!)', '}'], ['!2', '‖'], ['!:', 'ἆ'], ['!<', '≮']]")
+    assertCommandOutput("echo filter(digraph_getlist(1), 'v:val[0] == \"OK\"')", "[['OK', '✓']]")
+  }
+
+  @Test
+  fun `test digraph_getlist with true parameter returns builtin and custom digraphs`() {
+    enterCommand("digraph (0 9450")
+    assertCommandOutput("echo len(digraph_getlist(1))", "1364")
+    assertCommandOutput("echo filter(digraph_getlist(1), 'v:val[0] == \"OK\"')", "[['OK', '✓']]")
+    assertCommandOutput("echo filter(digraph_getlist(1), 'v:val[0] == \"(0\"')", "[['(0', '⓪']]")
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/mappingFunctions/DigraphSetFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/mappingFunctions/DigraphSetFunctionTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.functions.mappingFunctions
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class DigraphSetFunctionTest : VimTestCase("\n") {
+  @Test
+  fun `test digraph_set reports error when given less than two characters`() {
+    enterCommand("call digraph_set('a', 'a')")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1214: Digraph must be just two characters: a")
+  }
+
+  @Test
+  fun `test digraph_set reports error when given more than two characters`() {
+    enterCommand("call digraph_set('aaa', 'a')")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1214: Digraph must be just two characters: aaa")
+  }
+
+  @Test
+  fun `test digraph_set reports error when digraph is missing`() {
+    enterCommand("call digraph_set('a:', '')")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1215: Digraph must be one character: ")
+  }
+
+  @Test
+  fun `test digraph_set reports error when digraph is more than one character`() {
+    enterCommand("call digraph_set('a:', 'aa')")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1215: Digraph must be one character: aa")
+  }
+
+  @Test
+  fun `test digraph_set adds custom digraph`() {
+    assertCommandOutput("echo digraph_set('(0', '⓪')", "1")
+    typeText("i<C-K>(0<Esc>")
+    assertState("⓪\n")
+  }
+
+  @Test
+  fun `test digraph_set adds custom 32-bit digraph digraph`() {
+    assertCommandOutput("echo digraph_set('co', '🟠')", "1")
+    typeText("i<C-K>co<Esc>")
+    assertState("🟠\n")
+  }
+
+  @Test
+  fun `test digraph_set overrides builtin digraph`() {
+    assertCommandOutput("echo digraph_set('OK', '✗')", "1")
+    typeText("i<C-K>OK<Esc>")
+    assertState("✗\n")
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/mappingFunctions/DigraphSetListFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/mappingFunctions/DigraphSetListFunctionTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.functions.mappingFunctions
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class DigraphSetListFunctionTest : VimTestCase("\n") {
+  @Test
+  fun `test digraph_setlist with non-list argument reports error`() {
+    enterCommand("call digraph_setlist('oops')")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1216: digraph_setlist() argument must be a list of lists with two items")
+  }
+
+  @Test
+  fun `test digraph_setlist with simple list argument reports error`() {
+    enterCommand("call digraph_setlist([1])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1216: digraph_setlist() argument must be a list of lists with two items")
+  }
+
+  @Test
+  fun `test digraph_setlist sets single digraph`() {
+    assertCommandOutput("echo digraph_setlist([['(0', '⓪']])", "1")
+    typeText("i", "<C-K>(0", "<Esc>")
+    assertState("⓪\n")
+  }
+
+  @Test
+  fun `test digraph_setlist sets multiple digraphs`() {
+    assertCommandOutput("echo digraph_setlist([['(0', '⓪'], ['(z', 'ⓩ']])", "1")
+    typeText("i", "<C-K>(0", "<C-K>(z", "<Esc>")
+    assertState("⓪ⓩ\n")
+  }
+
+  @Test
+  fun `test digraph_setlist overrides builtin digraphs`() {
+    assertCommandOutput("echo digraph_setlist([['OK', '∥'], ['XX', '¶']])", "1")
+    typeText("i", "<C-K>OK", "<C-K>XX", "<Esc>")
+    assertState("∥¶\n")
+  }
+
+  @Test
+  fun `test digraph_setlist sets 32-bit Unicode digraph`() {
+    assertCommandOutput("echo digraph_setlist([['co', '🟠']])", "1")
+    typeText("i", "<C-K>co", "<Esc>")
+    assertState("🟠\n")
+  }
+
+  @Test
+  fun `test digraph_setlist with list item with too few elements reports error`() {
+    enterCommand("call digraph_setlist([ ['a'] ])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1216: digraph_setlist() argument must be a list of lists with two items")
+  }
+
+  @Test
+  fun `test digraph_setlist with list item with too many elements reports error`() {
+    enterCommand("call digraph_setlist([ ['a', 'b', 'c'] ])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1216: digraph_setlist() argument must be a list of lists with two items")
+  }
+
+  @Test
+  fun `test digraph_setlist with list item with too few characters reports error`() {
+    enterCommand("call digraph_setlist([ ['a', 'c'] ])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1214: Digraph must be just two characters: a")
+  }
+
+  @Test
+  fun `test digraph_setlist with list item with too many characters reports error`() {
+    enterCommand("call digraph_setlist([ ['abc', 'c'] ])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1214: Digraph must be just two characters: abc")
+  }
+
+  @Test
+  fun `test digraph_setlist with list item with too many characters for digraph reports error`() {
+    enterCommand("call digraph_setlist([ ['ab', 'cc'] ])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1215: Digraph must be one character: cc")
+  }
+
+  @Test
+  fun `test digraph_setlist with subsequent list item with too many elements reports error`() {
+    enterCommand("call digraph_setlist([ ['(0', '⓪'], ['a', 'b', 'c'] ])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1216: digraph_setlist() argument must be a list of lists with two items")
+  }
+
+  @Test
+  fun `test digraph_setlist with subsequent list item with too few characters reports error`() {
+    enterCommand("call digraph_setlist([ ['(0', '⓪'], ['a', 'c'] ])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1214: Digraph must be just two characters: a")
+  }
+
+  @Test
+  fun `test digraph_setlist with subsequent list item with too many characters reports error`() {
+    enterCommand("call digraph_setlist([ ['(0', '⓪'], ['abc', 'c'] ])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1214: Digraph must be just two characters: abc")
+  }
+
+  @Test
+  fun `test digraph_setlist with subsequent list item with too many characters for digraph reports error`() {
+    enterCommand("call digraph_setlist([ ['(0', '⓪'], ['ab', 'cc'] ])")
+    assertPluginError(true)
+    assertPluginErrorMessage("E1215: Digraph must be one character: cc")
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDigraphGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDigraphGroup.kt
@@ -16,6 +16,17 @@ interface VimDigraphGroup {
    * this function retuns a codepoint.
    */
   fun getCharacterForDigraph(ch1: Char, ch2: Char): Int
+
+  /**
+   * Get a list of all digraphs, including user-defined and built-in
+   */
+  fun getAllDigraphs(): List<Pair<String, Int>>
+
+  /**
+   * Get a list of user-defined digraphs
+   */
+  fun getCustomDigraphs(): List<Pair<String, Int>>
+
   fun displayAsciiInfo(editor: VimEditor)
   fun parseCommandLine(editor: VimEditor, args: String): Boolean
   fun showDigraphs(editor: VimEditor, showHeaders: Boolean)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDigraphGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDigraphGroup.kt
@@ -27,6 +27,11 @@ interface VimDigraphGroup {
    */
   fun getCustomDigraphs(): List<Pair<String, Int>>
 
+  /**
+   * Add a custom digraph, potentially overwriting a builtin value
+   */
+  fun setDigraph(digraph: String, codepoint: Int)
+
   fun displayAsciiInfo(editor: VimEditor)
   fun parseCommandLine(editor: VimEditor, args: String): Boolean
   fun showDigraphs(editor: VimEditor, showHeaders: Boolean)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDigraphGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDigraphGroupBase.kt
@@ -47,6 +47,11 @@ open class VimDigraphGroupBase : VimDigraphGroup {
     customDigraphToCodepoint.forEach { (chars, codepoint) -> add(chars to codepoint) }
   }
 
+  override fun setDigraph(digraph: String, codepoint: Int) {
+    // Because we check custom digraphs first, setting this will "overwrite" a builtin digraph
+    addCustomDigraph(digraph, codepoint)
+  }
+
   override fun displayAsciiInfo(editor: VimEditor) {
     val offset = editor.currentCaret().offset
     val charsSequence = editor.text()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDigraphGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDigraphGroupBase.kt
@@ -38,6 +38,15 @@ open class VimDigraphGroupBase : VimDigraphGroup {
       ?: ch2.code
   }
 
+  override fun getAllDigraphs(): List<Pair<String, Int>> = buildList {
+    digraphToCodepoint.forEach { (chars, codepoint) -> add(chars to codepoint) }
+    customDigraphToCodepoint.forEach { (chars, codepoint) -> add(chars to codepoint) }
+  }
+
+  override fun getCustomDigraphs(): List<Pair<String, Int>> = buildList {
+    customDigraphToCodepoint.forEach { (chars, codepoint) -> add(chars to codepoint) }
+  }
+
   override fun displayAsciiInfo(editor: VimEditor) {
     val offset = editor.currentCaret().offset
     val charsSequence = editor.text()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/mappingFunctions/DigraphGetFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/mappingFunctions/DigraphGetFunctionHandler.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions
+
+import com.intellij.vim.annotations.VimscriptFunction
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.ex.exExceptionMessage
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
+import com.maddyhome.idea.vim.vimscript.model.datatypes.asVimString
+import com.maddyhome.idea.vim.vimscript.model.functions.UnaryFunctionHandler
+
+@VimscriptFunction("digraph_get")
+internal class DigraphGetFunctionHandler : UnaryFunctionHandler<VimString>() {
+  override fun doFunction(
+    arguments: Arguments,
+    editor: VimEditor,
+    context: ExecutionContext,
+    vimContext: VimLContext,
+  ): VimString {
+    val chars = arguments.getString(0).value
+
+    if (chars.length != 2) {
+      throw exExceptionMessage("E1214", chars)
+    }
+
+    val codepoint =  injector.digraphGroup.getCharacterForDigraph(chars[0], chars[1])
+    return String(intArrayOf(codepoint), 0, 1).asVimString()
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/mappingFunctions/DigraphGetListFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/mappingFunctions/DigraphGetListFunctionHandler.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions
+
+import com.intellij.vim.annotations.VimscriptFunction
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDataType
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimList
+import com.maddyhome.idea.vim.vimscript.model.datatypes.asVimString
+import com.maddyhome.idea.vim.vimscript.model.functions.BuiltinFunctionHandler
+
+@VimscriptFunction("digraph_getlist")
+internal class DigraphGetListFunctionHandler : BuiltinFunctionHandler<VimList>(minArity = 0, maxArity = 1) {
+  override fun doFunction(
+    arguments: Arguments,
+    editor: VimEditor,
+    context: ExecutionContext,
+    vimContext: VimLContext,
+  ): VimList {
+    val listAll = arguments.getNumberOrNull(0)?.booleanValue ?: false
+
+    val digraphs = if (listAll) {
+      injector.digraphGroup.getAllDigraphs()
+    } else {
+      injector.digraphGroup.getCustomDigraphs()
+    }
+    val list = mutableListOf<VimDataType>()
+    digraphs.forEach { (chars, codepoint) ->
+      list.add(VimList(mutableListOf(chars.asVimString(), String(intArrayOf(codepoint), 0, 1).asVimString())))
+    }
+    return VimList(list)
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/mappingFunctions/DigraphSetFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/mappingFunctions/DigraphSetFunctionHandler.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions
+
+import com.intellij.vim.annotations.VimscriptFunction
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.ex.exExceptionMessage
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
+import com.maddyhome.idea.vim.vimscript.model.functions.BinaryFunctionHandler
+
+@VimscriptFunction("digraph_set")
+internal class DigraphSetFunctionHandler : BinaryFunctionHandler<VimInt>() {
+  override fun doFunction(
+    arguments: Arguments,
+    editor: VimEditor,
+    context: ExecutionContext,
+    vimContext: VimLContext,
+  ): VimInt {
+    val chars = arguments.getString(0).value
+    val digraph = arguments.getString(1).value
+
+    if (chars.length != 2) {
+      throw exExceptionMessage("E1214", chars)
+    }
+
+    if (digraph.codePointCount(0, digraph.length) != 1) {
+      throw exExceptionMessage("E1215", digraph)
+    }
+
+    injector.digraphGroup.setDigraph(chars, digraph.codePointAt(0))
+    return VimInt.ONE
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/mappingFunctions/DigraphSetListFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/mappingFunctions/DigraphSetListFunctionHandler.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions
+
+import com.intellij.vim.annotations.VimscriptFunction
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.ex.exExceptionMessage
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimList
+import com.maddyhome.idea.vim.vimscript.model.functions.UnaryFunctionHandler
+
+@VimscriptFunction("digraph_setlist")
+internal class DigraphSetListFunctionHandler : UnaryFunctionHandler<VimInt>() {
+  override fun doFunction(
+    arguments: Arguments,
+    editor: VimEditor,
+    context: ExecutionContext,
+    vimContext: VimLContext,
+  ): VimInt {
+    val list = arguments[0] as? VimList ?: throw exExceptionMessage("E1216")
+    if (list.values.any { it !is VimList || it.size != 2 }) {
+      throw exExceptionMessage("E1216")
+    }
+
+    list.values.forEach {
+      val chars = ((it as VimList).values[0]).toVimString().value // TODO: We don't get the exception about converting Float to String
+      if (chars.length != 2) {
+        throw exExceptionMessage("E1214", chars)
+      }
+
+      val digraph = it.values[1].toVimString().value
+      if (digraph.codePointCount(0, digraph.length) != 1) {
+        throw exExceptionMessage("E1215", digraph)
+      }
+
+      injector.digraphGroup.setDigraph(chars, digraph.codePointAt(0))
+    }
+
+    return VimInt.ONE
+  }
+}

--- a/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
@@ -18,6 +18,7 @@
   "digraph_get": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphGetFunctionHandler",
   "digraph_getlist": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphGetListFunctionHandler",
   "digraph_set": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphSetFunctionHandler",
+  "digraph_setlist": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphSetListFunctionHandler",
   "empty": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.collectionFunctions.EmptyFunctionHandler",
   "err_teapot": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.variousFunctions.ErrTeapotFunctionHandler",
   "escape": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.stringFunctions.EscapeFunctionHandler",

--- a/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
@@ -16,6 +16,7 @@
   "count": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.collectionFunctions.CountFunctionHandler",
   "deepcopy": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.DeepCopyFunctionHandler",
   "digraph_get": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphGetFunctionHandler",
+  "digraph_getlist": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphGetListFunctionHandler",
   "empty": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.collectionFunctions.EmptyFunctionHandler",
   "err_teapot": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.variousFunctions.ErrTeapotFunctionHandler",
   "escape": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.stringFunctions.EscapeFunctionHandler",

--- a/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
@@ -17,6 +17,7 @@
   "deepcopy": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.DeepCopyFunctionHandler",
   "digraph_get": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphGetFunctionHandler",
   "digraph_getlist": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphGetListFunctionHandler",
+  "digraph_set": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphSetFunctionHandler",
   "empty": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.collectionFunctions.EmptyFunctionHandler",
   "err_teapot": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.variousFunctions.ErrTeapotFunctionHandler",
   "escape": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.stringFunctions.EscapeFunctionHandler",

--- a/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
@@ -15,6 +15,7 @@
   "cosh": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.floatFunctions.CoshFunctionHandler",
   "count": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.collectionFunctions.CountFunctionHandler",
   "deepcopy": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.DeepCopyFunctionHandler",
+  "digraph_get": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.DigraphGetFunctionHandler",
   "empty": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.collectionFunctions.EmptyFunctionHandler",
   "err_teapot": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.variousFunctions.ErrTeapotFunctionHandler",
   "escape": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.stringFunctions.EscapeFunctionHandler",

--- a/vim-engine/src/main/resources/messages/IdeaVimEngineBundle.properties
+++ b/vim-engine/src/main/resources/messages/IdeaVimEngineBundle.properties
@@ -171,6 +171,7 @@ E1203=E1203: Dot can only be used on a dictionary
 E1206=E1206: Dictionary required for argument {0}
 E1211=E1211: List required for argument {0}
 E1214=E1214: Digraph must be just two characters: {0}
+E1215=E1215: Digraph must be one character: {0}
 E1225=E1225: String, List or Dictionary required for argument {0}
 E1226=E1226: List or Blob required for argument {0}
 E1250=E1250: Argument of {0} must be a List, String, Dictionary or Blob

--- a/vim-engine/src/main/resources/messages/IdeaVimEngineBundle.properties
+++ b/vim-engine/src/main/resources/messages/IdeaVimEngineBundle.properties
@@ -172,6 +172,7 @@ E1206=E1206: Dictionary required for argument {0}
 E1211=E1211: List required for argument {0}
 E1214=E1214: Digraph must be just two characters: {0}
 E1215=E1215: Digraph must be one character: {0}
+E1216=E1216: digraph_setlist() argument must be a list of lists with two items
 E1225=E1225: String, List or Dictionary required for argument {0}
 E1226=E1226: List or Blob required for argument {0}
 E1250=E1250: Argument of {0} must be a List, String, Dictionary or Blob

--- a/vimscript-info/FUNCTIONS_INFO.MD
+++ b/vimscript-info/FUNCTIONS_INFO.MD
@@ -628,7 +628,7 @@ See `:help mapping-functions`.
 |--------|---------------------|------------------------------------|
 | ✅      | `digraph_get()`     | get digraph                        |
 | ✅      | `digraph_getlist()` | get all digraphs                   |
-|        | `digraph_set()`     | register digraph                   |
+| ✅      | `digraph_set()`     | register digraph                   |
 |        | `digraph_setlist()` | register multiple digraphs         |
 | ✅      | `hasmapto()`        | check if a mapping exists          |
 | ✅      | `mapcheck()`        | check if a matching mapping exists |

--- a/vimscript-info/FUNCTIONS_INFO.MD
+++ b/vimscript-info/FUNCTIONS_INFO.MD
@@ -627,7 +627,7 @@ See `:help mapping-functions`.
 | Status | Function            | Description                        |
 |--------|---------------------|------------------------------------|
 | ✅      | `digraph_get()`     | get digraph                        |
-|        | `digraph_getlist()` | get all digraphs                   |
+| ✅      | `digraph_getlist()` | get all digraphs                   |
 |        | `digraph_set()`     | register digraph                   |
 |        | `digraph_setlist()` | register multiple digraphs         |
 | ✅      | `hasmapto()`        | check if a mapping exists          |

--- a/vimscript-info/FUNCTIONS_INFO.MD
+++ b/vimscript-info/FUNCTIONS_INFO.MD
@@ -629,7 +629,7 @@ See `:help mapping-functions`.
 | ✅      | `digraph_get()`     | get digraph                        |
 | ✅      | `digraph_getlist()` | get all digraphs                   |
 | ✅      | `digraph_set()`     | register digraph                   |
-|        | `digraph_setlist()` | register multiple digraphs         |
+| ✅      | `digraph_setlist()` | register multiple digraphs         |
 | ✅      | `hasmapto()`        | check if a mapping exists          |
 | ✅      | `mapcheck()`        | check if a matching mapping exists |
 | ✅      | `maparg()`          | get rhs of a mapping               |

--- a/vimscript-info/FUNCTIONS_INFO.MD
+++ b/vimscript-info/FUNCTIONS_INFO.MD
@@ -626,7 +626,7 @@ See `:help mapping-functions`.
 
 | Status | Function            | Description                        |
 |--------|---------------------|------------------------------------|
-|        | `digraph_get()`     | get digraph                        |
+| ✅      | `digraph_get()`     | get digraph                        |
 |        | `digraph_getlist()` | get all digraphs                   |
 |        | `digraph_set()`     | register digraph                   |
 |        | `digraph_setlist()` | register multiple digraphs         |


### PR DESCRIPTION
This PR adds the digraph functions `digraph_get()`, `digraph_getlist()`, `digraph_set()` and `digraph_setlist()`.

It follows on from #1746, so contains those changes too. It's marked as draft until that PR is merged, then I'll rebase, force push and make ready for review.