### PR TITLE
Add Abolish plugin

### DIFF
--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -16,6 +16,38 @@ in `~/.ideavimrc`. E.g. `set nosurround`.
 Available plugins:
 
 <details>
+<summary><h2>abolish: Case-aware substitute and coercion mappings between case styles</h2></summary>
+
+Original plugin: [vim-abolish](https://github.com/tpope/vim-abolish).
+
+### Summary:
+Coercion mappings (`crs`, `crm`, `crc`, `cru`, `cr-`, `cr.`, `cr<Space>`, `crt`) recase the word under
+the cursor between snake_case, MixedCase, camelCase, UPPER_SNAKE, kebab-case, dot.case, space case
+and Title Case. `:Subvert` (alias `:S`) is a case-aware `:substitute` that handles all case
+variants and `{a,b,c}` brace alternatives in a single command.
+
+### Setup:
+- Add the following command to `~/.ideavimrc`: `Plug 'tpope/vim-abolish'`
+    <details>
+      <summary>Alternative syntax</summary>
+      <code>Plugin 'tpope/vim-abolish'</code>
+      <br/>
+      <code>Plug 'https://github.com/tpope/vim-abolish'</code>
+      <br/>
+      <code>Plug 'vim-abolish'</code>
+      <br/>
+      <code>set abolish</code>
+      </details>
+
+### Instructions
+
+https://github.com/tpope/vim-abolish/blob/master/doc/abolish.txt
+
+`:Abolish` (insert-mode auto-correcting abbreviations) is not supported.
+
+</details>
+
+<details>
 <summary><h2>anyobject: Useful text objects like functions, arguments, classes, loops, list items, block comments, and more.</h2></summary>
 
 ### Summary:

--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -24,7 +24,8 @@ Original plugin: [vim-abolish](https://github.com/tpope/vim-abolish).
 Coercion mappings (`crs`/`cr_`, `crm`/`crp`, `crc`, `cru`/`crU`, `cr-`/`crk`, `cr.`, `cr<Space>`, `crt`)
 recase the word under the cursor between snake_case, MixedCase, camelCase, UPPER_SNAKE, kebab-case,
 dot.case, space case and Title Case. `:Subvert` (alias `:S`) is a case-aware `:substitute` that
-handles all case variants and `{a,b,c}` brace alternatives in a single command.
+handles all case variants and `{a,b,c}` brace alternatives in a single command. With only a pattern
+(`:S/foo/` or `:S?foo?`) it does a case-aware forward or backward search instead.
 
 ### Setup:
 - Add the following command to `~/.ideavimrc`: `Plug 'tpope/vim-abolish'`

--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -45,6 +45,21 @@ https://github.com/tpope/vim-abolish/blob/master/doc/abolish.txt
 
 `:Abolish` (insert-mode auto-correcting abbreviations) is not supported.
 
+By default each `cr<x>` mapping recases the inner word under the cursor.
+To get tpope-style motion support (`crsiw`, `crsap`, `crs2w`, …) remap to the
+per-style operator `<Plug>` mappings:
+
+```
+nmap crs <Plug>(abolish-coerce-snake)
+nmap crm <Plug>(abolish-coerce-pascal)
+nmap crc <Plug>(abolish-coerce-camel)
+nmap cru <Plug>(abolish-coerce-upper_snake)
+nmap cr- <Plug>(abolish-coerce-kebab)
+nmap cr. <Plug>(abolish-coerce-dot)
+nmap cr<Space> <Plug>(abolish-coerce-space)
+nmap crt <Plug>(abolish-coerce-title)
+```
+
 </details>
 
 <details>

--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -21,10 +21,10 @@ Available plugins:
 Original plugin: [vim-abolish](https://github.com/tpope/vim-abolish).
 
 ### Summary:
-Coercion mappings (`crs`, `crm`, `crc`, `cru`, `cr-`, `cr.`, `cr<Space>`, `crt`) recase the word under
-the cursor between snake_case, MixedCase, camelCase, UPPER_SNAKE, kebab-case, dot.case, space case
-and Title Case. `:Subvert` (alias `:S`) is a case-aware `:substitute` that handles all case
-variants and `{a,b,c}` brace alternatives in a single command.
+Coercion mappings (`crs`/`cr_`, `crm`/`crp`, `crc`, `cru`/`crU`, `cr-`/`crk`, `cr.`, `cr<Space>`, `crt`)
+recase the word under the cursor between snake_case, MixedCase, camelCase, UPPER_SNAKE, kebab-case,
+dot.case, space case and Title Case. `:Subvert` (alias `:S`) is a case-aware `:substitute` that
+handles all case variants and `{a,b,c}` brace alternatives in a single command.
 
 ### Setup:
 - Add the following command to `~/.ideavimrc`: `Plug 'tpope/vim-abolish'`
@@ -59,6 +59,17 @@ nmap cr. <Plug>(abolish-coerce-dot)
 nmap cr<Space> <Plug>(abolish-coerce-space)
 nmap crt <Plug>(abolish-coerce-title)
 ```
+
+To bind extra trigger characters, set `g:abolish_coercions` *before* enabling
+the plugin. Each entry maps a single character to the name of a built-in case
+style (case-insensitive: `snake`, `pascal`, `camel`, `upper_snake`, `kebab`,
+`dot`, `space`, `title`).
+
+```
+let g:abolish_coercions = {'q': 'kebab', 'x': 'upper_snake'}
+```
+
+After this, `crq` recases to kebab-case and `crx` to UPPER_SNAKE.
 
 </details>
 

--- a/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
+++ b/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
@@ -289,6 +289,14 @@
 
   <!-- Frontend vim extensions (editor/text manipulation, no PSI/file-system dependency) -->
   <extensions defaultExtensionNs="IdeaVIM">
+    <vimExtension implementation="com.maddyhome.idea.vim.extension.abolish.AbolishExtension" name="abolish">
+      <aliases>
+        <alias name="https://github.com/tpope/vim-abolish"/>
+        <alias name="tpope/vim-abolish"/>
+        <alias name="vim-abolish"/>
+      </aliases>
+    </vimExtension>
+
     <vimExtension implementation="com.maddyhome.idea.vim.extension.commentary.CommentaryExtension" name="commentary">
       <aliases>
         <alias name="https://github.com/tpope/vim-commentary"/>

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
@@ -11,25 +11,38 @@ package com.maddyhome.idea.vim.extension.abolish
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.MappingMode
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.extension.ExtensionHandler
 import com.maddyhome.idea.vim.extension.VimExtension
+import com.maddyhome.idea.vim.extension.VimExtensionFacade
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.addCommand
+import com.maddyhome.idea.vim.extension.VimExtensionFacade.executeNormalWithoutMapping
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.putExtensionHandlerMapping
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMappingIfMissing
+import com.maddyhome.idea.vim.extension.exportOperatorFunction
+import com.maddyhome.idea.vim.key.OperatorFunction
+import com.maddyhome.idea.vim.newapi.ij
+import com.maddyhome.idea.vim.state.mode.SelectionType
 
 /**
  * Emulation of [vim-abolish](https://github.com/tpope/vim-abolish): `cr<x>`
  * coercions and `:Subvert`/`:S`. `:Abolish` is not implemented — IdeaVim has
  * no `:iabbrev` infrastructure to build insert-mode auto-correct on top of.
+ *
+ * Each coercion exposes two `<Plug>` mappings: `<Plug>(abolish-coerce-word-X)`
+ * recases the inner word under the cursor (bound to `crX` by default), and
+ * `<Plug>(abolish-coerce-X)` is operator-pending — `:nmap crs <Plug>(abolish-coerce-snake)`
+ * makes `crs{motion}` recase the motion target (e.g. `crsiw`, `crsap`).
  */
 internal class AbolishExtension : VimExtension {
 
   override fun getName(): String = "abolish"
 
   override fun init() {
+    VimExtensionFacade.exportOperatorFunction(OPERATOR_FUNC, CoercionOperator())
     COERCIONS.forEach(::registerCoercion)
     val subvert = SubvertCommand()
     addCommand("Subvert", subvert)
@@ -37,16 +50,26 @@ internal class AbolishExtension : VimExtension {
   }
 
   private fun registerCoercion(coercion: Coercion) {
-    val plug = injector.parser.parseKeys(coercion.plugName)
-    putExtensionHandlerMapping(MappingMode.N, plug, owner, CoercionHandler(coercion.style), false)
-    putKeyMappingIfMissing(MappingMode.N, injector.parser.parseKeys(coercion.keys), owner, plug, true)
+    putExtensionHandlerMapping(
+      MappingMode.N,
+      injector.parser.parseKeys(coercion.plugOperatorName),
+      owner,
+      CoercionOperatorTrigger(coercion.style),
+      false,
+    )
+    val plugWord = injector.parser.parseKeys(coercion.plugWordName)
+    putExtensionHandlerMapping(MappingMode.N, plugWord, owner, CoercionWordHandler(coercion.style), false)
+    putKeyMappingIfMissing(MappingMode.N, injector.parser.parseKeys(coercion.keys), owner, plugWord, true)
   }
 
   private data class Coercion(val keys: String, val style: CaseStyle) {
-    val plugName: String = "<Plug>(abolish-coerce-${style.name.lowercase()})"
+    val plugWordName: String = "<Plug>(abolish-coerce-word-${style.name.lowercase()})"
+    val plugOperatorName: String = "<Plug>(abolish-coerce-${style.name.lowercase()})"
   }
 
   private companion object {
+    private const val OPERATOR_FUNC = "AbolishCoerce"
+
     private val COERCIONS = listOf(
       Coercion("crs", CaseStyle.SNAKE),
       Coercion("crm", CaseStyle.PASCAL),
@@ -60,22 +83,56 @@ internal class AbolishExtension : VimExtension {
   }
 }
 
-private class CoercionHandler(private val targetStyle: CaseStyle) : ExtensionHandler {
+/** Default direct coercion: recase the inner word under each caret in normal mode. */
+private class CoercionWordHandler(private val targetStyle: CaseStyle) : ExtensionHandler {
 
   override val isRepeatable: Boolean = true
 
   override fun execute(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments) {
     // Right-to-left so an earlier caret's offsets survive a later replacement.
-    editor.sortedCarets().reversed().forEach { caret -> recaseWordAtCaret(editor, caret) }
+    editor.sortedCarets().reversed().forEach { caret -> recaseWordAtCaret(editor, caret, targetStyle) }
   }
+}
 
-  private fun recaseWordAtCaret(editor: VimEditor, caret: VimCaret) {
-    val wordRange = injector.searchHelper.findWordObject(editor, caret, 1, isOuter = false, isBig = false)
-    if (wordRange.startOffset == wordRange.endOffset) return
-    val originalWord = editor.text().substring(wordRange.startOffset, wordRange.endOffset)
-    val recased = targetStyle.recase(originalWord)
-    if (recased == originalWord) return
-    injector.changeGroup.replaceText(editor, caret, wordRange.startOffset, wordRange.endOffset, recased)
-    caret.moveToOffset(wordRange.startOffset)
+/**
+ * Operator-pending coercion: stash the chosen style, set `opfunc`, press `g@`.
+ * Vim then collects the motion and invokes the registered operator function,
+ * which reads the stashed style back. Same mechanism tpope uses with `s:transformation`.
+ */
+private class CoercionOperatorTrigger(private val style: CaseStyle) : ExtensionHandler {
+
+  override val isRepeatable: Boolean = true
+
+  override fun execute(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments) {
+    PendingCoercion.style = style
+    injector.globalOptions().operatorfunc = "AbolishCoerce"
+    executeNormalWithoutMapping(injector.parser.parseKeys("g@"), editor.ij)
   }
+}
+
+private class CoercionOperator : OperatorFunction {
+  override fun apply(editor: VimEditor, context: ExecutionContext, selectionType: SelectionType?): Boolean {
+    val style = PendingCoercion.style ?: return false
+    val range = injector.markService.getChangeMarks(editor.primaryCaret()) ?: return false
+    val original = editor.text().substring(range.startOffset, range.endOffset)
+    val recased = style.recase(original)
+    if (recased == original) return true
+    injector.changeGroup.replaceText(editor, editor.primaryCaret(), range.startOffset, range.endOffset, recased)
+    editor.primaryCaret().moveToOffset(range.startOffset)
+    return true
+  }
+}
+
+private object PendingCoercion {
+  @Volatile var style: CaseStyle? = null
+}
+
+private fun recaseWordAtCaret(editor: VimEditor, caret: VimCaret, targetStyle: CaseStyle) {
+  val wordRange = injector.searchHelper.findWordObject(editor, caret, 1, isOuter = false, isBig = false)
+  if (wordRange.startOffset == wordRange.endOffset) return
+  val originalWord = editor.text().substring(wordRange.startOffset, wordRange.endOffset)
+  val recased = targetStyle.recase(originalWord)
+  if (recased == originalWord) return
+  injector.changeGroup.replaceText(editor, caret, wordRange.startOffset, wordRange.endOffset, recased)
+  caret.moveToOffset(wordRange.startOffset)
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
@@ -65,26 +65,31 @@ internal class AbolishExtension : VimExtension {
     val dict = VimPlugin.getVariableService().getGlobalVariableValue(USER_COERCIONS_VARIABLE) as? VimDictionary ?: return
     dict.dictionary.forEach { (charKey, styleValue) ->
       val char = charKey.value.singleOrNull() ?: return@forEach
-      val styleName = (styleValue as? VimString)?.value ?: return@forEach
-      val style = CaseStyle.entries.firstOrNull { it.name.equals(styleName, ignoreCase = true) } ?: return@forEach
-      val plugWord = injector.parser.parseKeys("<Plug>(abolish-coerce-word-${style.name.lowercase()})")
-      val plugOperator = injector.parser.parseKeys("<Plug>(abolish-coerce-${style.name.lowercase()})")
-      bindAlias("cr$char", plugWord, plugOperator)
+      val style = resolveStyleByName((styleValue as? VimString)?.value) ?: return@forEach
+      bindAlias("cr$char", plugWordKeysFor(style), plugOperatorKeysFor(style))
     }
   }
 
   private fun registerCoercion(coercion: Coercion) {
-    val plugOperator = injector.parser.parseKeys(coercion.plugOperatorName)
-    putExtensionHandlerMapping(MappingMode.N, plugOperator, owner, CoercionOperatorTrigger(coercion.style), false)
-    // Same <Plug> name in visual mode: the selection is the operand, no motion needed.
-    putExtensionHandlerMapping(MappingMode.X, plugOperator, owner, CoercionVisualHandler(coercion.style), false)
+    val plugOperator = plugOperatorKeysFor(coercion.style)
+    val plugWord = plugWordKeysFor(coercion.style)
 
-    val plugWord = injector.parser.parseKeys(coercion.plugWordName)
+    putExtensionHandlerMapping(MappingMode.N, plugOperator, owner, CoercionOperatorTrigger(coercion.style), false)
+    putExtensionHandlerMapping(MappingMode.X, plugOperator, owner, CoercionVisualHandler(coercion.style), false)
     putExtensionHandlerMapping(MappingMode.N, plugWord, owner, CoercionWordHandler(coercion.style), false)
 
     bindPrimaryKeyUnlessUserOverrode(coercion.primaryKey, plugWord, plugOperator)
     coercion.aliases.forEach { alias -> bindAlias(alias, plugWord, plugOperator) }
   }
+
+  private fun plugWordKeysFor(style: CaseStyle): List<KeyStroke> =
+    injector.parser.parseKeys("<Plug>(abolish-coerce-word-${style.name.lowercase()})")
+
+  private fun plugOperatorKeysFor(style: CaseStyle): List<KeyStroke> =
+    injector.parser.parseKeys("<Plug>(abolish-coerce-${style.name.lowercase()})")
+
+  private fun resolveStyleByName(name: String?): CaseStyle? =
+    name?.let { needle -> CaseStyle.entries.firstOrNull { it.name.equals(needle, ignoreCase = true) } }
 
   private fun bindPrimaryKeyUnlessUserOverrode(
     key: String,
@@ -106,13 +111,10 @@ internal class AbolishExtension : VimExtension {
     putKeyMapping(MappingMode.X, parsed, owner, plugOperator, true)
   }
 
-  private data class Coercion(val style: CaseStyle, val primaryKey: String, val aliases: List<String> = emptyList()) {
-    val plugWordName: String = "<Plug>(abolish-coerce-word-${style.name.lowercase()})"
-    val plugOperatorName: String = "<Plug>(abolish-coerce-${style.name.lowercase()})"
-  }
+  private data class Coercion(val style: CaseStyle, val primaryKey: String, val aliases: List<String> = emptyList())
 
-  private companion object {
-    private const val OPERATOR_FUNC = "AbolishCoerce"
+  companion object {
+    internal const val OPERATOR_FUNC = "AbolishCoerce"
     private const val USER_COERCIONS_VARIABLE = "abolish_coercions"
 
     private val COERCIONS = listOf(
@@ -128,10 +130,6 @@ internal class AbolishExtension : VimExtension {
   }
 }
 
-/**
- * Visual-mode coercion: the current selection is the operand. Recase, replace,
- * exit visual back to normal with the caret at the start of the rewritten span.
- */
 private class CoercionVisualHandler(private val style: CaseStyle) : ExtensionHandler {
 
   override val isRepeatable: Boolean = true
@@ -150,7 +148,6 @@ private class CoercionVisualHandler(private val style: CaseStyle) : ExtensionHan
   }
 }
 
-/** Default direct coercion: recase the inner word under each caret in normal mode. */
 private class CoercionWordHandler(private val targetStyle: CaseStyle) : ExtensionHandler {
 
   override val isRepeatable: Boolean = true
@@ -173,7 +170,7 @@ private class CoercionOperatorTrigger(private val style: CaseStyle) : ExtensionH
 
   override fun execute(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments) {
     PendingCoercion.style = style
-    injector.globalOptions().operatorfunc = "AbolishCoerce"
+    injector.globalOptions().operatorfunc = AbolishExtension.OPERATOR_FUNC
     executeNormalWithoutMapping(injector.parser.parseKeys("g@"), editor.ij)
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
@@ -21,11 +21,13 @@ import com.maddyhome.idea.vim.extension.VimExtensionFacade
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.addCommand
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.executeNormalWithoutMapping
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.putExtensionHandlerMapping
+import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMapping
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMappingIfMissing
 import com.maddyhome.idea.vim.extension.exportOperatorFunction
 import com.maddyhome.idea.vim.key.OperatorFunction
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.state.mode.SelectionType
+import javax.swing.KeyStroke
 
 /**
  * Emulation of [vim-abolish](https://github.com/tpope/vim-abolish): `cr<x>`
@@ -58,12 +60,31 @@ internal class AbolishExtension : VimExtension {
     val plugWord = injector.parser.parseKeys(coercion.plugWordName)
     putExtensionHandlerMapping(MappingMode.N, plugWord, owner, CoercionWordHandler(coercion.style), false)
 
-    val keys = injector.parser.parseKeys(coercion.keys)
-    putKeyMappingIfMissing(MappingMode.N, keys, owner, plugWord, true)
-    putKeyMappingIfMissing(MappingMode.X, keys, owner, plugOperator, true)
+    bindPrimaryKeyUnlessUserOverrode(coercion.primaryKey, plugWord, plugOperator)
+    coercion.aliases.forEach { alias -> bindAlias(alias, plugWord, plugOperator) }
   }
 
-  private data class Coercion(val keys: String, val style: CaseStyle) {
+  private fun bindPrimaryKeyUnlessUserOverrode(
+    key: String,
+    plugWord: List<KeyStroke>,
+    plugOperator: List<KeyStroke>,
+  ) {
+    val parsed = injector.parser.parseKeys(key)
+    putKeyMappingIfMissing(MappingMode.N, parsed, owner, plugWord, true)
+    putKeyMappingIfMissing(MappingMode.X, parsed, owner, plugOperator, true)
+  }
+
+  private fun bindAlias(
+    key: String,
+    plugWord: List<KeyStroke>,
+    plugOperator: List<KeyStroke>,
+  ) {
+    val parsed = injector.parser.parseKeys(key)
+    putKeyMapping(MappingMode.N, parsed, owner, plugWord, true)
+    putKeyMapping(MappingMode.X, parsed, owner, plugOperator, true)
+  }
+
+  private data class Coercion(val style: CaseStyle, val primaryKey: String, val aliases: List<String> = emptyList()) {
     val plugWordName: String = "<Plug>(abolish-coerce-word-${style.name.lowercase()})"
     val plugOperatorName: String = "<Plug>(abolish-coerce-${style.name.lowercase()})"
   }
@@ -72,14 +93,14 @@ internal class AbolishExtension : VimExtension {
     private const val OPERATOR_FUNC = "AbolishCoerce"
 
     private val COERCIONS = listOf(
-      Coercion("crs", CaseStyle.SNAKE),
-      Coercion("crm", CaseStyle.PASCAL),
-      Coercion("crc", CaseStyle.CAMEL),
-      Coercion("cru", CaseStyle.UPPER_SNAKE),
-      Coercion("cr-", CaseStyle.KEBAB),
-      Coercion("cr.", CaseStyle.DOT),
-      Coercion("cr<Space>", CaseStyle.SPACE),
-      Coercion("crt", CaseStyle.TITLE),
+      Coercion(CaseStyle.SNAKE, primaryKey = "crs", aliases = listOf("cr_")),
+      Coercion(CaseStyle.PASCAL, primaryKey = "crm", aliases = listOf("crp")),
+      Coercion(CaseStyle.CAMEL, primaryKey = "crc"),
+      Coercion(CaseStyle.UPPER_SNAKE, primaryKey = "cru", aliases = listOf("crU")),
+      Coercion(CaseStyle.KEBAB, primaryKey = "cr-", aliases = listOf("crk")),
+      Coercion(CaseStyle.DOT, primaryKey = "cr."),
+      Coercion(CaseStyle.SPACE, primaryKey = "cr<Space>"),
+      Coercion(CaseStyle.TITLE, primaryKey = "crt"),
     )
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.extension.abolish
+
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimCaret
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.command.MappingMode
+import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.extension.ExtensionHandler
+import com.maddyhome.idea.vim.extension.VimExtension
+import com.maddyhome.idea.vim.extension.VimExtensionFacade.addCommand
+import com.maddyhome.idea.vim.extension.VimExtensionFacade.putExtensionHandlerMapping
+import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMappingIfMissing
+
+/**
+ * Emulation of [vim-abolish](https://github.com/tpope/vim-abolish): `cr<x>`
+ * coercions and `:Subvert`/`:S`. `:Abolish` is not implemented — IdeaVim has
+ * no `:iabbrev` infrastructure to build insert-mode auto-correct on top of.
+ */
+internal class AbolishExtension : VimExtension {
+
+  override fun getName(): String = "abolish"
+
+  override fun init() {
+    COERCIONS.forEach(::registerCoercion)
+    val subvert = SubvertCommand()
+    addCommand("Subvert", subvert)
+    addCommand("S", subvert)
+  }
+
+  private fun registerCoercion(coercion: Coercion) {
+    val plug = injector.parser.parseKeys(coercion.plugName)
+    putExtensionHandlerMapping(MappingMode.N, plug, owner, CoercionHandler(coercion.style), false)
+    putKeyMappingIfMissing(MappingMode.N, injector.parser.parseKeys(coercion.keys), owner, plug, true)
+  }
+
+  private data class Coercion(val keys: String, val style: CaseStyle) {
+    val plugName: String = "<Plug>(abolish-coerce-${style.name.lowercase()})"
+  }
+
+  private companion object {
+    private val COERCIONS = listOf(
+      Coercion("crs", CaseStyle.SNAKE),
+      Coercion("crm", CaseStyle.PASCAL),
+      Coercion("crc", CaseStyle.CAMEL),
+      Coercion("cru", CaseStyle.UPPER_SNAKE),
+      Coercion("cr-", CaseStyle.KEBAB),
+      Coercion("cr.", CaseStyle.DOT),
+      Coercion("cr<Space>", CaseStyle.SPACE),
+      Coercion("crt", CaseStyle.TITLE),
+    )
+  }
+}
+
+private class CoercionHandler(private val targetStyle: CaseStyle) : ExtensionHandler {
+
+  override val isRepeatable: Boolean = true
+
+  override fun execute(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments) {
+    // Right-to-left so an earlier caret's offsets survive a later replacement.
+    editor.sortedCarets().reversed().forEach { caret -> recaseWordAtCaret(editor, caret) }
+  }
+
+  private fun recaseWordAtCaret(editor: VimEditor, caret: VimCaret) {
+    val wordRange = injector.searchHelper.findWordObject(editor, caret, 1, isOuter = false, isBig = false)
+    if (wordRange.startOffset == wordRange.endOffset) return
+    val originalWord = editor.text().substring(wordRange.startOffset, wordRange.endOffset)
+    val recased = targetStyle.recase(originalWord)
+    if (recased == originalWord) return
+    injector.changeGroup.replaceText(editor, caret, wordRange.startOffset, wordRange.endOffset, recased)
+    caret.moveToOffset(wordRange.startOffset)
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
@@ -50,16 +50,17 @@ internal class AbolishExtension : VimExtension {
   }
 
   private fun registerCoercion(coercion: Coercion) {
-    putExtensionHandlerMapping(
-      MappingMode.N,
-      injector.parser.parseKeys(coercion.plugOperatorName),
-      owner,
-      CoercionOperatorTrigger(coercion.style),
-      false,
-    )
+    val plugOperator = injector.parser.parseKeys(coercion.plugOperatorName)
+    putExtensionHandlerMapping(MappingMode.N, plugOperator, owner, CoercionOperatorTrigger(coercion.style), false)
+    // Same <Plug> name in visual mode: the selection is the operand, no motion needed.
+    putExtensionHandlerMapping(MappingMode.X, plugOperator, owner, CoercionVisualHandler(coercion.style), false)
+
     val plugWord = injector.parser.parseKeys(coercion.plugWordName)
     putExtensionHandlerMapping(MappingMode.N, plugWord, owner, CoercionWordHandler(coercion.style), false)
-    putKeyMappingIfMissing(MappingMode.N, injector.parser.parseKeys(coercion.keys), owner, plugWord, true)
+
+    val keys = injector.parser.parseKeys(coercion.keys)
+    putKeyMappingIfMissing(MappingMode.N, keys, owner, plugWord, true)
+    putKeyMappingIfMissing(MappingMode.X, keys, owner, plugOperator, true)
   }
 
   private data class Coercion(val keys: String, val style: CaseStyle) {
@@ -80,6 +81,28 @@ internal class AbolishExtension : VimExtension {
       Coercion("cr<Space>", CaseStyle.SPACE),
       Coercion("crt", CaseStyle.TITLE),
     )
+  }
+}
+
+/**
+ * Visual-mode coercion: the current selection is the operand. Recase, replace,
+ * exit visual back to normal with the caret at the start of the rewritten span.
+ */
+private class CoercionVisualHandler(private val style: CaseStyle) : ExtensionHandler {
+
+  override val isRepeatable: Boolean = true
+
+  override fun execute(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments) {
+    val caret = editor.primaryCaret()
+    val start = caret.selectionStart
+    val end = caret.selectionEnd
+    if (start >= end) return
+    val original = editor.text().substring(start, end)
+    val recased = style.recase(original)
+    executeNormalWithoutMapping(injector.parser.parseKeys("<Esc>"), editor.ij)
+    if (recased == original) return
+    injector.changeGroup.replaceText(editor, caret, start, end, recased)
+    caret.moveToOffset(start)
   }
 }
 

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
@@ -112,8 +112,9 @@ private class CoercionWordHandler(private val targetStyle: CaseStyle) : Extensio
   override val isRepeatable: Boolean = true
 
   override fun execute(editor: VimEditor, context: ExecutionContext, operatorArguments: OperatorArguments) {
+    val count = operatorArguments.count0.coerceAtLeast(1)
     // Right-to-left so an earlier caret's offsets survive a later replacement.
-    editor.sortedCarets().reversed().forEach { caret -> recaseWordAtCaret(editor, caret, targetStyle) }
+    editor.sortedCarets().reversed().forEach { caret -> recaseWordAtCaret(editor, caret, targetStyle, count) }
   }
 }
 
@@ -150,8 +151,8 @@ private object PendingCoercion {
   @Volatile var style: CaseStyle? = null
 }
 
-private fun recaseWordAtCaret(editor: VimEditor, caret: VimCaret, targetStyle: CaseStyle) {
-  val wordRange = injector.searchHelper.findWordObject(editor, caret, 1, isOuter = false, isBig = false)
+private fun recaseWordAtCaret(editor: VimEditor, caret: VimCaret, targetStyle: CaseStyle, count: Int) {
+  val wordRange = injector.searchHelper.findWordObject(editor, caret, count, isOuter = false, isBig = false)
   if (wordRange.startOffset == wordRange.endOffset) return
   val originalWord = editor.text().substring(wordRange.startOffset, wordRange.endOffset)
   val recased = targetStyle.recase(originalWord)

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/AbolishExtension.kt
@@ -24,9 +24,12 @@ import com.maddyhome.idea.vim.extension.VimExtensionFacade.putExtensionHandlerMa
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMapping
 import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMappingIfMissing
 import com.maddyhome.idea.vim.extension.exportOperatorFunction
+import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.key.OperatorFunction
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.state.mode.SelectionType
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDictionary
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 import javax.swing.KeyStroke
 
 /**
@@ -46,9 +49,28 @@ internal class AbolishExtension : VimExtension {
   override fun init() {
     VimExtensionFacade.exportOperatorFunction(OPERATOR_FUNC, CoercionOperator())
     COERCIONS.forEach(::registerCoercion)
+    registerUserDefinedCoercions()
     val subvert = SubvertCommand()
     addCommand("Subvert", subvert)
     addCommand("S", subvert)
+  }
+
+  /**
+   * Reads `g:abolish_coercions` (a dict of single-character → built-in style name)
+   * and binds each entry as an additional `cr<char>` mapping. Values that don't
+   * match a [CaseStyle] are silently skipped — same forgiving policy tpope has
+   * for unknown letters.
+   */
+  private fun registerUserDefinedCoercions() {
+    val dict = VimPlugin.getVariableService().getGlobalVariableValue(USER_COERCIONS_VARIABLE) as? VimDictionary ?: return
+    dict.dictionary.forEach { (charKey, styleValue) ->
+      val char = charKey.value.singleOrNull() ?: return@forEach
+      val styleName = (styleValue as? VimString)?.value ?: return@forEach
+      val style = CaseStyle.entries.firstOrNull { it.name.equals(styleName, ignoreCase = true) } ?: return@forEach
+      val plugWord = injector.parser.parseKeys("<Plug>(abolish-coerce-word-${style.name.lowercase()})")
+      val plugOperator = injector.parser.parseKeys("<Plug>(abolish-coerce-${style.name.lowercase()})")
+      bindAlias("cr$char", plugWord, plugOperator)
+    }
   }
 
   private fun registerCoercion(coercion: Coercion) {
@@ -91,6 +113,7 @@ internal class AbolishExtension : VimExtension {
 
   private companion object {
     private const val OPERATOR_FUNC = "AbolishCoerce"
+    private const val USER_COERCIONS_VARIABLE = "abolish_coercions"
 
     private val COERCIONS = listOf(
       Coercion(CaseStyle.SNAKE, primaryKey = "crs", aliases = listOf("cr_")),

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/BraceExpansion.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/BraceExpansion.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.extension.abolish
+
+/**
+ * `foo{a,b,c}bar` parsed as `prefix + {alternatives} + suffix`.
+ *
+ * Patterns without braces become a literal with a single empty alternative.
+ * Empty braces (`anomal{}`) are a slot the other side of a substitution can
+ * fill — see [materialiseWith].
+ */
+internal data class BracePattern(
+  val prefix: String,
+  val alternatives: List<String>,
+  val suffix: String,
+  val hasSlot: Boolean,
+) {
+
+  fun materialise(): List<String> = alternatives.map { prefix + it + suffix }
+
+  /** Expand using a foreign list of alternatives, falling back to repeating the literal when there is no slot. */
+  fun materialiseWith(foreign: List<String>): List<String> {
+    if (!hasSlot) return List(foreign.size) { prefix + suffix }
+    return foreign.map { prefix + it + suffix }
+  }
+}
+
+internal fun parseBraces(pattern: String): BracePattern {
+  val openIndex = pattern.indexOf('{')
+  val closeIndex = pattern.indexOf('}', startIndex = openIndex + 1)
+  if (openIndex < 0 || closeIndex < 0) {
+    return BracePattern(prefix = pattern, alternatives = listOf(""), suffix = "", hasSlot = false)
+  }
+
+  val prefix = pattern.substring(0, openIndex)
+  val suffix = pattern.substring(closeIndex + 1)
+  val rawAlternatives = pattern.substring(openIndex + 1, closeIndex)
+  val alternatives = if (rawAlternatives.isEmpty()) listOf("") else rawAlternatives.split(',')
+  return BracePattern(prefix, alternatives, suffix, hasSlot = true)
+}

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/BraceExpansion.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/BraceExpansion.kt
@@ -29,6 +29,9 @@ internal data class BracePattern(
     if (!hasSlot) return List(foreign.size) { prefix + suffix }
     return foreign.map { prefix + it + suffix }
   }
+
+  fun materialiseCycling(count: Int): List<String> =
+    List(count) { i -> prefix + alternatives[i % alternatives.size] + suffix }
 }
 
 internal fun parseBraces(pattern: String): BracePattern {

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/CaseStyle.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/CaseStyle.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.extension.abolish
+
+/** Joins atoms in a particular case convention; `recase` is the round-trip with [splitIntoAtoms]. */
+internal enum class CaseStyle {
+  SNAKE {
+    override fun join(atoms: List<String>) = atoms.joinLowercase(separator = "_")
+  },
+  UPPER_SNAKE {
+    override fun join(atoms: List<String>) = atoms.joinUppercase(separator = "_")
+  },
+  KEBAB {
+    override fun join(atoms: List<String>) = atoms.joinLowercase(separator = "-")
+  },
+  DOT {
+    override fun join(atoms: List<String>) = atoms.joinLowercase(separator = ".")
+  },
+  SPACE {
+    override fun join(atoms: List<String>) = atoms.joinLowercase(separator = " ")
+  },
+  TITLE {
+    override fun join(atoms: List<String>) = atoms.joinToString(separator = " ") { it.toTitleAtom() }
+  },
+  CAMEL {
+    override fun join(atoms: List<String>): String {
+      if (atoms.isEmpty()) return ""
+      val head = atoms.first().lowercase()
+      val tail = atoms.drop(1).joinToString(separator = "") { it.toTitleAtom() }
+      return head + tail
+    }
+  },
+  PASCAL {
+    override fun join(atoms: List<String>) = atoms.joinToString(separator = "") { it.toTitleAtom() }
+  },
+  ;
+
+  abstract fun join(atoms: List<String>): String
+
+  fun recase(word: String): String = join(splitIntoAtoms(word))
+}
+
+private fun List<String>.joinLowercase(separator: String): String =
+  joinToString(separator) { it.lowercase() }
+
+private fun List<String>.joinUppercase(separator: String): String =
+  joinToString(separator) { it.uppercase() }
+
+internal fun String.toTitleAtom(): String =
+  if (isEmpty()) this else this[0].uppercaseChar() + substring(1).lowercase()

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/SubvertCommand.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/SubvertCommand.kt
@@ -8,17 +8,26 @@
 
 package com.maddyhome.idea.vim.extension.abolish
 
+import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.common.CommandAliasHandler
 import com.maddyhome.idea.vim.ex.ranges.Range
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDataType
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDictionary
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 
 /**
  * `:[range]S /lhs/rhs/[flags]` — abolish's case-aware substitute, also reachable as `:Subvert`.
  *
- * Limitations vs. tpope's plugin: flags other than `g` are silently ignored;
- * the lhs is matched literally rather than as a vim regex.
+ * Delegates to vim's `:substitute` so users get every standard flag (`g`, `c`, etc.)
+ * Tpope uses the same trick: build the variant dictionary, stash it as a global,
+ * then run `:s/.../\=get(g:abolish_last_dict, submatch(0), submatch(0))/...`.
+ *
+ * The lhs is still matched literally — vim regex atoms aren't honoured, and
+ * `\1`-style backreferences in the rhs are stored verbatim in the dictionary.
+ * Abolish-specific flags `I`, `v`, `w` are silently dropped.
  */
 internal class SubvertCommand : CommandAliasHandler {
 
@@ -26,58 +35,50 @@ internal class SubvertCommand : CommandAliasHandler {
     val invocation = SubvertInvocation.parse(command) ?: return
     val dictionary = buildVariantDictionary(invocation.lhsPattern, invocation.rhsPattern)
     if (dictionary.isEmpty()) return
-    val matcher = Regex(buildAlternationPattern(dictionary.keys))
+
+    storeAsLastDict(dictionary)
     val lineRange = range.getLineRange(editor, editor.primaryCaret())
-    // One write action so the whole substitution is one undo step.
-    injector.application.runWriteAction {
-      applySubstitutionToLines(editor, lineRange.startLine, lineRange.endLine, matcher, dictionary, invocation.replaceAll)
-    }
+    val substitute = buildSubstituteCommand(dictionary.keys, invocation.flags, lineRange.startLine1, lineRange.endLine1)
+    injector.vimscriptExecutor.execute(substitute, editor, context, skipHistory = true, indicateErrors = true, null)
   }
 }
 
-private fun applySubstitutionToLines(
-  editor: VimEditor,
-  startLine: Int,
-  endLine: Int,
-  matcher: Regex,
-  dictionary: Map<String, String>,
-  replaceAll: Boolean,
-) {
-  for (line in startLine..endLine) {
-    val (lineStart, lineEnd) = editor.getLineRange(line)
-    val lineText = editor.text().substring(lineStart, lineEnd)
-    val newLineText = substituteInLine(lineText, matcher, dictionary, replaceAll) ?: continue
-    injector.changeGroup.replaceText(editor, editor.primaryCaret(), lineStart, lineEnd, newLineText)
-  }
+/** Pushes the dictionary into `g:abolish_last_dict` so `\=get(...)` can read it. */
+private fun storeAsLastDict(dictionary: Map<String, String>) {
+  val entries = LinkedHashMap<VimString, VimDataType>()
+  dictionary.forEach { (key, value) -> entries[VimString(key)] = VimString(value) }
+  VimPlugin.getVariableService().storeGlobalVariable("abolish_last_dict", VimDictionary(entries))
 }
 
-private fun substituteInLine(
-  lineText: String,
-  matcher: Regex,
-  dictionary: Map<String, String>,
-  replaceAll: Boolean,
-): String? {
-  val replaceMatch: (MatchResult) -> CharSequence = { match -> dictionary[match.value] ?: match.value }
-  val rewritten = if (replaceAll) {
-    matcher.replace(lineText, replaceMatch)
-  } else {
-    val firstMatch = matcher.find(lineText) ?: return null
-    val replacement = replaceMatch(firstMatch)
-    lineText.replaceRange(firstMatch.range, replacement)
-  }
-  return rewritten.takeIf { it != lineText }
+private fun buildSubstituteCommand(keys: Set<String>, flags: String, startLine1: Int, endLine1: Int): String {
+  val pattern = buildVimAlternationPattern(keys)
+  return "${startLine1},${endLine1}s/$pattern/\\=get(g:abolish_last_dict, submatch(0), submatch(0))/$flags"
 }
 
-// Longest-first so a prefix key (`box`) can't shadow a longer one (`boxes`).
-// `Regex.escape` keeps regex specials in user input harmless. No anchoring —
-// vim's `:substitute` doesn't anchor and neither does tpope's `:Subvert`.
-private fun buildAlternationPattern(keys: Set<String>): String =
-  keys.sortedByDescending(String::length).joinToString(separator = "|", transform = Regex::escape)
+/**
+ * Build the alternation pattern in vim's very-magic case-sensitive mode.
+ *
+ * Sort longest-first so `box` can't shadow `boxes`; escape vim regex specials
+ * with the same character set tpope uses in `s:subesc`.
+ */
+private fun buildVimAlternationPattern(keys: Set<String>): String {
+  val alternation = keys.sortedByDescending(String::length).joinToString(separator = "|", transform = ::vimEscape)
+  return "\\v\\C%($alternation)"
+}
+
+private val VIM_REGEX_SPECIALS = setOf(']', '[', '\\', '/', '.', '*', '+', '?', '~', '%', '(', ')', '&', '|')
+
+private fun vimEscape(input: String): String = buildString {
+  input.forEach { c ->
+    if (c in VIM_REGEX_SPECIALS) append('\\')
+    append(c)
+  }
+}
 
 private data class SubvertInvocation(
   val lhsPattern: String,
   val rhsPattern: String,
-  val replaceAll: Boolean,
+  val flags: String,
 ) {
   companion object {
     fun parse(commandLine: String): SubvertInvocation? {
@@ -90,7 +91,7 @@ private data class SubvertInvocation(
       val rhs = parts[1]
       val flags = parts.getOrNull(2).orEmpty()
       if (lhs.isEmpty()) return null
-      return SubvertInvocation(lhs, rhs, replaceAll = flags.contains('g'))
+      return SubvertInvocation(lhs, rhs, flags)
     }
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/SubvertCommand.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/SubvertCommand.kt
@@ -13,17 +13,22 @@ import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.common.CommandAliasHandler
+import com.maddyhome.idea.vim.common.Direction
 import com.maddyhome.idea.vim.ex.ranges.Range
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDataType
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDictionary
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 
 /**
- * `:[range]S /lhs/rhs/[flags]` — abolish's case-aware substitute, also reachable as `:Subvert`.
+ * `:[range]S /lhs/rhs/[flags]` — abolish's case-aware substitute (also reachable as `:Subvert`).
+ * `:S /pattern/` and `:S ?pattern?` — case-aware forward / backward search.
  *
- * Delegates to vim's `:substitute` so users get every standard flag (`g`, `c`, etc.)
- * Tpope uses the same trick: build the variant dictionary, stash it as a global,
- * then run `:s/.../\=get(g:abolish_last_dict, submatch(0), submatch(0))/...`.
+ * Substitute delegates to vim's `:substitute` so the standard `:s` flag set
+ * (`g`, `c`, etc.) passes through. Tpope uses the same trick: build the variant
+ * dictionary, stash it as `g:abolish_last_dict`, then run
+ * `:s/.../\=get(g:abolish_last_dict, submatch(0), submatch(0))/...`. Search
+ * builds the same variant alternation and feeds it directly to vim's `/` and
+ * `?` machinery.
  *
  * The lhs is still matched literally — vim regex atoms aren't honoured, and
  * `\1`-style backreferences in the rhs are stored verbatim in the dictionary.
@@ -32,14 +37,34 @@ import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 internal class SubvertCommand : CommandAliasHandler {
 
   override fun execute(command: String, range: Range, editor: VimEditor, context: ExecutionContext) {
-    val invocation = SubvertInvocation.parse(command) ?: return
-    val dictionary = buildVariantDictionary(invocation.lhsPattern, invocation.rhsPattern)
-    if (dictionary.isEmpty()) return
+    when (val invocation = SubvertInvocation.parse(command) ?: return) {
+      is SubvertInvocation.Substitute -> executeSubstitute(invocation, range, editor, context)
+      is SubvertInvocation.Search -> executeSearch(invocation, editor)
+    }
+  }
+}
 
-    storeAsLastDict(dictionary)
-    val lineRange = range.getLineRange(editor, editor.primaryCaret())
-    val substitute = buildSubstituteCommand(dictionary.keys, invocation.flags, lineRange.startLine1, lineRange.endLine1)
-    injector.vimscriptExecutor.execute(substitute, editor, context, skipHistory = true, indicateErrors = true, null)
+private fun executeSubstitute(
+  invocation: SubvertInvocation.Substitute,
+  range: Range,
+  editor: VimEditor,
+  context: ExecutionContext,
+) {
+  val dictionary = buildVariantDictionary(invocation.lhsPattern, invocation.rhsPattern)
+  if (dictionary.isEmpty()) return
+  storeAsLastDict(dictionary)
+  val lineRange = range.getLineRange(editor, editor.primaryCaret())
+  val substitute = buildSubstituteCommand(dictionary.keys, invocation.flags, lineRange.startLine1, lineRange.endLine1)
+  injector.vimscriptExecutor.execute(substitute, editor, context, skipHistory = true, indicateErrors = true, null)
+}
+
+private fun executeSearch(invocation: SubvertInvocation.Search, editor: VimEditor) {
+  val dictionary = buildVariantDictionary(invocation.pattern, "")
+  if (dictionary.isEmpty()) return
+  val pattern = buildVimAlternationPattern(dictionary.keys)
+  val startOffset = editor.primaryCaret().offset
+  injector.searchGroup.processSearchCommand(editor, pattern, startOffset, 1, invocation.direction)?.let { (offset, _) ->
+    editor.primaryCaret().moveToOffset(offset)
   }
 }
 
@@ -75,23 +100,30 @@ private fun vimEscape(input: String): String = buildString {
   }
 }
 
-private data class SubvertInvocation(
-  val lhsPattern: String,
-  val rhsPattern: String,
-  val flags: String,
-) {
+private sealed interface SubvertInvocation {
+
+  data class Substitute(val lhsPattern: String, val rhsPattern: String, val flags: String) : SubvertInvocation
+
+  data class Search(val pattern: String, val direction: Direction) : SubvertInvocation
+
   companion object {
     fun parse(commandLine: String): SubvertInvocation? {
       val arguments = commandLine.trim().substringAfter(' ', missingDelimiterValue = "").trim()
       if (arguments.length < 2) return null
       val delimiter = arguments[0]
       val parts = arguments.drop(1).split(delimiter)
-      if (parts.size < 2) return null
-      val lhs = parts[0]
+      val lhs = parts.firstOrNull().orEmpty()
+      if (lhs.isEmpty()) return null
+
+      val direction = if (delimiter == '?') Direction.BACKWARDS else Direction.FORWARDS
+      if (parts.hasNoReplacement()) return Search(lhs, direction)
+
       val rhs = parts[1]
       val flags = parts.getOrNull(2).orEmpty()
-      if (lhs.isEmpty()) return null
-      return SubvertInvocation(lhs, rhs, flags)
+      return Substitute(lhs, rhs, flags)
     }
+
+    private fun List<String>.hasNoReplacement(): Boolean =
+      size == 1 || (size == 2 && this[1].isEmpty())
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/SubvertCommand.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/SubvertCommand.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.extension.abolish
+
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.common.CommandAliasHandler
+import com.maddyhome.idea.vim.ex.ranges.Range
+
+/**
+ * `:[range]S /lhs/rhs/[flags]` — abolish's case-aware substitute, also reachable as `:Subvert`.
+ *
+ * Limitations vs. tpope's plugin: flags other than `g` are silently ignored;
+ * the lhs is matched literally rather than as a vim regex.
+ */
+internal class SubvertCommand : CommandAliasHandler {
+
+  override fun execute(command: String, range: Range, editor: VimEditor, context: ExecutionContext) {
+    val invocation = SubvertInvocation.parse(command) ?: return
+    val dictionary = buildVariantDictionary(invocation.lhsPattern, invocation.rhsPattern)
+    if (dictionary.isEmpty()) return
+    val matcher = Regex(buildAlternationPattern(dictionary.keys))
+    val lineRange = range.getLineRange(editor, editor.primaryCaret())
+    // One write action so the whole substitution is one undo step.
+    injector.application.runWriteAction {
+      applySubstitutionToLines(editor, lineRange.startLine, lineRange.endLine, matcher, dictionary, invocation.replaceAll)
+    }
+  }
+}
+
+private fun applySubstitutionToLines(
+  editor: VimEditor,
+  startLine: Int,
+  endLine: Int,
+  matcher: Regex,
+  dictionary: Map<String, String>,
+  replaceAll: Boolean,
+) {
+  for (line in startLine..endLine) {
+    val (lineStart, lineEnd) = editor.getLineRange(line)
+    val lineText = editor.text().substring(lineStart, lineEnd)
+    val newLineText = substituteInLine(lineText, matcher, dictionary, replaceAll) ?: continue
+    injector.changeGroup.replaceText(editor, editor.primaryCaret(), lineStart, lineEnd, newLineText)
+  }
+}
+
+private fun substituteInLine(
+  lineText: String,
+  matcher: Regex,
+  dictionary: Map<String, String>,
+  replaceAll: Boolean,
+): String? {
+  val replaceMatch: (MatchResult) -> CharSequence = { match -> dictionary[match.value] ?: match.value }
+  val rewritten = if (replaceAll) {
+    matcher.replace(lineText, replaceMatch)
+  } else {
+    val firstMatch = matcher.find(lineText) ?: return null
+    val replacement = replaceMatch(firstMatch)
+    lineText.replaceRange(firstMatch.range, replacement)
+  }
+  return rewritten.takeIf { it != lineText }
+}
+
+// Longest-first so a prefix key (`box`) can't shadow a longer one (`boxes`).
+// `Regex.escape` keeps regex specials in user input harmless. No anchoring —
+// vim's `:substitute` doesn't anchor and neither does tpope's `:Subvert`.
+private fun buildAlternationPattern(keys: Set<String>): String =
+  keys.sortedByDescending(String::length).joinToString(separator = "|", transform = Regex::escape)
+
+private data class SubvertInvocation(
+  val lhsPattern: String,
+  val rhsPattern: String,
+  val replaceAll: Boolean,
+) {
+  companion object {
+    fun parse(commandLine: String): SubvertInvocation? {
+      val arguments = commandLine.trim().substringAfter(' ', missingDelimiterValue = "").trim()
+      if (arguments.length < 2) return null
+      val delimiter = arguments[0]
+      val parts = arguments.drop(1).split(delimiter)
+      if (parts.size < 2) return null
+      val lhs = parts[0]
+      val rhs = parts[1]
+      val flags = parts.getOrNull(2).orEmpty()
+      if (lhs.isEmpty()) return null
+      return SubvertInvocation(lhs, rhs, replaceAll = flags.contains('g'))
+    }
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/VariantDictionary.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/VariantDictionary.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.extension.abolish
+
+/**
+ * The lookup table that powers `:Subvert`: every `(lhs, rhs)` pair contributes
+ * three case-variants — lowercase, capitalised-first and UPPERCASE — and brace
+ * alternatives multiply the pairs.
+ */
+internal fun buildVariantDictionary(lhsPattern: String, rhsPattern: String): Map<String, String> {
+  val dictionary = mutableMapOf<String, String>()
+  expandAllBraces(lhsPattern, rhsPattern).forEach { (lhsWord, rhsWord) ->
+    addCaseVariants(dictionary, lhsWord, rhsWord)
+  }
+  return dictionary
+}
+
+/**
+ * One brace per pass, then recurse — same trick as tpope's `s:expand_braces`.
+ * Each call strictly reduces the brace count, so the recursion terminates.
+ */
+private fun expandAllBraces(lhs: String, rhs: String): List<Pair<String, String>> {
+  val lhsBrace = parseBraces(lhs)
+  if (!lhsBrace.hasSlot) return listOf(lhs to rhs)
+
+  val rhsBrace = parseBraces(rhs)
+  return pairAlternatives(lhsBrace, rhsBrace).flatMap { (l, r) -> expandAllBraces(l, r) }
+}
+
+private fun pairAlternatives(lhs: BracePattern, rhs: BracePattern): List<Pair<String, String>> {
+  val rhsVariants = if (rhs.borrowsAlternatives()) rhs.materialiseWith(lhs.alternatives) else rhs.materialise()
+  return lhs.materialise().zip(rhsVariants)
+}
+
+private fun BracePattern.borrowsAlternatives(): Boolean = !hasSlot || alternatives == listOf("")
+
+private fun addCaseVariants(dictionary: MutableMap<String, String>, lhs: String, rhs: String) {
+  dictionary[lhs.lowercase()] = rhs.lowercase()
+  // PascalCase variant — tpope's `mixedcase`. Snake-cased input also matches camel/Pascal occurrences.
+  dictionary[CaseStyle.PASCAL.recase(lhs)] = CaseStyle.PASCAL.recase(rhs)
+  dictionary[lhs.uppercase()] = rhs.uppercase()
+}

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/VariantDictionary.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/VariantDictionary.kt
@@ -34,8 +34,19 @@ private fun expandAllBraces(lhs: String, rhs: String): List<Pair<String, String>
 }
 
 private fun pairAlternatives(lhs: BracePattern, rhs: BracePattern): List<Pair<String, String>> {
-  val rhsVariants = if (rhs.borrowsAlternatives()) rhs.materialiseWith(lhs.alternatives) else rhs.materialise()
-  return lhs.materialise().zip(rhsVariants)
+  val lhsVariants = lhs.materialise()
+  val rhsVariants = generateRhsVariants(rhs, lhs, lhsVariants)
+  return lhsVariants.zip(rhsVariants)
+}
+
+private fun generateRhsVariants(
+  rhs: BracePattern,
+  lhs: BracePattern,
+  lhsVariants: List<String>,
+): List<String> = if (rhs.borrowsAlternatives()) {
+  rhs.materialiseWith(lhs.alternatives)
+} else {
+  rhs.materialiseCycling(lhsVariants.size)
 }
 
 private fun BracePattern.borrowsAlternatives(): Boolean = !hasSlot || alternatives == listOf("")

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/WordAtoms.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/WordAtoms.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.extension.abolish
+
+/**
+ * Splits a word into case-style-agnostic atoms so it can be re-joined in any
+ * other style. Boundaries: the separators `_ - . space`, the lower→upper
+ * transition (`fooBar`), and the end of an acronym (`HTTPRequest`).
+ */
+internal fun splitIntoAtoms(word: String): List<String> {
+  if (word.isEmpty()) return emptyList()
+
+  val atoms = mutableListOf<String>()
+  val current = StringBuilder()
+
+  fun flush() {
+    if (current.isNotEmpty()) {
+      atoms += current.toString()
+      current.clear()
+    }
+  }
+
+  for (index in word.indices) {
+    val ch = word[index]
+    if (isAtomSeparator(ch)) {
+      flush()
+      continue
+    }
+    if (isAtomBoundary(word, index)) {
+      flush()
+    }
+    current.append(ch)
+  }
+  flush()
+  return atoms
+}
+
+private fun isAtomSeparator(ch: Char): Boolean = ch == '_' || ch == '-' || ch == '.' || ch == ' '
+
+private fun isAtomBoundary(word: String, index: Int): Boolean {
+  if (index == 0) return false
+  val prev = word[index - 1]
+  val curr = word[index]
+
+  if (prev.isLowerCase() && curr.isUpperCase()) return true
+
+  // Acronym end ("HTTP|Request"): a one-char lookahead distinguishes the end
+  // of a run of caps from the middle of one.
+  val next = word.getOrNull(index + 1)
+  if (prev.isUpperCase() && curr.isUpperCase() && next != null && next.isLowerCase()) return true
+
+  return false
+}

--- a/src/main/java/com/maddyhome/idea/vim/extension/abolish/WordAtoms.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/abolish/WordAtoms.kt
@@ -49,6 +49,7 @@ private fun isAtomBoundary(word: String, index: Int): Boolean {
   val curr = word[index]
 
   if (prev.isLowerCase() && curr.isUpperCase()) return true
+  if (prev.isDigit() && curr.isUpperCase()) return true
 
   // Acronym end ("HTTP|Request"): a one-char lookahead distinguishes the end
   // of a run of caps from the middle of one.

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -179,6 +179,7 @@ class SetCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
       |--- Options ---
+      |noabolish           nohlsearch            operatorfunc=     nosurround
       |noargtextobj          ide=IntelliJ IDEA norelativenumber    notextobj-entire
       |nobomb              noideajoin            scroll=0          notextobj-indent
       |nobreakindent         ideamarks           scrolljump=1        textwidth=0
@@ -194,7 +195,6 @@ class SetCommandTest : VimTestCase() {
       |nogdefault          noNERDTree          nosmartcase           wrap
       |nohighlightedyank     nrformats=hex     nosneak               wrapscan
       |  history=50        nonumber              startofline
-      |nohlsearch            operatorfunc=     nosurround
       |  clipboard=ideaput,autoselect
       |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
       |  fileencoding=utf-8
@@ -254,6 +254,7 @@ class SetCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
     |--- Options ---
+    |noabolish
     |noargtextobj
     |nobomb
     |nobreakindent

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
@@ -432,6 +432,7 @@ class SetglobalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
     |--- Global option values ---
+    |noabolish             history=50        nonumber              startofline
     |noargtextobj        nohlsearch            operatorfunc=     nosurround
     |nobomb                ide=IntelliJ IDEA norelativenumber    notextobj-entire
     |nobreakindent       noideajoin            scroll=0          notextobj-indent
@@ -447,7 +448,6 @@ class SetglobalCommandTest : VimTestCase() {
     |nofunctextobj       nomultiple-cursors    sidescrolloff=0     whichwrap=b,s
     |nogdefault          noNERDTree          nosmartcase           wrap
     |nohighlightedyank     nrformats=hex     nosneak               wrapscan
-    |  history=50        nonumber              startofline
     |  clipboard=ideaput,autoselect
     |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
@@ -507,6 +507,7 @@ class SetglobalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
     |--- Global option values ---
+    |noabolish
     |noargtextobj
     |nobomb
     |nobreakindent

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
@@ -484,6 +484,7 @@ class SetlocalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
     |--- Local option values ---
+    |noabolish           nohlsearch          nonumber              startofline
     |noargtextobj          ide=IntelliJ IDEA   operatorfunc=     nosurround
     |nobomb              --ideajoin          norelativenumber    notextobj-entire
     |nobreakindent         ideamarks           scroll=0          notextobj-indent
@@ -499,7 +500,6 @@ class SetlocalCommandTest : VimTestCase() {
     |nogdefault          nomultiple-cursors    sidescrolloff=-1    wrap
     |nohighlightedyank   noNERDTree          nosmartcase           wrapscan
     |  history=50          nrformats=hex     nosneak
-    |nohlsearch          nonumber              startofline
     |  clipboard=ideaput,autoselect
     |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |  fileencoding=utf-8
@@ -559,6 +559,7 @@ class SetlocalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
     |--- Local option values ---
+    |noabolish
     |noargtextobj
     |nobomb
     |nobreakindent

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
@@ -111,4 +111,20 @@ class AbolishCoercionTest : VimTestCase() {
       Mode.NORMAL(),
     )
   }
+
+  @Test
+  fun `coerce-snake plug mapping accepts a motion target`() {
+    configureByText("let helloW${c}orld = 1")
+    enterCommand("nmap gs <Plug>(abolish-coerce-snake)")
+    typeText("gsiw")
+    assertState("let ${c}hello_world = 1")
+  }
+
+  @Test
+  fun `coerce-snake plug mapping with end-of-word motion`() {
+    configureByText("${c}fooBar baz")
+    enterCommand("nmap gs <Plug>(abolish-coerce-snake)")
+    typeText("gse")
+    assertState("${c}foo_bar baz")
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
@@ -157,4 +157,24 @@ class AbolishCoercionTest : VimTestCase() {
       Mode.NORMAL(),
     )
   }
+
+  @Test
+  fun `crp is an alias for PascalCase coercion`() {
+    doTest("crp", "let hello_${c}world = 1", "let ${c}HelloWorld = 1", Mode.NORMAL())
+  }
+
+  @Test
+  fun `cr_ is an alias for snake_case coercion`() {
+    doTest("cr_", "let helloW${c}orld = 1", "let ${c}hello_world = 1", Mode.NORMAL())
+  }
+
+  @Test
+  fun `crk is an alias for kebab-case coercion`() {
+    doTest("crk", "let hello_${c}world = 1", "let ${c}hello-world = 1", Mode.NORMAL())
+  }
+
+  @Test
+  fun `crU is an alias for UPPER_SNAKE coercion`() {
+    doTest("crU", "let hello_${c}world = 1", "let ${c}HELLO_WORLD = 1", Mode.NORMAL())
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.abolish
+
+import com.maddyhome.idea.vim.state.mode.Mode
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+
+class AbolishCoercionTest : VimTestCase() {
+
+  @BeforeEach
+  override fun setUp(testInfo: TestInfo) {
+    super.setUp(testInfo)
+    enableExtensions("abolish")
+  }
+
+  @Test
+  fun `crs converts camelCase under cursor to snake_case`() {
+    doTest(
+      "crs",
+      "let helloW${c}orld = 1",
+      "let ${c}hello_world = 1",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `crm converts snake_case under cursor to PascalCase`() {
+    doTest(
+      "crm",
+      "let hello_${c}world = 1",
+      "let ${c}HelloWorld = 1",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `crc converts snake_case under cursor to camelCase`() {
+    doTest(
+      "crc",
+      "let hello_${c}world = 1",
+      "let ${c}helloWorld = 1",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `cru converts snake_case under cursor to UPPER_SNAKE`() {
+    doTest(
+      "cru",
+      "let hello_${c}world = 1",
+      "let ${c}HELLO_WORLD = 1",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `cr- converts snake_case under cursor to kebab-case`() {
+    doTest(
+      "cr-",
+      "let hello_${c}world = 1",
+      "let ${c}hello-world = 1",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `cr-dot converts snake_case under cursor to dot-case`() {
+    doTest(
+      "cr.",
+      "let hello_${c}world = 1",
+      "let ${c}hello.world = 1",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `crt converts snake_case under cursor to Title Case`() {
+    doTest(
+      "crt",
+      "let hello_${c}world = 1",
+      "let ${c}Hello World = 1",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `crs recases each word independently in multi-caret mode`() {
+    doTest(
+      "crs",
+      "fooBa${c}r and bazQu${c}x",
+      "${c}foo_bar and ${c}baz_qux",
+      Mode.NORMAL(),
+    )
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
@@ -127,4 +127,24 @@ class AbolishCoercionTest : VimTestCase() {
     typeText("gse")
     assertState("${c}foo_bar baz")
   }
+
+  @Test
+  fun `crs in visual mode recases the selected text`() {
+    doTest(
+      "viwcrs",
+      "let helloW${c}orld = 1",
+      "let ${c}hello_world = 1",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `crm in visual mode recases a multi-word selection`() {
+    doTest(
+      "v2ecrm",
+      "${c}hello world end",
+      "${c}HelloWorld end",
+      Mode.NORMAL(),
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
@@ -101,4 +101,14 @@ class AbolishCoercionTest : VimTestCase() {
       Mode.NORMAL(),
     )
   }
+
+  @Test
+  fun `crs splits between a digit and an uppercase letter`() {
+    doTest(
+      "crs",
+      "let foo2Ba${c}r = 1",
+      "let ${c}foo2_bar = 1",
+      Mode.NORMAL(),
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
@@ -177,4 +177,14 @@ class AbolishCoercionTest : VimTestCase() {
   fun `crU is an alias for UPPER_SNAKE coercion`() {
     doTest("crU", "let hello_${c}world = 1", "let ${c}HELLO_WORLD = 1", Mode.NORMAL())
   }
+
+  @Test
+  fun `g abolish_coercions registers a user-defined coercion key`() {
+    configureByText("let hello_${c}world = 1")
+    enterCommand("let g:abolish_coercions = {'q': 'kebab'}")
+    enterCommand("set noabolish")
+    enterCommand("set abolish")
+    typeText("crq")
+    assertState("let ${c}hello-world = 1")
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishCoercionTest.kt
@@ -147,4 +147,14 @@ class AbolishCoercionTest : VimTestCase() {
       Mode.NORMAL(),
     )
   }
+
+  @Test
+  fun `crs with a count extends the inner-word range`() {
+    doTest(
+      "3crs",
+      "${c}fooBar bazQux end",
+      "${c}foo_bar_baz_qux end",
+      Mode.NORMAL(),
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.abolish
+
+import com.maddyhome.idea.vim.state.mode.Mode
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+
+class AbolishSubvertTest : VimTestCase() {
+
+  @BeforeEach
+  override fun setUp(testInfo: TestInfo) {
+    super.setUp(testInfo)
+    enableExtensions("abolish")
+  }
+
+  @Test
+  fun `S replaces all three case variants on the current line`() {
+    doTest(
+      ":S /foo/bar/g<CR>",
+      "${c}foo and Foo and FOO end",
+      "${c}bar and Bar and BAR end",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `S with brace alternatives pairs singular and plural variants`() {
+    doTest(
+      ":S /box{,es}/bag{,s}/g<CR>",
+      "${c}box Box BOX boxes Boxes BOXES",
+      "${c}bag Bag BAG bags Bags BAGS",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `S with placeholder reuses lhs alternatives in rhs`() {
+    doTest(
+      ":S /anomol{y,ies}/anomal{}/g<CR>",
+      "${c}anomoly Anomoly ANOMOLY anomolies",
+      "${c}anomaly Anomaly ANOMALY anomalies",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `Subvert long name works the same as S`() {
+    doTest(
+      ":Subvert /foo/bar/g<CR>",
+      "${c}foo Foo FOO end",
+      "${c}bar Bar BAR end",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `S matches inside larger identifiers like substitute does`() {
+    doTest(
+      ":S /request/record/g<CR>",
+      "${c}setRequestId(String requestId) REQUEST_ID",
+      "${c}setRecordId(String recordId) RECORD_ID",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `S without g flag replaces only the first match per line`() {
+    doTest(
+      ":S /foo/bar/<CR>",
+      "${c}foo Foo FOO",
+      "${c}bar Foo FOO",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `S with two brace groups expands multiplicatively`() {
+    doTest(
+      ":S /{a,b}_{x,y}/{p,q}_{r,s}/g<CR>",
+      "${c}a_x b_y a_y b_x",
+      "${c}p_r q_s p_s q_r",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `S on snake_case input also rewrites PascalCase occurrences`() {
+    doTest(
+      ":S /foo_bar/baz_qux/g<CR>",
+      "${c}foo_bar and FooBar and FOO_BAR",
+      "${c}baz_qux and BazQux and BAZ_QUX",
+      Mode.NORMAL(),
+    )
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
@@ -132,4 +132,34 @@ class AbolishSubvertTest : VimTestCase() {
     )
   }
 
+  @Test
+  fun `S without rhs searches forward across case variants`() {
+    doTest(
+      ":S/foo<CR>",
+      "${c}begin FOO middle Foo end foo",
+      "begin ${c}FOO middle Foo end foo",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `S with question mark delimiter searches backward`() {
+    doTest(
+      ":S?foo<CR>",
+      "begin Foo middle FOO end ${c}some here",
+      "begin Foo middle ${c}FOO end some here",
+      Mode.NORMAL(),
+    )
+  }
+
+  @Test
+  fun `n key navigates to the next match after a S search`() {
+    doTest(
+      listOf(":S/foo<CR>", "n"),
+      "${c}begin FOO middle Foo end foo",
+      "begin FOO middle ${c}Foo end foo",
+      Mode.NORMAL(),
+    )
+  }
+
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
@@ -111,4 +111,14 @@ class AbolishSubvertTest : VimTestCase() {
       Mode.NORMAL(),
     )
   }
+
+  @Test
+  fun `S accepts no space between command and pattern`() {
+    doTest(
+      ":S/foo/bar/g<CR>",
+      "${c}foo Foo FOO",
+      "${c}bar Bar BAR",
+      Mode.NORMAL(),
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
@@ -101,4 +101,14 @@ class AbolishSubvertTest : VimTestCase() {
       Mode.NORMAL(),
     )
   }
+
+  @Test
+  fun `S cycles rhs alternatives when lhs has more of them`() {
+    doTest(
+      ":S /{red,green,blue,yellow}/{warm,cool}/g<CR>",
+      "${c}red green blue yellow",
+      "${c}warm cool warm cool",
+      Mode.NORMAL(),
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/AbolishSubvertTest.kt
@@ -121,4 +121,15 @@ class AbolishSubvertTest : VimTestCase() {
       Mode.NORMAL(),
     )
   }
+
+  @Test
+  fun `S with c flag prompts before each match and applies according to user choice`() {
+    doTest(
+      listOf(":S/foo/bar/gc<CR>", "y", "n", "y"),
+      "${c}foo Foo FOO",
+      "${c}bar Foo BAR",
+      Mode.NORMAL(),
+    )
+  }
+
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/BraceExpansionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/BraceExpansionTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.abolish
+
+import com.maddyhome.idea.vim.extension.abolish.parseBraces
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class BraceExpansionTest {
+
+  @Test
+  fun `a pattern with no braces is a single variant`() {
+    val expansion = parseBraces("hello")
+    assertEquals(listOf("hello"), expansion.materialise())
+  }
+
+  @Test
+  fun `braces expand to one variant per alternative`() {
+    val expansion = parseBraces("foo{a,b,c}bar")
+    assertEquals(listOf("fooabar", "foobbar", "foocbar"), expansion.materialise())
+  }
+
+  @Test
+  fun `empty alternative is allowed`() {
+    val expansion = parseBraces("box{,es}")
+    assertEquals(listOf("box", "boxes"), expansion.materialise())
+  }
+
+  @Test
+  fun `empty braces have no alternatives of their own`() {
+    val expansion = parseBraces("anomal{}")
+    assertEquals(listOf("anomal"), expansion.materialise())
+  }
+
+  @Test
+  fun `materialise with override substitutes external alternatives into the slot`() {
+    val expansion = parseBraces("anomal{}")
+    assertEquals(listOf("anomaly", "anomalies"), expansion.materialiseWith(listOf("y", "ies")))
+  }
+
+  @Test
+  fun `materialiseWith on a literal pattern repeats it for each alternative`() {
+    val expansion = parseBraces("hello")
+    assertEquals(listOf("hello", "hello"), expansion.materialiseWith(listOf("a", "b")))
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/CaseStyleTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/CaseStyleTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.abolish
+
+import com.maddyhome.idea.vim.extension.abolish.CaseStyle
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class CaseStyleTest {
+
+  @Test
+  fun `snake_case joins atoms with underscores in lowercase`() {
+    assertEquals("hello_world_again", CaseStyle.SNAKE.join(listOf("Hello", "world", "AGAIN")))
+  }
+
+  @Test
+  fun `UPPER_SNAKE joins atoms with underscores in uppercase`() {
+    assertEquals("HELLO_WORLD", CaseStyle.UPPER_SNAKE.join(listOf("hello", "world")))
+  }
+
+  @Test
+  fun `kebab-case joins atoms with dashes in lowercase`() {
+    assertEquals("hello-world", CaseStyle.KEBAB.join(listOf("Hello", "World")))
+  }
+
+  @Test
+  fun `dot-case joins atoms with dots in lowercase`() {
+    assertEquals("hello.world", CaseStyle.DOT.join(listOf("Hello", "World")))
+  }
+
+  @Test
+  fun `space case joins atoms with spaces in lowercase`() {
+    assertEquals("hello world", CaseStyle.SPACE.join(listOf("Hello", "World")))
+  }
+
+  @Test
+  fun `title case capitalises every atom and joins with spaces`() {
+    assertEquals("Hello World", CaseStyle.TITLE.join(listOf("hello", "WORLD")))
+  }
+
+  @Test
+  fun `camelCase lowercases the first atom and capitalises the rest`() {
+    assertEquals("helloWorldAgain", CaseStyle.CAMEL.join(listOf("hello", "world", "again")))
+  }
+
+  @Test
+  fun `PascalCase capitalises every atom and concatenates`() {
+    assertEquals("HelloWorld", CaseStyle.PASCAL.join(listOf("hello", "world")))
+  }
+
+  @Test
+  fun `joining no atoms yields empty string`() {
+    assertEquals("", CaseStyle.SNAKE.join(emptyList()))
+  }
+
+  @Test
+  fun `recase converts camelCase to snake_case`() {
+    assertEquals("hello_world", CaseStyle.SNAKE.recase("helloWorld"))
+  }
+
+  @Test
+  fun `recase converts snake_case to PascalCase`() {
+    assertEquals("HelloWorld", CaseStyle.PASCAL.recase("hello_world"))
+  }
+
+  @Test
+  fun `recase converts kebab to UPPER_SNAKE`() {
+    assertEquals("HELLO_WORLD", CaseStyle.UPPER_SNAKE.recase("hello-world"))
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/VariantDictionaryTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/VariantDictionaryTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.abolish
+
+import com.maddyhome.idea.vim.extension.abolish.buildVariantDictionary
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class VariantDictionaryTest {
+
+  @Test
+  fun `a single pair produces three case variants`() {
+    val dict = buildVariantDictionary("foo", "bar")
+    assertEquals(
+      mapOf(
+        "foo" to "bar",
+        "Foo" to "Bar",
+        "FOO" to "BAR",
+      ),
+      dict,
+    )
+  }
+
+  @Test
+  fun `brace alternatives become separate dictionary entries`() {
+    val dict = buildVariantDictionary("box{,es}", "bag{,s}")
+    assertEquals(
+      mapOf(
+        "box" to "bag", "Box" to "Bag", "BOX" to "BAG",
+        "boxes" to "bags", "Boxes" to "Bags", "BOXES" to "BAGS",
+      ),
+      dict,
+    )
+  }
+
+  @Test
+  fun `empty braces on the rhs reuse the lhs alternatives`() {
+    val dict = buildVariantDictionary("anomol{y,ies}", "anomal{}")
+    assertEquals(
+      mapOf(
+        "anomoly" to "anomaly", "Anomoly" to "Anomaly", "ANOMOLY" to "ANOMALY",
+        "anomolies" to "anomalies", "Anomolies" to "Anomalies", "ANOMOLIES" to "ANOMALIES",
+      ),
+      dict,
+    )
+  }
+
+  @Test
+  fun `mixedcase already-capitalised lhs preserves its capitalisation`() {
+    val dict = buildVariantDictionary("FooBar", "BazQux")
+    assertEquals(
+      mapOf(
+        "foobar" to "bazqux",
+        "FooBar" to "BazQux",
+        "FOOBAR" to "BAZQUX",
+      ),
+      dict,
+    )
+  }
+
+  @Test
+  fun `two brace groups pair lockstep at each position and multiply across positions`() {
+    val dict = buildVariantDictionary("{a,b}_{x,y}", "{p,q}_{r,s}")
+    // PascalCase of single-letter atoms collapses to the uppercase form without the separator.
+    assertEquals(
+      mapOf(
+        "a_x" to "p_r", "AX" to "PR", "A_X" to "P_R",
+        "a_y" to "p_s", "AY" to "PS", "A_Y" to "P_S",
+        "b_x" to "q_r", "BX" to "QR", "B_X" to "Q_R",
+        "b_y" to "q_s", "BY" to "QS", "B_Y" to "Q_S",
+      ),
+      dict,
+    )
+  }
+
+  @Test
+  fun `snake_case lhs also matches PascalCase variant`() {
+    val dict = buildVariantDictionary("foo_bar", "baz_qux")
+    assertEquals(
+      mapOf(
+        "foo_bar" to "baz_qux",
+        "FooBar" to "BazQux",
+        "FOO_BAR" to "BAZ_QUX",
+      ),
+      dict,
+    )
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/VariantDictionaryTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/VariantDictionaryTest.kt
@@ -91,4 +91,18 @@ class VariantDictionaryTest {
       dict,
     )
   }
+
+  @Test
+  fun `rhs alternatives cycle when the lhs has more of them`() {
+    val dict = buildVariantDictionary("{red,green,blue,yellow}", "{warm,cool}")
+    assertEquals(
+      mapOf(
+        "red" to "warm", "Red" to "Warm", "RED" to "WARM",
+        "green" to "cool", "Green" to "Cool", "GREEN" to "COOL",
+        "blue" to "warm", "Blue" to "Warm", "BLUE" to "WARM",
+        "yellow" to "cool", "Yellow" to "Cool", "YELLOW" to "COOL",
+      ),
+      dict,
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/WordAtomsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/WordAtomsTest.kt
@@ -63,4 +63,24 @@ class WordAtomsTest {
   fun `empty string is no atoms`() {
     assertEquals(emptyList(), splitIntoAtoms(""))
   }
+
+  @Test
+  fun `digit followed by uppercase is an atom boundary`() {
+    assertEquals(listOf("foo2", "Bar"), splitIntoAtoms("foo2Bar"))
+  }
+
+  @Test
+  fun `digit followed by uppercase splits even when the word starts uppercase`() {
+    assertEquals(listOf("Foo2", "Bar"), splitIntoAtoms("Foo2Bar"))
+  }
+
+  @Test
+  fun `digit followed by lowercase is not a boundary`() {
+    assertEquals(listOf("foo2bar"), splitIntoAtoms("foo2bar"))
+  }
+
+  @Test
+  fun `consecutive digits stay inside the atom they belong to`() {
+    assertEquals(listOf("v2", "Engine"), splitIntoAtoms("v2Engine"))
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/WordAtomsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/abolish/WordAtomsTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.extension.abolish
+
+import com.maddyhome.idea.vim.extension.abolish.splitIntoAtoms
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class WordAtomsTest {
+
+  @Test
+  fun `single lowercase word is one atom`() {
+    assertEquals(listOf("hello"), splitIntoAtoms("hello"))
+  }
+
+  @Test
+  fun `snake_case splits on underscores`() {
+    assertEquals(listOf("hello", "world"), splitIntoAtoms("hello_world"))
+  }
+
+  @Test
+  fun `kebab-case splits on dashes`() {
+    assertEquals(listOf("hello", "world"), splitIntoAtoms("hello-world"))
+  }
+
+  @Test
+  fun `dot-case splits on dots`() {
+    assertEquals(listOf("hello", "world"), splitIntoAtoms("hello.world"))
+  }
+
+  @Test
+  fun `space case splits on spaces`() {
+    assertEquals(listOf("hello", "world"), splitIntoAtoms("hello world"))
+  }
+
+  @Test
+  fun `camelCase splits on case boundaries`() {
+    assertEquals(listOf("hello", "World"), splitIntoAtoms("helloWorld"))
+  }
+
+  @Test
+  fun `PascalCase splits on case boundaries`() {
+    assertEquals(listOf("Hello", "World"), splitIntoAtoms("HelloWorld"))
+  }
+
+  @Test
+  fun `acronym is kept together`() {
+    assertEquals(listOf("HTTP", "Request"), splitIntoAtoms("HTTPRequest"))
+  }
+
+  @Test
+  fun `UPPER_SNAKE splits on underscores`() {
+    assertEquals(listOf("HELLO", "WORLD"), splitIntoAtoms("HELLO_WORLD"))
+  }
+
+  @Test
+  fun `empty string is no atoms`() {
+    assertEquals(emptyList(), splitIntoAtoms(""))
+  }
+}


### PR DESCRIPTION
Partial implementaion of abolish plugin.
We support `:Subvret` method for subverting and searching using abolish coercions.
We cannot support now `:Abolish` as it requires implementing `:iabbrev` first.