### PR TITLE
VIM-4245 Use custom visual block renderer

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/VimTypedActionHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/VimTypedActionHandler.kt
@@ -20,6 +20,8 @@ import com.maddyhome.idea.vim.helper.inInsertMode
 import com.maddyhome.idea.vim.helper.isIdeaVimDisabledHere
 import com.maddyhome.idea.vim.key.KeyHandlerKeeper
 import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.state.mode.Mode
+import com.maddyhome.idea.vim.state.mode.SelectionType
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
@@ -79,6 +81,14 @@ class VimTypedActionHandler(origHandler: TypedActionHandler) : TypedActionHandle
 
     try {
       LOG.trace("Executing typed action")
+      // Select-block under the virtual renderer needs N native carets so IntelliJ's typing
+      // handler replicates the insert across rows. Visual-block goes through initBlockInsert
+      // + setInsertRepeat which doesn't need this.
+      val vimEditor = editor.vim
+      val mode = vimEditor.mode
+      if (mode is Mode.SELECT && mode.selectionType == SelectionType.BLOCK_WISE) {
+        injector.blockSelectionRenderer.materializeCarets(vimEditor)
+      }
       val modifiers = if (charTyped == ' ' && VimKeyListener.isSpaceShift) KeyEvent.SHIFT_DOWN_MASK else 0
       val keyStroke = KeyStroke.getKeyStroke(charTyped, modifiers)
       val startTime = if (traceTime) System.currentTimeMillis() else null

--- a/src/main/java/com/maddyhome/idea/vim/group/visual/IjBlockSelectionRenderer.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/visual/IjBlockSelectionRenderer.kt
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.group.visual
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.CaretState
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorModificationUtil
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.editor.VisualPosition
+import com.intellij.openapi.editor.colors.EditorColors
+import com.intellij.openapi.editor.markup.HighlighterLayer
+import com.intellij.openapi.editor.markup.HighlighterTargetArea
+import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.maddyhome.idea.vim.api.BufferPosition
+import com.maddyhome.idea.vim.api.VimBlockSelectionRenderer
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.VimMotionGroupBase
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.common.ModeChangeListener
+import com.maddyhome.idea.vim.helper.resetVimLastColumn
+import com.maddyhome.idea.vim.helper.vimLastColumn
+import com.maddyhome.idea.vim.newapi.IjVimEditor
+import com.maddyhome.idea.vim.state.mode.Mode
+import com.maddyhome.idea.vim.state.mode.SelectionType
+import com.maddyhome.idea.vim.state.mode.inBlockSelection
+
+/**
+ * Renders block-visual selection using IDE-level [RangeHighlighter]s plus a single primary
+ * caret, instead of N native IntelliJ carets. Operators read block bounds from the primary
+ * caret's `vimSelectionStart` + `offset` (see `VisualOperatorActionHandler.collectSelections`)
+ * so N native carets are not required for correctness.
+ *
+ * Gated behind the `ideavim.virtual.block` system property. Default: off.
+ */
+internal class IjBlockSelectionRenderer : VimBlockSelectionRenderer, ModeChangeListener {
+  private val highlightersPerEditor = HashMap<Editor, List<RangeHighlighter>>()
+
+  // Primary's IntelliJ selection alone can't serve as the bounds source — it clamps at line
+  // ends, losing the block's logical width on short rows.
+  private val blockBoundsPerEditor = HashMap<Editor, VimBlockSelectionRenderer.BlockBounds>()
+
+  // Snapshot of bounds at the most-recent block-visual exit, consumed by ex commands and the
+  // undo fallback that run in Normal mode after the exit (see commandsSinceExitPerEditor).
+  private val lastExitedBoundsPerEditor = HashMap<Editor, VimBlockSelectionRenderer.BlockBounds>()
+
+  // Non-undo commands seen since the most recent block-visual exit. Lets the undo fallback
+  // tell "undo of the immediate destructive block edit" (≤ 1) from "undo of a later op that
+  // happened to follow a block-visual exit" (> 1), e.g. `<C-V>jjl y $ p u`.
+  private val commandsSinceExitPerEditor = HashMap<Editor, Int>()
+
+  init {
+    ensureModeChangeListenerRegistered()
+  }
+
+  override fun isEnabled(editor: VimEditor): Boolean {
+    return editor is IjVimEditor
+  }
+
+  override fun notifyCommandFinished(editor: VimEditor) {
+    val ij = (editor as? IjVimEditor)?.editor ?: return
+    tickCommandsSinceExit(ij)
+    if (editor.inBlockSelection) dropIntendedColumnIfPrimaryOnTab(ij)
+  }
+
+  fun consumeLastExitedBounds(editor: VimEditor): VimBlockSelectionRenderer.BlockBounds? {
+    val ij = (editor as? IjVimEditor)?.editor ?: return null
+    return lastExitedBoundsPerEditor.remove(ij)
+  }
+
+  fun commandsSinceExit(editor: VimEditor): Int? {
+    val ij = (editor as? IjVimEditor)?.editor ?: return null
+    return commandsSinceExitPerEditor[ij]
+  }
+
+  private fun ensureModeChangeListenerRegistered() {
+    val listeners = injector.listenersNotifier.modeChangeListeners
+    if (this !in listeners) listeners.add(this)
+  }
+
+  private fun tickCommandsSinceExit(ij: Editor) {
+    commandsSinceExitPerEditor[ij]?.let { commandsSinceExitPerEditor[ij] = it + 1 }
+  }
+
+  /**
+   * Native block-visual rebuilds carets each motion, so the action handler's
+   * `caret.vimLastColumn = motion.intendedColumn` becomes a no-op on the new primary and the
+   * next motion tracks the achieved visual column — exactly what tab per-row clamping needs.
+   * Virtual-block keeps the same caret, so when primary lands on a tab we drop the intended
+   * column here to restore the native behaviour. Other "adjusted offset" cases (short/empty
+   * lines) want the intent preserved so the block re-widens on later longer rows.
+   */
+  private fun dropIntendedColumnIfPrimaryOnTab(ij: Editor) {
+    val primary = ij.caretModel.primaryCaret
+    if (primary.vimLastColumn >= VimMotionGroupBase.LAST_COLUMN) return
+    val text = ij.document.charsSequence
+    if (primary.offset < text.length && text[primary.offset] == '\t') {
+      primary.resetVimLastColumn()
+    }
+  }
+
+  override fun update(
+    editor: VimEditor,
+    blockStart: BufferPosition,
+    blockEnd: BufferPosition,
+    dollarExtension: Boolean,
+  ) {
+    ensureModeChangeListenerRegistered()
+    val ij = (editor as? IjVimEditor)?.editor ?: return
+    blockBoundsPerEditor[ij] = VimBlockSelectionRenderer.BlockBounds(
+      blockStart.line, blockStart.column, blockEnd.line, blockEnd.column, dollarExtension,
+    )
+    repaintHighlighterBand(ij, blockStart, blockEnd, dollarExtension)
+  }
+
+  private fun repaintHighlighterBand(
+    ij: Editor,
+    blockStart: BufferPosition,
+    blockEnd: BufferPosition,
+    dollarExtension: Boolean,
+  ) {
+    clearHighlightersOnly(ij)
+    val minLine = minOf(blockStart.line, blockEnd.line)
+    val maxLine = maxOf(blockStart.line, blockEnd.line)
+    val minCol = minOf(blockStart.column, blockEnd.column)
+    val maxCol = maxOf(blockStart.column, blockEnd.column)
+    val attributes = selectionAttributes(ij)
+    val highlighters = ArrayList<RangeHighlighter>(maxLine - minLine + 1)
+    for (line in minLine..maxLine) {
+      addRowHighlighter(ij, line, minCol, maxCol, dollarExtension, attributes)?.let(highlighters::add)
+    }
+    highlightersPerEditor[ij] = highlighters
+  }
+
+  private fun addRowHighlighter(
+    ij: Editor,
+    line: Int,
+    minCol: Int,
+    maxCol: Int,
+    dollarExtension: Boolean,
+    attributes: TextAttributes,
+  ): RangeHighlighter? {
+    val startOffset = ij.logicalPositionToOffset(LogicalPosition(line, minCol))
+    val endOffset = if (dollarExtension) {
+      ij.document.getLineEndOffset(line)
+    } else {
+      ij.logicalPositionToOffset(LogicalPosition(line, maxCol))
+    }
+    if (endOffset <= startOffset) return null
+    return ij.markupModel.addRangeHighlighter(
+      startOffset,
+      endOffset,
+      HighlighterLayer.SELECTION - 1,
+      attributes,
+      HighlighterTargetArea.EXACT_RANGE,
+    )
+  }
+
+  override fun clear(editor: VimEditor) {
+    val ij = (editor as? IjVimEditor)?.editor ?: return
+    clearFor(ij)
+  }
+
+  override fun getBounds(editor: VimEditor): VimBlockSelectionRenderer.BlockBounds? {
+    val ij = (editor as? IjVimEditor)?.editor ?: return null
+    return blockBoundsPerEditor[ij]
+  }
+
+  override fun materializeCarets(editor: VimEditor) {
+    materializeFromBounds(editor) { blockBoundsPerEditor[it] }
+  }
+
+  override fun materializeCaretsFromSavedExit(editor: VimEditor) {
+    materializeFromBounds(editor) { lastExitedBoundsPerEditor[it] }
+  }
+
+  private fun materializeFromBounds(
+    editor: VimEditor,
+    boundsLookup: (Editor) -> VimBlockSelectionRenderer.BlockBounds?,
+  ) {
+    if (editor !is IjVimEditor) return
+    ApplicationManager.getApplication().invokeAndWait {
+      val ij = editor.editor
+      val mode = editor.mode
+      val bounds = boundsLookup(ij)
+      if (bounds == null) {
+        defendAgainstStaleBlockState(ij, mode)
+        return@invokeAndWait
+      }
+      applyCaretStatesPreservingVimEngineState(editor, ij, bounds, isSelectMode(mode))
+      clearHighlightersOnly(ij)
+    }
+  }
+
+  /**
+   * The mode-change listener that normally clears block state may have been reset (e.g. test
+   * teardown). If we still hold bounds/highlighters while the editor is no longer in a
+   * block-wise mode, drop them ourselves. The hasStaleState guard avoids wiping legitimate
+   * non-block selections (e.g. one created by `:action EditorSelectWord` in Normal mode).
+   */
+  private fun defendAgainstStaleBlockState(ij: Editor, mode: Mode) {
+    val hasStaleState = blockBoundsPerEditor.containsKey(ij) || highlightersPerEditor.containsKey(ij)
+    if (hasStaleState && !isBlockWiseMode(mode)) dropStaleBlockState(ij, mode)
+  }
+
+  /**
+   * Replace the IntelliJ caret set in a single bulk call (one event dispatch instead of N) and
+   * restore the bits of vim-engine state that `setCaretsAndSelections` invalidates by replacing
+   * the primary IJ caret wholesale. Critical for 500+ row blocks.
+   */
+  private fun applyCaretStatesPreservingVimEngineState(
+    editor: IjVimEditor,
+    ij: Editor,
+    bounds: VimBlockSelectionRenderer.BlockBounds,
+    selectMode: Boolean,
+  ) {
+    val primaryOffsetBefore = ij.caretModel.primaryCaret.offset
+    val savedVimLastColumn = editor.primaryCaret().vimLastColumn
+    val savedVimSelectionStart = editor.primaryCaret().vimSelectionStart
+
+    val states = buildCaretStates(ij, bounds, selectMode)
+    ij.caretModel.setCaretsAndSelections(states)
+
+    // The last CaretState's caretPosition becomes primary, but for $-extended rows we placed
+    // it at rowEnd-1, not at the user's pre-materialize offset — restore that.
+    if (ij.caretModel.primaryCaret.offset != primaryOffsetBefore) {
+      ij.caretModel.primaryCaret.moveToOffset(primaryOffsetBefore)
+    }
+    // The setter pins _vimLastColumnPos to the new visualPosition so the getter's invalidation
+    // check (UserDataManager.Caret.vimLastColumn) won't reset it on the next read.
+    val newPrimary = editor.primaryCaret()
+    newPrimary.vimLastColumn = savedVimLastColumn
+    newPrimary.vimSelectionStart = savedVimSelectionStart
+  }
+
+  /**
+   * Uses [EditorModificationUtil.calcBlockSelectionState] as the base so column clamping and
+   * empty-row filtering match IntelliJ's `setBlockSelection` exactly, then bakes per-row
+   * adjustments in so the full caret set can be applied with one
+   * [com.intellij.openapi.editor.CaretModel.setCaretsAndSelections] call.
+   */
+  private fun buildCaretStates(
+    ij: Editor,
+    bounds: VimBlockSelectionRenderer.BlockBounds,
+    selectMode: Boolean,
+  ): List<CaretState> {
+    val anchor = LogicalPosition(bounds.anchorLine, bounds.anchorCol)
+    val active = LogicalPosition(bounds.activeLine, bounds.activeCol)
+    val baseStates = EditorModificationUtil.calcBlockSelectionState(ij, anchor, active)
+    if (selectMode) return baseStates
+    return baseStates.map { state ->
+      val caretLine = state.caretPosition?.line ?: return@map state
+      if (bounds.dollarExtension) {
+        dollarExtendedCaretState(ij, caretLine, state.selectionStart)
+      } else {
+        inclusiveEndAdjustedCaretState(ij, state) ?: state
+      }
+    }
+  }
+
+  private fun dollarExtendedCaretState(
+    ij: Editor,
+    caretLine: Int,
+    selectionStart: LogicalPosition?,
+  ): CaretState {
+    val rowStart = ij.document.getLineStartOffset(caretLine)
+    val rowEnd = ij.document.getLineEndOffset(caretLine)
+    val selEnd = ij.offsetToLogicalPosition(rowEnd)
+    val caret = ij.offsetToLogicalPosition((rowEnd - 1).coerceAtLeast(rowStart))
+    return CaretState(caret, selectionStart, selEnd)
+  }
+
+  /**
+   * Visual char-wise: caret sits one VISUAL cell left of the exclusive selection end, so tabs
+   * are walked one display cell at a time. Returns null when this row has no adjustable
+   * selection (empty line / zero-width range).
+   */
+  private fun inclusiveEndAdjustedCaretState(ij: Editor, state: CaretState): CaretState? {
+    val caretLine = state.caretPosition?.line ?: return null
+    val rowStart = ij.document.getLineStartOffset(caretLine)
+    val rowEnd = ij.document.getLineEndOffset(caretLine)
+    val selStart = state.selectionStart ?: return null
+    val selEnd = state.selectionEnd ?: return null
+    val selStartOffset = ij.logicalPositionToOffset(selStart)
+    val selEndOffset = ij.logicalPositionToOffset(selEnd)
+    if (rowEnd <= rowStart || selEndOffset <= selStartOffset || selEndOffset - 1 < rowStart) return null
+
+    val visualPos = ij.offsetToVisualPosition(selEndOffset)
+    val adjusted = VisualPosition(visualPos.line, (visualPos.column - 1).coerceAtLeast(0))
+    val adjustedLog = ij.visualToLogicalPosition(adjusted)
+    // For multi-visual-cell chars (tabs, inlays), the logical position can resolve to an
+    // earlier visual column than `adjusted`. visualColumnAdjustment pins the effective visual
+    // position to `adjusted`, matching the old moveToVisualPosition behaviour.
+    val backToVisual = ij.logicalToVisualPosition(adjustedLog)
+    val visualAdjust = adjusted.column - backToVisual.column
+    return CaretState(adjustedLog, visualAdjust, selStart, selEnd)
+  }
+
+  private fun dropStaleBlockState(ij: Editor, mode: Mode) {
+    clearFor(ij)
+    // Only clear primary's IJ selection when we're back in NORMAL — VISUAL/SELECT char- or
+    // line-wise own a valid selection set elsewhere.
+    if (mode is Mode.NORMAL && ij.caretModel.primaryCaret.hasSelection()) {
+      ij.caretModel.primaryCaret.removeSelection()
+    }
+  }
+
+  override fun modeChanged(editor: VimEditor, oldMode: Mode) {
+    // Only act when leaving block-wise selection entirely. Transitions between
+    // VISUAL(BLOCK_WISE), SELECT(BLOCK_WISE), and CMD_LINE wrapping either should preserve the
+    // band — block selection stays semantically active even though the mode changes.
+    if (!isBlockWiseMode(oldMode) || isBlockWiseMode(editor.mode)) return
+    if (editor !is IjVimEditor) return
+
+    snapshotBoundsOnExit(editor.editor)
+    clear(editor)
+    dropPrimaryRowSelection(editor.editor)
+  }
+
+  /**
+   * Move active bounds into the dedicated "last exited" slot so Normal-mode followups can use
+   * them: ex commands from `'<,'>` block-visual ranges (`Command.execute`) re-materialize
+   * carets, and the undo fallback positions primary at the block's top-left.
+   */
+  private fun snapshotBoundsOnExit(ij: Editor) {
+    blockBoundsPerEditor[ij]?.let {
+      lastExitedBoundsPerEditor[ij] = it
+      commandsSinceExitPerEditor[ij] = 0
+    }
+  }
+
+  /**
+   * Primary's IJ selection was set on its own row during the virtual block phase. Mode exit
+   * (`x` delete, `<Esc>`, ...) doesn't go through any path that clears it, so do it here.
+   */
+  private fun dropPrimaryRowSelection(ij: Editor) {
+    val primary = ij.caretModel.primaryCaret
+    if (primary.hasSelection()) primary.removeSelection()
+  }
+
+  private fun isBlockWiseMode(mode: Mode): Boolean {
+    val effective = if (mode is Mode.CMD_LINE && mode.returnTo is Mode.VISUAL) mode.returnTo else mode
+    val selectionType = when (effective) {
+      is Mode.VISUAL -> effective.selectionType
+      is Mode.SELECT -> effective.selectionType
+      else -> null
+    }
+    return selectionType == SelectionType.BLOCK_WISE
+  }
+
+  private fun isSelectMode(mode: Mode): Boolean {
+    return mode is Mode.SELECT || (mode is Mode.CMD_LINE && mode.returnTo is Mode.SELECT)
+  }
+
+  private fun clearFor(ij: Editor) {
+    blockBoundsPerEditor.remove(ij)
+    clearHighlightersOnly(ij)
+  }
+
+  private fun clearHighlightersOnly(ij: Editor) {
+    val existing = highlightersPerEditor.remove(ij) ?: return
+    for (highlighter in existing) {
+      if (highlighter.isValid) ij.markupModel.removeHighlighter(highlighter)
+    }
+  }
+
+  private fun selectionAttributes(editor: Editor): TextAttributes {
+    val scheme = editor.colorsScheme
+    return TextAttributes().apply {
+      backgroundColor = scheme.getColor(EditorColors.SELECTION_BACKGROUND_COLOR)
+    }
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/helper/UndoRedoHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/UndoRedoHelper.kt
@@ -20,11 +20,13 @@ import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.util.PlatformUtils
 import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimBlockSelectionRenderer
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.common.ChangesListener
 import com.maddyhome.idea.vim.common.InsertSequence
+import com.maddyhome.idea.vim.group.visual.IjBlockSelectionRenderer
 import com.maddyhome.idea.vim.newapi.IjVimCaret
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.newapi.ij
@@ -61,6 +63,7 @@ class UndoRedoHelper : VimTimestampBasedUndoService {
       scrollingModel.flushViewportChanges()
 
       collapseRestoredBlockVisualCarets(editor, caretCountBeforeUndo)
+      moveCaretToVirtualBlockTopLeftIfPending(editor)
 
       return true
     }
@@ -215,6 +218,43 @@ class UndoRedoHelper : VimTimestampBasedUndoService {
     val blockTopOffset = caretModel.allCarets.minOf { it.offset }
     caretModel.removeSecondaryCarets()
     caretModel.primaryCaret.moveToOffset(blockTopOffset)
+  }
+
+  /**
+   * Virtual-block counterpart to [collapseRestoredBlockVisualCarets]. The native heuristic
+   * relies on IntelliJ's undo restoring N carets at a block-edit's command-start snapshot — but
+   * the virtual flow only ever has one caret, so that snapshot is 1, and the heuristic can't
+   * fire. Instead, position primary at the saved block top-left here.
+   *
+   * Gate: only fire when the undo we just performed is plausibly *the* immediate block edit.
+   * Without the gate, `<C-V>jjl y $ p u` would wrongly snap primary to the block top-left even
+   * though `u` is undoing the unrelated `p` paste.
+   */
+  private fun moveCaretToVirtualBlockTopLeftIfPending(editor: VimEditor) {
+    if (editor.mode !is Mode.NORMAL) return
+    val renderer = injector.blockSelectionRenderer as? IjBlockSelectionRenderer ?: return
+    if (!isUndoingImmediateBlockEdit(renderer, editor)) return
+    val bounds = renderer.consumeLastExitedBounds(editor) ?: return
+    editor.ij.caretModel.primaryCaret.moveToOffset(blockTopLeftOffset(editor.ij, bounds))
+  }
+
+  /**
+   * `commandsSinceExit` is reset to 0 when the renderer snapshots bounds on block-visual exit,
+   * then ticked by [com.maddyhome.idea.vim.KeyHandler] when the saving command finishes (→ 1).
+   * So a value of exactly 1 here means the destructive block edit is the prior command — i.e.
+   * the undo we just performed must be undoing *that* edit.
+   */
+  private fun isUndoingImmediateBlockEdit(renderer: IjBlockSelectionRenderer, editor: VimEditor): Boolean {
+    val cmdsSinceExit = renderer.commandsSinceExit(editor) ?: return false
+    return cmdsSinceExit <= 1
+  }
+
+  private fun blockTopLeftOffset(ij: Editor, bounds: VimBlockSelectionRenderer.BlockBounds): Int {
+    val topLine = minOf(bounds.anchorLine, bounds.activeLine)
+    val topCol = minOf(bounds.anchorCol, bounds.activeCol)
+    val lineStart = ij.document.getLineStartOffset(topLine)
+    val lineEnd = ij.document.getLineEndOffset(topLine)
+    return (lineStart + topCol).coerceAtMost(lineEnd)
   }
 
   private fun removeSelections(editor: VimEditor) {

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
@@ -20,6 +20,7 @@ import com.maddyhome.idea.vim.api.NativeActionManager
 import com.maddyhome.idea.vim.api.SystemInfoService
 import com.maddyhome.idea.vim.api.VimActionExecutor
 import com.maddyhome.idea.vim.api.VimApplication
+import com.maddyhome.idea.vim.api.VimBlockSelectionRenderer
 import com.maddyhome.idea.vim.api.VimChangeGroup
 import com.maddyhome.idea.vim.api.VimClipboardManager
 import com.maddyhome.idea.vim.api.VimCommandGroup
@@ -73,6 +74,7 @@ import com.maddyhome.idea.vim.group.GlobalIjOptions
 import com.maddyhome.idea.vim.group.IjVimOptionGroup
 import com.maddyhome.idea.vim.group.TabService
 import com.maddyhome.idea.vim.group.VimWindowGroup
+import com.maddyhome.idea.vim.group.visual.IjBlockSelectionRenderer
 import com.maddyhome.idea.vim.history.VimHistory
 import com.maddyhome.idea.vim.macro.VimMacro
 import com.maddyhome.idea.vim.put.VimPut
@@ -222,6 +224,9 @@ internal class IjVimInjector : VimInjectorBase() {
     get() = service()
   override val pluginActivator: VimPluginActivator
     get() = service()
+
+  // Lazy so the renderer registers its mode-change listener after the injector is fully wired.
+  override val blockSelectionRenderer: VimBlockSelectionRenderer by lazy { IjBlockSelectionRenderer() }
 
   override val autoCmd: AutoCmdService get() = service<AutoCmdService>()
 }

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -550,6 +550,9 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
   }
 
   fun assertState(textAfter: String) {
+    // The fixture's checkResult inspects the IJ caret model directly; under the virtual-block
+    // renderer that only holds the primary caret, so we must materialize N carets first.
+    injector.blockSelectionRenderer.materializeCarets(fixture.editor.vim)
     fixture.checkResult(textAfter)
     NeovimTesting.assertState(fixture.editor, testInfo)
   }
@@ -742,8 +745,7 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
       // If there's no output, there's a good chance we've got an error
       val message = "No Ex output" + if (injector.messages.isError()) {
         ". Error reported: " + VimPlugin.getMessage()
-      }
-      else ""
+      } else ""
 
       assertNotNull(actual, message)
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -281,6 +281,8 @@ class KeyHandler {
     val cmdAction = command.action
     val name = cmdAction.id
     injector.actionExecutor.executeCommand(editor, action, name, action)
+    // Drives the renderer's undo-discrimination counter — see IjBlockSelectionRenderer.commandsSinceExit.
+    injector.blockSelectionRenderer.notifyCommandFinished(editor)
   }
 
   /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualSwapEndsAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/visual/VisualSwapEndsAction.kt
@@ -10,6 +10,7 @@ package com.maddyhome.idea.vim.action.motion.visual
 
 import com.intellij.vim.annotations.CommandOrMotion
 import com.intellij.vim.annotations.Mode
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
@@ -72,11 +73,18 @@ private fun swapVisualEnds(caret: VimCaret): Boolean {
 }
 
 private fun swapVisualEndsBigO(editor: VimEditor): Boolean {
+  val natives = editor.nativeCarets()
+  return if (natives.size >= 2) {
+    swapBlockEndsAcrossNativeCarets(editor, natives)
+  } else {
+    swapBlockEndsFromPrimaryLogicalBounds(editor)
+  }
+}
+
+private fun swapBlockEndsAcrossNativeCarets(editor: VimEditor, natives: List<VimCaret>): Boolean {
   val caret = editor.primaryCaret()
-  val anotherSideCaret = editor.nativeCarets().let { if (it.first() == caret) it.last() else it.first() }
-
   val adj = injector.visualMotionGroup.selectionAdj
-
+  val anotherSideCaret = if (natives.first() == caret) natives.last() else natives.first()
   if (caret.offset == caret.selectionStart) {
     caret.vimSelectionStart = anotherSideCaret.selectionStart
     caret.moveToOffset(caret.selectionEnd - adj)
@@ -84,6 +92,18 @@ private fun swapVisualEndsBigO(editor: VimEditor): Boolean {
     caret.vimSelectionStart = anotherSideCaret.selectionEnd - adj
     caret.moveToOffset(caret.selectionStart)
   }
+  return true
+}
 
+// Virtual-block path: no secondary carets exist, so swap by computing new corners from the
+// primary's logical anchor (vimSelectionStart) + active (offset).
+private fun swapBlockEndsFromPrimaryLogicalBounds(editor: VimEditor): Boolean {
+  val caret = editor.primaryCaret()
+  val anchorPos = editor.offsetToBufferPosition(caret.vimSelectionStart)
+  val activePos = caret.getBufferPosition()
+  val newAnchor = BufferPosition(anchorPos.line, activePos.column)
+  val newActive = BufferPosition(activePos.line, anchorPos.column)
+  caret.vimSelectionStart = editor.bufferPositionToOffset(newAnchor)
+  caret.moveToOffset(editor.bufferPositionToOffset(newActive))
   return true
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimBlockSelectionRenderer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimBlockSelectionRenderer.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.api
+
+/**
+ * Renders the block-visual selection band using IDE-level highlighters instead of N native
+ * IntelliJ carets. Allows navigation (e.g., held `j` / `k`) to update the visible selection
+ * in O(1) per motion rather than O(rows).
+ *
+ * Active only when the experimental virtual-block-selection path is enabled (see
+ * EngineVisualGroup#setVisualSelection). Default implementation is a no-op so non-IDE editors
+ * and tests are unaffected.
+ */
+interface VimBlockSelectionRenderer {
+  fun isEnabled(editor: VimEditor): Boolean = false
+
+  fun update(
+    editor: VimEditor,
+    blockStart: BufferPosition,
+    blockEnd: BufferPosition,
+    dollarExtension: Boolean = false,
+  ) {
+  }
+
+  /** Called on mode change or editor disposal. */
+  fun clear(editor: VimEditor) {}
+
+  /** Returns the current block's logical corners, or null when no virtual block is active. */
+  fun getBounds(editor: VimEditor): BlockBounds? = null
+
+  /**
+   * Materialize N real IntelliJ carets matching the current block bounds, then dispose the
+   * highlighter band. Call this immediately before invoking a mutation that needs IntelliJ's
+   * standard multi-caret semantics (e.g. typing in Select-block mode that replaces the
+   * selection across N rows). No-op when no virtual block is active.
+   */
+  fun materializeCarets(editor: VimEditor) {}
+
+  /**
+   * Materialize from the bounds saved at the most recent block-visual exit. Used by ex
+   * commands (`Command.execute`) that run in Normal mode after the visual exit — by then the
+   * active bounds have been cleared but the snapshot still reflects the block range.
+   */
+  fun materializeCaretsFromSavedExit(editor: VimEditor) {}
+
+  /**
+   * Called by KeyHandler after each Vim command (including undo) finishes. The renderer uses
+   * this to count commands since the most recent block-visual exit, so the undo virtual fallback
+   * (UndoRedoHelper) can distinguish "the immediate destructive block edit" from later edits.
+   */
+  fun notifyCommandFinished(editor: VimEditor) {}
+
+  data class BlockBounds(
+    val anchorLine: Int,
+    val anchorCol: Int,
+    val activeLine: Int,
+    val activeCol: Int,
+    /** True if the active corner was extended via `$` — each row's selection runs to its own line end. */
+    val dollarExtension: Boolean = false,
+  )
+}
+
+/** No-op default — used by test stubs / regex evaluator. */
+internal object NoOpVimBlockSelectionRenderer : VimBlockSelectionRenderer

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
@@ -160,6 +160,10 @@ interface VimInjector {
   val pathExpansion: VimPathExpansion
 
   val pluginActivator: VimPluginActivator
+
+  /** Experimental: renderer for block-visual selection without N native carets. */
+  val blockSelectionRenderer: VimBlockSelectionRenderer
+    get() = NoOpVimBlockSelectionRenderer
 }
 
 lateinit var injector: VimInjector

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimVisualMotionGroupBase.kt
@@ -37,7 +37,13 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
     // vimLeadSelectionOffset requires read action
     injector.application.runReadAction {
       if (selectionType == SelectionType.BLOCK_WISE) {
-        editor.primaryCaret().run { vimSelectionStart = vimLeadSelectionOffset }
+        // In virtual-block mode, the primary caret's IntelliJ selection only covers the
+        // primary's row, so vimLeadSelectionOffset would collapse the anchor onto primary's
+        // row and we'd lose the block's row span. Preserve the existing anchor here — it was
+        // set correctly when block visual / select was first entered.
+        if (!injector.blockSelectionRenderer.isEnabled(editor)) {
+          editor.primaryCaret().run { vimSelectionStart = vimLeadSelectionOffset }
+        }
       } else {
         editor.nativeCarets().forEach { it.vimSelectionStart = it.vimLeadSelectionOffset }
       }
@@ -51,14 +57,21 @@ abstract class VimVisualMotionGroupBase : VimVisualMotionGroup {
     // If we're entering from Normal, use its own returnTo, as this will handle both Normal and "Internal Normal".
     // And return back to Select if we were originally in Select and entered Visual for a single command (eg `gh<C-O>e`)
     val mode = editor.mode
+    val wasVirtualBlock = mode is Mode.VISUAL &&
+      mode.selectionType == SelectionType.BLOCK_WISE &&
+      injector.blockSelectionRenderer.isEnabled(editor)
     editor.mode = when {
       mode is Mode.VISUAL && mode.isSelectPending -> mode.returnTo
       mode is Mode.VISUAL || mode is Mode.SELECT -> Mode.SELECT(selectionType, mode.returnTo)
       mode is Mode.NORMAL -> Mode.SELECT(selectionType, mode.returnTo)
       else -> Mode.SELECT(selectionType, mode)
     }
-    injector.application.runReadAction {
-      editor.forEachCaret { it.vimSelectionStart = it.vimLeadSelectionOffset }
+    // Preserve the anchor across virtual-block transitions — see comment in enterVisualMode.
+    val preserveVirtualBlockAnchor = wasVirtualBlock && selectionType == SelectionType.BLOCK_WISE
+    if (!preserveVirtualBlockAnchor) {
+      injector.application.runReadAction {
+        editor.forEachCaret { it.vimSelectionStart = it.vimLeadSelectionOffset }
+      }
     }
     return true
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
@@ -8,14 +8,13 @@
 
 package com.maddyhome.idea.vim.group.visual
 
+import com.maddyhome.idea.vim.api.BufferPosition
 import com.maddyhome.idea.vim.api.ImmutableVimCaret
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimMotionGroupBase
-import com.maddyhome.idea.vim.api.VimVisualPosition
 import com.maddyhome.idea.vim.api.getLineEndOffset
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.api.isLineEmpty
 import com.maddyhome.idea.vim.helper.VimLockLabel
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
@@ -41,59 +40,47 @@ fun setVisualSelection(selectionStart: Int, selectionEnd: Int, caret: VimCaret) 
       caret.vimSetSystemSelectionSilently(nativeStart, nativeEnd)
     }
 
-    SelectionType.BLOCK_WISE -> {
-      // This will invalidate any secondary carets, but we shouldn't have any of these cached in local variables, etc.
-      editor.removeSecondaryCarets()
-
-      // Set system selection
-      val (blockStart, blockEnd) = blockToNativeSelection(editor, selectionStart, selectionEnd, mode)
-      val lastColumn = editor.primaryCaret().vimLastColumn
-
-      // WARNING! This can invalidate the primary caret! I.e. the `caret` parameter will no longer be the primary caret.
-      // Given an existing visual block selection, moving the caret will first remove all secondary carets (above) then
-      // this method will ask IntelliJ to create a new multi-caret block selection. If we're moving up (`k`) a new caret
-      // is added, and becomes the new primary caret. The current `caret` parameter remains valid, but is no longer the
-      // primary caret. Make sure to fetch the new primary caret if necessary.
-      editor.vimSetSystemBlockSelectionSilently(blockStart, blockEnd)
-
-      // We've just added secondary carets again, hide them to better emulate block selection
-      injector.editorGroup.updateCaretsVisualAttributes(editor)
-
-      for (aCaret in editor.nativeCarets()) {
-        if (!aCaret.isValid) continue
-        val line = aCaret.getBufferPosition().line
-        val lineEndOffset = editor.getLineEndOffset(line, true)
-        val lineStartOffset = editor.getLineStartOffset(line)
-
-        // Extend selection to line end if it was made with `$` command
-        if (lastColumn >= VimMotionGroupBase.LAST_COLUMN) {
-          aCaret.vimSetSystemSelectionSilently(aCaret.selectionStart, lineEndOffset)
-          val newOffset = (lineEndOffset - injector.visualMotionGroup.selectionAdj).coerceAtLeast(lineStartOffset)
-          aCaret.moveToInlayAwareOffset(newOffset)
-        }
-        val visualPosition = editor.offsetToVisualPosition(aCaret.selectionEnd)
-        if (aCaret.offset == aCaret.selectionEnd && visualPosition != aCaret.getVisualPosition()) {
-          // Put right caret position for tab character
-          aCaret.moveToVisualPosition(visualPosition)
-        }
-        if (mode !is Mode.SELECT &&
-          !editor.isLineEmpty(line, false) &&
-          aCaret.offset == aCaret.selectionEnd &&
-          aCaret.selectionEnd - 1 >= lineStartOffset &&
-          aCaret.selectionEnd - aCaret.selectionStart != 0
-        ) {
-          // Move all carets one char left in case if it's on selection end
-          aCaret.moveToVisualPosition(VimVisualPosition(visualPosition.line, visualPosition.column - 1))
-        }
-      }
-
-      editor.primaryCaret().moveToInlayAwareOffset(selectionEnd)
-    }
+    SelectionType.BLOCK_WISE -> setVirtualBlockSelection(editor, selectionStart, selectionEnd, mode)
   }
 
   // Selection-change notification for the IDE clipboard layer (vim-engine doesn't know how
   // PRIMARY should behave on each platform). Clipboard I/O must never break visual mode setup.
   runCatching { injector.clipboardManager.onVisualSelectionChange(caret.editor, caret) }
+}
+
+/**
+ * Virtual-block path: a single primary caret plus an IDE-level highlighter band, instead of
+ * N native carets. Operators read block bounds from primary's `vimSelectionStart` + `offset`
+ * (see VisualOperatorActionHandler.collectSelections). Held `j`/`k` becomes O(1) per motion
+ * instead of O(rows).
+ */
+private fun setVirtualBlockSelection(editor: VimEditor, selectionStart: Int, selectionEnd: Int, mode: Mode) {
+  val (blockStart, blockEnd) = blockToNativeSelection(editor, selectionStart, selectionEnd, mode)
+  val dollarExtension = editor.primaryCaret().vimLastColumn >= VimMotionGroupBase.LAST_COLUMN
+
+  editor.removeSecondaryCarets()
+  editor.primaryCaret().moveToInlayAwareOffset(selectionEnd)
+  setPrimaryRowSelection(editor, blockStart, blockEnd)
+
+  injector.blockSelectionRenderer.update(editor, blockStart, blockEnd, dollarExtension)
+}
+
+/**
+ * Maintain a real IntelliJ selection on the primary caret matching the block's column range
+ * *on the primary's row*. Code that reads `caret.selectionStart/End` (e.g.
+ * `adjustCaretsForSelectionPolicy` during `<C-G>` Visual<->Select toggle) needs this. We
+ * deliberately don't span the block diagonally — that would render in the IDE as a continuous
+ * character-mode selection across rows, obscuring the per-row band painted by RangeHighlighters.
+ */
+private fun setPrimaryRowSelection(editor: VimEditor, blockStart: BufferPosition, blockEnd: BufferPosition) {
+  val minCol = minOf(blockStart.column, blockEnd.column)
+  val maxCol = maxOf(blockStart.column, blockEnd.column)
+  val primaryRow = editor.primaryCaret().getBufferPosition().line
+  val rowStart = editor.getLineStartOffset(primaryRow)
+  val rowEnd = editor.getLineEndOffset(primaryRow)
+  val selStart = (rowStart + minCol).coerceAtMost(rowEnd)
+  val selEnd = (rowStart + maxCol).coerceAtMost(rowEnd)
+  editor.primaryCaret().vimSetSystemSelectionSilently(selStart, selEnd)
 }
 
 /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/thinapi/editor/caret/CaretReadImpl.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/thinapi/editor/caret/CaretReadImpl.kt
@@ -15,6 +15,7 @@ import com.intellij.vim.api.models.Range
 import com.intellij.vim.api.models.TextType
 import com.intellij.vim.api.scopes.editor.caret.CaretRead
 import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimBlockSelectionRenderer
 import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
@@ -47,19 +48,42 @@ class CaretReadImpl(
 
   override val selection: Range
     get() {
-      val mode = injector.vimState.mode
-      val isVisualBlockMode = mode is Mode.VISUAL && mode.selectionType == SelectionType.BLOCK_WISE
-
-      return if (isVisualBlockMode) {
-        // For block selection, gather all carets' selections and use min start / max end
-        val allCarets = vimEditor.nativeCarets()
-        val start = allCarets.minOf { it.selectionStart }
-        val end = allCarets.maxOf { it.selectionEnd }
-        Range.Block(start, end)
-      } else {
-        Range.Simple(vimCaret.selectionStart, vimCaret.selectionEnd)
+      if (!isVisualBlockMode()) {
+        return Range.Simple(vimCaret.selectionStart, vimCaret.selectionEnd)
       }
+      val bounds = injector.blockSelectionRenderer.getBounds(vimEditor)
+        ?: return blockRangeFromNativeCarets()
+      return blockRangeFromBounds(bounds)
     }
+
+  private fun isVisualBlockMode(): Boolean {
+    val mode = injector.vimState.mode
+    return mode is Mode.VISUAL && mode.selectionType == SelectionType.BLOCK_WISE
+  }
+
+  private fun blockRangeFromBounds(bounds: VimBlockSelectionRenderer.BlockBounds): Range.Block {
+    val minLine = minOf(bounds.anchorLine, bounds.activeLine)
+    val maxLine = maxOf(bounds.anchorLine, bounds.activeLine)
+    val minCol = minOf(bounds.anchorCol, bounds.activeCol)
+    val maxCol = maxOf(bounds.anchorCol, bounds.activeCol)
+    val start = rowOffsetClampedToLineEnd(minLine, minCol)
+    val end = rowOffsetClampedToLineEnd(maxLine, maxCol)
+    return Range.Block(start, end)
+  }
+
+  private fun rowOffsetClampedToLineEnd(line: Int, column: Int): Int {
+    val rowStart = vimEditor.getLineStartOffset(line)
+    val rowEnd = vimEditor.getLineEndOffset(line)
+    return (rowStart + column).coerceAtMost(rowEnd)
+  }
+
+  // Fallback (should be rare): aggregate whatever native carets exist.
+  private fun blockRangeFromNativeCarets(): Range.Block {
+    val allCarets = vimEditor.nativeCarets()
+    val start = allCarets.minOf { it.selectionStart }
+    val end = allCarets.maxOf { it.selectionEnd }
+    return Range.Block(start, end)
+  }
 
   override val line: Line
     get() {
@@ -106,16 +130,11 @@ class CaretReadImpl(
 
   override val selectionMarks: Range?
     get() {
-      val mode = injector.vimState.mode
-      val isVisualBlockMode = mode is Mode.VISUAL && mode.selectionType == SelectionType.BLOCK_WISE
-
-      return if (isVisualBlockMode) {
+      if (isVisualBlockMode()) {
         val marks = injector.markService.getVisualSelectionMarks(vimEditor.primaryCaret()) ?: return null
-        Range.Block(marks.startOffset, marks.endOffset)
-      } else {
-        val visualSelectionMarks = injector.markService.getVisualSelectionMarks(vimCaret) ?: return null
-        visualSelectionMarks.toRange()
+        return Range.Block(marks.startOffset, marks.endOffset)
       }
+      return injector.markService.getVisualSelectionMarks(vimCaret)?.toRange()
     }
 
   override val changeMarks: Range?

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/ActionCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/ActionCommand.kt
@@ -16,6 +16,7 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.ex.ExException
 import com.maddyhome.idea.vim.ex.ranges.Range
+import com.maddyhome.idea.vim.state.mode.isBlock
 import com.maddyhome.idea.vim.vimscript.model.ExecutionResult
 
 /**
@@ -40,6 +41,12 @@ data class ActionCommand(val range: Range, val modifier: CommandModifier, val ar
     val actionName = argument.trim()
     val action = injector.actionExecutor.getAction(actionName)
       ?: throw ExException(injector.messages.message("command.action.not.found", actionName))
+    // IDE actions run per-IntelliJ-caret; the virtual-block path only has one. SAVE_SELECTION
+    // means we're already in Normal mode (active bounds gone), so re-materialize N carets
+    // from the bounds snapshot saved at block-visual exit.
+    if (editor.primaryCaret().lastSelectionInfo.selectionType.isBlock) {
+      injector.blockSelectionRenderer.materializeCaretsFromSavedExit(editor)
+    }
     if (injector.application.isUnitTest()) {
       executeAction(editor, action, context)
     } else {


### PR DESCRIPTION
We were creating new cursor for each line in visual block mode which resulted in poor performance or even crashes for a large number of lines. In this commit we change it to use virtual selection renderer which uses oinly single caret.