### PR TITLE
Fix(VIM-4233): focus ex entry panel race condition

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
@@ -193,7 +193,7 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
       }
       positionPanel()
       glassPane.isVisible = true
-      entry.requestFocusInWindow()
+      SwingUtilities.invokeLater { entry.requestFocusInWindow() }
     }
     this.isActive = true
   }


### PR DESCRIPTION
When user typed / twice in a row there could be race condition between deactivate and activate panel requesting focus. so becouse of focus parent in deactivate is asnyc it could happen after requestFocusInWindow in activate