### PR TITLE
Fix Incorrect behavior of C-u in insert mode (VIM-768)

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertDeleteInsertedTextActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertDeleteInsertedTextActionTest.kt
@@ -124,4 +124,15 @@ class InsertDeleteInsertedTextActionTest : VimTestCase() {
       enterCommand("set nooldundo")
     }
   }
+
+  // VIM-768
+  @Test
+  fun `test ctrl u in insert mode preserves indentation`() {
+    doTest(
+      listOf("A", "<C-U>"),
+      "    # This is not timepass${c}",
+      "    ${c}",
+      Mode.INSERT,
+    )
+  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertDeleteInsertedTextAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertDeleteInsertedTextAction.kt
@@ -61,7 +61,7 @@ private fun insertDeleteInsertedText(editor: VimEditor, context: ExecutionContex
       caret,
       TextRange(deleteTo, offset),
       SelectionType.CHARACTER_WISE,
-      false,
+      true,
     )
     return true
   }


### PR DESCRIPTION
now when using A in normal mode and then C-u do not move caret to wrong one past position