### PR TITLE
Fix(VIM-4184): mirror PRIMARY on Wayland via xclip/wl-copy

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjClipboardManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjClipboardManager.kt
@@ -14,7 +14,6 @@ import com.intellij.codeInsight.editorActions.TextBlockTransferable
 import com.intellij.codeInsight.editorActions.TextBlockTransferableData
 import com.intellij.ide.CopyPasteManagerEx
 import com.intellij.openapi.editor.CaretStateTransferableData
-import com.intellij.openapi.editor.RawText
 import com.intellij.openapi.editor.richcopy.view.HtmlTransferableData
 import com.intellij.openapi.editor.richcopy.view.RtfTransferableData
 import com.intellij.openapi.project.DumbService
@@ -22,13 +21,18 @@ import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.util.ui.EmptyClipboardOwner
 import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.ImmutableVimCaret
 import com.maddyhome.idea.vim.api.VimClipboardManager
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.common.VimCopiedText
 import com.maddyhome.idea.vim.diagnostic.debug
 import com.maddyhome.idea.vim.diagnostic.vimLogger
+import com.maddyhome.idea.vim.state.mode.SelectionType
+import com.maddyhome.idea.vim.state.mode.inVisualMode
+import com.maddyhome.idea.vim.state.mode.selectionType
 import java.awt.HeadlessException
 import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
@@ -38,6 +42,8 @@ import java.io.IOException
 
 
 internal class IjClipboardManager : VimClipboardManager {
+  private val primaryWriter: PrimarySelectionWriter = primarySelectionWriter()
+
   override fun getPrimaryContent(editor: VimEditor, context: ExecutionContext): IjVimCopiedText? {
     val clipboard = Toolkit.getDefaultToolkit()?.systemSelection ?: return null
     val contents = clipboard.getContents(null) ?: return null
@@ -103,11 +109,38 @@ internal class IjClipboardManager : VimClipboardManager {
     textData: VimCopiedText,
   ): Boolean {
     require(textData is IjVimCopiedText)
-    return handleTextSetting(textData.text, textData.text, textData.transferableData) { content ->
-      val clipboard = Toolkit.getDefaultToolkit()?.systemSelection ?: return@handleTextSetting null
-      clipboard.setContents(content, EmptyClipboardOwner.INSTANCE)
-    } != null
+    return primaryWriter.write(textData.text, textData.transferableData)
   }
+
+  override fun onVisualSelectionChange(editor: VimEditor, caret: ImmutableVimCaret) {
+    if (!shouldRepublishVisualSelection(editor)) return
+    val text = readVisualSelectionText(editor, caret) ?: return
+    val context = injector.executionContextManager.getEditorExecutionContext(editor)
+    setPrimaryContent(editor, context, dumbCopiedText(text))
+  }
+
+  // vim-engine invokes setVisualSelection transiently from operators (yy, dd, c…), text-object
+  // handlers, and put-with-selection too — pushing those would corrupt PRIMARY mid-operation.
+  private fun shouldRepublishVisualSelection(editor: VimEditor): Boolean {
+    if (!editor.inVisualMode) return false
+    if (injector.vimState.executingCommand?.type in OPERATORS_SKIPPING_PRIMARY_PUSH) return false
+    return injector.registerGroup.isPrimaryRegisterSupported()
+  }
+
+  private fun readVisualSelectionText(editor: VimEditor, caret: ImmutableVimCaret): String? {
+    val start = caret.selectionStart
+    val end = caret.selectionEnd
+    if (start >= end) return null
+    val rawText = runCatching { editor.text().subSequence(start, end).toString() }.getOrNull() ?: return null
+    if (rawText.isEmpty()) return null
+    return ensureLinewiseTrailingNewline(rawText, editor.mode.selectionType)
+  }
+
+  // `lineToNativeSelection` ends the selection at the trailing `\n` rather than after it, so the
+  // raw substring excludes the newline. Re-add it for line-wise selections so external readers
+  // observe linewise content.
+  private fun ensureLinewiseTrailingNewline(text: String, selectionType: SelectionType?): String =
+    if (selectionType == SelectionType.LINE_WISE && !text.endsWith("\n")) "$text\n" else text
 
 //  override fun setPrimaryText(editor: VimEditor, context: ExecutionContext, entry: ClipboardEntry): Boolean {
 //    require(entry is IJClipboardEntry)
@@ -129,27 +162,19 @@ internal class IjClipboardManager : VimClipboardManager {
     return IjVimCopiedText(text, emptyList())
   }
 
-  @Suppress("UNCHECKED_CAST")
   private fun handleTextSetting(
     text: String,
     rawText: String,
     transferableData: List<Any>,
     setContent: (TextBlockTransferable) -> Unit?,
   ): Transferable? {
-    val mutableTransferableData = (transferableData as List<TextBlockTransferableData>).toMutableList()
-    try {
-      val s = TextBlockTransferable.convertLineSeparators(text, "\n", mutableTransferableData)
-      if (mutableTransferableData.none { it is CaretStateTransferableData }) {
-        // Manually add CaretStateTransferableData to avoid adjustment of a copied text to multicaret
-        mutableTransferableData += CaretStateTransferableData(intArrayOf(0), intArrayOf(s.length))
-      }
-      logger.debug { "Paste text with transferable data: ${mutableTransferableData.joinToString { it.javaClass.name }}" }
-      val content = TextBlockTransferable(s, mutableTransferableData, RawText(rawText))
+    return try {
+      val content = buildIjTextTransferable(text, rawText, transferableData)
       setContent(content)
-      return content
-    } catch (ignored: HeadlessException) {
+      content
+    } catch (_: HeadlessException) {
+      null
     }
-    return null
   }
 
   override fun getTransferableData(vimEditor: VimEditor, textRange: TextRange): List<TextBlockTransferableData> {
@@ -238,6 +263,14 @@ internal class IjClipboardManager : VimClipboardManager {
 
   companion object {
     val logger = vimLogger<IjClipboardManager>()
+
+    private val OPERATORS_SKIPPING_PRIMARY_PUSH = setOf(
+      Command.Type.COPY,
+      Command.Type.DELETE,
+      Command.Type.CHANGE,
+      Command.Type.PASTE,
+      Command.Type.INSERT,
+    )
   }
 }
 

--- a/src/main/java/com/maddyhome/idea/vim/newapi/PrimarySelectionWriter.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/PrimarySelectionWriter.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.newapi
+
+import com.intellij.codeInsight.editorActions.TextBlockTransferable
+import com.intellij.codeInsight.editorActions.TextBlockTransferableData
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.editor.CaretStateTransferableData
+import com.intellij.openapi.editor.RawText
+import com.intellij.util.ui.EmptyClipboardOwner
+import com.maddyhome.idea.vim.diagnostic.debug
+import com.maddyhome.idea.vim.diagnostic.vimLogger
+import java.awt.HeadlessException
+import java.awt.Toolkit
+import java.io.File
+
+/**
+ * Pushes text to the windowing system's PRIMARY selection.
+ *
+ * AWT is fine on X11 / macOS / Windows. On Wayland, Mutter's Wayland→X11 bridge drops JBR's
+ * writes under fast visual selection — external X11 readers see stale content — so we shell out
+ * to xclip/wl-copy instead.
+ */
+internal interface PrimarySelectionWriter {
+  /** `true` if the write was performed or reliably scheduled; `false` if PRIMARY isn't reachable here. */
+  fun write(text: String, transferableData: List<Any>): Boolean
+}
+
+internal fun primarySelectionWriter(): PrimarySelectionWriter =
+  if (System.getenv("WAYLAND_DISPLAY") != null) WaylandPrimarySelectionWriter()
+  else AwtPrimarySelectionWriter()
+
+/**
+ * Builds the `TextBlockTransferable` for clipboard and PRIMARY writes. We pin a single-range
+ * `CaretStateTransferableData` so IntelliJ doesn't reshape the pasted text to match whatever
+ * multi-caret arrangement the destination editor has.
+ *
+ * Throws [HeadlessException] on a headless JVM; callers handle.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun buildIjTextTransferable(
+  text: String,
+  rawText: String,
+  transferableData: List<Any>,
+): TextBlockTransferable {
+  val mutableData = (transferableData as List<TextBlockTransferableData>).toMutableList()
+  val normalized = TextBlockTransferable.convertLineSeparators(text, "\n", mutableData)
+  if (mutableData.none { it is CaretStateTransferableData }) {
+    mutableData += CaretStateTransferableData(intArrayOf(0), intArrayOf(normalized.length))
+  }
+  return TextBlockTransferable(normalized, mutableData, RawText(rawText))
+}
+
+internal class AwtPrimarySelectionWriter : PrimarySelectionWriter {
+  override fun write(text: String, transferableData: List<Any>): Boolean {
+    val clipboard = Toolkit.getDefaultToolkit()?.systemSelection ?: return false
+    return try {
+      val content = buildIjTextTransferable(text, text, transferableData)
+      clipboard.setContents(content, EmptyClipboardOwner.INSTANCE)
+      true
+    } catch (_: HeadlessException) {
+      false
+    }
+  }
+}
+
+/**
+ * Mirrors PRIMARY through xclip (preferred) or wl-copy (fallback).
+ *
+ * xclip writes X11 PRIMARY through XWayland and Mutter mirrors X11→Wayland reliably — both
+ * sides see the content. wl-copy writes Wayland-native and relies on the broken Wayland→X11
+ * bridge, which is the symptom we're working around.
+ *
+ * The tool is resolved once at construction so the hot path doesn't fork-exec-and-fail. Writes
+ * are deferred so they land *after* IntelliJ's synchronous post-yank `updateSystemSelection`
+ * overwrite; `ModalityState.any()` keeps them from being queued behind modal dialogs.
+ */
+internal class WaylandPrimarySelectionWriter : PrimarySelectionWriter {
+  private val command: List<String>? = candidates.firstOrNull { isExecutableInPath(it.first()) }
+
+  init {
+    if (command == null) {
+      logger.warn("Neither xclip nor wl-copy found on PATH; IdeaVim cannot mirror PRIMARY on Wayland")
+    } else {
+      logger.debug { "PRIMARY mirror will use: ${command.joinToString(" ")}" }
+    }
+  }
+
+  override fun write(text: String, transferableData: List<Any>): Boolean {
+    val argv = command ?: return false
+    ApplicationManager.getApplication().invokeLater(
+      { runCommand(argv, text) },
+      ModalityState.any(),
+    )
+    return true
+  }
+
+  private fun runCommand(argv: List<String>, text: String) {
+    try {
+      val process = ProcessBuilder(argv).redirectErrorStream(true).start()
+      process.outputStream.use { it.write(text.toByteArray(Charsets.UTF_8)) }
+    } catch (e: Exception) {
+      logger.debug { "${argv.joinToString(" ")} failed: ${e.message}" }
+    }
+  }
+
+  companion object {
+    private val logger = vimLogger<WaylandPrimarySelectionWriter>()
+
+    private val candidates = listOf(
+      listOf("xclip", "-selection", "primary"),
+      listOf("wl-copy", "--primary"),
+    )
+
+    private fun isExecutableInPath(name: String): Boolean {
+      val path = System.getenv("PATH") ?: return false
+      return path.split(File.pathSeparator).any { dir ->
+        val candidate = File(dir, name)
+        candidate.isFile && candidate.canExecute()
+      }
+    }
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimClipboardManager.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimClipboardManager.kt
@@ -27,6 +27,15 @@ interface VimClipboardManager {
   fun setClipboardContent(editor: VimEditor, context: ExecutionContext, textData: VimCopiedText): Boolean
   fun setPrimaryContent(editor: VimEditor, context: ExecutionContext, textData: VimCopiedText): Boolean
 
+  /**
+   * Fired when the user's visible visual selection changes. Whether to republish the new
+   * selection to the windowing system's PRIMARY is platform policy, so vim-engine just notifies
+   * and the IDE-specific implementation decides what (if anything) to do.
+   *
+   * Default: no-op.
+   */
+  fun onVisualSelectionChange(editor: VimEditor, caret: ImmutableVimCaret) {}
+
   @Deprecated("Please use com.maddyhome.idea.vim.api.VimClipboardManager#setClipboardContent")
   fun setClipboardText(text: String, rawText: String = text, transferableData: List<Any>): Transferable?
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2023 The IdeaVim authors
+ * Copyright 2003-2026 The IdeaVim authors
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE.txt file or at
@@ -90,6 +90,10 @@ fun setVisualSelection(selectionStart: Int, selectionEnd: Int, caret: VimCaret) 
       editor.primaryCaret().moveToInlayAwareOffset(selectionEnd)
     }
   }
+
+  // Selection-change notification for the IDE clipboard layer (vim-engine doesn't know how
+  // PRIMARY should behave on each platform). Clipboard I/O must never break visual mode setup.
+  runCatching { injector.clipboardManager.onVisualSelectionChange(caret.editor, caret) }
 }
 
 /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
@@ -426,6 +426,14 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
     injector.clipboardManager.setClipboardContent(editor, context, copiedText)
   }
 
+  // Wayland's clipboard reader strips trailing newlines, so a line-wise yank cached as "foo\n"
+  // re-reads from PRIMARY as "foo". Treat the missing-trailing-newline variant as a match too,
+  // otherwise every poll of PRIMARY would overwrite our cached line-wise register with a
+  // character-wise one.
+  private fun cachedRegisterMatchesClipboard(cached: Register, clipboard: VimCopiedText): Boolean {
+    return clipboard.text == cached.text || clipboard.text + "\n" == cached.text
+  }
+
   private fun refreshPrimaryRegister(editor: VimEditor, context: ExecutionContext): Register? {
     logger.trace("Syncing cached primary selection value..")
     if (!isPrimaryRegisterSupported()) {
@@ -441,7 +449,7 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
         return myRegisters[PRIMARY_REGISTER]
       }
       val currentRegister = myRegisters[PRIMARY_REGISTER]
-      if (currentRegister != null && clipboardData.text == currentRegister.text) {
+      if (currentRegister != null && cachedRegisterMatchesClipboard(currentRegister, clipboardData)) {
         return currentRegister
       }
       return Register(PRIMARY_REGISTER, clipboardData, guessSelectionType(clipboardData.text))


### PR DESCRIPTION
JBR's WLClipboard takes Wayland-side primary ownership and Mutter's Wayland→X11 bridge is racy under rapid visual selection, so external readers (xclip, middle-click-paste) see stale content. Route PRIMARY writes through xclip (preferred) or wl-copy (fallback) on Wayland, deferred past IntelliJ's CaretModelImpl.updateSystemSelection post-yank clobber. AWT path unchanged on X11/macOS/Windows.