### PR TITLE
VIM-4245 Fix repeat-insert undo grouping so one `u` reverts one logical change

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/change/RepeatChangeAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/change/RepeatChangeAction.kt
@@ -16,6 +16,7 @@ import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.group.withVimUndoGroup
 import com.maddyhome.idea.vim.handler.VimActionHandler
 import com.maddyhome.idea.vim.newapi.ij
 
@@ -44,32 +45,39 @@ internal class RepeatChangeAction : VimActionHandler.SingleExecution() {
 
     state.isDotRepeatInProgress = true
 
-    // A fancy 'redo-register' feature
-    // VIM-2643, :h redo-register
-    if (VimRepeater.lastChangeRegister in '1'..'8') {
-      VimRepeater.lastChangeRegister = VimRepeater.lastChangeRegister.inc()
-    }
-
-    injector.registerGroup.selectRegister(VimRepeater.lastChangeRegister)
-
-    if (repeatHandler && lastHandler != null) {
-      val processor = CommandProcessor.getInstance()
-      processor.executeCommand(
-        editor.ij.project,
-        { lastHandler.execute(editor, context, operatorArguments) },
-        "Vim " + lastHandler.javaClass.simpleName,
-        null,
-      )
-    } else if (!repeatHandler && lastCommand != null) {
-      if (cmd.rawCount > 0) {
-        lastCommand = lastCommand.copy(rawCount = cmd.rawCount)
+    // Group the entire dot replay into one undo step on the JBC backend so that
+    // `s`/`c`-style commands (which delete *and* insert) revert with a single
+    // `u`. Without this the backend records each atomic edit (delete, insert,
+    // caret) as a separate undo entry because speculative undo disables the
+    // platform's command grouping.
+    withVimUndoGroup(editor, "Vim Dot Repeat") {
+      // A fancy 'redo-register' feature
+      // VIM-2643, :h redo-register
+      if (VimRepeater.lastChangeRegister in '1'..'8') {
+        VimRepeater.lastChangeRegister = VimRepeater.lastChangeRegister.inc()
       }
-      state.executingCommand = lastCommand
 
-      val arguments = operatorArguments.copy(count0 = lastCommand.rawCount)
-      injector.actionExecutor.executeVimAction(editor, lastCommand.action, context, arguments)
+      injector.registerGroup.selectRegister(VimRepeater.lastChangeRegister)
 
-      VimRepeater.saveLastChange(lastCommand)
+      if (repeatHandler && lastHandler != null) {
+        val processor = CommandProcessor.getInstance()
+        processor.executeCommand(
+          editor.ij.project,
+          { lastHandler.execute(editor, context, operatorArguments) },
+          "Vim " + lastHandler.javaClass.simpleName,
+          null,
+        )
+      } else if (!repeatHandler && lastCommand != null) {
+        if (cmd.rawCount > 0) {
+          lastCommand = lastCommand.copy(rawCount = cmd.rawCount)
+        }
+        state.executingCommand = lastCommand
+
+        val arguments = operatorArguments.copy(count0 = lastCommand.rawCount)
+        injector.actionExecutor.executeVimAction(editor, lastCommand.action, context, arguments)
+
+        VimRepeater.saveLastChange(lastCommand)
+      }
     }
 
     state.isDotRepeatInProgress = false

--- a/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/ChangeGroup.kt
@@ -26,9 +26,7 @@ import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimChangeGroupBase
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.common.TextRange
-import com.maddyhome.idea.vim.group.change.ChangeRemoteApi
 import com.maddyhome.idea.vim.group.format.FormatRemoteApi
 import com.maddyhome.idea.vim.helper.CodeWrapper
 import com.maddyhome.idea.vim.helper.CommentLeaderParser
@@ -102,38 +100,53 @@ class ChangeGroup : VimChangeGroupBase() {
     injector.scroll.scrollCaretIntoView(editor)
   }
 
-  override fun repeatInsert(editor: VimEditor, context: ExecutionContext, count: Int, started: Boolean) {
-    withVimRepeatUndoMark(editor) {
-      super.repeatInsert(editor, context, count, started)
-    }
-  }
-
-  override fun insertPreviousInsert(
+  override fun initBlockInsert(
     editor: VimEditor,
     context: ExecutionContext,
-    exit: Boolean,
-    operatorArguments: OperatorArguments,
-  ) {
-    withVimRepeatUndoMark(editor) {
-      super.insertPreviousInsert(editor, context, exit, operatorArguments)
+    range: TextRange,
+    append: Boolean,
+  ): Boolean {
+    // Block insert spans: enter insert at top-of-block (user types `#`) → `<Esc>`
+    // triggers `repeatInsert` which replays across N-1 lines below. To group all
+    // N lines into one undo step, start the mark here (before the top-line `#`
+    // is typed) and finish it in `repeatInsert`.
+    startVimUndoGroup(editor, "Vim Block Insert")
+    blockInsertActive = true
+    return try {
+      super.initBlockInsert(editor, context, range, append)
+    } catch (t: Throwable) {
+      finishVimUndoGroup(editor)
+      blockInsertActive = false
+      throw t
     }
   }
 
-  // Register start/finish undo marks on the backend via RPC so that all
-  // replayed strokes (text insertions + actions like backspace) across every
-  // caret and repeat-line are grouped into a single undo step on both frontend
-  // and backend. We cannot use StartMarkAction locally because the UndoSpy /
-  // CmdMeta pipeline does not reliably transmit marks to the backend.
-  private inline fun withVimRepeatUndoMark(editor: VimEditor, block: () -> Unit) {
-    val ijEditor = (editor as IjVimEditor).editor
-    val editorId = ijEditor.editorId()
-    rpcSplitModeOnly(ijEditor.project) { ChangeRemoteApi.getInstance().startUndoMark(editorId, "Vim Repeat") }
-    try {
-      block()
-    } finally {
-      rpcSplitModeOnly(ijEditor.project) { ChangeRemoteApi.getInstance().finishUndoMark(editorId) }
+  override fun repeatInsert(editor: VimEditor, context: ExecutionContext, count: Int, started: Boolean) {
+    // Replay paths to group as one undo step:
+    //   • Block insert: `initBlockInsert` already opened the mark — close it.
+    //   • count > 1 (e.g. `5iHi <Esc>`) — open+close locally.
+    // Plain `iHi <Esc>` (count <= 1, no block) is NOT a replay and must not be
+    // wrapped — an empty start/finish group on the backend would swallow the
+    // first `u` (the frontend speculative-undo flicker we observed earlier).
+    // Dot-repeat (started=false) is wrapped one level up in `RepeatChangeAction`
+    // so the wrap covers the *whole* replayed command (incl. `s`/`c`'s delete).
+    when {
+      blockInsertActive -> {
+        try {
+          super.repeatInsert(editor, context, count, started)
+        } finally {
+          finishVimUndoGroup(editor)
+          blockInsertActive = false
+        }
+      }
+      count > 1 -> withVimUndoGroup(editor, "Vim Repeat") {
+        super.repeatInsert(editor, context, count, started)
+      }
+      else -> super.repeatInsert(editor, context, count, started)
     }
   }
+
+  private var blockInsertActive: Boolean = false
 
   override fun reformatCode(editor: VimEditor, start: Int, end: Int) {
     val project = (editor as IjVimEditor).editor.project ?: return

--- a/src/main/java/com/maddyhome/idea/vim/group/VimUndoGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/VimUndoGroup.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.group
+
+import com.intellij.openapi.editor.impl.editorId
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.group.change.ChangeRemoteApi
+import com.maddyhome.idea.vim.newapi.IjVimEditor
+
+/**
+ * Groups a sequence of document edits into a single undo step on the JBC backend.
+ *
+ * On JBC 2025.3+ speculative undo disables the platform's own command-boundary
+ * grouping (`RdUndoCapabilities.isSupported = !isSpeculativeUndoEnabled`), so
+ * without an explicit mark each atomic edit (insert, delete, caret move) lands
+ * as its own undo entry — breaking vim's "one command = one `u`" semantics.
+ *
+ * Use [withVimUndoGroup] when the edits live in a single block;
+ * use [startVimUndoGroup] / [finishVimUndoGroup] when start and finish must
+ * span different methods (e.g. block-insert: start in `initBlockInsert`,
+ * finish in `repeatInsert`).
+ *
+ * In non-split (monolith) mode the calls are no-ops because
+ * [rpcSplitModeOnly] short-circuits.
+ */
+internal inline fun withVimUndoGroup(editor: VimEditor, name: String, block: () -> Unit) {
+  startVimUndoGroup(editor, name)
+  try {
+    block()
+  } finally {
+    finishVimUndoGroup(editor)
+  }
+}
+
+internal fun startVimUndoGroup(editor: VimEditor, name: String) {
+  val ijEditor = (editor as IjVimEditor).editor
+  val editorId = ijEditor.editorId()
+  rpcSplitModeOnly(ijEditor.project) { ChangeRemoteApi.getInstance().startUndoMark(editorId, name) }
+}
+
+internal fun finishVimUndoGroup(editor: VimEditor) {
+  val ijEditor = (editor as IjVimEditor).editor
+  val editorId = ijEditor.editorId()
+  rpcSplitModeOnly(ijEditor.project) { ChangeRemoteApi.getInstance().finishUndoMark(editorId) }
+}

--- a/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/IdeaVimStarterTestBase.kt
+++ b/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/IdeaVimStarterTestBase.kt
@@ -213,6 +213,17 @@ abstract class IdeaVimStarterTestBase {
     }
   }
 
+  /** Presses Ctrl-V (visual-block mode). */
+  protected fun ctrlV() {
+    driver.withContext {
+      ideFrame {
+        codeEditor().apply {
+          keyboard { hotKey(java.awt.event.KeyEvent.VK_CONTROL, java.awt.event.KeyEvent.VK_V) }
+        }
+      }
+    }
+  }
+
   /** Triggers the IDE "Navigate > Back" action (Cmd+[ on macOS, Ctrl+Alt+Left on Linux). */
   protected fun ideaGoBack() {
     driver.withContext {

--- a/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/RepeatUndoSplitTest.kt
+++ b/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/RepeatUndoSplitTest.kt
@@ -40,9 +40,7 @@ class RepeatUndoSplitTest : IdeaVimStarterTestBase() {
     assertEditorContains("XXcdef", "Second char should also be X")
 
     typeVim("u")
-    pause()
-    typeVim("u")
-    assertEditorContains("Xbcdef", "First undo should revert dot-repeat only")
+    assertEditorContains("Xbcdef", "Single undo should revert dot-repeat only (the dot is grouped)")
   }
 
   @Test
@@ -80,5 +78,38 @@ class RepeatUndoSplitTest : IdeaVimStarterTestBase() {
     typeVim("u")
     pause()
     assertEditorContains("HELLO", "Original change should remain")
+  }
+
+  @Test
+  fun `block insert across multiple lines undoes as single group`() {
+    // Vim block-insert: Ctrl-V <down>×9, then `I#<Esc>` prepends `#` to all 10
+    // selected lines. The vim engine replays the `#` across lines via
+    // ChangeGroup.repeatInsert; on JBC that needs to be wrapped in one undo
+    // mark group so a single `u` reverts the whole block insert.
+    val lines = (1..15).joinToString("\n") { "line $it" }
+    openFile(createFile("src/BlockInsert.txt", lines + "\n"))
+
+    typeVim("gg")
+    pause()
+    ctrlV()
+    typeVim("9j")
+    typeVim("I#")
+    esc()
+    pause(1000)
+
+    val afterInsert = editorText()
+    val firstTen = afterInsert.lines().take(10)
+    assertTrue(firstTen.all { it.startsWith("#") }) {
+      "Expected first 10 lines to start with '#' after block insert. Actual:\n$afterInsert"
+    }
+
+    typeVim("u")
+    pause(1000)
+
+    val afterUndo = editorText()
+    val firstTenAfterUndo = afterUndo.lines().take(10)
+    assertTrue(firstTenAfterUndo.none { it.startsWith("#") }) {
+      "Single `u` should undo the block insert across all 10 lines. Actual:\n$afterUndo"
+    }
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -53,7 +53,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 abstract class VimChangeGroupBase : VimChangeGroup {
-  private var repeatLines: Int = 0
+  protected var repeatLines: Int = 0
   private var repeatColumn: Int = 0
   private var repeatAppend: Boolean = false
 


### PR DESCRIPTION
Wrap the undo-mark only when there's actual replay work (count > 1,  block insert, or dot-repeat) — otherwise the always-fired wrap on plain `iHi<Esc>` emitted an empty mark group that swallowed the first `u`.