### PR TITLE
VIM-4217 Persist widget state

### DIFF
--- a/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
+++ b/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
@@ -192,6 +192,7 @@
                         serviceInterface="com.maddyhome.idea.vim.yank.VimYankGroup"/>
     <applicationService serviceImplementation="com.maddyhome.idea.vim.vimscript.services.IjVariableService"
                         serviceInterface="com.maddyhome.idea.vim.vimscript.services.VariableService"/>
+    <applicationService serviceImplementation="com.maddyhome.idea.vim.ui.widgets.mode.ModeWidgetSettings"/>
     <applicationService serviceImplementation="com.maddyhome.idea.vim.group.IjStatisticsService"
                         serviceInterface="com.maddyhome.idea.vim.api.VimStatistics"/>
     <applicationService serviceImplementation="com.maddyhome.idea.vim.vimscript.services.FunctionStorage"

--- a/src/main/java/com/maddyhome/idea/vim/statistic/WidgetState.kt
+++ b/src/main/java/com/maddyhome/idea/vim/statistic/WidgetState.kt
@@ -15,8 +15,9 @@ import com.intellij.internal.statistic.eventLog.events.VarargEventId
 import com.intellij.internal.statistic.service.fus.collectors.ApplicationUsagesCollector
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.WindowManager
-import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.ui.widgets.mode.ModeWidgetFactory
+import com.maddyhome.idea.vim.ui.widgets.mode.resolveBoolean
+import com.maddyhome.idea.vim.ui.widgets.mode.resolveString
 
 class WidgetState : ApplicationUsagesCollector() {
   override fun getGroup(): EventLogGroup = GROUP
@@ -43,12 +44,10 @@ class WidgetState : ApplicationUsagesCollector() {
   }
 
   private fun getModeWidgetTheme(postfix: String): String {
-    if (injector.variableService.getGlobalVariableValue("widget_mode_is_full_customization$postfix")
-        ?.toVimNumber()?.booleanValue == true
-    ) {
+    if (resolveBoolean("widget_mode_is_full_customization$postfix")) {
       return "ADVANCED CUSTOMIZATION"
     }
-    val themeString = injector.variableService.getGlobalVariableValue("widget_mode_theme$postfix")?.toVimString()?.value
+    val themeString = resolveString("widget_mode_theme$postfix")
     return if (themeString?.lowercase() == "colorless") {
       "COLORLESS"
     } else {

--- a/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/ModeWidgetPopup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/ModeWidgetPopup.kt
@@ -29,10 +29,7 @@ import com.intellij.ui.dsl.builder.selected
 import com.intellij.ui.dsl.builder.toNullableProperty
 import com.intellij.ui.layout.not
 import com.intellij.util.Alarm
-import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.helper.MessageHelper
-import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
-import com.maddyhome.idea.vim.vimscript.model.datatypes.asVimInt
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.FlowLayout
@@ -316,59 +313,56 @@ class ModeWidgetPopup : AnAction() {
     selectBlockBgKey: String,
     selectBlockFgKey: String,
   ) {
-    var isFullCustomization: Boolean by VimScopeBooleanVariable(isFullCustomizationKey)
-    var theme: ModeWidgetTheme by VimScopeThemeVariable(themeKey)
-    var normalBg: String by VimScopeStringVariable(normalBgKey)
-    var normalFg: String by VimScopeStringVariable(normalFgKey)
-    var insertBg: String by VimScopeStringVariable(insertBgKey)
-    var insertFg: String by VimScopeStringVariable(insertFgKey)
-    var replaceBg: String by VimScopeStringVariable(replaceBgKey)
-    var replaceFg: String by VimScopeStringVariable(replaceFgKey)
-    var commandBg: String by VimScopeStringVariable(commandBgKey)
-    var commandFg: String by VimScopeStringVariable(commandFgKey)
-    var visualBg: String by VimScopeStringVariable(visualBgKey)
-    var visualFg: String by VimScopeStringVariable(visualFgKey)
-    var visualLineBg: String by VimScopeStringVariable(visualLineBgKey)
-    var visualLineFg: String by VimScopeStringVariable(visualLineFgKey)
-    var visualBlockBg: String by VimScopeStringVariable(visualBlockBgKey)
-    var visualBlockFg: String by VimScopeStringVariable(visualBlockFgKey)
-    var selectBg: String by VimScopeStringVariable(selectBgKey)
-    var selectFg: String by VimScopeStringVariable(selectFgKey)
-    var selectLineBg: String by VimScopeStringVariable(selectLineBgKey)
-    var selectLineFg: String by VimScopeStringVariable(selectLineFgKey)
-    var selectBlockBg: String by VimScopeStringVariable(selectBlockBgKey)
-    var selectBlockFg: String by VimScopeStringVariable(selectBlockFgKey)
+    var isFullCustomization: Boolean by SettingsBoolean(isFullCustomizationKey)
+    var theme: ModeWidgetTheme by SettingsTheme(themeKey)
+    var normalBg: String by SettingsString(normalBgKey)
+    var normalFg: String by SettingsString(normalFgKey)
+    var insertBg: String by SettingsString(insertBgKey)
+    var insertFg: String by SettingsString(insertFgKey)
+    var replaceBg: String by SettingsString(replaceBgKey)
+    var replaceFg: String by SettingsString(replaceFgKey)
+    var commandBg: String by SettingsString(commandBgKey)
+    var commandFg: String by SettingsString(commandFgKey)
+    var visualBg: String by SettingsString(visualBgKey)
+    var visualFg: String by SettingsString(visualFgKey)
+    var visualLineBg: String by SettingsString(visualLineBgKey)
+    var visualLineFg: String by SettingsString(visualLineFgKey)
+    var visualBlockBg: String by SettingsString(visualBlockBgKey)
+    var visualBlockFg: String by SettingsString(visualBlockFgKey)
+    var selectBg: String by SettingsString(selectBgKey)
+    var selectFg: String by SettingsString(selectFgKey)
+    var selectLineBg: String by SettingsString(selectLineBgKey)
+    var selectLineFg: String by SettingsString(selectLineFgKey)
+    var selectBlockBg: String by SettingsString(selectBlockBgKey)
+    var selectBlockFg: String by SettingsString(selectBlockFgKey)
 
-    private class VimScopeBooleanVariable(private var key: String) : ReadWriteProperty<ModeColors, Boolean> {
-      override fun getValue(thisRef: ModeColors, property: KProperty<*>): Boolean {
-        return injector.variableService.getGlobalVariableValue(key)?.toVimNumber()?.booleanValue ?: false
-      }
+    private class SettingsBoolean(private val key: String) : ReadWriteProperty<ModeColors, Boolean> {
+      override fun getValue(thisRef: ModeColors, property: KProperty<*>): Boolean =
+        ModeWidgetSettings.getInstance().getBoolean(key)
 
       override fun setValue(thisRef: ModeColors, property: KProperty<*>, value: Boolean) {
-        injector.variableService.storeGlobalVariable(key, value.asVimInt())
+        ModeWidgetSettings.getInstance().setBoolean(key, value)
       }
     }
 
-    private class VimScopeStringVariable(private var key: String) : ReadWriteProperty<ModeColors, String> {
-      override fun getValue(thisRef: ModeColors, property: KProperty<*>): String {
-        return injector.variableService.getGlobalVariableValue(key)?.toVimString()?.value ?: ""
-      }
+    private class SettingsString(private val key: String) : ReadWriteProperty<ModeColors, String> {
+      override fun getValue(thisRef: ModeColors, property: KProperty<*>): String =
+        ModeWidgetSettings.getInstance().getString(key) ?: ""
 
       override fun setValue(thisRef: ModeColors, property: KProperty<*>, value: String) {
-        injector.variableService.storeGlobalVariable(key, VimString(value))
+        ModeWidgetSettings.getInstance().setString(key, value)
       }
     }
 
-    private class VimScopeThemeVariable(private var key: String) : ReadWriteProperty<ModeColors, ModeWidgetTheme> {
+    private class SettingsTheme(private val key: String) : ReadWriteProperty<ModeColors, ModeWidgetTheme> {
       override fun getValue(thisRef: ModeColors, property: KProperty<*>): ModeWidgetTheme {
         val themeString =
-          injector.variableService.getGlobalVariableValue(key)?.toVimString()?.value
-            ?: return ModeWidgetTheme.getDefaultTheme()
+          ModeWidgetSettings.getInstance().getString(key) ?: return ModeWidgetTheme.getDefaultTheme()
         return ModeWidgetTheme.parseString(themeString) ?: ModeWidgetTheme.getDefaultTheme()
       }
 
       override fun setValue(thisRef: ModeColors, property: KProperty<*>, value: ModeWidgetTheme) {
-        injector.variableService.storeGlobalVariable(key, VimString(value.toString()))
+        ModeWidgetSettings.getInstance().setString(key, value.toString())
       }
     }
   }

--- a/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/ModeWidgetSettings.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/ModeWidgetSettings.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.ui.widgets.mode
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.RoamingType
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
+import org.jdom.Element
+
+// Persists popup choices for the mode widget. Readers prefer `g:widget_mode_*` (e.g. set in
+// `.ideavimrc`) and fall back to this component, so user config beats remembered popup state.
+@State(
+  name = "ModeWidgetSettings",
+  storages = [Storage(value = "\$APP_CONFIG$/vim_settings_local.xml", roamingType = RoamingType.DISABLED)]
+)
+internal class ModeWidgetSettings : PersistentStateComponent<Element> {
+  private val entries: MutableMap<String, String> = mutableMapOf()
+  private var migrated = false
+
+  fun getString(key: String): String? {
+    ensureMigrated()
+    return entries[key]
+  }
+
+  fun getBoolean(key: String): Boolean {
+    ensureMigrated()
+    return entries[key]?.let { it == "1" || it.equals("true", ignoreCase = true) } ?: false
+  }
+
+  fun setString(key: String, value: String) {
+    entries[key] = value
+  }
+
+  fun setBoolean(key: String, value: Boolean) {
+    entries[key] = if (value) "1" else "0"
+  }
+
+  override fun getState(): Element {
+    val element = Element(ROOT_ELEMENT)
+    element.setAttribute(MIGRATED_ATTR, migrated.toString())
+    for ((key, value) in entries) {
+      val entry = Element(ENTRY_ELEMENT)
+      entry.setAttribute(KEY_ATTR, key)
+      entry.setAttribute(VALUE_ATTR, value)
+      element.addContent(entry)
+    }
+    return element
+  }
+
+  override fun loadState(state: Element) {
+    migrated = state.getAttributeValue(MIGRATED_ATTR)?.toBoolean() ?: false
+    for (entry in state.getChildren(ENTRY_ELEMENT)) {
+      val key = entry.getAttributeValue(KEY_ATTR) ?: continue
+      val value = entry.getAttributeValue(VALUE_ATTR) ?: continue
+      entries[key] = value
+    }
+  }
+
+  private fun ensureMigrated() {
+    if (migrated) return
+    migrated = true
+    // Older builds stored these values under <vim-variables> in the same XML file; pick them up
+    // once so users with existing config don't lose their popup choices on upgrade.
+    for (key in LEGACY_KEYS) {
+      if (entries.containsKey(key)) continue
+      val legacy = injector.variableService.getVimVariable(key) ?: continue
+      entries[key] = when (legacy) {
+        is VimString -> legacy.value
+        is VimInt -> legacy.value.toString()
+        else -> continue
+      }
+    }
+  }
+
+  companion object {
+    fun getInstance(): ModeWidgetSettings =
+      ApplicationManager.getApplication().getService(ModeWidgetSettings::class.java)
+
+    private const val ROOT_ELEMENT = "settings"
+    private const val ENTRY_ELEMENT = "entry"
+    private const val KEY_ATTR = "key"
+    private const val VALUE_ATTR = "value"
+    private const val MIGRATED_ATTR = "migrated"
+
+    private val MODE_PREFIXES = listOf(
+      "normal", "insert", "replace", "command",
+      "visual", "visual_line", "visual_block",
+      "select", "select_line", "select_block",
+    )
+
+    private val LEGACY_KEYS: List<String> = buildList {
+      for (suffix in listOf("_light", "_dark")) {
+        add("widget_mode_is_full_customization$suffix")
+        add("widget_mode_theme$suffix")
+        for (mode in MODE_PREFIXES) {
+          add("widget_mode_${mode}_background$suffix")
+          add("widget_mode_${mode}_foreground$suffix")
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/Util.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/widgets/mode/Util.kt
@@ -19,11 +19,8 @@ import java.awt.Color
 fun getModeBackground(mode: Mode?): Color {
   val isLight = !(LafManager.getInstance()?.currentUIThemeLookAndFeel?.isDark ?: false)
   val keyPostfix = if (isLight) "_light" else "_dark"
-  if (injector.variableService.getGlobalVariableValue("widget_mode_is_full_customization$keyPostfix")
-      ?.toVimNumber()?.booleanValue != true
-  ) {
-    val themeString =
-      injector.variableService.getGlobalVariableValue("widget_mode_theme$keyPostfix")?.toVimString()?.value ?: ""
+  if (!resolveBoolean("widget_mode_is_full_customization$keyPostfix")) {
+    val themeString = resolveString("widget_mode_theme$keyPostfix") ?: ""
     val theme = ModeWidgetTheme.parseString(themeString) ?: ModeWidgetTheme.getDefaultTheme()
     when (theme) {
       ModeWidgetTheme.TERM -> {
@@ -53,38 +50,36 @@ fun getModeBackground(mode: Mode?): Color {
     }
   } else {
     val colorString = when (mode) {
-      Mode.INSERT -> injector.variableService.getGlobalVariableValue("widget_mode_insert_background$keyPostfix")
-      Mode.REPLACE -> injector.variableService.getGlobalVariableValue("widget_mode_replace_background$keyPostfix")
-      is Mode.NORMAL -> injector.variableService.getGlobalVariableValue("widget_mode_normal_background$keyPostfix")
-      is Mode.CMD_LINE -> injector.variableService.getGlobalVariableValue("widget_mode_command_background$keyPostfix")
+      Mode.INSERT -> resolveString("widget_mode_insert_background$keyPostfix")
+      Mode.REPLACE -> resolveString("widget_mode_replace_background$keyPostfix")
+      is Mode.NORMAL -> resolveString("widget_mode_normal_background$keyPostfix")
+      is Mode.CMD_LINE -> resolveString("widget_mode_command_background$keyPostfix")
       is Mode.VISUAL -> {
-        val visualModeBackground =
-          injector.variableService.getGlobalVariableValue("widget_mode_visual_background$keyPostfix")
+        val visualModeBackground = resolveString("widget_mode_visual_background$keyPostfix")
         when (mode.selectionType) {
           SelectionType.CHARACTER_WISE -> visualModeBackground
-          SelectionType.LINE_WISE -> injector.variableService.getGlobalVariableValue("widget_mode_visual_line_background$keyPostfix")
+          SelectionType.LINE_WISE -> resolveString("widget_mode_visual_line_background$keyPostfix")
             ?: visualModeBackground
 
-          SelectionType.BLOCK_WISE -> injector.variableService.getGlobalVariableValue("widget_mode_visual_block_background$keyPostfix")
+          SelectionType.BLOCK_WISE -> resolveString("widget_mode_visual_block_background$keyPostfix")
             ?: visualModeBackground
         }
       }
 
       is Mode.SELECT -> {
-        val selectModeBackground =
-          injector.variableService.getGlobalVariableValue("widget_mode_select_background$keyPostfix")
+        val selectModeBackground = resolveString("widget_mode_select_background$keyPostfix")
         when (mode.selectionType) {
           SelectionType.CHARACTER_WISE -> selectModeBackground
-          SelectionType.LINE_WISE -> injector.variableService.getGlobalVariableValue("widget_mode_select_line_background$keyPostfix")
+          SelectionType.LINE_WISE -> resolveString("widget_mode_select_line_background$keyPostfix")
             ?: selectModeBackground
 
-          SelectionType.BLOCK_WISE -> injector.variableService.getGlobalVariableValue("widget_mode_select_block_background$keyPostfix")
+          SelectionType.BLOCK_WISE -> resolveString("widget_mode_select_block_background$keyPostfix")
             ?: selectModeBackground
         }
       }
 
       is Mode.OP_PENDING, null -> null
-    }?.toVimString()?.value
+    }
     val defaultColor = UIUtil.getPanelBackground()
     val color = when (colorString) {
       "v:status_bar_bg" -> UIUtil.getPanelBackground()
@@ -108,11 +103,8 @@ fun getModeBackground(mode: Mode?): Color {
 fun getModeForeground(mode: Mode?): Color {
   val isLight = !(LafManager.getInstance()?.currentUIThemeLookAndFeel?.isDark ?: false)
   val keyPostfix = if (isLight) "_light" else "_dark"
-  if (injector.variableService.getGlobalVariableValue("widget_mode_is_full_customization$keyPostfix")
-      ?.toVimNumber()?.booleanValue != true
-  ) {
-    val themeString =
-      injector.variableService.getGlobalVariableValue("widget_mode_theme$keyPostfix")?.toVimString()?.value ?: ""
+  if (!resolveBoolean("widget_mode_is_full_customization$keyPostfix")) {
+    val themeString = resolveString("widget_mode_theme$keyPostfix") ?: ""
     val theme = ModeWidgetTheme.parseString(themeString) ?: ModeWidgetTheme.getDefaultTheme()
     return when (theme) {
       ModeWidgetTheme.TERM -> if (isLight) JBColor.WHITE else JBColor.BLACK
@@ -121,38 +113,36 @@ fun getModeForeground(mode: Mode?): Color {
     }
   } else {
     val colorString = when (mode) {
-      Mode.INSERT -> injector.variableService.getGlobalVariableValue("widget_mode_insert_foreground$keyPostfix")
-      Mode.REPLACE -> injector.variableService.getGlobalVariableValue("widget_mode_replace_foreground$keyPostfix")
-      is Mode.NORMAL -> injector.variableService.getGlobalVariableValue("widget_mode_normal_foreground$keyPostfix")
-      is Mode.CMD_LINE -> injector.variableService.getGlobalVariableValue("widget_mode_command_foreground$keyPostfix")
+      Mode.INSERT -> resolveString("widget_mode_insert_foreground$keyPostfix")
+      Mode.REPLACE -> resolveString("widget_mode_replace_foreground$keyPostfix")
+      is Mode.NORMAL -> resolveString("widget_mode_normal_foreground$keyPostfix")
+      is Mode.CMD_LINE -> resolveString("widget_mode_command_foreground$keyPostfix")
       is Mode.VISUAL -> {
-        val visualModeBackground =
-          injector.variableService.getGlobalVariableValue("widget_mode_visual_foreground$keyPostfix")
+        val visualModeBackground = resolveString("widget_mode_visual_foreground$keyPostfix")
         when (mode.selectionType) {
           SelectionType.CHARACTER_WISE -> visualModeBackground
-          SelectionType.LINE_WISE -> injector.variableService.getGlobalVariableValue("widget_mode_visual_line_foreground$keyPostfix")
+          SelectionType.LINE_WISE -> resolveString("widget_mode_visual_line_foreground$keyPostfix")
             ?: visualModeBackground
 
-          SelectionType.BLOCK_WISE -> injector.variableService.getGlobalVariableValue("widget_mode_visual_block_foreground$keyPostfix")
+          SelectionType.BLOCK_WISE -> resolveString("widget_mode_visual_block_foreground$keyPostfix")
             ?: visualModeBackground
         }
       }
 
       is Mode.SELECT -> {
-        val selectModeBackground =
-          injector.variableService.getGlobalVariableValue("widget_mode_select_foreground$keyPostfix")
+        val selectModeBackground = resolveString("widget_mode_select_foreground$keyPostfix")
         when (mode.selectionType) {
           SelectionType.CHARACTER_WISE -> selectModeBackground
-          SelectionType.LINE_WISE -> injector.variableService.getGlobalVariableValue("widget_mode_select_line_foreground$keyPostfix")
+          SelectionType.LINE_WISE -> resolveString("widget_mode_select_line_foreground$keyPostfix")
             ?: selectModeBackground
 
-          SelectionType.BLOCK_WISE -> injector.variableService.getGlobalVariableValue("widget_mode_select_block_foreground$keyPostfix")
+          SelectionType.BLOCK_WISE -> resolveString("widget_mode_select_block_foreground$keyPostfix")
             ?: selectModeBackground
         }
       }
 
       is Mode.OP_PENDING, null -> null
-    }?.toVimString()?.value
+    }
     val defaultColor = UIUtil.getLabelForeground()
     val color = when (colorString) {
       "v:status_bar_bg" -> UIUtil.getPanelBackground()
@@ -171,4 +161,17 @@ fun getModeForeground(mode: Mode?): Color {
     }
     return color
   }
+}
+
+/**
+ * `g:` (e.g. set in `.ideavimrc`) wins; otherwise fall back to the popup-managed PSC.
+ */
+internal fun resolveString(key: String): String? {
+  injector.variableService.getGlobalVariableValue(key)?.toVimString()?.value?.let { return it }
+  return ModeWidgetSettings.getInstance().getString(key)
+}
+
+internal fun resolveBoolean(key: String): Boolean {
+  injector.variableService.getGlobalVariableValue(key)?.toVimNumber()?.booleanValue?.let { return it }
+  return ModeWidgetSettings.getInstance().getBoolean(key)
 }


### PR DESCRIPTION
Previously we changed widget variables from vim variables to global one but those are not being persisted. We should not persist then so we've decided to persist them in `ModeWidgetSettings` and override if user will manually set global variable