### PR TITLE
VIM-4235 use native saveFile action in :w

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,6 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="jbr-21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
+++ b/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
@@ -105,18 +105,6 @@ internal class FileRemoteApiImpl : FileRemoteApi {
     }
   }
 
-  override suspend fun saveFile(editorId: EditorId, saveAll: Boolean) =
-    onEdt {
-      val editor = editorId.findEditorOrNull() ?: return@onEdt
-      if (saveAll) {
-        ApplicationManager.getApplication().saveAll()
-      } else {
-        val document = editor.document
-        val fileDocumentManager = FileDocumentManager.getInstance()
-        fileDocumentManager.saveDocument(document)
-      }
-    }
-
   override suspend fun selectFile(count: Int, projectId: ProjectId?): Boolean = onEdt {
     var idx = count
     val project = projectId?.findProjectOrNull() ?: return@onEdt false

--- a/ideavim-common/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApi.kt
+++ b/ideavim-common/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApi.kt
@@ -39,7 +39,6 @@ interface FileRemoteApi : RemoteApi<Unit> {
   suspend fun openFile(filename: String, projectId: ProjectId?, focusEditor: Boolean = true): String?
   suspend fun closeCurrentFile(projectId: ProjectId?, virtualFileId: VirtualFileId?)
   suspend fun closeFile(number: Int, projectId: ProjectId?)
-  suspend fun saveFile(editorId: EditorId, saveAll: Boolean)
   suspend fun selectFile(count: Int, projectId: ProjectId?): Boolean
   suspend fun selectNextFile(count: Int, projectId: ProjectId?)
   suspend fun buildFileInfoMessage(editorId: EditorId, fullPath: Boolean): String?

--- a/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.kt
@@ -39,7 +39,6 @@ import com.maddyhome.idea.vim.newapi.IjVimEditor
 import com.maddyhome.idea.vim.newapi.ij
 import com.maddyhome.idea.vim.newapi.ijOptions
 import com.maddyhome.idea.vim.options.OptionAccessScope
-import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.undo.VimKeyBasedUndoService
 import com.maddyhome.idea.vim.undo.VimTimestampBasedUndoService
 

--- a/src/main/java/com/maddyhome/idea/vim/group/IjFileGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjFileGroup.kt
@@ -39,11 +39,11 @@ import com.maddyhome.idea.vim.newapi.vim
  *
  * Extends [VimFileBase] for pure-engine operations (`displayHexInfo`, `displayLocationInfo`).
  *
- * Backend-dependent operations (file finding, opening, saving, file-info messages) are
+ * Backend-dependent operations (file finding, opening, file-info messages) are
  * delegated via [FileRemoteApi] RPC. Works in both monolith and split mode.
  *
  * Local UI operations that only affect window/tab state on the frontend
- * (closeFile by editor) remain in this class.
+ * (closeFile by editor, saveFile via the platform action) remain in this class.
  *
  * Options (e.g. `ideawrite`) are read here on the frontend, never on the backend.
  */
@@ -87,15 +87,20 @@ class IjFileGroup : VimFileBase() {
     rpc { FileRemoteApi.getInstance().closeFile(number, extractProjectId(context)) }
   }
 
+  // Must dispatch the SaveDocument/SaveAll action, not call FileDocumentManager directly —
+  // a direct save bypasses "Actions on Save" (reformat, optimize imports). Broken in Rider split mode.
   override fun saveFile(editor: VimEditor, context: ExecutionContext) {
-    val saveAll = injector.globalIjOptions().ideawrite.contains(IjOptionConstants.ideawrite_all)
-    val editorId = (editor as IjVimEditor).editor.editorId()
-    rpc { FileRemoteApi.getInstance().saveFile(editorId, saveAll) }
+    val action = if (injector.globalIjOptions().ideawrite.contains(IjOptionConstants.ideawrite_all)) {
+      injector.nativeActionManager.saveAll
+    } else {
+      injector.nativeActionManager.saveCurrent
+    } ?: return
+    injector.actionExecutor.executeAction(editor, action, context)
   }
 
   override fun saveFiles(editor: VimEditor, context: ExecutionContext) {
-    val editorId = (editor as IjVimEditor).editor.editorId()
-    rpc { FileRemoteApi.getInstance().saveFile(editorId, true) }
+    val action = injector.nativeActionManager.saveAll ?: return
+    injector.actionExecutor.executeAction(editor, action, context)
   }
 
   override fun selectFile(count: Int, context: ExecutionContext): Boolean {

--- a/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/ReformatOnSaveSplitTest.kt
+++ b/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/ReformatOnSaveSplitTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.split
+
+import org.junit.jupiter.api.Test
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+/**
+ * Regression coverage for VIM-XXXX: in split mode, `:w` saved the document directly via
+ * `FileDocumentManager.saveDocument()` instead of dispatching the platform `SaveDocument`
+ * action. As a result, "Settings > Tools > Actions on Save > Reformat code" never ran.
+ *
+ * The project here enables [Reformat on Save] via `.idea/workspace.xml`. A Java file with
+ * deliberately broken whitespace is opened, a line is edited via Vim (so it counts as
+ * changed for the "process changed text only" mode), and `:w` is issued. If `:w` invokes
+ * the `SaveDocument` action, the reformat runs and the line gets corrected spaces.
+ */
+class ReformatOnSaveSplitTest : IdeaVimStarterTestBase() {
+
+  override fun beforeContextCreated() {
+    val ideaDir = projectDir.resolve(".idea")
+    ideaDir.createDirectories()
+    ideaDir.resolve("workspace.xml").writeText(
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project version="4">
+        <component name="FormatOnSaveOptions">
+          <option name="myRunOnSave" value="true" />
+          <option name="myAllFileTypesSelected" value="true" />
+          <option name="myProcessChangedTextOnly" value="false" />
+        </component>
+      </project>
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `write command triggers reformat on save`() {
+    openFile(
+      createFile(
+        "src/ReformatOnSave.java",
+        """
+        public class ReformatOnSave {
+            int x=1;
+        }
+        """.trimIndent() + "\n",
+      ),
+    )
+
+    // Edit line 2 so that even "process changed text only" reformat covers this line.
+    goToLine(2)
+    typeVimAndEscape("A // edit")
+    pause()
+
+    exCommand("w")
+    pause(2000)
+
+    assertEditorContains(
+      "int x = 1;",
+      "Reformat on Save should add spaces around '=' when :w invokes the SaveDocument action",
+    )
+  }
+}


### PR DESCRIPTION
using FilerometeApi didn't trigger reformat on save action in splitmode/rider so I chagned it to native action execution in on save