### PR TITLE
Remove trailing whitespace in VimApi.kt

### DIFF
--- a/api/src/main/kotlin/com/intellij/vim/api/VimApi.kt
+++ b/api/src/main/kotlin/com/intellij/vim/api/VimApi.kt
@@ -291,13 +291,13 @@ interface VimApi {
    * ```kotlin
    * // Get option value
    * val history = option { get<Int>("history") }
-   * 
+   *
    * // Set option value and return result
-   * val wasSet = option { 
+   * val wasSet = option {
    *     set("number", true)
    *     true
    * }
-   * 
+   *
    * // Multiple operations
    * option {
    *     set("ignorecase", true)


### PR DESCRIPTION
## Summary
- Trim trailing whitespace in the kdoc example block of `VimApi.option`

## Test plan
- [ ] CI passes (no behavior change — comment-only)

Recreated from #1751 (which had become stale relative to master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)