### PR TITLE
VIM-4234 Restore IntelliJ 2026.1 for split-mode tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # https://data.services.jetbrains.com/products?code=IU
 # Maven releases are here: https://www.jetbrains.com/intellij-repository/releases
 # And snapshots: https://www.jetbrains.com/intellij-repository/snapshots
-ideaVersion=2025.3
+ideaVersion=2026.1
 # Values for type: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 ideaType=IU
 instrumentPluginCode=true

--- a/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/IdeaVimStarterTestBase.kt
+++ b/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/IdeaVimStarterTestBase.kt
@@ -18,10 +18,7 @@ import com.intellij.driver.sdk.ui.components.common.ideFrame
 import com.intellij.driver.sdk.waitForIndicators
 import com.intellij.ide.starter.config.ConfigurationStorage
 import com.intellij.ide.starter.config.splitMode
-import com.intellij.ide.starter.di.di
-import com.intellij.ide.starter.driver.driver.remoteDev.RemDevDriverRunner
 import com.intellij.ide.starter.driver.engine.BackgroundRun
-import com.intellij.ide.starter.driver.engine.DriverRunner
 import com.intellij.ide.starter.driver.engine.runIdeWithDriver
 import com.intellij.ide.starter.ide.IDERemDevTestContext
 import com.intellij.ide.starter.ide.IDETestContext
@@ -35,10 +32,6 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
-import org.kodein.di.DI
-import org.kodein.di.bindProvider
-import org.kodein.di.direct
-import org.kodein.di.instanceOrNull
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
@@ -76,9 +69,7 @@ abstract class IdeaVimStarterTestBase {
 
     val context = Starter.newContext(
       this::class.simpleName ?: "split-test",
-      // Match the IDE version used by `runIdeSplitMode` (gradle.properties: ideaVersion=2025.3).
-      // `useEAP()` would download a newer EAP where a platform regression broke split-mode tests.
-      TestCase(IDEA_ULTIMATE, LocalProjectInfo(projectDir)).useRelease("2025.3")
+      TestCase(IDEA_ULTIMATE, LocalProjectInfo(projectDir)).useRelease("2026.1")
     )
 
     val pluginPath = resolvePluginPath()
@@ -89,14 +80,6 @@ abstract class IdeaVimStarterTestBase {
         PluginConfigurator(context.frontendIDEContext).installPluginFromPath(pluginPath)
       }
       context.patchForMacOsSplitMode()
-
-      val hasDriverRunner = di.direct.instanceOrNull<DriverRunner>() != null
-      if (!hasDriverRunner) {
-        di = DI {
-          extend(di)
-          bindProvider<DriverRunner> { RemDevDriverRunner() }
-        }
-      }
     }
 
     configureContext(context)


### PR DESCRIPTION
The VIM-4234 rollback dropped both Java 25→21 *and* ideaVersion 2026.1→2025.3 because Java 25 was incompatible with the platform. The Java rollback was the necessary fix; the IDE-version rollback was a side change that broke 3 split-mode tests due to 2025.3 JBC regressions in speculative undo and `IdeDocumentHistoryImpl.RecentPlacesListener.isChanged`.

Java 21 + IntelliJ 2026.1 is the prior known-working combination (`Ideavim_IdeaVimTests_2026_1` build config has been green on master), so restoring it here gets all 24 split-mode tests passing again. Verified locally and on TeamCity personal build #16791.