### PR TITLE
VIM-4184 remove wl-copy from primary writers

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjClipboardManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjClipboardManager.kt
@@ -14,6 +14,7 @@ import com.intellij.codeInsight.editorActions.TextBlockTransferable
 import com.intellij.codeInsight.editorActions.TextBlockTransferableData
 import com.intellij.ide.CopyPasteManagerEx
 import com.intellij.openapi.editor.CaretStateTransferableData
+import com.intellij.openapi.editor.RawText
 import com.intellij.openapi.editor.richcopy.view.HtmlTransferableData
 import com.intellij.openapi.editor.richcopy.view.RtfTransferableData
 import com.intellij.openapi.project.DumbService
@@ -276,4 +277,25 @@ internal class IjClipboardManager : VimClipboardManager {
 
 data class IjVimCopiedText(override val text: String, val transferableData: List<Any>) : VimCopiedText {
   override fun updateText(newText: String): VimCopiedText = IjVimCopiedText(newText, transferableData)
+}
+
+/**
+ * Builds the `TextBlockTransferable` for clipboard and PRIMARY writes. We pin a single-range
+ * `CaretStateTransferableData` so IntelliJ doesn't reshape the pasted text to match whatever
+ * multi-caret arrangement the destination editor has.
+ *
+ * Throws [HeadlessException] on a headless JVM; callers handle.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun buildIjTextTransferable(
+  text: String,
+  rawText: String,
+  transferableData: List<Any>,
+): TextBlockTransferable {
+  val mutableData = (transferableData as List<TextBlockTransferableData>).toMutableList()
+  val normalized = TextBlockTransferable.convertLineSeparators(text, "\n", mutableData)
+  if (mutableData.none { it is CaretStateTransferableData }) {
+    mutableData += CaretStateTransferableData(intArrayOf(0), intArrayOf(normalized.length))
+  }
+  return TextBlockTransferable(normalized, mutableData, RawText(rawText))
 }

--- a/src/main/java/com/maddyhome/idea/vim/newapi/PrimarySelectionWriter.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/PrimarySelectionWriter.kt
@@ -8,54 +8,30 @@
 
 package com.maddyhome.idea.vim.newapi
 
-import com.intellij.codeInsight.editorActions.TextBlockTransferable
-import com.intellij.codeInsight.editorActions.TextBlockTransferableData
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.editor.CaretStateTransferableData
-import com.intellij.openapi.editor.RawText
 import com.intellij.util.ui.EmptyClipboardOwner
 import com.maddyhome.idea.vim.diagnostic.debug
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import java.awt.HeadlessException
 import java.awt.Toolkit
 import java.io.File
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Pushes text to the windowing system's PRIMARY selection.
- *
- * AWT is fine on X11 / macOS / Windows. On Wayland, Mutter's Wayland→X11 bridge drops JBR's
- * writes under fast visual selection — external X11 readers see stale content — so we shell out
- * to xclip/wl-copy instead.
  */
 internal interface PrimarySelectionWriter {
   /** `true` if the write was performed or reliably scheduled; `false` if PRIMARY isn't reachable here. */
   fun write(text: String, transferableData: List<Any>): Boolean
 }
 
-internal fun primarySelectionWriter(): PrimarySelectionWriter =
-  if (System.getenv("WAYLAND_DISPLAY") != null) WaylandPrimarySelectionWriter()
-  else AwtPrimarySelectionWriter()
-
-/**
- * Builds the `TextBlockTransferable` for clipboard and PRIMARY writes. We pin a single-range
- * `CaretStateTransferableData` so IntelliJ doesn't reshape the pasted text to match whatever
- * multi-caret arrangement the destination editor has.
- *
- * Throws [HeadlessException] on a headless JVM; callers handle.
- */
-@Suppress("UNCHECKED_CAST")
-internal fun buildIjTextTransferable(
-  text: String,
-  rawText: String,
-  transferableData: List<Any>,
-): TextBlockTransferable {
-  val mutableData = (transferableData as List<TextBlockTransferableData>).toMutableList()
-  val normalized = TextBlockTransferable.convertLineSeparators(text, "\n", mutableData)
-  if (mutableData.none { it is CaretStateTransferableData }) {
-    mutableData += CaretStateTransferableData(intArrayOf(0), intArrayOf(normalized.length))
-  }
-  return TextBlockTransferable(normalized, mutableData, RawText(rawText))
+internal fun primarySelectionWriter(): PrimarySelectionWriter {
+  XclipPrimarySelectionWriter.tryCreate()?.let { return it }
+  return AwtPrimarySelectionWriter()
 }
 
 internal class AwtPrimarySelectionWriter : PrimarySelectionWriter {
@@ -72,57 +48,53 @@ internal class AwtPrimarySelectionWriter : PrimarySelectionWriter {
 }
 
 /**
- * Mirrors PRIMARY through xclip (preferred) or wl-copy (fallback).
- *
- * xclip writes X11 PRIMARY through XWayland and Mutter mirrors X11→Wayland reliably — both
- * sides see the content. wl-copy writes Wayland-native and relies on the broken Wayland→X11
- * bridge, which is the symptom we're working around.
- *
- * The tool is resolved once at construction so the hot path doesn't fork-exec-and-fail. Writes
- * are deferred so they land *after* IntelliJ's synchronous post-yank `updateSystemSelection`
- * overwrite; `ModalityState.any()` keeps them from being queued behind modal dialogs.
+ * Mirrors PRIMARY through `xclip -selection primary`.
  */
-internal class WaylandPrimarySelectionWriter : PrimarySelectionWriter {
-  private val command: List<String>? = candidates.firstOrNull { isExecutableInPath(it.first()) }
-
-  init {
-    if (command == null) {
-      logger.warn("Neither xclip nor wl-copy found on PATH; IdeaVim cannot mirror PRIMARY on Wayland")
-    } else {
-      logger.debug { "PRIMARY mirror will use: ${command.joinToString(" ")}" }
-    }
+internal class XclipPrimarySelectionWriter private constructor() : PrimarySelectionWriter {
+  private val pendingText = AtomicReference<String?>()
+  private val executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { runnable ->
+    Thread(runnable, "IdeaVim-PrimarySelection").apply { isDaemon = true }
   }
 
   override fun write(text: String, transferableData: List<Any>): Boolean {
-    val argv = command ?: return false
+    pendingText.set(text)
     ApplicationManager.getApplication().invokeLater(
-      { runCommand(argv, text) },
+      { executor.schedule(::drain, DEBOUNCE_MS, TimeUnit.MILLISECONDS) },
       ModalityState.any(),
     )
     return true
   }
 
-  private fun runCommand(argv: List<String>, text: String) {
+  private fun drain() {
+    val text = pendingText.getAndSet(null) ?: return
     try {
-      val process = ProcessBuilder(argv).redirectErrorStream(true).start()
+      val process = ProcessBuilder(XCLIP_ARGV).redirectErrorStream(true).start()
       process.outputStream.use { it.write(text.toByteArray(Charsets.UTF_8)) }
     } catch (e: Exception) {
-      logger.debug { "${argv.joinToString(" ")} failed: ${e.message}" }
+      logger.debug { "xclip failed: ${e.message}" }
     }
   }
 
   companion object {
-    private val logger = vimLogger<WaylandPrimarySelectionWriter>()
+    private const val DEBOUNCE_MS = 20L
+    private val logger = vimLogger<XclipPrimarySelectionWriter>()
+    private val XCLIP_ARGV = listOf("xclip", "-selection", "primary")
 
-    private val candidates = listOf(
-      listOf("xclip", "-selection", "primary"),
-      listOf("wl-copy", "--primary"),
-    )
+    fun tryCreate(): XclipPrimarySelectionWriter? {
+      if (!isExecutableInPath()) {
+        if (System.getenv("WAYLAND_DISPLAY") != null) {
+          logger.warn("xclip not on PATH; falling back to AWT for PRIMARY (native-Wayland readers may see stale content)")
+        }
+        return null
+      }
+      logger.debug { "PRIMARY mirror will use xclip" }
+      return XclipPrimarySelectionWriter()
+    }
 
-    private fun isExecutableInPath(name: String): Boolean {
+    private fun isExecutableInPath(): Boolean {
       val path = System.getenv("PATH") ?: return false
       return path.split(File.pathSeparator).any { dir ->
-        val candidate = File(dir, name)
+        val candidate = File(dir, "xclip")
         candidate.isFile && candidate.canExecute()
       }
     }


### PR DESCRIPTION
Use only xclip on wayland as wl-copy makes whole IDE flickers