### PR TITLE
VIM-4223 proper hide command abbreviation

### DIFF
--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/QuitCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/QuitCommand.kt
@@ -19,7 +19,7 @@ import com.maddyhome.idea.vim.vimscript.model.ExecutionResult
 /**
  * see "h :quit" / "h :close" / "h :quit"
  */
-@ExCommand(command = "q[uit],clo[se],hi[de]")
+@ExCommand(command = "q[uit],clo[se],hid[e]")
 data class QuitCommand(val range: Range, val modifier: CommandModifier, val argument: String) :
   Command.SingleExecution(range, modifier, argument) {
 

--- a/vim-engine/src/main/resources/ksp-generated/engine_ex_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_ex_commands.json
@@ -44,7 +44,7 @@
   "fir[st]": "com.maddyhome.idea.vim.vimscript.model.commands.SelectFirstFileCommand",
   "g[lobal]": "com.maddyhome.idea.vim.vimscript.model.commands.GlobalCommand",
   "go[to]": "com.maddyhome.idea.vim.vimscript.model.commands.GotoCharacterCommand",
-  "hi[de]": "com.maddyhome.idea.vim.vimscript.model.commands.QuitCommand",
+  "hid[e]": "com.maddyhome.idea.vim.vimscript.model.commands.QuitCommand",
   "his[tory]": "com.maddyhome.idea.vim.vimscript.model.commands.HistoryCommand",
   "im[ap]": "com.maddyhome.idea.vim.vimscript.model.commands.mapping.MapCommand",
   "imapc[lear]": "com.maddyhome.idea.vim.vimscript.model.commands.mapping.MapClearCommand",


### PR DESCRIPTION
with `hi[de]` users that had hi in their ideavimrc expected it to change highlight, but it was closing editor instead