### PR TITLE
Add history functions

### DIFF
--- a/ideavim-common/src/main/resources/dictionaries/ideavim.dic
+++ b/ideavim-common/src/main/resources/dictionaries/ideavim.dic
@@ -180,6 +180,7 @@ getregtype
 hasmapto
 histadd
 histget
+histnr
 indexof
 isinf
 maparg

--- a/ideavim-common/src/main/resources/dictionaries/ideavim.dic
+++ b/ideavim-common/src/main/resources/dictionaries/ideavim.dic
@@ -178,6 +178,7 @@ getline
 getreg
 getregtype
 hasmapto
+histadd
 indexof
 isinf
 maparg

--- a/ideavim-common/src/main/resources/dictionaries/ideavim.dic
+++ b/ideavim-common/src/main/resources/dictionaries/ideavim.dic
@@ -179,6 +179,7 @@ getreg
 getregtype
 hasmapto
 histadd
+histget
 indexof
 isinf
 maparg

--- a/ideavim-common/src/main/resources/dictionaries/ideavim.dic
+++ b/ideavim-common/src/main/resources/dictionaries/ideavim.dic
@@ -179,6 +179,7 @@ getreg
 getregtype
 hasmapto
 histadd
+histdel
 histget
 histnr
 indexof

--- a/src/main/java/com/maddyhome/idea/vim/group/HistoryGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/HistoryGroup.java
@@ -73,7 +73,7 @@ public class HistoryGroup extends VimHistoryBase
 
   private void readData(@NotNull Element element, String key) {
     final Type type = getTypeForString(key);
-    if (!isInitialised(type)) {
+    if (isInitialised(type)) {
       return;
     }
 

--- a/src/main/java/com/maddyhome/idea/vim/group/HistoryGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/HistoryGroup.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.components.RoamingType;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.diagnostic.Logger;
-import com.maddyhome.idea.vim.history.HistoryBlock;
 import com.maddyhome.idea.vim.history.HistoryEntry;
 import com.maddyhome.idea.vim.history.VimHistory;
 import com.maddyhome.idea.vim.history.VimHistoryBase;
@@ -21,7 +20,6 @@ import com.maddyhome.idea.vim.newapi.VimLegacyStateLoader;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
 
 import java.util.List;
 
@@ -36,7 +34,7 @@ public class HistoryGroup extends VimHistoryBase
     logger.debug("saveData");
     Element hist = new Element("history");
 
-    for (Type type : getHistories().keySet()) {
+    for (Type type : getInitialisedTypes()) {
       saveData(hist, type);
     }
 
@@ -44,14 +42,14 @@ public class HistoryGroup extends VimHistoryBase
   }
 
   private void saveData(@NotNull Element element, VimHistory.Type type) {
-    final HistoryBlock block = getHistories().get(type);
-    if (block == null) {
+    var entries = getEntries(type, 0, 0);
+    if (entries.isEmpty()) {
       return;
     }
 
     final Element root = new Element("history-" + typeToKey(type));
 
-    for (HistoryEntry entry : block.getEntries()) {
+    for (HistoryEntry entry : entries) {
       final Element entryElement = new Element("entry");
       XMLGroup.getInstance().setSafeXmlText(entryElement, entry.getEntry());
       root.addContent(entryElement);
@@ -74,13 +72,10 @@ public class HistoryGroup extends VimHistoryBase
   }
 
   private void readData(@NotNull Element element, String key) {
-    HistoryBlock block = getHistories().get(getTypeForString(key));
-    if (block != null) {
+    final Type type = getTypeForString(key);
+    if (!isInitialised(type)) {
       return;
     }
-
-    block = new HistoryBlock();
-    getHistories().put(getTypeForString(key), block);
 
     final Element root = element.getChild("history-" + key);
     if (root != null) {
@@ -88,7 +83,7 @@ public class HistoryGroup extends VimHistoryBase
       for (Element item : items) {
         final String text = XMLGroup.getInstance().getSafeXmlText(item);
         if (text != null) {
-          block.addEntry(text);
+          addEntry(type, text);
         }
       }
     }
@@ -126,10 +121,5 @@ public class HistoryGroup extends VimHistoryBase
   @Override
   public void loadState(@NotNull Element state) {
     readData(state);
-  }
-
-  @TestOnly
-  public void clear() {
-    getHistories().clear();
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
@@ -79,7 +79,6 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
   var inputInterceptor: VimInputInterceptor? = null
   private var weakEditor: WeakReference<Editor?>? = null
   var context: DataContext? = null
-  override var histIndex: Int = 0
   override var lastEntry: String? = null
   override var activeCompletion: CommandLineCompletion? = null
 
@@ -165,8 +164,6 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
 
     this.context = context
     setEditor(editor)
-
-    histIndex = VimPlugin.getHistory().getEntries(historyType, 0, 0).size
 
     entry.document.addDocumentListener(fontListener)
     if (this.isIncSearchEnabled) {

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/ex/SelectNewerHistoryActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/ex/SelectNewerHistoryActionTest.kt
@@ -25,122 +25,242 @@ class SelectNewerHistoryActionTest : VimExTestCase() {
   }
 
   @Test
+  fun `test Shift+Down with no command history beeps`() {
+    typeText(":<S-Down>")
+    assertExText("")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test Shift+Down with no command history and typed entry beeps and does not change typed entry`() {
+    typeText(":map<S-Down>")
+    assertExText("map")
+    assertPluginError(true)
+  }
+
+  @Test
   fun `test Shift+Down selects newer command history entry ignoring typed prefix`() {
-    typeText(":map<S-Up>")
+    typeText(":map<S-Up>")  // Selects #3 as current entry
     assertExText("set incsearch")
-    typeText("<S-Up>")
+    typeText("<S-Up>")      // Selects #2 as current entry
     assertExText("digraph")
 
+    // <S-Down> ignores the typed `map` prefix and selects next entry (#3 - "set incsearch")
     typeText("<S-Down>")
     assertExText("set incsearch")
   }
 
   @Test
-  fun `test Shift+Down selects last typed command value`() {
-    typeText(":map<S-Up>")
+  fun `test Shift+Down on last saved entry selects last typed command value`() {
+    typeText(":map<S-Up>")  // Selects #3 as current entry
     assertExText("set incsearch")
 
-    typeText("<S-Down>")
+    typeText("<S-Down>")    // Next newer entry is the in-progress typed entry "map"
     assertExText("map")
+  }
+
+  @Test
+  fun `test Shift+Down after hitting start of history selects second oldest entry`() {
+    typeText(":<S-Up>")   // Selects #3 as current entry
+    typeText("<S-Up>")    // Selects #2 as current entry
+    typeText("<S-Up>")    // Selects #1 as current entry
+    typeText("<S-Up>")    // Tries to move past start of history, beeps, but doesn't change content
+    assertExText("set digraph")
+    assertPluginError(true)
+
+    typeText("<S-Down>")  // #1 is still current entry. Selects #2 as current entry
+    assertExText("digraph")
+    assertPluginError(false)
+  }
+
+  @Test
+  fun `test select older entry after hitting end of history`() {
+    typeText(":map<S-Up>")   // Selects #3 as current entry
+    typeText("<S-Down>")     // Selects in-progress entry as current entry
+    assertExText("map")
+    assertPluginError(false)
+
+    typeText("<S-Down>")    // Can't select anything, error
+    assertExText("map")
+    assertPluginError(true)
+
+    typeText("<S-Up>")      // Selects #3 as current entry
+    assertExText("set incsearch")
+    assertPluginError(false)
+  }
+
+  @Test
+  fun `test Ctrl-N with no command history beeps`() {
+    typeText(":<C-N>")
+    assertExText("")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test Ctrl-N with no command history and typed entry beeps and does not change typed entry`() {
+    typeText(":map<C-N>")
+    assertExText("map")
+    assertPluginError(true)
   }
 
   @Test
   fun `test Ctrl-N selects newer command history entry ignoring typed prefix`() {
-    typeText(":map<C-P>")
+    typeText(":map<C-P>")   // Selects #3 as current entry
     assertExText("set incsearch")
-    typeText("<C-P>")
+    typeText("<C-P>")       // Selects #2 as current entry
     assertExText("digraph")
 
+    // <C-N> ignores the typed `map` prefix and selects next entry (#3 - "set incsearch")
     typeText("<C-N>")
     assertExText("set incsearch")
   }
 
   @Test
-  fun `test Ctrl-N selects last typed comamnd value`() {
-    typeText(":map<C-P>")
+  fun `test Ctrl-N on last saved entry selects last typed command value`() {
+    typeText(":map<C-P>")   // Selects #3 as current entry
     assertExText("set incsearch")
 
-    typeText("<C-N>")
+    typeText("<C-N>")       // Next newer entry is in-progress typed entry "map"
     assertExText("map")
+  }
+
+  @Test
+  fun `test PageDown with no command history beeps`() {
+    typeText(":<PageDown>")
+    assertExText("")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test PageDown with no command history and typed entry beeps and does not change typed entry`() {
+    typeText(":map<PageDown>")
+    assertExText("map")
+    assertPluginError(true)
   }
 
   @Test
   fun `test PageDown selects newer command history entry ignoring typed prefix`() {
-    typeText(":map<PageUp>")
+    typeText(":map<PageUp>")  // Selects #3 as current entry
     assertExText("set incsearch")
-    typeText("<PageUp>")
+    typeText("<PageUp>")      // Selects #2 as current entry
     assertExText("digraph")
 
+    // <PageDown> ignores the typed `map` prefix and selects the next entry (#3 - "set incsearch")
     typeText("<PageDown>")
     assertExText("set incsearch")
   }
 
   @Test
-  fun `test PageDown selects last typed command value`() {
-    typeText(":map<PageUp>")
+  fun `test PageDown on last saved entry selects last typed command value`() {
+    typeText(":map<PageUp>")  // Selects #3 as current entry
     assertExText("set incsearch")
 
-    typeText("<PageDown>")
+    typeText("<PageDown>")    // Next newer entry is the in-progress typed entry "map"
     assertExText("map")
+  }
+
+  @Test
+  fun `test Shift+Down with no search history beeps`() {
+    typeText("/<S-Down>")
+    assertExText("")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test Shift+Down with no search history and typed entry beeps and does not change typed entry`() {
+    typeText("/map<S-Down>")
+    assertExText("map")
+    assertPluginError(true)
   }
 
   @Test
   fun `test Shift+Down selects newer search history entry ignoring typed prefix`() {
-    typeText("/map<S-Up>")
+    typeText("/map<S-Up>")  // Selects #3 as current entry
     assertExText("so cool")
-    typeText("<S-Up>")
+    typeText("<S-Up>")      // Selects #2 as current entry
     assertExText("not cool")
 
+    // <S-Down> ignores the typed `map` prefix and selects next entry (#3 - "so cool")
     typeText("<S-Down>")
     assertExText("so cool")
   }
 
   @Test
-  fun `test Shift+Down selects last typed search value`() {
-    typeText("/map<S-Up>")
+  fun `test Shift+Down on last saved entry selects last typed search value`() {
+    typeText("/map<S-Up>")  // Selects #3 as current entry
     assertExText("so cool")
 
-    typeText("<S-Down>")
+    typeText("<S-Down>")    // Next newer entry is the in-progress typed entry "map"
     assertExText("map")
+  }
+
+  @Test
+  fun `test Ctrl-N with no search history beeps`() {
+    typeText("/<C-N>")
+    assertExText("")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test Ctrl-N with no search history and typed entry beeps and does not change typed entry`() {
+    typeText("/map<C-N>")
+    assertExText("map")
+    assertPluginError(true)
   }
 
   @Test
   fun `test Ctrl-N selects newer search history entry ignoring typed prefix`() {
-    typeText("/map<C-P>")
+    typeText("/map<C-P>")   // Selects #3 as current entry
     assertExText("so cool")
-    typeText("<C-P>")
+    typeText("<C-P>")       // Selects #2 as current entry
     assertExText("not cool")
 
+    // <C-N> ignores the typed `map` prefix and selects next entry (#3 - "so cool")
     typeText("<C-N>")
     assertExText("so cool")
   }
 
   @Test
-  fun `test Ctrl-N selects last typed search value`() {
-    typeText("/map<C-P>")
+  fun `test Ctrl-N on last saved entry selects last typed search value`() {
+    typeText("/map<C-P>")   // Selects #3 as current entry
     assertExText("so cool")
 
-    typeText("<C-N>")
+    typeText("<C-N>")       // Next newer entry is in-progress typed entry "map"
     assertExText("map")
   }
 
   @Test
+  fun `test PageDown with no search history beeps`() {
+    typeText("/<PageDown>")
+    assertExText("")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test PageDown with no search history and typed entry beeps and does not change typed entry`() {
+    typeText("/map<PageDown>")
+    assertExText("map")
+    assertPluginError(true)
+  }
+
+  @Test
   fun `test PageDown selects newer search history entry ignoring typed prefix`() {
-    typeText("/map<PageUp>")
+    typeText("/map<PageUp>")  // Selects #3 as current entry
     assertExText("so cool")
-    typeText("<PageUp>")
+    typeText("<PageUp>")      // Selects #2 as current entry
     assertExText("not cool")
 
+    // <PageDown> ignores the typed `map` prefix and selects the next entry (#3 - "so cool")
     typeText("<PageDown>")
     assertExText("so cool")
   }
 
   @Test
-  fun `test PageDown selects last typed search value`() {
-    typeText("/map<PageUp>")
+  fun `test PageDown on last saved entry selects last typed search value`() {
+    typeText("/map<PageUp>")  // Selects #3 as current entry
     assertExText("so cool")
 
-    typeText("<PageDown>")
+    typeText("<PageDown>")    // Next newer entry is the in-progress typed entry "map"
     assertExText("map")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/ex/SelectNewerHistoryFilteredActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/ex/SelectNewerHistoryFilteredActionTest.kt
@@ -25,12 +25,26 @@ class SelectNewerHistoryFilteredActionTest : VimExTestCase() {
   }
 
   @Test
+  fun `test Down with no command history beeps`() {
+    typeText(":<Down>")
+    assertExText("")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test Down with no command history and typed entry beeps and does not change typed entry`() {
+    typeText(":map<Down>")
+    assertExText("map")
+    assertPluginError(true)
+  }
+
+  @Test
   fun `test Down selects newer command history entry filtered by typed prefix`() {
-    typeText(":set<S-Up>")  // Not filtered
+    typeText(":set<S-Up>")  // Not filtered. Selects #3 as current entry
     assertExText("set incsearch")
-    typeText("<S-Up>")  // Not filtered
+    typeText("<S-Up>")      // Not filtered. Selects #2 as current entry
     assertExText("digraph")
-    typeText("<S-Up>")  // Not filtered
+    typeText("<S-Up>")      // Not filtered. Selects #1 as current entry
     assertExText("set digraph")
 
     // Skips "digraph" because it doesn't match the "set" prefix
@@ -39,31 +53,100 @@ class SelectNewerHistoryFilteredActionTest : VimExTestCase() {
   }
 
   @Test
-  fun `test Down selects last typed command value`() {
-    typeText(":set<S-Up>")
+  fun `test Down on last saved entry selects last typed command value`() {
+    typeText(":set<S-Up>")  // Selects #3 as current entry
     assertExText("set incsearch")
 
-    typeText("<Down>")
+    typeText("<Down>")      // Next newer entry is the in-progress typed entry "set"
     assertExText("set")
   }
 
   @Test
+  fun `test Down after hitting start of history selects second oldest entry`() {
+    typeText(":<S-Up>")   // Selects #3 as current entry
+    typeText("<S-Up>")    // Selects #2 as current entry
+    typeText("<S-Up>")    // Selects #1 as current entry
+    typeText("<S-Up>")    // Tries to move past start of history, beeps, but doesn't change content
+    assertExText("set digraph")
+    assertPluginError(true)
+
+    typeText("<Down>")    // #1 is still current entry. Selects #2 as current entry
+    assertExText("digraph")
+    assertPluginError(false)
+  }
+
+  @Test
+  fun `test Down after hitting start of history selects second oldest entry matching prefix`() {
+    typeText(":set<S-Up>")  // Selects #3 as current entry
+    typeText("<S-Up>")      // Selects #2 as current entry
+    typeText("<S-Up>")      // Selects #1 as current entry
+    typeText("<S-Up>")      // Tries to move past start of history, beeps, but doesn't change content
+    assertExText("set digraph")
+    assertPluginError(true)
+
+    typeText("<Down>")      // #1 is still current entry. Skips #3 due to matching prefix
+    assertExText("set incsearch")
+    assertPluginError(false)
+  }
+
+  @Test
+  fun `test Down after failing to select newer filtered entry remains on last typed value and beeps`() {
+    typeText(":foo<Up>")    // No filtered previous item. Remains no current entry
+    assertExText("foo")
+    assertPluginError(true)
+
+    typeText("<Down>")      // No current entry, so nowhere to move to
+    assertExText("foo")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test select older entry after hitting end of history`() {
+    typeText(":map<S-Up>")   // Selects #3 as current entry
+    typeText("<Down>")       // Selects in-progress entry as current entry
+    assertExText("map")
+    assertPluginError(false)
+
+    typeText("<Down>")      // Can't select anything, error
+    assertExText("map")
+    assertPluginError(true)
+
+    typeText("<S-Up>")      // Selects #3 as current entry
+    assertExText("set incsearch")
+    assertPluginError(false)
+  }
+
+  @Test
+  fun `test Down with no search history beeps`() {
+    typeText("/<Down>")
+    assertExText("")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test Down with no search history and typed entry beeps and does not change typed entry`() {
+    typeText("/map<Down>")
+    assertExText("map")
+    assertPluginError(true)
+  }
+
+  @Test
   fun `test Down selects newer search history entry filtered by typed prefix`() {
-    typeText("/so<S-Up>") // Not filtered
+    typeText("/so<S-Up>")   // Not filtered. Selects #3 as current entry
     assertExText("so cool")
-    typeText("<S-Up>")  // Not filtered
+    typeText("<S-Up>")      // Not filtered. Selects #2 as current entry
     assertExText("not cool")
-    typeText("<S-Up>")  // Not filtered
+    typeText("<S-Up>")      // Not filtered. Selects #1 as current entry
     assertExText("something cool")
 
-    // Skips "digraph" because it doesn't match the "set" prefix
+    // Skips "digraph" because it doesn't match the "so" prefix
     typeText("<Down>")
     assertExText("so cool")
   }
 
   @Test
-  fun `test Down selects last typed search value`() {
-    typeText("/so<S-Up>")
+  fun `test Down on last saved entry selects last typed search value`() {
+    typeText("/so<S-Up>")   // Not filtered. Selects #3 as current entry
     assertExText("so cool")
 
     typeText("<Down>")

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/ex/SelectOlderHistoryActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/ex/SelectOlderHistoryActionTest.kt
@@ -36,8 +36,10 @@ class SelectOlderHistoryActionTest : VimExTestCase() {
     typeText("<S-Up>")
     assertExText("set digraph")
 
+    // Hit the end of history, beep and stay where we are
     typeText("<S-Up>")
     assertExText("set digraph")
+    assertPluginError(true)
   }
 
   @Test
@@ -51,8 +53,10 @@ class SelectOlderHistoryActionTest : VimExTestCase() {
     typeText("<C-P>")
     assertExText("set digraph")
 
+    // Hit the end of history, beep and stay where we are
     typeText("<C-P>")
     assertExText("set digraph")
+    assertPluginError(true)
   }
 
   @Test
@@ -66,8 +70,34 @@ class SelectOlderHistoryActionTest : VimExTestCase() {
     typeText("<PageUp>")
     assertExText("set digraph")
 
+    // Hit the end of history, beep and stay where we are
     typeText("<PageUp>")
     assertExText("set digraph")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test Shift-Up selects next older command history entry from current entry even after typing`() {
+    typeText(":<S-Up><S-Up>")
+    assertExText("digraph")   // #2 is the current history entry
+    typeText("22")
+    assertExText("digraph22")
+
+    typeText("<S-Up>")  // #2 ("digraph") is still the current history entry
+    assertExText("set digraph") // #1
+  }
+
+  @Test
+  fun `test Shift-Up does not maintain current history entry across command line instances`() {
+    typeText(":<S-Up><S-Up>")   // #2 is the current history entry
+    assertExText("digraph")
+
+    // Cancel the command line. This will add the current ex-entry as the newest history entry #4 (removing #2 since the
+    // text is the same) and resets the current history entry to past the end of the command history list
+    typeText("<Esc>")
+
+    typeText(":<S-Up><S-Up>") // Select #4 and then #3 as the current history entry
+    assertExText("set incsearch")
   }
 
   @Test
@@ -81,8 +111,10 @@ class SelectOlderHistoryActionTest : VimExTestCase() {
     typeText("<S-Up>")
     assertExText("something cool")
 
+    // Tries to move past the start of history. Beep, but keep the text
     typeText("<S-Up>")
     assertExText("something cool")
+    assertPluginError(true)
   }
 
   @Test
@@ -96,8 +128,10 @@ class SelectOlderHistoryActionTest : VimExTestCase() {
     typeText("<C-P>")
     assertExText("something cool")
 
+    // Tries to move past the start of history. Beep, but keep the text
     typeText("<C-P>")
     assertExText("something cool")
+    assertPluginError(true)
   }
 
   @Test
@@ -111,7 +145,33 @@ class SelectOlderHistoryActionTest : VimExTestCase() {
     typeText("<PageUp>")
     assertExText("something cool")
 
+    // Tries to move past the start of history. Beep, but keep the text
     typeText("<PageUp>")
     assertExText("something cool")
+    assertPluginError(true)
+  }
+
+  @Test
+  fun `test Shift-Up selects next older search history entry from current entry even after typing`() {
+    typeText("/<S-Up><S-Up>")
+    assertExText("not cool")    // #2 is the current entry
+    typeText("22")
+    assertExText("not cool22")
+
+    typeText("<S-Up>")  // #2 ("not cool") is still the current history entry
+    assertExText("something cool") // #1
+  }
+
+  @Test
+  fun `test Shift-Up does not maintain current history entry across search instances`() {
+    typeText("/<S-Up><S-Up>")   // #2 is the current history entry
+    assertExText("not cool")
+
+    // Cancel the command line. This will add the current ex-entry as the newest history entry #4 (removing #2 since the
+    // text is the same) and resets the current history entry to past the end of the command history list
+    typeText("<Esc>")
+
+    typeText("/<S-Up><S-Up>") // Select #4 and then #3 as the current history entry
+    assertExText("so cool")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/ex/SelectOlderHistoryFilteredActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/ex/SelectOlderHistoryFilteredActionTest.kt
@@ -26,15 +26,16 @@ class SelectOlderHistoryFilteredActionTest : VimExTestCase() {
 
   @Test
   fun `test Up selects older command history entry filtered by typed prefix`() {
-    typeText(":set<Up>")
+    typeText(":set<Up>")    // Not filtered. Selects #3 as current entry
     assertExText("set incsearch")
 
-    // Skips "digraph" because it doesn't match the "set" prefix
-    typeText("<Up>")
+    typeText("<Up>")        // Skips #2, selects #1 as current entry
     assertExText("set digraph")
 
+    // Hit the end of history, beep and stay where we are
     typeText("<Up>")
     assertExText("set digraph")
+    assertPluginError(true)
   }
 
   @Test
@@ -48,5 +49,19 @@ class SelectOlderHistoryFilteredActionTest : VimExTestCase() {
 
     typeText("<Up>")
     assertExText("something cool")
+  }
+
+  @Test
+  fun `test Up selects next older filtered command history entry after current entry`() {
+    enterCommand("echo food_is_nice")   // #1
+    enterCommand("echo fool")           // #2
+    enterCommand("echo baz")            // #3
+    enterCommand("echo foo")            // #4
+    enterCommand("echo food_yes")       // #5
+    enterCommand("echo bar")            // #6
+    typeText(":echo f<Up><Up>") // Skip #6 and #5 and make #4 the current entry
+    assertExText("echo foo")
+    typeText("d<Up>") // Next oldest from #4 matching "echo food" -> #1
+    assertExText("echo food_is_nice")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/GlobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/GlobalCommandTest.kt
@@ -239,7 +239,6 @@ class GlobalCommandTest : VimTestCase() {
 
   @Test
   fun `test check history`() {
-    (VimPlugin.getHistory() as com.maddyhome.idea.vim.group.HistoryGroup).clear()
     val initialEntries = VimPlugin.getHistory().getEntries(VimHistory.Type.Command, 0, 0)
     doTest(
       "g/found/d",

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/HistoryCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/HistoryCommandTest.kt
@@ -8,21 +8,12 @@
 
 package org.jetbrains.plugins.ideavim.ex.implementation.commands
 
-import com.maddyhome.idea.vim.api.injector
 import org.jetbrains.plugins.ideavim.VimBehaviorDiffers
 import org.jetbrains.plugins.ideavim.VimTestCase
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInfo
 
 @Suppress("SpellCheckingInspection")
-class HistoryCommandTest : VimTestCase() {
-  @BeforeEach
-  override fun setUp(testInfo: TestInfo) {
-    super.setUp(testInfo)
-    configureByText("\n")
-  }
-
+class HistoryCommandTest : VimTestCase("\n") {
   @Test
   fun `test history lists current cmd history by default`() {
     assertCommandOutput(
@@ -37,7 +28,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history lists all entries in cmd history by default`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history cmd",
       """
@@ -102,7 +92,6 @@ class HistoryCommandTest : VimTestCase() {
   fun `test history adds indicator to current entry`() {
     repeat(5) { i -> enterSearch("foo${i + 1}") }
     repeat(5) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history all",
       """
@@ -128,7 +117,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history does not show indicator if not including current entry`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history : 1,5",
       """
@@ -145,7 +133,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history with no name and first number lists single entry from command history`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history 3",
       """
@@ -158,7 +145,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history with no name and two numbers lists command history range`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history 3, 6",
       """
@@ -185,7 +171,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history with colon and first number lists single entry from command history`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history : 3",
       """
@@ -198,7 +183,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history with colon and no space before first number lists single entry from command history`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history :3",
       """
@@ -211,7 +195,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history with colon and two numbers lists command history range`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history : 3, 6",
       """
@@ -266,7 +249,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history cmd with first number lists single entry from command history`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history cmd 3",
       """
@@ -279,7 +261,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history cmd with no space before first number lists single entry from command history`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history cmd3",
       """
@@ -292,7 +273,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history cmd with two numbers lists command history range`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history cmd 3, 6",
       """
@@ -308,14 +288,12 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history cmd with two numbers incorrectly ordered lists nothing from command history range`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput("history cmd 6,3", "      #  cmd history")
   }
 
   @Test
   fun `test history cmd with number that is no longer used`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     // This will make "echo 1" the last used entry, remove it from position 1 and add it at position 11
     typeText(":<Up><Up><Up><Up><Up><Up><Up><Up><Up><Up><Esc>")
     assertCommandOutput("history cmd 1", "      #  cmd history")
@@ -324,7 +302,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history cmd with range starting from number that is no longer used`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     // This will make "echo 1" the last used entry, remove it from position 1 and add it at position 11
     typeText(":<Up><Up><Up><Up><Up><Up><Up><Up><Up><Up><Esc>")
     assertCommandOutput(
@@ -347,7 +324,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history cmd -1 shows last entry`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history cmd -1",
       """
@@ -360,7 +336,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history cmd with negative number shows list of entries relative to last entry`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history cmd -4,-1",
       """
@@ -376,14 +351,12 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history cmd with two negative numbers incorrectly ordered lists nothing from command history range`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput("history cmd -1,-4", "      #  cmd history")
   }
 
   @Test
   fun `test history with positive start number and negative last number`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history cmd 4,-3",
       """
@@ -401,7 +374,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history with negative start number and positive last number`() {
     repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history cmd -8,8",
       """
@@ -490,7 +462,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history search with first number lists single entry from search history`() {
     repeat(10) { i -> enterSearch("foo${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history search 3",
       """
@@ -503,7 +474,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history search with no space before first number lists single entry from search history`() {
     repeat(10) { i -> enterSearch("foo${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history search3",
       """
@@ -516,7 +486,6 @@ class HistoryCommandTest : VimTestCase() {
   @Test
   fun `test history search with two numbers lists search history range`() {
     repeat(10) { i -> enterSearch("foo${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history search 3, 6",
       """
@@ -574,7 +543,6 @@ class HistoryCommandTest : VimTestCase() {
   fun `test history all includes history entries`() {
     repeat(5) { i -> enterSearch("foo${i + 1}") }
     repeat(5) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history all",
       """
@@ -601,7 +569,6 @@ class HistoryCommandTest : VimTestCase() {
   fun `test history all applies first number to all history entries`() {
     repeat(5) { i -> enterSearch("foo${i + 1}") }
     repeat(5) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history all 3",
       """
@@ -619,7 +586,6 @@ class HistoryCommandTest : VimTestCase() {
   fun `test history all applies range to all history entries`() {
     repeat(5) { i -> enterSearch("foo${i + 1}") }
     repeat(5) { i -> enterCommand("echo ${i + 1}") }
-    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     assertCommandOutput(
       "history all 2,4",
       """

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/HistoryCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/HistoryCommandTest.kt
@@ -90,6 +90,16 @@ class HistoryCommandTest : VimTestCase("\n") {
 
   @Test
   fun `test history adds indicator to current entry`() {
+    // It doesn't seem possible to change the current history entry while not editing the command line. (Vim's command
+    // line window `q:` can interact with it, but also seems limited to while the command line is active). Essentially,
+    // when the `:history` command runs, the command line has just been completed, so a new entry has been saved, and
+    // the current entry has been reset. The search history is obviously not active either, so the last search command
+    // line would have saved a new entry and reset the current entry too. Therefore, the `:history` command always seems
+    // to use the last history entry as the current entry.
+    // Furthermore, the current entry can never actually be the last entry in this scenario. The current entry is
+    // supposed to be used to navigate _from_ when moving through history. So pressing `<S-Up>` on an empty command line
+    // will navigate to the last history entry. If the current entry was already the last entry, we would select the
+    // second to last, which is clearly wrong.
     repeat(5) { i -> enterSearch("foo${i + 1}") }
     repeat(5) { i -> enterCommand("echo ${i + 1}") }
     assertCommandOutput(
@@ -158,7 +168,7 @@ class HistoryCommandTest : VimTestCase("\n") {
   }
 
   @Test
-  fun `test history with colon lists empty cmd history`() {
+  fun `test history with colon and empty cmd history lists just invoked command`() {
     assertCommandOutput(
       "history :",
       """
@@ -208,7 +218,7 @@ class HistoryCommandTest : VimTestCase("\n") {
   }
 
   @Test
-  fun `test history cmd lists current cmd in history`() {
+  fun `test history cmd lists self in history`() {
     assertCommandOutput(
       "history cmd",
       """
@@ -292,31 +302,74 @@ class HistoryCommandTest : VimTestCase("\n") {
   }
 
   @Test
-  fun `test history cmd with number that is no longer used`() {
-    repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    // This will make "echo 1" the last used entry, remove it from position 1 and add it at position 11
-    typeText(":<Up><Up><Up><Up><Up><Up><Up><Up><Up><Up><Esc>")
+  fun `test history cmd does not include duplicate entries`() {
+    enterCommand("echo 1")  // #1
+    enterCommand("echo 2")  // #2
+    enterCommand("echo 3")  // #3
+    enterCommand("echo 1")  // Removes #1 and adds as #4
+    assertCommandOutput("history cmd", """
+      |      #  cmd history
+      |      2  echo 2
+      |      3  echo 3
+      |      4  echo 1
+      |>     5  history cmd
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test history cmd does not include empty commands`() {
+    enterCommand("")
+    assertCommandOutput("history cmd", """
+      |      #  cmd history
+      |>     1  history cmd
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test history cmd includes cancelled commands`() {
+    enterCommand("echo 1")
+    enterCommand("echo 2")
+    typeText(":echo 'cancelled'<Esc>")  // Cancelled!
+    assertCommandOutput("history cmd", """
+      |      #  cmd history
+      |      1  echo 1
+      |      2  echo 2
+      |      3  echo 'cancelled'
+      |>     4  history cmd
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test history cmd does not include empty cancelled commands`() {
+    typeText(":<Esc>")  // Cancelled!
+    assertCommandOutput("history cmd", """
+      |      #  cmd history
+      |>     1  history cmd
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test history cmd with number that is no longer used outputs no entries`() {
+    enterCommand("echo 1")  // #1
+    enterCommand("echo 2")  // #2
+    enterCommand("echo 3")  // #3
+    enterCommand("echo 1")  // Removes #1 and adds as #4
     assertCommandOutput("history cmd 1", "      #  cmd history")
   }
 
   @Test
   fun `test history cmd with range starting from number that is no longer used`() {
-    repeat(10) { i -> enterCommand("echo ${i + 1}") }
-    // This will make "echo 1" the last used entry, remove it from position 1 and add it at position 11
-    typeText(":<Up><Up><Up><Up><Up><Up><Up><Up><Up><Up><Esc>")
+    enterCommand("echo 1")  // #1
+    enterCommand("echo 2")  // #2
+    enterCommand("echo 3")  // #3
+    enterCommand("echo 1")  // Removes #1 and adds as #4
     assertCommandOutput(
-      "history cmd 1,10",
+      "history cmd 1,4",
       """
         |      #  cmd history
         |      2  echo 2
         |      3  echo 3
-        |      4  echo 4
-        |      5  echo 5
-        |      6  echo 6
-        |      7  echo 7
-        |      8  echo 8
-        |      9  echo 9
-        |     10  echo 10
+        |      4  echo 1
       """.trimMargin()
     )
   }
@@ -496,6 +549,53 @@ class HistoryCommandTest : VimTestCase("\n") {
         |      6  foo6
       """.trimMargin()
     )
+  }
+
+  @Test
+  fun `test history search does not include duplicate entries`() {
+    enterSearch("foo 1")  // #1
+    enterSearch("foo 2")  // #2
+    enterSearch("foo 3")  // #3
+    enterSearch("foo 1")  // Removes #1 and adds as #4
+    assertCommandOutput("history search", """
+      |      #  search history
+      |      2  foo 2
+      |      3  foo 3
+      |>     4  foo 1
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test history search does not include empty entries`() {
+    enterSearch("foo 1")
+    enterSearch("foo 2")
+    enterSearch("") // Search for last entry, but does not move #2 to #3
+    assertCommandOutput("history search", """
+      |      #  search history
+      |      1  foo 1
+      |>     2  foo 2
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test history search includes cancelled commands`() {
+    enterSearch("foo 1")
+    enterSearch("foo 2")
+    typeText("/foo 'cancelled'<Esc>")  // Cancelled!
+    assertCommandOutput("history search", """
+      |      #  search history
+      |      1  foo 1
+      |      2  foo 2
+      |>     3  foo 'cancelled'
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test history search does not include empty cancelled commands`() {
+    typeText("/<Esc>")  // Cancelled!
+    assertCommandOutput("history search", """
+      |      #  search history
+    """.trimMargin())
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistAddFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistAddFunctionTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.functions.historyFunctions
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class HistAddFunctionTest : VimTestCase("\n") {
+  @Test
+  fun `test histadd returns 1 on success`() {
+    assertCommandOutput("echo histadd('cmd', 'echo hello')", "1")
+  }
+
+  @Test
+  fun `test histadd returns 0 for unknown history type`() {
+    assertCommandOutput("echo histadd('unknown', 'echo hello')", "0")
+  }
+
+  @Test
+  fun `test histadd adds entry to cmd history using full name`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput(
+      "history cmd",
+      """
+        |      #  cmd history
+        |      1  call histadd('cmd', 'echo hello')
+        |      2  echo hello
+        |>     3  history cmd
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to cmd history using colon shortcut`() {
+    enterCommand("call histadd(':', 'echo hello')")
+    assertCommandOutput(
+      "history cmd",
+      """
+        |      #  cmd history
+        |      1  call histadd(':', 'echo hello')
+        |      2  echo hello
+        |>     3  history cmd
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to cmd history using abbreviated name`() {
+    enterCommand("call histadd('c', 'echo hello')")
+    assertCommandOutput(
+      "history cmd",
+      """
+        |      #  cmd history
+        |      1  call histadd('c', 'echo hello')
+        |      2  echo hello
+        |>     3  history cmd
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to search history using full name`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput(
+      "history search",
+      """
+        |      #  search history
+        |>     1  foo
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to search history using slash shortcut`() {
+    enterCommand("call histadd('/', 'foo')")
+    assertCommandOutput(
+      "history search",
+      """
+        |      #  search history
+        |>     1  foo
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to search history using abbreviated name`() {
+    enterCommand("call histadd('s', 'foo')")
+    assertCommandOutput(
+      "history search",
+      """
+        |      #  search history
+        |>     1  foo
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to expr history using full name`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    assertCommandOutput(
+      "history =",
+      """
+        |      #  expr history
+        |>     1  1 + 1
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to expr history using equals shortcut`() {
+    enterCommand("call histadd('=', '1 + 1')")
+    assertCommandOutput(
+      "history =",
+      """
+        |      #  expr history
+        |>     1  1 + 1
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to expr history using abbreviated name`() {
+    enterCommand("call histadd('e', '1 + 1')")
+    assertCommandOutput(
+      "history =",
+      """
+        |      #  expr history
+        |>     1  1 + 1
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to input history using full name`() {
+    enterCommand("call histadd('input', 'my input')")
+    assertCommandOutput(
+      "history @",
+      """
+        |      #  input history
+        |>     1  my input
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to input history using at shortcut`() {
+    enterCommand("call histadd('@', 'my input')")
+    assertCommandOutput(
+      "history @",
+      """
+        |      #  input history
+        |>     1  my input
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds entry to input history using abbreviated name`() {
+    enterCommand("call histadd('i', 'my input')")
+    assertCommandOutput(
+      "history @",
+      """
+        |      #  input history
+        |>     1  my input
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd does not add duplicate entry to search history`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput(
+      "history search",
+      """
+        |      #  search history
+        |>     2  foo
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histadd adds multiple distinct entries to search history`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    assertCommandOutput(
+      "history search",
+      """
+        |      #  search history
+        |      1  foo
+        |>     2  bar
+      """.trimMargin()
+    )
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistDelFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistDelFunctionTest.kt
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.functions.historyFunctions
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class HistDelFunctionTest : VimTestCase("\n") {
+  @Test
+  fun `test histdel returns 0 for unknown history type`() {
+    assertCommandOutput("echo histdel('unknown', 1)", "0")
+  }
+
+  @Test
+  fun `test histdel with no second argument clears entire search history`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    assertCommandOutput("echo histdel('search')", "1")
+    assertCommandOutput("history search", "      #  search history")
+  }
+
+  @Test
+  fun `test histdel with no second argument clears entire expr history`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    enterCommand("call histadd('expr', '2 + 2')")
+    assertCommandOutput("echo histdel('expr')", "1")
+    assertCommandOutput("history expr", "      #  expr history")
+  }
+
+  @Test
+  fun `test histdel with no second argument clears entire input history`() {
+    enterCommand("call histadd('input', 'first')")
+    enterCommand("call histadd('input', 'second')")
+    assertCommandOutput("echo histdel('input')", "1")
+    assertCommandOutput("history input", "      #  input history")
+  }
+
+  @Test
+  fun `test histdel with no second argument clears entire command history`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput("echo histdel('cmd')", "1")
+    // Obviously, the command to output the history adds something to the history...
+    assertCommandOutput("history cmd", """
+      |      #  cmd history
+      |>     1  history cmd
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test histdel returns 1 when clearing non-empty history`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histdel('search')", "1")
+  }
+
+  @Test
+  fun `test histdel returns 1 when clearing empty history`() {
+    assertCommandOutput("echo histdel('search')", "1")
+  }
+
+  @Test
+  fun `test histdel removes correct entry by positive index from search history`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    assertCommandOutput("echo histdel('search', 1)", "1")
+    assertCommandOutput(
+      "history search",
+      """
+      |      #  search history
+      |>     2  bar
+    """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histdel removes no entries with invalid positive index from search history`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    enterCommand("call histadd('search', 'baz')")
+    enterCommand("call histadd('search', 'bar')") // Moves 'bar' from #2 to #4
+    assertCommandOutput(
+      "history search",
+      """
+      |      #  search history
+      |      1  foo
+      |      3  baz
+      |>     4  bar
+    """.trimMargin()
+    )
+    assertCommandOutput("echo histdel('search', 2)", "0")
+    assertCommandOutput(
+      "history search",
+      """
+      |      #  search history
+      |      1  foo
+      |      3  baz
+      |>     4  bar
+    """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histdel returns 1 when deleting existing entry by positive index`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histdel('search', 1)", "1")
+  }
+
+  @Test
+  fun `test histdel returns 0 when deleting nonexistent entry by positive index`() {
+    assertCommandOutput("echo histdel('search', 99)", "0")
+  }
+
+  @Test
+  fun `test histdel removes most recent entry with index -1`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    assertCommandOutput("echo histdel('search', -1)", "1")
+    assertCommandOutput(
+      "history search", """
+      |      #  search history
+      |>     1  foo
+    """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histdel removes second-most-recent entry with index -2`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    assertCommandOutput("echo histdel('search', -2)", "1")
+    assertCommandOutput(
+      "history search", """
+      |      #  search history
+      |>     2  bar
+    """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histdel with index 0 incorrectly removes first entry`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    assertCommandOutput("echo histdel('search', 0)", "0")
+    assertCommandOutput(
+      "history search",
+      """
+      |      #  search history
+      |      1  foo
+      |>     2  bar
+    """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histdel returns 1 when deleting entry by negative index`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histdel('search', -1)", "1")
+  }
+
+  @Test
+  fun `test histdel returns 0 when deleting by negative index from empty history`() {
+    assertCommandOutput("echo histdel('search', -1)", "0")
+  }
+
+  @Test
+  fun `test histdel with exact pattern removes matching entry`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histdel('search', 'foo')")
+    assertCommandOutput("history search", "      #  search history")
+  }
+
+  @Test
+  fun `test histdel with partial pattern removes matching entry`() {
+    enterCommand("call histadd('search', 'foobar')")
+    enterCommand("call histadd('search', 'baz')")
+    // partial match: 'oo' should match 'foobar'
+    assertCommandOutput("echo histdel('search', 'oo')", "1")
+    assertCommandOutput(
+      "history search", """
+      |      #  search history
+      |>     2  baz
+    """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histdel with pattern removes all matching entries`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'foobar')")
+    enterCommand("call histadd('search', 'baz')")
+    assertCommandOutput("echo histdel('search', 'foo')", "1")
+    assertCommandOutput(
+      "history search", """
+      |      #  search history
+      |>     3  baz
+    """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histdel with regex pattern removes matching entries`() {
+    enterCommand("call histadd('search', 'abc')")
+    enterCommand("call histadd('search', 'def')")
+    enterCommand("call histadd('search', 'abx')")
+    // 'ab.' matches 'abc' and 'abx'
+    assertCommandOutput("echo histdel('search', 'ab.')", "1")
+    assertCommandOutput(
+      "history search", """
+      |      #  search history
+      |>     2  def
+    """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histdel with non-matching pattern leaves history unchanged`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histdel('search', 'xyz')", "0")
+    assertCommandOutput(
+      "history search", """
+      |      #  search history
+      |>     1  foo
+    """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test histdel returns 1 when pattern matches an entry`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histdel('search', 'foo')", "1")
+  }
+
+  @Test
+  fun `test histdel returns 0 when pattern matches no entries`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histdel('search', 'xyz')", "0")
+  }
+
+  @Test
+  fun `test histdel works with search history using slash shortcut`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histdel('/', 1)")
+    assertCommandOutput("history search", "      #  search history")
+  }
+
+  @Test
+  fun `test histdel works with search history using abbreviated name`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histdel('s', 1)")
+    assertCommandOutput("history search", "      #  search history")
+  }
+
+  @Test
+  fun `test histdel works with expr history using full name`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    enterCommand("call histdel('expr', 1)")
+    assertCommandOutput("history expr", "      #  expr history")
+  }
+
+  @Test
+  fun `test histdel works with expr history using equals shortcut`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    enterCommand("call histdel('=', 1)")
+    assertCommandOutput("history expr", "      #  expr history")
+  }
+
+  @Test
+  fun `test histdel works with expr history using abbreviated name`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    enterCommand("call histdel('e', 1)")
+    assertCommandOutput("history expr", "      #  expr history")
+  }
+
+  @Test
+  fun `test histdel works with input history using full name`() {
+    enterCommand("call histadd('input', 'my input')")
+    enterCommand("call histdel('input', 1)")
+    assertCommandOutput("history input", "      #  input history")
+  }
+
+  @Test
+  fun `test histdel works with input history using at shortcut`() {
+    enterCommand("call histadd('input', 'my input')")
+    enterCommand("call histdel('@', 1)")
+    assertCommandOutput("history input", "      #  input history")
+  }
+
+  @Test
+  fun `test histdel works with input history using abbreviated name`() {
+    enterCommand("call histadd('input', 'my input')")
+    enterCommand("call histdel('i', 1)")
+    assertCommandOutput("history input", "      #  input history")
+  }
+
+  @Test
+  fun `test histdel works with cmd history using full name`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    // #1 = call histadd, #2 = echo hello, #3 = call histdel, #4 = history cmd
+    assertCommandOutput("echo histdel('cmd', 2)", "1")
+    assertCommandOutput("history cmd", """
+      |      #  cmd history
+      |      1  call histadd('cmd', 'echo hello')
+      |      3  echo histdel('cmd', 2)
+      |>     4  history cmd
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test histdel works with cmd history using colon shortcut`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput("echo histdel(':', 2)", "1")
+    assertCommandOutput("history cmd", """
+      |      #  cmd history
+      |      1  call histadd('cmd', 'echo hello')
+      |      3  echo histdel(':', 2)
+      |>     4  history cmd
+    """.trimMargin())
+  }
+
+  @Test
+  fun `test histdel works with cmd history using abbreviated name`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput("echo histdel('c', 2)", "1")
+    assertCommandOutput("history cmd", """
+      |      #  cmd history
+      |      1  call histadd('cmd', 'echo hello')
+      |      3  echo histdel('c', 2)
+      |>     4  history cmd
+    """.trimMargin())
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistGetFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistGetFunctionTest.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.functions.historyFunctions
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class HistGetFunctionTest : VimTestCase("\n") {
+  @Test
+  fun `test histget returns empty string for unknown history type`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput("echo histget('unknown', 1)", "")
+  }
+
+  // Note: `enterCommand` auto-adds each executed command to cmd history.
+  // After `enterCommand("call histadd('cmd', 'echo hello')")`, cmd history has:
+  //   #1: call histadd('cmd', 'echo hello')  (auto-added on execution)
+  //   #2: echo hello                          (added by histadd)
+  // Similarly, when `assertCommandOutput("echo histget(...)")` runs its command,
+  // the command itself is added to history first, so -1 resolves to that command.
+
+  @Test
+  fun `test histget returns entry from cmd history using full name`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    // Entry #1 = the enterCommand call itself; #2 = "echo hello" added by histadd
+    assertCommandOutput("echo histget('cmd', 2)", "echo hello")
+  }
+
+  @Test
+  fun `test histget returns entry from cmd history using colon shortcut`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput("echo histget(':', 2)", "echo hello")
+  }
+
+  @Test
+  fun `test histget returns entry from cmd history using abbreviated name`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput("echo histget('c', 2)", "echo hello")
+  }
+
+  @Test
+  fun `test histget returns specific cmd history entry using negative index`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    enterCommand("call histadd('cmd', 'echo world')")
+    // History: [#1: call histadd hello, #2: echo hello, #3: call histadd world, #4: echo world]
+    // When `echo histget('cmd', -2)` runs, it is added as #5, so -1 = #5 and -2 = #4 = "echo world"
+    assertCommandOutput("echo histget('cmd', -2)", "echo world")
+  }
+
+  @Test
+  fun `test histget returns earlier cmd history entry by positive index`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    enterCommand("call histadd('cmd', 'echo world')")
+    // "echo hello" is at index 2; "echo world" is at index 4
+    assertCommandOutput("echo histget('cmd', 2)", "echo hello")
+  }
+
+  @Test
+  fun `test histget returns empty string for deleted cmd history entry`() {
+    enterCommand("call histadd('cmd', 'echo hello')") // histadd #1 + echo hello #2
+    enterCommand("call histadd('cmd', 'echo world')") // histadd #3 + echo world #4
+    enterCommand("call histadd('cmd', 'echo hello')") // histadd #5 (replaces #1) + echo hello #6 (replaces #2)
+    assertCommandOutput("echo string(histget('cmd', 2))", "''")
+    assertCommandOutput("echo string(histget('cmd', 6))", "'echo hello'")
+  }
+
+  @Test
+  fun `test histget returns empty string for out-of-range cmd history index`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput("echo string(histget('cmd', 99))", "''")
+  }
+
+  @Test
+  fun `test histget returns entry from search history using full name`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histget('search', 1)", "foo")
+  }
+
+  @Test
+  fun `test histget returns entry from search history using slash shortcut`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histget('/', 1)", "foo")
+  }
+
+  @Test
+  fun `test histget returns entry from search history using abbreviated name`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histget('s', 1)", "foo")
+  }
+
+  @Test
+  fun `test histget returns most recent search history entry using negative index`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    assertCommandOutput("echo histget('search', -1)", "bar")
+  }
+
+  @Test
+  fun `test histget returns empty string for empty search history`() {
+    assertCommandOutput("echo string(histget('search'))", "''")
+  }
+
+  @Test
+  fun `test histget returns entry from expr history using full name`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    assertCommandOutput("echo histget('expr', 1)", "1 + 1")
+  }
+
+  @Test
+  fun `test histget returns entry from expr history using equals shortcut`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    assertCommandOutput("echo histget('=', 1)", "1 + 1")
+  }
+
+  @Test
+  fun `test histget returns entry from expr history using abbreviated name`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    assertCommandOutput("echo histget('e', 1)", "1 + 1")
+  }
+
+  @Test
+  fun `test histget returns most recent expr history entry using negative index`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    enterCommand("call histadd('expr', '2 + 2')")
+    assertCommandOutput("echo histget('expr', -1)", "2 + 2")
+  }
+
+  @Test
+  fun `test histget returns empty string for empty expr history`() {
+    assertCommandOutput("echo string(histget('expr'))", "''")
+  }
+
+  @Test
+  fun `test histget returns entry from input history using full name`() {
+    enterCommand("call histadd('input', 'my input')")
+    assertCommandOutput("echo histget('input', 1)", "my input")
+  }
+
+  @Test
+  fun `test histget returns entry from input history using at shortcut`() {
+    enterCommand("call histadd('input', 'my input')")
+    assertCommandOutput("echo histget('@', 1)", "my input")
+  }
+
+  @Test
+  fun `test histget returns entry from input history using abbreviated name`() {
+    enterCommand("call histadd('input', 'my input')")
+    assertCommandOutput("echo histget('i', 1)", "my input")
+  }
+
+  @Test
+  fun `test histget returns most recent input history entry using negative index`() {
+    enterCommand("call histadd('input', 'first')")
+    enterCommand("call histadd('input', 'second')")
+    assertCommandOutput("echo histget('input', -1)", "second")
+  }
+
+  @Test
+  fun `test histget returns empty string for empty input history`() {
+    assertCommandOutput("echo string(histget('input'))", "''")
+  }
+
+  @Test
+  fun `test histget with no index returns most recent entry`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histget('search')", "foo")
+  }
+
+  @Test
+  fun `test histget with no index returns empty string when history is empty`() {
+    assertCommandOutput("echo histget('search')", "")
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistGetFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistGetFunctionTest.kt
@@ -45,7 +45,7 @@ class HistGetFunctionTest : VimTestCase("\n") {
   }
 
   @Test
-  fun `test histget returns specific cmd history entry using negative index`() {
+  fun `test histget returns cmd history entry relative to end of list when using negative index`() {
     enterCommand("call histadd('cmd', 'echo hello')")
     enterCommand("call histadd('cmd', 'echo world')")
     // History: [#1: call histadd hello, #2: echo hello, #3: call histadd world, #4: echo world]
@@ -54,11 +54,24 @@ class HistGetFunctionTest : VimTestCase("\n") {
   }
 
   @Test
-  fun `test histget returns earlier cmd history entry by positive index`() {
+  fun `test histget returns specific cmd history entry by positive index`() {
     enterCommand("call histadd('cmd', 'echo hello')")
     enterCommand("call histadd('cmd', 'echo world')")
     // "echo hello" is at index 2; "echo world" is at index 4
     assertCommandOutput("echo histget('cmd', 2)", "echo hello")
+  }
+
+  @Test
+  fun `test histget returns empty string for cmd history when index is 0`() {
+    enterCommand("call histadd('cmd', 'echo hello')") // histadd #1 + echo hello #2
+    assertCommandOutput("echo string(histget('cmd', 0))", "''")
+  }
+
+  @Test
+  fun `test histget returns most recent cmd history entry when index is omitted`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    enterCommand("call histadd('cmd', 'echo world')")
+    assertCommandOutput("echo histget('cmd')", "echo histget('cmd')")
   }
 
   @Test
@@ -75,6 +88,9 @@ class HistGetFunctionTest : VimTestCase("\n") {
     enterCommand("call histadd('cmd', 'echo hello')")
     assertCommandOutput("echo string(histget('cmd', 99))", "''")
   }
+
+
+
 
   @Test
   fun `test histget returns entry from search history using full name`() {
@@ -102,9 +118,63 @@ class HistGetFunctionTest : VimTestCase("\n") {
   }
 
   @Test
+  fun `test histget returns search history entry relative to end of list when using negative index`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    enterCommand("call histadd('search', 'baz')")
+    assertCommandOutput("echo histget('search', -2)", "bar")
+  }
+
+  @Test
+  fun `test histget returns specific search history entry by positive index`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    enterCommand("call histadd('search', 'baz')")
+    assertCommandOutput("echo histget('search', 2)", "bar")
+  }
+
+  @Test
+  fun `test histget returns empty string for search history when index is 0`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    enterCommand("call histadd('search', 'baz')")
+    assertCommandOutput("echo string(histget('search', 0))", "''")
+  }
+
+  @Test
+  fun `test histget returns most recent search entry when index is omitted`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    enterCommand("call histadd('search', 'baz')")
+    assertCommandOutput("echo histget('search')", "baz")
+  }
+
+  @Test
   fun `test histget returns empty string for empty search history`() {
     assertCommandOutput("echo string(histget('search'))", "''")
   }
+
+  @Test
+  fun `test histget returns emptry string deleted search history entry`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    enterCommand("call histadd('search', 'baz')")
+    enterCommand("call histdel('search', 2)")
+    assertCommandOutput("echo string(histget('search', 2))", "''")
+  }
+
+  @Test
+  fun `test histget returns empty string for out-of-range search history entry`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    enterCommand("call histadd('search', 'baz')")
+    assertCommandOutput("echo string(histget('search', 99))", "''")
+  }
+
+
+
+
+
 
   @Test
   fun `test histget returns entry from expr history using full name`() {
@@ -164,16 +234,5 @@ class HistGetFunctionTest : VimTestCase("\n") {
   @Test
   fun `test histget returns empty string for empty input history`() {
     assertCommandOutput("echo string(histget('input'))", "''")
-  }
-
-  @Test
-  fun `test histget with no index returns most recent entry`() {
-    enterCommand("call histadd('search', 'foo')")
-    assertCommandOutput("echo histget('search')", "foo")
-  }
-
-  @Test
-  fun `test histget with no index returns empty string when history is empty`() {
-    assertCommandOutput("echo histget('search')", "")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistNrFunctionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/functions/historyFunctions/HistNrFunctionTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.ex.implementation.functions.historyFunctions
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+class HistNrFunctionTest : VimTestCase("\n") {
+  @Test
+  fun `test histnr returns -1 for unknown history type`() {
+    assertCommandOutput("echo histnr('unknown')", "-1")
+  }
+
+  @Test
+  fun `test histnr returns -1 for empty search history`() {
+    assertCommandOutput("echo histnr('search')", "-1")
+  }
+
+  @Test
+  fun `test histnr returns -1 for empty expr history`() {
+    assertCommandOutput("echo histnr('expr')", "-1")
+  }
+
+  @Test
+  fun `test histnr returns -1 for empty input history`() {
+    assertCommandOutput("echo histnr('input')", "-1")
+  }
+
+  @Test
+  fun `test histnr returns 1 after first search history entry`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histnr('search')", "1")
+  }
+
+  @Test
+  fun `test histnr increments with each new search history entry`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'bar')")
+    assertCommandOutput("echo histnr('search')", "2")
+  }
+
+  @Test
+  fun `test histnr increments even when duplicate is added to search history`() {
+    enterCommand("call histadd('search', 'foo')")
+    enterCommand("call histadd('search', 'foo')")
+    // Duplicate is removed and re-added with a higher counter
+    assertCommandOutput("echo histnr('search')", "2")
+  }
+
+  @Test
+  fun `test histnr returns entry number from search history using slash shortcut`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histnr('/')", "1")
+  }
+
+  @Test
+  fun `test histnr returns entry number from search history using abbreviated name`() {
+    enterCommand("call histadd('search', 'foo')")
+    assertCommandOutput("echo histnr('s')", "1")
+  }
+
+  @Test
+  fun `test histnr returns 1 after first expr history entry`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    assertCommandOutput("echo histnr('expr')", "1")
+  }
+
+  @Test
+  fun `test histnr increments with each new expr history entry`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    enterCommand("call histadd('expr', '2 + 2')")
+    assertCommandOutput("echo histnr('expr')", "2")
+  }
+
+  @Test
+  fun `test histnr returns entry number from expr history using equals shortcut`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    assertCommandOutput("echo histnr('=')", "1")
+  }
+
+  @Test
+  fun `test histnr returns entry number from expr history using abbreviated name`() {
+    enterCommand("call histadd('expr', '1 + 1')")
+    assertCommandOutput("echo histnr('e')", "1")
+  }
+
+  @Test
+  fun `test histnr returns 1 after first input history entry`() {
+    enterCommand("call histadd('input', 'my input')")
+    assertCommandOutput("echo histnr('input')", "1")
+  }
+
+  @Test
+  fun `test histnr increments with each new input history entry`() {
+    enterCommand("call histadd('input', 'first')")
+    enterCommand("call histadd('input', 'second')")
+    assertCommandOutput("echo histnr('input')", "2")
+  }
+
+  @Test
+  fun `test histnr returns entry number from input history using at shortcut`() {
+    enterCommand("call histadd('input', 'my input')")
+    assertCommandOutput("echo histnr('@')", "1")
+  }
+
+  @Test
+  fun `test histnr returns entry number from input history using abbreviated name`() {
+    enterCommand("call histadd('input', 'my input')")
+    assertCommandOutput("echo histnr('i')", "1")
+  }
+
+  // Note: `enterCommand` auto-adds each executed command to cmd history.
+  // After `enterCommand("call histadd('cmd', 'echo hello')")`, cmd history has:
+  //   #1: call histadd('cmd', 'echo hello')  (auto-added on execution)
+  //   #2: echo hello                          (added by histadd)
+  // When `assertCommandOutput("echo histnr('cmd')")` runs, it adds `echo histnr('cmd')` as #3.
+  @Test
+  fun `test histnr returns entry number from cmd history using full name`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    // cmd history: [#1: call histadd..., #2: echo hello]
+    // assertCommandOutput adds "echo histnr('cmd')" as #3 before evaluation
+    assertCommandOutput("echo histnr('cmd')", "3")
+  }
+
+  @Test
+  fun `test histnr returns entry number from cmd history using colon shortcut`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput("echo histnr(':')", "3")
+  }
+
+  @Test
+  fun `test histnr returns entry number from cmd history using abbreviated name`() {
+    enterCommand("call histadd('cmd', 'echo hello')")
+    assertCommandOutput("echo histnr('c')", "3")
+  }
+}

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -731,6 +731,7 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
   }
 
   fun assertCommandOutput(command: String, expected: String) {
+    injector.outputPanel.getCurrentOutputPanel()?.clearText()
     enterCommand(command)
     assertExOutput(expected)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/SelectNewerHistoryAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/SelectNewerHistoryAction.kt
@@ -14,7 +14,7 @@ import com.maddyhome.idea.vim.api.VimCommandLine
 @CommandOrMotion(keys = ["<S-Down>", "<C-N>", "<PageDown>"], modes = [Mode.CMD_LINE])
 class SelectNewerHistoryAction : CommandLineActionHandler() {
   override fun execute(commandLine: VimCommandLine): Boolean {
-    commandLine.selectHistory(isUp = false, filter = false)
+    commandLine.selectNewerHistory(filter = false)
     return true
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/SelectNewerHistoryFilteredAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/SelectNewerHistoryFilteredAction.kt
@@ -14,7 +14,7 @@ import com.maddyhome.idea.vim.api.VimCommandLine
 @CommandOrMotion(keys = ["<Down>"], modes = [Mode.CMD_LINE])
 class SelectNewerHistoryFilteredAction : CommandLineActionHandler() {
   override fun execute(commandLine: VimCommandLine): Boolean {
-    commandLine.selectHistory(isUp = false, filter = true)
+    commandLine.selectNewerHistory(filter = true)
     return true
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/SelectOlderHistoryAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/SelectOlderHistoryAction.kt
@@ -14,7 +14,7 @@ import com.maddyhome.idea.vim.api.VimCommandLine
 @CommandOrMotion(keys = ["<S-Up>", "<C-P>", "<PageUp>"], modes = [Mode.CMD_LINE])
 class SelectOlderHistoryAction : CommandLineActionHandler() {
   override fun execute(commandLine: VimCommandLine): Boolean {
-    commandLine.selectHistory(isUp = true, filter = false)
+    commandLine.selectOlderHistory(filter = false)
     return true
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/SelectOlderHistoryFilteredAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/SelectOlderHistoryFilteredAction.kt
@@ -15,7 +15,7 @@ import com.maddyhome.idea.vim.api.VimCommandLine
 @CommandOrMotion(keys = ["<Up>"], modes = [Mode.CMD_LINE])
 class SelectOlderHistoryFilteredAction : CommandLineActionHandler() {
   override fun execute(commandLine: VimCommandLine): Boolean {
-    commandLine.selectHistory(isUp = true, filter = true)
+    commandLine.selectOlderHistory(filter = true)
     return true
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
@@ -9,18 +9,10 @@
 package com.maddyhome.idea.vim.api
 
 import com.maddyhome.idea.vim.KeyHandler
-import com.maddyhome.idea.vim.history.HistoryEntry
 import com.maddyhome.idea.vim.history.VimHistory
 import org.jetbrains.annotations.TestOnly
 import javax.swing.KeyStroke
 
-/**
- * This interface is not supposed to have any implementation logic.
- * The reason why we have implementation details here is
- * that this class extended by [ExEntryPanel] that already extends [JPanel]
- * and can't extend a base implementation of [VimCommandLine].
- * TODO: Consider creating a derived instance that has-a instance of ExEntryPanel
- */
 interface VimCommandLine {
   val inputProcessing: ((String) -> Unit)?
   val finishOn: Char?
@@ -31,7 +23,6 @@ interface VimCommandLine {
   fun getLabel(): String
   val isReplaceMode: Boolean
 
-  var histIndex: Int
   var lastEntry: String?
   val historyType: VimHistory.Type
     get() = VimHistory.Type.getTypeByLabel(getLabel())
@@ -104,7 +95,7 @@ interface VimCommandLine {
    * commands. If a keystroke is not consumed as part of a mapping or command, it is returned to the command line for
    * further processing. If it is mapped to a new keystroke, the new keystroke is passed instead. Typically, commands
    * exist for cursor movements (`<Left>` and `<Right>`) as well as for shortcuts for Vim actions (`<Up>`, `<Down>`,
-   * `<C-U>`, etc.). Typed characters are usually not mapped, and passed back to the command line component, where they
+   * `<C-U>`, etc.). Typed characters are usually not mapped and passed back to the command line component, where they
    * are added to the text content.
    */
   fun handleKey(key: KeyStroke)
@@ -139,53 +130,32 @@ interface VimCommandLine {
   // FIXME I don't want it to conflict with Swings `requestFocus` and can suggest a better name
   fun focus()
 
-  fun selectHistory(isUp: Boolean, filter: Boolean) {
-    val history = injector.historyGroup.getEntries(historyType, 0, 0)
-
-    val dir = if (isUp) -1 else 1
-    if (histIndex + dir < 0 || histIndex + dir > history.size) {
-      injector.messages.indicateError()
-
+  fun selectNewerHistory(filter: Boolean) {
+    val previousCurrent = injector.historyGroup.getCurrentEntry(historyType)
+    val newCurrent = injector.historyGroup.selectNewerEntry(historyType, if (filter) lastEntry else null)
+    if (newCurrent == null) {
+      selectHistory(lastEntry)
+      if (previousCurrent == null) {
+        injector.messages.indicateError()
+      }
       return
     }
+    selectHistory(newCurrent.entry)
+  }
 
-    if (filter) {
-      var i: Int = histIndex + dir
-      while (i >= 0 && i <= history.size) {
-        var txt: String?
-        if (i == history.size) {
-          txt = lastEntry
-        } else {
-          val entry: HistoryEntry = history[i]
-          txt = entry.entry
-        }
-
-        val myLastEntry = lastEntry
-        if (txt != null && myLastEntry != null && txt.startsWith(myLastEntry)) {
-          setText(txt, updateLastEntry = false)
-          caret.offset = txt.length
-          histIndex = i
-
-          return
-        }
-        i += dir
-      }
-
+  fun selectOlderHistory(filter: Boolean) {
+    val newCurrent = injector.historyGroup.selectOlderEntry(historyType, if (filter) lastEntry else null)
+    if (newCurrent == null) {
       injector.messages.indicateError()
-    } else {
-      histIndex += dir
-      val txt: String?
-      if (histIndex == history.size) {
-        txt = lastEntry
-      } else {
-        val entry: HistoryEntry = history[histIndex]
-        txt = entry.entry
-      }
+      return
+    }
+    selectHistory(newCurrent.entry)
+  }
 
-      if (txt != null) {
-        setText(txt, updateLastEntry = false)
-        caret.offset = txt.length
-      }
+  private fun selectHistory(entry: String?) {
+    if (entry != null) {
+      setText(entry, updateLastEntry = false)
+      caret.offset = entry.length
     }
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
@@ -1279,15 +1279,12 @@ abstract class VimSearchGroupBase : VimSearchGroup {
         lastSubstitutePattern = pattern
         lastPatternType = PatternType.SUBSTITUTE
       }
+
+      injector.historyGroup.addEntry(VimHistory.Type.Search, pattern)
     }
 
     // Vim never actually sets this register, but looks it up on request
     injector.registerGroup.storeTextSpecial(RegisterConstants.LAST_SEARCH_REGISTER, pattern)
-
-    // This will remove an existing entry and add it back to the end, and is expected to do so even if the string value
-    // is the same
-    injector.historyGroup.addEntry(VimHistory.Type.Search, pattern)
-
   }
 
   override fun findDecimalNumber(line: String): Int? {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryBlock.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryBlock.kt
@@ -17,6 +17,8 @@ internal class HistoryBlock {
   private var counter = 0
 
   fun addEntry(text: String) {
+    if (text.isEmpty()) return
+
     // If we have a last entry, it's no longer the current one
     if (entries.isNotEmpty()) {
       val last = entries.removeLast()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryBlock.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryBlock.kt
@@ -11,7 +11,7 @@ package com.maddyhome.idea.vim.history
 import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 
-class HistoryBlock {
+internal class HistoryBlock {
   private val entries = mutableListOf<HistoryEntry>()
 
   private var counter = 0

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryBlock.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryBlock.kt
@@ -41,6 +41,18 @@ class HistoryBlock {
     }
   }
 
+  fun removeEntryByNumber(number: Int): Boolean {
+    val index = entries.indexOfFirst { it.number == number }
+    if (index != -1) {
+      val entry = entries.removeAt(index)
+      if (entry.current) {
+        entries.removeLastOrNull()?.let { entries.add(it.copy(current = true)) }
+      }
+      return true
+    }
+    return false
+  }
+
   fun getEntries(): List<HistoryEntry> {
     return entries
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryBlock.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryBlock.kt
@@ -13,29 +13,34 @@ import com.maddyhome.idea.vim.api.injector
 
 internal class HistoryBlock {
   private val entries = mutableListOf<HistoryEntry>()
-
   private var counter = 0
+  private var current: HistoryEntry? = null
+
+  /**
+   * Returns the current history entry if available, or null otherwise
+   */
+  val currentEntry: HistoryEntry?
+    get() = current
+
+  /**
+   * Returns the most recent entry in the history, the last saved value, or null
+   */
+  val mostRecentEntry: HistoryEntry?
+    get() = entries.lastOrNull()
 
   fun addEntry(text: String) {
     if (text.isEmpty()) return
 
-    // If we have a last entry, it's no longer the current one
-    if (entries.isNotEmpty()) {
-      val last = entries.removeLast()
-      entries.add(HistoryEntry(last.number, last.entry, current = false))
-    }
-
     // If this entry already exists, remove it so we can add it as the newest entry
     for (i in entries.indices) {
-      val entry = entries[i]
-      if (text == entry.entry) {
+      if (text == entries[i].entry) {
         entries.removeAt(i)
         break
       }
     }
 
-    // Add the new entry as the current one
-    entries.add(HistoryEntry(++counter, text, current = true))
+    entries.add(HistoryEntry(++counter, text))
+    resetCurrentEntry()
 
     // If we're over the maximum number of entries, remove the oldest one
     if (entries.size > maxLength()) {
@@ -46,10 +51,8 @@ internal class HistoryBlock {
   fun removeEntryByNumber(number: Int): Boolean {
     val index = entries.indexOfFirst { it.number == number }
     if (index != -1) {
-      val entry = entries.removeAt(index)
-      if (entry.current) {
-        entries.removeLastOrNull()?.let { entries.add(it.copy(current = true)) }
-      }
+      entries.removeAt(index)
+      resetCurrentEntry()
       return true
     }
     return false
@@ -57,6 +60,45 @@ internal class HistoryBlock {
 
   fun getEntries(): List<HistoryEntry> {
     return entries
+  }
+
+  fun selectNewerEntry(filter: String?): HistoryEntry? {
+    if (current == null) {
+      // We're at the end of history, so there's no newer entry
+      return null
+    }
+
+    var index = entries.indexOf(current) + 1
+    while (filter != null && index != entries.size && !entries[index].entry.startsWith(filter)) {
+      index++
+    }
+
+    if (index == entries.size) {
+      current = null
+      return null
+    }
+
+    current = entries[index]
+    return current
+  }
+
+  fun selectOlderEntry(filter: String?): HistoryEntry? {
+    var index = if (current == null) (entries.size - 1) else (entries.indexOf(current) - 1)
+    while (filter != null && index >= 0 && !entries[index].entry.startsWith(filter)) {
+      index--
+    }
+
+    if (index < 0) {
+      return null
+    }
+
+    current = entries[index]
+    return current
+  }
+
+  private fun resetCurrentEntry() {
+    // Reset the current entry to null, indicating we're past the end of the history
+    current = null
   }
 
   companion object {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryEntry.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/HistoryEntry.kt
@@ -8,4 +8,4 @@
 
 package com.maddyhome.idea.vim.history
 
-data class HistoryEntry(val number: Int, val entry: String, val current: Boolean)
+data class HistoryEntry(val number: Int, val entry: String)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistory.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistory.kt
@@ -11,8 +11,41 @@ package com.maddyhome.idea.vim.history
 import org.jetbrains.annotations.TestOnly
 
 interface VimHistory {
+  /**
+   * Add an item to the end of the list for the given history type
+   */
   fun addEntry(type: Type, text: String)
+
+  /**
+   * Get a list of history entries for the given history type, within the specified range
+   *
+   * The values of [first] and [last] can be either positive or negative. When the value is negative, it is an index
+   * relative to the end of the history list. When positive, it is the item's absolute index. Remember that duplicate
+   * items are removed when a new item is added, leaving an empty "slot" in the list. This means an absolute index might
+   * not contain an item. See `:help history-indexing` for more details.
+   *
+   * The function will return any history items whose absolute index is within the range specified by [first] and
+   * [last]. If [last] is `0`, all entries after [first] are returned. If both values are `0`, all entries are returned.
+   */
   fun getEntries(type: Type, first: Int, last: Int): List<HistoryEntry>
+
+  /**
+   * Removes an item from the history, either by number or relative position
+   *
+   * If [item] is negative, it is relative to the end of the history list. If positive, it is the number of the item in
+   * the list of entries (not an index!). See `:help history-indexing` for more details.
+   */
+  fun removeEntry(type: Type, item: Int): Boolean
+
+  /**
+   * Remove any entries from the history that match the given regex pattern
+   */
+  fun removeEntries(type: Type, pattern: String): Boolean
+
+  /**
+   * Clear the entire history for the given history type
+   */
+  fun clearHistory(type: Type)
 
   @TestOnly
   fun resetHistory()

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistory.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistory.kt
@@ -43,6 +43,60 @@ interface VimHistory {
   fun removeEntries(type: Type, pattern: String): Boolean
 
   /**
+   * Get the current history entry, if selected, or null otherwise
+   *
+   * Vim keeps track of the current entry while the user navigates through the history while editing the command line
+   * (and search/input/expression entry). When the command line is first displayed, there is no stored current history
+   * entry, only the current entry being edited. That means the current entry is initially `null`, and represents the
+   * item *after* the most recent entry, past the end of the history list.
+   *
+   * When the user navigates to an older entry with `<S-Up>` or filtered older entry with `<Up>`, the current entry is
+   * moved to the next oldest entry - starting with the last entry in the list, the most recently saved entry. When the
+   * command line is completed or canceled, the new entry is saved and the current entry is reset.
+   */
+  fun getCurrentEntry(type: Type): HistoryEntry?
+
+  /**
+   * Get the most recent history entry
+   *
+   * This function returns the most recently saved history entry, the item at the end of the history list, if available.
+   * It returns `null` if there are no saved entries.
+   *
+   * This is used to mark the current entry when displaying entries in the output of the `:history` command, when the
+   * current entry has a default value of `null` (meaning past the last entry in the history).
+   */
+  fun getMostRecentEntry(type: Type): HistoryEntry?
+
+  /**
+   * Select the next older entry from the given type's history, if possible, updating the current entry
+   *
+   * This is typically used when navigating through the history using the `<Up>` or `<S-Up>` keys. By default, the
+   * current entry starts as being the entry past the end of the history list, so pressing up will get the most recent
+   * entry. Pressing up again would get the next older entry, which would be the second most recent entry, and so on.
+   *
+   * If the filter value is given, the next older entry must start with the value.
+   *
+   * If there are no matching entries, or the start of the history is reached, the current entry will not be updated and
+   * `null` is returned.
+   */
+  fun selectOlderEntry(type: Type, filter: String?): HistoryEntry?
+
+  /**
+   * Select the next newer entry from the given type's history, if possible, updating the current entry
+   *
+   * This function is typically used when navigating through the history using the `<Down>` or `<S-Down>` keys. By
+   * default, the current entry starts as being the entry past the beginning of the history list, and there are no newer
+   * entries. If the user navigates to older entries, this function will return the next newer entry after the current
+   * entry, updating the current entry as it does.
+   *
+   * If the filter value is given, the next newer entry must start with the value.
+   *
+   * If there are no matching entries, or the end of the history is reached, the current entry will not be updated and
+   * `null` is returned.
+   */
+  fun selectNewerEntry(type: Type, filter: String?): HistoryEntry?
+
+  /**
    * Clear the entire history for the given history type
    */
   fun clearHistory(type: Type)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistory.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistory.kt
@@ -12,11 +12,6 @@ import org.jetbrains.annotations.TestOnly
 
 interface VimHistory {
   /**
-   * Add an item to the end of the list for the given history type
-   */
-  fun addEntry(type: Type, text: String)
-
-  /**
    * Get a list of history entries for the given history type, within the specified range
    *
    * The values of [first] and [last] can be either positive or negative. When the value is negative, it is an index
@@ -28,6 +23,11 @@ interface VimHistory {
    * [last]. If [last] is `0`, all entries after [first] are returned. If both values are `0`, all entries are returned.
    */
   fun getEntries(type: Type, first: Int, last: Int): List<HistoryEntry>
+
+  /**
+   * Add an item to the end of the list for the given history type
+   */
+  fun addEntry(type: Type, text: String)
 
   /**
    * Removes an item from the history, either by number or relative position

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistory.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistory.kt
@@ -17,7 +17,7 @@ interface VimHistory {
   @TestOnly
   fun resetHistory()
 
-  sealed class Type() {
+  sealed class Type {
     data object Search : Type()
     data object Command : Type()
     data object Expression : Type()
@@ -31,6 +31,20 @@ interface VimHistory {
           "/", "?" -> Search
           "=" -> Expression
           else -> Custom(label)
+        }
+      }
+
+      fun getTypeByString(value: String): Type? {
+        if ("cmd".startsWith(value)) return Command
+        if ("search".startsWith(value)) return Search
+        if ("expression".startsWith(value)) return Expression
+        if ("input".startsWith(value)) return Input
+        return when (value) {
+          ":" -> Command
+          "/" -> Search
+          "=" -> Expression
+          "@" -> Input
+          else -> null
         }
       }
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistoryBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistoryBase.kt
@@ -11,6 +11,9 @@ package com.maddyhome.idea.vim.history
 import com.maddyhome.idea.vim.diagnostic.VimLogger
 import com.maddyhome.idea.vim.diagnostic.debug
 import com.maddyhome.idea.vim.diagnostic.vimLogger
+import com.maddyhome.idea.vim.ex.exExceptionMessage
+import com.maddyhome.idea.vim.regexp.VimRegex
+import com.maddyhome.idea.vim.regexp.VimRegexException
 
 open class VimHistoryBase : VimHistory {
   protected val histories: MutableMap<VimHistory.Type, HistoryBlock> = mutableMapOf()
@@ -58,6 +61,42 @@ open class VimHistoryBase : VimHistory {
     }
 
     return res
+  }
+
+  override fun removeEntry(type: VimHistory.Type, item: Int):Boolean {
+    val block = getEntriesBlockByType(type)
+    return if (item > 0) {
+      block.removeEntryByNumber(item)
+    }
+    else {
+      val entry = getEntries(type, item, 0).firstOrNull() ?: return false
+      block.removeEntryByNumber(entry.number)
+    }
+  }
+
+  override fun removeEntries(type: VimHistory.Type, pattern: String): Boolean {
+    try {
+      val block = getEntriesBlockByType(type)
+      val regex = VimRegex(pattern)
+      var result = false
+      block.getEntries().toList().forEach {
+        if (regex.containsMatchIn(it.entry)) {
+          result = result or block.removeEntryByNumber(it.number)
+        }
+      }
+      return result
+    }
+    catch (e: VimRegexException) {
+      when (e.message) {
+        "E383" -> throw exExceptionMessage("E383", pattern)
+        "E486" -> throw exExceptionMessage("E486", pattern)
+      }
+      throw e
+    }
+  }
+
+  override fun clearHistory(type: VimHistory.Type) {
+    histories.remove(type)
   }
 
   override fun resetHistory() {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistoryBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistoryBase.kt
@@ -95,6 +95,16 @@ open class VimHistoryBase : VimHistory {
     }
   }
 
+  override fun getCurrentEntry(type: VimHistory.Type) = getEntriesBlockByType(type).currentEntry
+
+  override fun getMostRecentEntry(type: VimHistory.Type) = getEntriesBlockByType(type).mostRecentEntry
+
+  override fun selectNewerEntry(type: VimHistory.Type, filter: String?) =
+    getEntriesBlockByType(type).selectNewerEntry(filter)
+
+  override fun selectOlderEntry(type: VimHistory.Type, filter: String?) =
+    getEntriesBlockByType(type).selectOlderEntry(filter)
+
   override fun clearHistory(type: VimHistory.Type) {
     histories.remove(type)
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistoryBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/history/VimHistoryBase.kt
@@ -16,7 +16,7 @@ import com.maddyhome.idea.vim.regexp.VimRegex
 import com.maddyhome.idea.vim.regexp.VimRegexException
 
 open class VimHistoryBase : VimHistory {
-  protected val histories: MutableMap<VimHistory.Type, HistoryBlock> = mutableMapOf()
+  private val histories: MutableMap<VimHistory.Type, HistoryBlock> = mutableMapOf()
 
   override fun addEntry(type: VimHistory.Type, text: String) {
     val block = getEntriesBlockByType(type)
@@ -105,6 +105,14 @@ open class VimHistoryBase : VimHistory {
 
   private fun getEntriesBlockByType(type: VimHistory.Type): HistoryBlock {
     return histories.getOrPut(type) { HistoryBlock() }
+  }
+
+  protected fun isInitialised(type: VimHistory.Type): Boolean {
+    return histories.contains(type)
+  }
+
+  protected fun getInitialisedTypes(): Set<VimHistory.Type> {
+    return histories.keys
   }
 
   companion object {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/HistoryCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/HistoryCommand.kt
@@ -122,8 +122,16 @@ data class HistoryCommand(val range: Range, val modifier: CommandModifier, val a
 
   private fun StringBuilder.outputHistory(name: String, type: VimHistory.Type, start: Int, end: Int) {
     append("      #  $name history")
-    injector.historyGroup.getEntries(type, start, end).forEachIndexed { index, it ->
-      val indicator = if (it.current) ">" else " "
+
+    // There appears to be no scenario in which current entry will be valid at this point. When editing, the initial
+    // current entry is the one being edited, and which has not yet been saved - the stored current entry is null. While
+    // editing, the current entry can be updated, but when this command is invoked, editing has finished and the current
+    // command has been added as a new entry and the current entry has been reset to null. It does not appear to be
+    // possible to have any value other than null for the current entry at this point. But that would mean we've got
+    // nothing to mark as current. Vim marks the most recent entry as current, which we do here.
+    val current = injector.historyGroup.getCurrentEntry(type) ?: injector.historyGroup.getMostRecentEntry(type)
+    injector.historyGroup.getEntries(type, start, end).forEach {
+      val indicator = if (it == current) ">" else " "
       val num = it.number.toString().padStart(6)
       appendLine()
       append("$indicator$num  ${it.entry}")

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistAddFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistAddFunctionHandler.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions
+
+import com.intellij.vim.annotations.VimscriptFunction
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.history.VimHistory
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
+import com.maddyhome.idea.vim.vimscript.model.functions.BinaryFunctionHandler
+
+@VimscriptFunction("histadd")
+internal class HistAddFunctionHandler : BinaryFunctionHandler<VimInt>() {
+  override fun doFunction(
+    arguments: Arguments,
+    editor: VimEditor,
+    context: ExecutionContext,
+    vimContext: VimLContext,
+  ): VimInt {
+    val history = arguments.getString(0).value
+    val item = arguments.getString(1)
+
+    val type = when {
+      "cmd".startsWith(history) || history == ":" -> VimHistory.Type.Command
+      "search".startsWith(history) || history == "/" -> VimHistory.Type.Search
+      "expr".startsWith(history) || history == "=" -> VimHistory.Type.Expression
+      "input".startsWith(history) || history == "@" -> VimHistory.Type.Input
+      // IdeaVim does not support debug command history
+//      "debug", ">" -> VimHistory.Type.Debug
+
+      // If nothing provided, try to use the history type of the current command line, if any
+      else -> injector.commandLine.getActiveCommandLine()?.historyType
+    }
+
+    if (type == null) {
+      return VimInt.ZERO
+    }
+
+    injector.historyGroup.addEntry(type, item.value)
+    return VimInt.ONE
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistDelFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistDelFunctionHandler.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions
+
+import com.intellij.vim.annotations.VimscriptFunction
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.history.VimHistory
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDataType
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
+import com.maddyhome.idea.vim.vimscript.model.datatypes.asVimInt
+import com.maddyhome.idea.vim.vimscript.model.functions.BuiltinFunctionHandler
+
+@VimscriptFunction("histdel")
+internal class HistDelFunctionHandler : BuiltinFunctionHandler<VimDataType>(minArity = 1, maxArity = 2) {
+  override fun doFunction(
+    arguments: Arguments,
+    editor: VimEditor,
+    context: ExecutionContext,
+    vimContext: VimLContext,
+  ): VimDataType {
+    val history = arguments.getString(0).value
+    val item = arguments.getOrNull(1)
+
+    val historyType = VimHistory.Type.getTypeByString(history)
+      ?: injector.commandLine.getActiveCommandLine()?.historyType
+      ?: return VimInt.ZERO
+
+    return when (item) {
+      is VimInt -> {
+        if (item.value == 0) VimInt.ZERO else injector.historyGroup.removeEntry(historyType, item.value).asVimInt()
+      }
+
+      is VimString -> injector.historyGroup.removeEntries(historyType, item.value).asVimInt()
+
+      else -> {
+        injector.historyGroup.clearHistory(historyType)
+        VimInt.ONE
+      }
+    }
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistGetFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistGetFunctionHandler.kt
@@ -14,25 +14,26 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.history.VimHistory
 import com.maddyhome.idea.vim.vimscript.model.VimLContext
-import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
-import com.maddyhome.idea.vim.vimscript.model.functions.BinaryFunctionHandler
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
+import com.maddyhome.idea.vim.vimscript.model.datatypes.asVimString
+import com.maddyhome.idea.vim.vimscript.model.functions.BuiltinFunctionHandler
 
-@VimscriptFunction("histadd")
-internal class HistAddFunctionHandler : BinaryFunctionHandler<VimInt>() {
+@VimscriptFunction("histget")
+internal class HistGetFunctionHandler : BuiltinFunctionHandler<VimString>(minArity = 1, maxArity = 2) {
   override fun doFunction(
     arguments: Arguments,
     editor: VimEditor,
     context: ExecutionContext,
     vimContext: VimLContext,
-  ): VimInt {
+  ): VimString {
     val history = arguments.getString(0).value
-    val item = arguments.getString(1)
+    val index = arguments.getNumberOrNull(1)?.value
 
     val historyType = VimHistory.Type.getTypeByString(history)
       ?: injector.commandLine.getActiveCommandLine()?.historyType
-      ?: return VimInt.ZERO
+      ?: return VimString.EMPTY
 
-    injector.historyGroup.addEntry(historyType, item.value)
-    return VimInt.ONE
+    val entries = injector.historyGroup.getEntries(historyType, index ?: 0, 0)
+    return if (entries.size == 1) entries[0].entry.asVimString() else VimString.EMPTY
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistGetFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistGetFunctionHandler.kt
@@ -27,13 +27,17 @@ internal class HistGetFunctionHandler : BuiltinFunctionHandler<VimString>(minAri
     vimContext: VimLContext,
   ): VimString {
     val history = arguments.getString(0).value
-    val index = arguments.getNumberOrNull(1)?.value
+    val index = arguments.getNumberOrNull(1)?.value ?: -1
+
+    if (index == 0) {
+      return VimString.EMPTY
+    }
 
     val historyType = VimHistory.Type.getTypeByString(history)
       ?: injector.commandLine.getActiveCommandLine()?.historyType
       ?: return VimString.EMPTY
 
-    val entries = injector.historyGroup.getEntries(historyType, index ?: 0, 0)
+    val entries = injector.historyGroup.getEntries(historyType, index, 0)
     return if (entries.size == 1) entries[0].entry.asVimString() else VimString.EMPTY
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistNrFunctionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/functions/handlers/historyFunctions/HistNrFunctionHandler.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions
+
+import com.intellij.vim.annotations.VimscriptFunction
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.history.VimHistory
+import com.maddyhome.idea.vim.vimscript.model.VimLContext
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
+import com.maddyhome.idea.vim.vimscript.model.datatypes.asVimInt
+import com.maddyhome.idea.vim.vimscript.model.functions.UnaryFunctionHandler
+
+@VimscriptFunction("histnr")
+internal class HistNrFunctionHandler : UnaryFunctionHandler<VimInt>() {
+  override fun doFunction(
+    arguments: Arguments,
+    editor: VimEditor,
+    context: ExecutionContext,
+    vimContext: VimLContext,
+  ): VimInt {
+    val history = arguments.getString(0).value
+
+    val historyType = VimHistory.Type.getTypeByString(history)
+      ?: injector.commandLine.getActiveCommandLine()?.historyType
+      ?: return VimInt.MINUS_ONE
+
+    val entries = injector.historyGroup.getEntries(historyType, -1, 0)
+    val item = entries.lastOrNull()
+    return item?.number?.asVimInt() ?: VimInt.MINUS_ONE
+  }
+}

--- a/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
@@ -41,6 +41,7 @@
   "has_key": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.dictionaryFunctions.HasKeyFunctionHandler",
   "hasmapto": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.HasMapToFunctionHandler",
   "histadd": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistAddFunctionHandler",
+  "histget": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistGetFunctionHandler",
   "index": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.IndexFunctionHandler",
   "indexof": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.IndexOfFunctionHandler",
   "insert": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.InsertFunctionHandler",

--- a/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
@@ -42,6 +42,7 @@
   "hasmapto": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.HasMapToFunctionHandler",
   "histadd": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistAddFunctionHandler",
   "histget": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistGetFunctionHandler",
+  "histnr": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistNrFunctionHandler",
   "index": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.IndexFunctionHandler",
   "indexof": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.IndexOfFunctionHandler",
   "insert": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.InsertFunctionHandler",

--- a/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
@@ -40,6 +40,7 @@
   "getline": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.textFunctions.GetLineFunctionHandler",
   "has_key": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.dictionaryFunctions.HasKeyFunctionHandler",
   "hasmapto": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.HasMapToFunctionHandler",
+  "histadd": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistAddFunctionHandler",
   "index": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.IndexFunctionHandler",
   "indexof": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.IndexOfFunctionHandler",
   "insert": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.InsertFunctionHandler",

--- a/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_vimscript_functions.json
@@ -41,6 +41,7 @@
   "has_key": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.dictionaryFunctions.HasKeyFunctionHandler",
   "hasmapto": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.mappingFunctions.HasMapToFunctionHandler",
   "histadd": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistAddFunctionHandler",
+  "histdel": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistDelFunctionHandler",
   "histget": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistGetFunctionHandler",
   "histnr": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.historyFunctions.HistNrFunctionHandler",
   "index": "com.maddyhome.idea.vim.vimscript.model.functions.handlers.listFunctions.IndexFunctionHandler",

--- a/vim-engine/src/main/resources/messages/IdeaVimEngineBundle.properties
+++ b/vim-engine/src/main/resources/messages/IdeaVimEngineBundle.properties
@@ -77,6 +77,7 @@ E348=E348: No string under cursor
 E354=E354: Invalid register name: '{0}'
 E363=E363: Pattern caused out-of-stack error
 E369=E369: invalid item in {0}%[]
+E383=E383: Invalid search string: {0}
 E384=E384: Search hit TOP without match for: {0}
 E385=E385: Search hit BOTTOM without match for: {0}
 E418=E418: I am a teapot

--- a/vimscript-info/FUNCTIONS_INFO.MD
+++ b/vimscript-info/FUNCTIONS_INFO.MD
@@ -548,7 +548,7 @@ See `:help history-functions`.
 
 | Status | Function    | Description                         |
 |--------|-------------|-------------------------------------|
-|        | `histadd()` | add an item to a history            |
+| ✅      | `histadd()` | add an item to a history            |
 |        | `histdel()` | delete an item from a history       |
 |        | `histget()` | get an item from a history          |
 |        | `histnr()`  | get highest index of a history list |

--- a/vimscript-info/FUNCTIONS_INFO.MD
+++ b/vimscript-info/FUNCTIONS_INFO.MD
@@ -549,7 +549,7 @@ See `:help history-functions`.
 | Status | Function    | Description                         |
 |--------|-------------|-------------------------------------|
 | ✅      | `histadd()` | add an item to a history            |
-|        | `histdel()` | delete an item from a history       |
+| ✅      | `histdel()` | delete an item from a history       |
 | ✅      | `histget()` | get an item from a history          |
 | ✅      | `histnr()`  | get highest index of a history list |
 

--- a/vimscript-info/FUNCTIONS_INFO.MD
+++ b/vimscript-info/FUNCTIONS_INFO.MD
@@ -551,7 +551,7 @@ See `:help history-functions`.
 | ✅      | `histadd()` | add an item to a history            |
 |        | `histdel()` | delete an item from a history       |
 | ✅      | `histget()` | get an item from a history          |
-|        | `histnr()`  | get highest index of a history list |
+| ✅      | `histnr()`  | get highest index of a history list |
 
 ## Interactive
 

--- a/vimscript-info/FUNCTIONS_INFO.MD
+++ b/vimscript-info/FUNCTIONS_INFO.MD
@@ -550,7 +550,7 @@ See `:help history-functions`.
 |--------|-------------|-------------------------------------|
 | ✅      | `histadd()` | add an item to a history            |
 |        | `histdel()` | delete an item from a history       |
-|        | `histget()` | get an item from a history          |
+| ✅      | `histget()` | get an item from a history          |
 |        | `histnr()`  | get highest index of a history list |
 
 ## Interactive


### PR DESCRIPTION
This PR adds the history functions:

* `histadd()`
* `histdel()`
* `histget()`
* `histnr()`

It also does a little bit of refactoring and cleanup around the history implementation, encapsulating tracking the current history item in `HistoryBlock` rather than as part of the command line UI. It also fixes a couple of minor bugs related to navigation through the history, with additional tests.

~~It follows on from #1749, so contains those changes too. It's marked as draft until that PR is merged, then I'll rebase, force push and make ready for review.~~