### PR TITLE
Fix vim 315 incorrect insert normal mode behavior

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertSingleCommandActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertSingleCommandActionTest.kt
@@ -15,11 +15,31 @@ import org.junit.jupiter.api.Test
 class InsertSingleCommandActionTest : SingleCommandActionTest() {
   override val command: String = "i"
   override val mode: Mode = Mode.INSERT
+
+  @Test
+  fun `test ctrl-o at end of line`() {
+    doTest(
+      listOf(command, "<C-O>", "db"),
+      "first line${c}\nsecond line",
+      "first e${c}\nsecond line",
+      mode,
+    )
+  }
 }
 
 class ReplaceSingleCommandActionTest : SingleCommandActionTest() {
   override val command: String = "R"
   override val mode: Mode = Mode.REPLACE
+
+  @Test
+  fun `test ctrl-o at end of line`() {
+    doTest(
+      listOf(command, "<C-O>", "db"),
+      "first line${c}\nsecond line",
+      "first ${c}e\nsecond line",
+      mode,
+    )
+  }
 }
 
 abstract class SingleCommandActionTest : VimTestCase() {
@@ -47,13 +67,4 @@ abstract class SingleCommandActionTest : VimTestCase() {
     )
   }
 
-  @Test
-  fun `test ctrl-o at end of line`() {
-    doTest(
-      listOf(command, "<C-O>", "db"),
-      "first line${c}\nsecond line",
-      "first e${c}\nsecond line",
-      mode,
-    )
-  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertSingleCommandActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertSingleCommandActionTest.kt
@@ -17,11 +17,51 @@ class InsertSingleCommandActionTest : SingleCommandActionTest() {
   override val mode: Mode = Mode.INSERT
 
   @Test
-  fun `test ctrl-o at end of line`() {
+  fun `test ctrl-o db at end of line`() {
     doTest(
       listOf(command, "<C-O>", "db"),
       "first line${c}\nsecond line",
-      "first e${c}\nsecond line",
+      "first ${c}e\nsecond line",
+      mode,
+    )
+  }
+
+  @Test
+  fun `test ctrl-o x at end of line`() {
+    doTest(
+      listOf(command, "<C-O>", "x"),
+      "first line${c}\nsecond line",
+      "first lin${c}\nsecond line",
+      mode,
+    )
+  }
+
+  @Test
+  fun `test ctrl-o D at end of line`() {
+    doTest(
+      listOf(command, "<C-O>", "D"),
+      "first line${c}\nsecond line",
+      "first lin${c}\nsecond line",
+      mode,
+    )
+  }
+
+  @Test
+  fun `test ctrl-o db not at end of line`() {
+    doTest(
+      listOf(command, "<C-O>", "db"),
+      "first li${c}ne\nsecond line",
+      "first ${c}ne\nsecond line",
+      mode,
+    )
+  }
+
+  @Test
+  fun `test ctrl-o x not at end of line`() {
+    doTest(
+      listOf(command, "<C-O>", "x"),
+      "first li${c}ne\nsecond line",
+      "first l${c}ne\nsecond line",
       mode,
     )
   }
@@ -32,11 +72,31 @@ class ReplaceSingleCommandActionTest : SingleCommandActionTest() {
   override val mode: Mode = Mode.REPLACE
 
   @Test
-  fun `test ctrl-o at end of line`() {
+  fun `test ctrl-o db at end of line`() {
     doTest(
       listOf(command, "<C-O>", "db"),
       "first line${c}\nsecond line",
       "first ${c}e\nsecond line",
+      mode,
+    )
+  }
+
+  @Test
+  fun `test ctrl-o x at end of line`() {
+    doTest(
+      listOf(command, "<C-O>", "x"),
+      "first line${c}\nsecond line",
+      "first lin${c}\nsecond line",
+      mode,
+    )
+  }
+
+  @Test
+  fun `test ctrl-o x not at end of line`() {
+    doTest(
+      listOf(command, "<C-O>", "x"),
+      "first li${c}ne\nsecond line",
+      "first l${c}ne\nsecond line",
       mode,
     )
   }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertSingleCommandActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertSingleCommandActionTest.kt
@@ -46,4 +46,14 @@ abstract class SingleCommandActionTest : VimTestCase() {
       mode,
     )
   }
+
+  @Test
+  fun `test ctrl-o at end of line`() {
+    doTest(
+      listOf(command, "<C-O>", "db"),
+      "first line${c}\nsecond line",
+      "first e${c}\nsecond line",
+      mode,
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertSingleCommandActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertSingleCommandActionTest.kt
@@ -21,7 +21,7 @@ class InsertSingleCommandActionTest : SingleCommandActionTest() {
     doTest(
       listOf(command, "<C-O>", "db"),
       "first line${c}\nsecond line",
-      "first ${c}e\nsecond line",
+      "first e${c}\nsecond line",
       mode,
     )
   }
@@ -61,7 +61,7 @@ class InsertSingleCommandActionTest : SingleCommandActionTest() {
     doTest(
       listOf(command, "<C-O>", "x"),
       "first li${c}ne\nsecond line",
-      "first l${c}ne\nsecond line",
+      "first li${c}e\nsecond line",
       mode,
     )
   }
@@ -96,7 +96,7 @@ class ReplaceSingleCommandActionTest : SingleCommandActionTest() {
     doTest(
       listOf(command, "<C-O>", "x"),
       "first li${c}ne\nsecond line",
-      "first l${c}ne\nsecond line",
+      "first li${c}e\nsecond line",
       mode,
     )
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -260,6 +260,7 @@ class KeyHandler {
     val command = keyState.commandBuilder.buildCommand()
     val operatorArguments = OperatorArguments(command.rawCount, editorState.mode)
 
+    //true if goes form insert to OpPending
     val wasOpPendingFromInsert = (editor.mode as? Mode.OP_PENDING)?.let {
       it.returnTo is Mode.INSERT
     } ?: false
@@ -370,6 +371,7 @@ class KeyHandler {
       }
       injector.actionExecutor.executeVimAction(editor, cmd.action, context, operatorArguments)
 
+      // this restore the caret position when use C-o then db from the end of the line
       if (wasOpPendingFromInsert && editorState.mode is Mode.INSERT) {
         restoreAllowEndCaretPosition(editor, editorState)
       }
@@ -389,11 +391,7 @@ class KeyHandler {
       // mode commands. An exception is if this command should leave us in the temporary mode such as
       // "select register"
       if (editorState.mode is Mode.NORMAL && !cmd.flags.contains(CommandFlags.FLAG_EXPECT_MORE)) {
-        val oldMode = editorState.mode as Mode.NORMAL
-        editor.mode = oldMode.returnTo
-        if (oldMode.isInsertPending || oldMode.isReplacePending) {
-          restoreAllowEndCaretPosition(editor, editorState)
-        }
+        editor.mode = editorState.mode.returnTo
       }
 
       instance.reset(keyState, editorState.mode)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -370,16 +370,8 @@ class KeyHandler {
       }
       injector.actionExecutor.executeVimAction(editor, cmd.action, context, operatorArguments)
 
-      //C-o followed by db, this will move the caret one past
       if (wasOpPendingFromInsert && editorState.mode is Mode.INSERT) {
-        for (caret in editor.nativeCarets()) {
-          val line = caret.getBufferPosition().line
-          val lineEndNotAllowed = editor.getLineEndOffset(line, false)
-          val lineEndAllowed = editor.getLineEndOffset(line, true)
-          if (caret.offset == lineEndNotAllowed && lineEndAllowed != lineEndNotAllowed) {
-            caret.moveToOffset(lineEndAllowed)
-          }
-        }
+        restoreAllowEndCaretPosition(editor, editorState)
       }
 
       if (editorState.mode is Mode.INSERT || editorState.mode is Mode.REPLACE) {
@@ -397,10 +389,27 @@ class KeyHandler {
       // mode commands. An exception is if this command should leave us in the temporary mode such as
       // "select register"
       if (editorState.mode is Mode.NORMAL && !cmd.flags.contains(CommandFlags.FLAG_EXPECT_MORE)) {
-        editor.mode = editorState.mode.returnTo
+        val oldMode = editorState.mode as Mode.NORMAL
+        editor.mode = oldMode.returnTo
+        if (oldMode.isInsertPending || oldMode.isReplacePending) {
+          restoreAllowEndCaretPosition(editor, editorState)
+        }
       }
 
       instance.reset(keyState, editorState.mode)
+    }
+
+    private fun restoreAllowEndCaretPosition(editor: VimEditor, editorState: VimStateMachine) {
+      if (!editorState.wasCaretAtEndOfLineBeforeInsertNormal) return
+      for (caret in editor.nativeCarets()) {
+        val line = caret.getBufferPosition().line
+        val lineEndNotAllowed = editor.getLineEndOffset(line, false)
+        val lineEndAllowed = editor.getLineEndOffset(line, true)
+        if (caret.offset == lineEndNotAllowed && lineEndAllowed != lineEndNotAllowed) {
+          caret.moveToOffset(lineEndAllowed)
+        }
+      }
+      editorState.wasCaretAtEndOfLineBeforeInsertNormal = false
     }
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -9,6 +9,7 @@ package com.maddyhome.idea.vim
 
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.getLineEndOffset
 import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Command
@@ -259,6 +260,10 @@ class KeyHandler {
     val command = keyState.commandBuilder.buildCommand()
     val operatorArguments = OperatorArguments(command.rawCount, editorState.mode)
 
+    val wasOpPendingFromInsert = (editor.mode as? Mode.OP_PENDING)?.let {
+      it.returnTo is Mode.INSERT
+    } ?: false
+
     // If we were in "operator pending" mode, reset back to normal mode.
     // But opening command line should not reset operator pending mode (e.g. `d/foo`)
     if (!command.flags.contains(CommandFlags.FLAG_START_EX)) {
@@ -277,7 +282,7 @@ class KeyHandler {
       }
     }
 
-    val action: Runnable = ActionRunner(editor, context, command, keyState, operatorArguments)
+    val action: Runnable = ActionRunner(editor, context, command, keyState, operatorArguments, wasOpPendingFromInsert)
     val cmdAction = command.action
     val name = cmdAction.id
     injector.actionExecutor.executeCommand(editor, action, name, action)
@@ -354,6 +359,7 @@ class KeyHandler {
     val cmd: Command,
     val keyState: KeyHandlerState,
     val operatorArguments: OperatorArguments,
+    val wasOpPendingFromInsert: Boolean = false,
   ) : Runnable {
     override fun run() {
       val editorState = injector.vimState
@@ -363,6 +369,19 @@ class KeyHandler {
         injector.registerGroup.selectRegister(register)
       }
       injector.actionExecutor.executeVimAction(editor, cmd.action, context, operatorArguments)
+
+      //C-o followed by db, this will move the caret one past
+      if (wasOpPendingFromInsert && editorState.mode is Mode.INSERT) {
+        for (caret in editor.nativeCarets()) {
+          val line = caret.getBufferPosition().line
+          val lineEndNotAllowed = editor.getLineEndOffset(line, false)
+          val lineEndAllowed = editor.getLineEndOffset(line, true)
+          if (caret.offset == lineEndNotAllowed && lineEndAllowed != lineEndNotAllowed) {
+            caret.moveToOffset(lineEndAllowed)
+          }
+        }
+      }
+
       if (editorState.mode is Mode.INSERT || editorState.mode is Mode.REPLACE) {
         injector.changeGroup.processCommand(editor, cmd)
       }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -19,6 +19,7 @@ import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.diagnostic.VimLogger
 import com.maddyhome.idea.vim.diagnostic.trace
 import com.maddyhome.idea.vim.diagnostic.vimLogger
+import com.maddyhome.idea.vim.helper.isCaretAtLineEnd
 import com.maddyhome.idea.vim.impl.state.toMappingMode
 import com.maddyhome.idea.vim.key.KeyConsumer
 import com.maddyhome.idea.vim.key.KeyStack
@@ -261,9 +262,11 @@ class KeyHandler {
     val operatorArguments = OperatorArguments(command.rawCount, editorState.mode)
 
     //true if goes form insert to OpPending
-    val wasOpPendingFromInsert = (editor.mode as? Mode.OP_PENDING)?.let {
-      it.returnTo is Mode.INSERT
-    } ?: false
+    val isSingleCommandFromInsert = when (val m = editor.mode) {
+      is Mode.NORMAL -> m.isInsertPending || m.isReplacePending
+      is Mode.OP_PENDING -> m.returnTo is Mode.INSERT || m.returnTo is Mode.REPLACE
+      else -> false
+    }
 
     // If we were in "operator pending" mode, reset back to normal mode.
     // But opening command line should not reset operator pending mode (e.g. `d/foo`)
@@ -283,7 +286,7 @@ class KeyHandler {
       }
     }
 
-    val action: Runnable = ActionRunner(editor, context, command, keyState, operatorArguments, wasOpPendingFromInsert)
+    val action: Runnable = ActionRunner(editor, context, command, keyState, operatorArguments, isSingleCommandFromInsert)
     val cmdAction = command.action
     val name = cmdAction.id
     injector.actionExecutor.executeCommand(editor, action, name, action)
@@ -360,7 +363,7 @@ class KeyHandler {
     val cmd: Command,
     val keyState: KeyHandlerState,
     val operatorArguments: OperatorArguments,
-    val wasOpPendingFromInsert: Boolean = false,
+    val isSingleCommandFromInsert: Boolean = false,
   ) : Runnable {
     override fun run() {
       val editorState = injector.vimState
@@ -372,7 +375,7 @@ class KeyHandler {
       injector.actionExecutor.executeVimAction(editor, cmd.action, context, operatorArguments)
 
       // this restore the caret position when use C-o then db from the end of the line
-      if (wasOpPendingFromInsert && editorState.mode is Mode.INSERT) {
+      if (isSingleCommandFromInsert && editorState.mode is Mode.INSERT) {
         restoreAllowEndCaretPosition(editor, editorState)
       }
 
@@ -392,6 +395,9 @@ class KeyHandler {
       // "select register"
       if (editorState.mode is Mode.NORMAL && !cmd.flags.contains(CommandFlags.FLAG_EXPECT_MORE)) {
         editor.mode = editorState.mode.returnTo
+        if (isSingleCommandFromInsert) {
+          restoreAllowEndCaretPosition(editor, editorState)
+        }
       }
 
       instance.reset(keyState, editorState.mode)
@@ -400,11 +406,9 @@ class KeyHandler {
     private fun restoreAllowEndCaretPosition(editor: VimEditor, editorState: VimStateMachine) {
       if (!editorState.wasCaretAtEndOfLineBeforeInsertNormal) return
       for (caret in editor.nativeCarets()) {
-        val line = caret.getBufferPosition().line
-        val lineEndNotAllowed = editor.getLineEndOffset(line, false)
-        val lineEndAllowed = editor.getLineEndOffset(line, true)
-        if (caret.offset == lineEndNotAllowed && lineEndAllowed != lineEndNotAllowed) {
-          caret.moveToOffset(lineEndAllowed)
+        if (editor.isCaretAtLineEnd(caret, allowEnd = false)) {
+          val line = caret.getBufferPosition().line
+          caret.moveToOffset(editor.getLineEndOffset(line, true))
         }
       }
       editorState.wasCaretAtEndOfLineBeforeInsertNormal = false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertSingleCommandAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertSingleCommandAction.kt
@@ -12,7 +12,6 @@ import com.intellij.vim.annotations.Mode
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.api.normalizeOffset
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertSingleCommandAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertSingleCommandAction.kt
@@ -34,14 +34,6 @@ class InsertSingleCommandAction : VimActionHandler.SingleExecution() {
     operatorArguments: OperatorArguments,
   ): Boolean {
     injector.changeGroup.processSingleCommand(editor)
-
-    editor.forEachCaret { caret ->
-      val normalized = editor.normalizeOffset(caret.offset, allowEnd = false)
-      if (normalized != caret.offset) {
-        caret.moveToOffset(normalized)
-      }
-    }
-
     return true
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertSingleCommandAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertSingleCommandAction.kt
@@ -12,6 +12,7 @@ import com.intellij.vim.annotations.Mode
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.api.normalizeOffset
 import com.maddyhome.idea.vim.command.Command
 import com.maddyhome.idea.vim.command.CommandFlags
 import com.maddyhome.idea.vim.command.OperatorArguments
@@ -33,6 +34,14 @@ class InsertSingleCommandAction : VimActionHandler.SingleExecution() {
     operatorArguments: OperatorArguments,
   ): Boolean {
     injector.changeGroup.processSingleCommand(editor)
+
+    editor.forEachCaret { caret ->
+      val normalized = editor.normalizeOffset(caret.offset, allowEnd = false)
+      if (normalized != caret.offset) {
+        caret.moveToOffset(normalized)
+      }
+    }
+
     return true
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -30,6 +30,7 @@ import com.maddyhome.idea.vim.helper.CharacterHelper.charType
 import com.maddyhome.idea.vim.helper.NumberType
 import com.maddyhome.idea.vim.helper.StrictMode
 import com.maddyhome.idea.vim.helper.endOffsetInclusive
+import com.maddyhome.idea.vim.helper.isCaretAtLineEnd
 import com.maddyhome.idea.vim.helper.usesVirtualSpace
 import com.maddyhome.idea.vim.key.AbbreviationContext
 import com.maddyhome.idea.vim.key.findAndResolveAbbreviation
@@ -705,12 +706,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
    */
   override fun processSingleCommand(editor: VimEditor) {
 
-    injector.vimState.wasCaretAtEndOfLineBeforeInsertNormal = editor.nativeCarets().any { caret ->
-      val line = caret.getBufferPosition().line
-      val lineEndAllowed = editor.getLineEndOffset(line, true)
-      val lineEndNotAllowed = editor.getLineEndOffset(line, false)
-      caret.offset == lineEndAllowed && lineEndAllowed != lineEndNotAllowed
-    }
+    injector.vimState.wasCaretAtEndOfLineBeforeInsertNormal = editor.nativeCarets().any { editor.isCaretAtLineEnd(it, allowEnd = true) }
 
     editor.mode = Mode.NORMAL(editor.mode)
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -704,7 +704,22 @@ abstract class VimChangeGroupBase : VimChangeGroup {
    * @param editor The editor to put into NORMAL mode for one command
    */
   override fun processSingleCommand(editor: VimEditor) {
+
+    injector.vimState.wasCaretAtEndOfLineBeforeInsertNormal = editor.nativeCarets().any { caret ->
+      val line = caret.getBufferPosition().line
+      val lineEndAllowed = editor.getLineEndOffset(line, true)
+      val lineEndNotAllowed = editor.getLineEndOffset(line, false)
+      caret.offset == lineEndAllowed && lineEndAllowed != lineEndNotAllowed
+    }
+
     editor.mode = Mode.NORMAL(editor.mode)
+
+    editor.forEachCaret { caret ->
+      val normalized = editor.normalizeOffset(caret.offset, allowEnd = false)
+      if (normalized != caret.offset) {
+        caret.moveToOffset(normalized)
+      }
+    }
     clearStrokes(editor)
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineHelper.kt
@@ -8,7 +8,9 @@
 
 package com.maddyhome.idea.vim.helper
 
+import com.maddyhome.idea.vim.api.ImmutableVimCaret
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.getLineEndOffset
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.options
 import com.maddyhome.idea.vim.common.TextRange
@@ -51,6 +53,18 @@ fun VimEditor.isEndAllowed(mode: Mode): Boolean {
     Mode.INSERT, Mode.REPLACE, is Mode.VISUAL, is Mode.SELECT -> true
     is Mode.NORMAL -> if (mode.isInsertPending || mode.isReplacePending) true else usesVirtualSpace
     is Mode.CMD_LINE, is Mode.OP_PENDING -> usesVirtualSpace
+  }
+}
+
+fun VimEditor.isCaretAtLineEnd(caret: ImmutableVimCaret, allowEnd: Boolean): Boolean {
+  val line = caret.getBufferPosition().line
+  val lineEndAllowed = getLineEndOffset(line, true)
+  val lineEndNotAllowed = getLineEndOffset(line, false)
+  if (lineEndAllowed == lineEndNotAllowed) return false
+  return if (allowEnd) {
+    caret.offset == lineEndAllowed
+  } else {
+    caret.offset == lineEndNotAllowed
   }
 }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/impl/state/VimStateMachineImpl.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/impl/state/VimStateMachineImpl.kt
@@ -23,6 +23,8 @@ class VimStateMachineImpl : VimStateMachine {
   override var isDotRepeatInProgress: Boolean = false
   override var isReplaceCharacter: Boolean = false
 
+  override var wasCaretAtEndOfLineBeforeInsertNormal: Boolean = false
+
   /**
    * The currently executing command
    *
@@ -43,6 +45,7 @@ class VimStateMachineImpl : VimStateMachine {
     isDotRepeatInProgress = false
     isReplaceCharacter = false
     executingCommand = null
+    wasCaretAtEndOfLineBeforeInsertNormal = false
   }
 }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/VimStateMachine.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/state/VimStateMachine.kt
@@ -21,6 +21,8 @@ interface VimStateMachine {
   var isDotRepeatInProgress: Boolean
   val isReplaceCharacter: Boolean
 
+  var wasCaretAtEndOfLineBeforeInsertNormal: Boolean
+
   /**
    * The currently executing command
    *


### PR DESCRIPTION
while at the end of the line in insert mode pressing C-o , caret goes out of the end character leads to incorrect behavior, so i normalize it. and when returning to insert mode again restore the caret, so it match vim behavior when using C-o and then db from the end of the line