### PR TITLE
Fix(VIM-4245): Batch caret events in block-visual to unfreeze split mode

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -955,12 +955,18 @@ object VimListenerManager {
       }
     }
 
-    override fun caretAdded(event: CaretEvent) {
-      event.editor.updateCaretsVisualAttributes()
-    }
+    override fun caretAdded(event: CaretEvent) = updateAttributesUnlessSuppressed(event)
+    override fun caretRemoved(event: CaretEvent) = updateAttributesUnlessSuppressed(event)
 
-    override fun caretRemoved(event: CaretEvent) {
-      event.editor.updateCaretsVisualAttributes()
+    // updateCaretsVisualAttributes() walks every caret in the editor. A single block-visual
+    // motion can fire caretAdded/caretRemoved N times (one per caret added/removed by
+    // setBlockSelection), giving O(N²) per motion. When wrapped in
+    // [CaretVisualAttributesListenerSuppressor], skip the walk; the bulk op runs one final
+    // update at the end.
+    private fun updateAttributesUnlessSuppressed(event: CaretEvent) {
+      if (CaretVisualAttributesListenerSuppressor.isNotLocked) {
+        event.editor.updateCaretsVisualAttributes()
+      }
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
@@ -10,6 +10,7 @@ package com.maddyhome.idea.vim.newapi
 
 import com.intellij.codeInsight.folding.impl.FoldingUtil
 import com.intellij.execution.impl.ConsoleViewImpl
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.openapi.editor.FoldRegion
@@ -346,6 +347,41 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor, VimEditorBase() {
     val startPosition = LogicalPosition(start.line, start.column, start.leansForward)
     val endPosition = LogicalPosition(end.line, end.column, end.leansForward)
     editor.selectionModel.vimSetSystemBlockSelectionSilently(startPosition, endPosition)
+  }
+
+  override fun runBatchCaretOperation(runnable: () -> Unit) {
+    editor.caretModel.runBatchCaretOperation(runnable)
+  }
+
+  override fun runAsAllCaretsAction(runnable: () -> Unit) {
+    // Piggy-back on runForEachCaret to fire the CaretActionListener
+    // `beforeAllCaretsAction`/`afterAllCaretsAction` pair, which is split-mode's
+    // PatchEngineEditorSynchronizer's batching window: per-caret events fired during the
+    // runnable get swallowed (`isInsideAllCaretsAction` is true), and a single snapshot is sent
+    // over the RD protocol at the end — instead of N caret events × walk-all-N-carets
+    // serialization, which is O(N²) for block-visual motions on large blocks.
+    //
+    // The action is run exactly once regardless of caret count; we use runForEachCaret purely
+    // for its lifecycle. Caller must guarantee no nested runForEachCaret (e.g. no IDE actions);
+    // we fall back to a plain batch if that contract is broken.
+    if (ApplicationManager.getApplication().isDispatchThread()) {
+      try {
+        runOnceInsideRunForEachCaret(runnable)
+        return
+      } catch (_: IllegalStateException) {
+        // Already inside runForEachCaret — fall back to plain batch.
+      }
+    }
+    editor.caretModel.runBatchCaretOperation(runnable)
+  }
+
+  private fun runOnceInsideRunForEachCaret(runnable: () -> Unit) {
+    var alreadyRan = false
+    editor.caretModel.runForEachCaret {
+      if (alreadyRan) return@runForEachCaret
+      alreadyRan = true
+      runnable()
+    }
   }
 
   override fun getLineStartOffset(line: Int): Int {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -319,38 +319,46 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     count: Int,
     started: Boolean,
   ) {
-    for (caret in editor.nativeCarets()) {
-      if (repeatLines > 0) {
-        val visualLine = caret.getVisualPosition().line
-        val bufferLine = caret.getBufferPosition().line
-        val position = editor.bufferPositionToOffset(BufferPosition(bufferLine, repeatColumn, false))
-        for (i in 0 until repeatLines) {
-          if (repeatAppend &&
-            (repeatColumn < VimMotionGroupBase.LAST_COLUMN) &&
-            (injector.engineEditorHelper.getVisualLineLength(editor, visualLine + i) < repeatColumn)
-          ) {
-            val pad = injector.engineEditorHelper.pad(editor, bufferLine + i, repeatColumn)
-            if (pad.isNotEmpty()) {
-              val offset = editor.getLineEndOffset(bufferLine + i)
-              insertText(editor, caret, offset, pad)
+    // Defer caret merging across the row-by-row replay. We deliberately do NOT use
+    // `runAsAllCaretsAction` here: the replay may execute IDE actions (e.g. `<BS>` as a
+    // NativeAction stroke), and those typically call `runForEachCaret` themselves — nesting
+    // throws `IllegalStateException`. The plain batch is safe and still gives us merging
+    // deferral; the split-mode caret-event explosion is bounded by the listener gating in
+    // `EditorCaretHandler` and the wraps at the (non-replay) call sites.
+    editor.runBatchCaretOperation {
+      for (caret in editor.nativeCarets()) {
+        if (repeatLines > 0) {
+          val visualLine = caret.getVisualPosition().line
+          val bufferLine = caret.getBufferPosition().line
+          val position = editor.bufferPositionToOffset(BufferPosition(bufferLine, repeatColumn, false))
+          for (i in 0 until repeatLines) {
+            if (repeatAppend &&
+              (repeatColumn < VimMotionGroupBase.LAST_COLUMN) &&
+              (injector.engineEditorHelper.getVisualLineLength(editor, visualLine + i) < repeatColumn)
+            ) {
+              val pad = injector.engineEditorHelper.pad(editor, bufferLine + i, repeatColumn)
+              if (pad.isNotEmpty()) {
+                val offset = editor.getLineEndOffset(bufferLine + i)
+                insertText(editor, caret, offset, pad)
+              }
+            }
+            val updatedCount = if (started) (if (i == 0) count else count + 1) else count
+            if (repeatColumn >= VimMotionGroupBase.LAST_COLUMN) {
+              caret.moveToOffset(injector.motion.moveCaretToLineEnd(editor, bufferLine + i, true))
+              repeatInsertText(editor, context, updatedCount)
+            } else if (injector.engineEditorHelper.getVisualLineLength(editor, visualLine + i) >= repeatColumn) {
+              val visualPosition = VimVisualPosition(visualLine + i, repeatColumn, false)
+              val inlaysCount = injector.engineEditorHelper.amountOfInlaysBeforeVisualPosition(editor, visualPosition)
+              caret.moveToVisualPosition(VimVisualPosition(visualLine + i, repeatColumn + inlaysCount, false))
+              repeatInsertText(editor, context, updatedCount)
             }
           }
-          val updatedCount = if (started) (if (i == 0) count else count + 1) else count
-          if (repeatColumn >= VimMotionGroupBase.LAST_COLUMN) {
-            caret.moveToOffset(injector.motion.moveCaretToLineEnd(editor, bufferLine + i, true))
-            repeatInsertText(editor, context, updatedCount)
-          } else if (injector.engineEditorHelper.getVisualLineLength(editor, visualLine + i) >= repeatColumn) {
-            val visualPosition = VimVisualPosition(visualLine + i, repeatColumn, false)
-            val inlaysCount = injector.engineEditorHelper.amountOfInlaysBeforeVisualPosition(editor, visualPosition)
-            caret.moveToVisualPosition(VimVisualPosition(visualLine + i, repeatColumn + inlaysCount, false))
-            repeatInsertText(editor, context, updatedCount)
-          }
+          caret.moveToOffset(position)
+        } else {
+          repeatInsertText(editor, context, count)
+          val position = injector.motion.getHorizontalMotion(editor, caret, -1, false)
+          caret.moveToMotion(position)
         }
-        caret.moveToOffset(position)
-      } else {
-        repeatInsertText(editor, context, count)
-        val position = injector.motion.getHorizontalMotion(editor, caret, -1, false)
-        caret.moveToMotion(position)
       }
     }
     repeatLines = 0

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
@@ -185,6 +185,34 @@ interface VimEditor {
   fun removeSecondaryCarets()
   fun vimSetSystemBlockSelectionSilently(start: BufferPosition, end: BufferPosition)
 
+  /**
+   * Run a bulk caret-modifying operation. On IntelliJ this delegates to
+   * `CaretModel.runBatchCaretOperation`, which defers caret-merging until the runnable returns
+   * — useful when replacing many carets at once (e.g. block-visual `setBlockSelection`).
+   * Default is to just invoke the runnable; non-IDE editors don't need merging semantics.
+   *
+   * Safe to use around IDE-action replay (e.g. `repeatInsert`).
+   */
+  fun runBatchCaretOperation(runnable: () -> Unit) {
+    runnable()
+  }
+
+  /**
+   * Run a bulk caret-modifying operation inside an "all-carets-action" lifecycle. On IntelliJ
+   * this piggy-backs on `CaretModel.runForEachCaret` so the `beforeAllCaretsAction` /
+   * `afterAllCaretsAction` listener pair fires around the runnable. Split-mode's caret
+   * synchronizer uses that pair as a batching window — without it, every per-caret event ships
+   * a separate RD-protocol message, giving O(N²) per block-visual motion.
+   *
+   * IMPORTANT: the runnable must NOT execute IntelliJ actions that themselves call
+   * `runForEachCaret` (e.g. `EditorActionExecutor.executeAction(<BS>)`). Such nested calls
+   * throw `IllegalStateException("Recursive runForEachCaret invocations are not allowed")`.
+   * Use [runBatchCaretOperation] for IDE-action replay.
+   */
+  fun runAsAllCaretsAction(runnable: () -> Unit) {
+    runnable()
+  }
+
   fun getLineStartOffset(line: Int): Int
   fun getLineEndOffset(line: Int): Int
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
@@ -17,6 +17,7 @@ import com.maddyhome.idea.vim.api.getLineEndOffset
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.api.isLineEmpty
 import com.maddyhome.idea.vim.helper.VimLockLabel
+import com.maddyhome.idea.vim.listener.CaretVisualAttributesListenerSuppressor
 import com.maddyhome.idea.vim.state.mode.Mode
 import com.maddyhome.idea.vim.state.mode.SelectionType
 import com.maddyhome.idea.vim.state.mode.inBlockSelection
@@ -42,52 +43,71 @@ fun setVisualSelection(selectionStart: Int, selectionEnd: Int, caret: VimCaret) 
     }
 
     SelectionType.BLOCK_WISE -> {
-      // This will invalidate any secondary carets, but we shouldn't have any of these cached in local variables, etc.
-      editor.removeSecondaryCarets()
+      // Suppress our own EditorCaretHandler during the bulk caret replacement — without this,
+      // each of the N caretAdded/caretRemoved events fired by setBlockSelection triggers an
+      // O(N) `updateCaretsVisualAttributes` walk, giving O(N²) per block-visual motion and an
+      // unresponsive EDT on large blocks. The single update at the end of this block is enough.
+      //
+      // runAsAllCaretsAction fires the all-carets-action listener pair so split mode's
+      // PatchEngineEditorSynchronizer batches its per-event protocol sends into one snapshot.
+      // Safe here because the body doesn't run any IDE actions (only Vim-internal caret moves).
+      CaretVisualAttributesListenerSuppressor.lock().use {
+        editor.runAsAllCaretsAction {
+          // This will invalidate any secondary carets, but we shouldn't have any of these cached
+          // in local variables, etc. Required for correctness: setCaretsAndSelections reuses
+          // existing carets by insertion order, and Vim's `vimSelectionStart` user-data is
+          // attached to a specific caret instance — if a different caret becomes primary
+          // (e.g. after `O`-swap then `k` shrinking the block), the anchor stored on the now-
+          // removed caret is lost. Pre-clearing ensures primary is always the same caret
+          // throughout a block-visual session.
+          editor.removeSecondaryCarets()
 
-      // Set system selection
-      val (blockStart, blockEnd) = blockToNativeSelection(editor, selectionStart, selectionEnd, mode)
-      val lastColumn = editor.primaryCaret().vimLastColumn
+          // WARNING! This can invalidate the primary caret! I.e. the `caret` parameter will no
+          // longer be the primary caret. Given an existing visual block selection, moving the
+          // caret will first remove all secondary carets (above) then this method will ask
+          // IntelliJ to create a new multi-caret block selection. If we're moving up (`k`) a new
+          // caret is added, and becomes the new primary caret. The current `caret` parameter
+          // remains valid, but is no longer the primary caret. Make sure to fetch the new
+          // primary caret if necessary.
+          val (blockStart, blockEnd) = blockToNativeSelection(editor, selectionStart, selectionEnd, mode)
+          val lastColumn = editor.primaryCaret().vimLastColumn
+          editor.vimSetSystemBlockSelectionSilently(blockStart, blockEnd)
 
-      // WARNING! This can invalidate the primary caret! I.e. the `caret` parameter will no longer be the primary caret.
-      // Given an existing visual block selection, moving the caret will first remove all secondary carets (above) then
-      // this method will ask IntelliJ to create a new multi-caret block selection. If we're moving up (`k`) a new caret
-      // is added, and becomes the new primary caret. The current `caret` parameter remains valid, but is no longer the
-      // primary caret. Make sure to fetch the new primary caret if necessary.
-      editor.vimSetSystemBlockSelectionSilently(blockStart, blockEnd)
+          for (aCaret in editor.nativeCarets()) {
+            if (!aCaret.isValid) continue
+            val line = aCaret.getBufferPosition().line
+            val lineEndOffset = editor.getLineEndOffset(line, true)
+            val lineStartOffset = editor.getLineStartOffset(line)
 
-      // We've just added secondary carets again, hide them to better emulate block selection
-      injector.editorGroup.updateCaretsVisualAttributes(editor)
+            // Extend selection to line end if it was made with `$` command
+            if (lastColumn >= VimMotionGroupBase.LAST_COLUMN) {
+              aCaret.vimSetSystemSelectionSilently(aCaret.selectionStart, lineEndOffset)
+              val newOffset = (lineEndOffset - injector.visualMotionGroup.selectionAdj).coerceAtLeast(lineStartOffset)
+              aCaret.moveToInlayAwareOffset(newOffset)
+            }
+            val visualPosition = editor.offsetToVisualPosition(aCaret.selectionEnd)
+            if (aCaret.offset == aCaret.selectionEnd && visualPosition != aCaret.getVisualPosition()) {
+              // Put right caret position for tab character
+              aCaret.moveToVisualPosition(visualPosition)
+            }
+            if (mode !is Mode.SELECT &&
+              !editor.isLineEmpty(line, false) &&
+              aCaret.offset == aCaret.selectionEnd &&
+              aCaret.selectionEnd - 1 >= lineStartOffset &&
+              aCaret.selectionEnd - aCaret.selectionStart != 0
+            ) {
+              // Move all carets one char left in case if it's on selection end
+              aCaret.moveToVisualPosition(VimVisualPosition(visualPosition.line, visualPosition.column - 1))
+            }
+          }
 
-      for (aCaret in editor.nativeCarets()) {
-        if (!aCaret.isValid) continue
-        val line = aCaret.getBufferPosition().line
-        val lineEndOffset = editor.getLineEndOffset(line, true)
-        val lineStartOffset = editor.getLineStartOffset(line)
-
-        // Extend selection to line end if it was made with `$` command
-        if (lastColumn >= VimMotionGroupBase.LAST_COLUMN) {
-          aCaret.vimSetSystemSelectionSilently(aCaret.selectionStart, lineEndOffset)
-          val newOffset = (lineEndOffset - injector.visualMotionGroup.selectionAdj).coerceAtLeast(lineStartOffset)
-          aCaret.moveToInlayAwareOffset(newOffset)
-        }
-        val visualPosition = editor.offsetToVisualPosition(aCaret.selectionEnd)
-        if (aCaret.offset == aCaret.selectionEnd && visualPosition != aCaret.getVisualPosition()) {
-          // Put right caret position for tab character
-          aCaret.moveToVisualPosition(visualPosition)
-        }
-        if (mode !is Mode.SELECT &&
-          !editor.isLineEmpty(line, false) &&
-          aCaret.offset == aCaret.selectionEnd &&
-          aCaret.selectionEnd - 1 >= lineStartOffset &&
-          aCaret.selectionEnd - aCaret.selectionStart != 0
-        ) {
-          // Move all carets one char left in case if it's on selection end
-          aCaret.moveToVisualPosition(VimVisualPosition(visualPosition.line, visualPosition.column - 1))
+          editor.primaryCaret().moveToInlayAwareOffset(selectionEnd)
         }
       }
 
-      editor.primaryCaret().moveToInlayAwareOffset(selectionEnd)
+      // Hide secondary carets to better emulate block selection (suppressor skipped this
+      // during the bulk update).
+      injector.editorGroup.updateCaretsVisualAttributes(editor)
     }
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineModeExtensions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineModeExtensions.kt
@@ -22,10 +22,19 @@ import com.maddyhome.idea.vim.state.mode.selectionType
 fun VimEditor.exitVisualMode() {
   val selectionType = mode.selectionType ?: SelectionType.CHARACTER_WISE
   SelectionVimListenerSuppressor.lock().use {
+    val clearAllSelections = { nativeCarets().forEach(VimCaret::removeSelection) }
     if (inBlockSelection) {
-      removeSecondaryCarets()
+      // removeSecondaryCarets() fires N-1 caretRemoved events. In split mode those events drive
+      // PatchEngineEditorSynchronizer, which walks all carets and ships an RD-protocol message
+      // per event — O(N²) per exit. Run inside the all-carets-action lifecycle so the
+      // synchronizer batches the deletions into a single end-of-op snapshot.
+      runAsAllCaretsAction {
+        removeSecondaryCarets()
+        clearAllSelections()
+      }
+    } else {
+      clearAllSelections()
     }
-    nativeCarets().forEach(VimCaret::removeSelection)
   }
   if (inVisualMode || inCommandLineModeWithVisual) {
     vimLastSelectionType = selectionType

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/listener/ListenerSuppressor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/listener/ListenerSuppressor.kt
@@ -88,3 +88,14 @@ sealed class VimListenerSuppressor {
 }
 
 object SelectionVimListenerSuppressor : VimListenerSuppressor()
+
+/**
+ * Suppresses IdeaVim's per-caret `updateCaretsVisualAttributes` side-effect that normally
+ * fires from `EditorCaretHandler.caretAdded`/`caretRemoved`. That handler is O(N) (walks all
+ * carets); when IntelliJ's `setBlockSelection` adds/removes N carets it fires N events, giving
+ * O(N²) per block-visual motion and a frozen EDT on large blocks.
+ *
+ * Lock around bulk caret-replacement operations, then run `updateCaretsVisualAttributes` once
+ * at the end (see [com.maddyhome.idea.vim.group.visual.setVisualSelection]'s BLOCK_WISE branch).
+ */
+object CaretVisualAttributesListenerSuppressor : VimListenerSuppressor()


### PR DESCRIPTION
In split mode every per-caret event drove PatchEngineEditorSynchronizer, which walks all carets to build a model and ships an RD-protocol message per event — block-visual motion fires N caret events × O(N) per event = O(N²) per keystroke on the host, freezing the EDT.

Bulk caret-mutating sites (block-visual setVisualSelection, exitVisualMode's secondary-caret removal, repeatInsert's row-by-row replay) now run inside caretModel.runForEachCaret so beforeAllCaretsAction/afterAllCaretsAction fire and the synchronizer batches per-event sends into one end-of-op snapshot; a new CaretVisualAttributesListenerSuppressor gates IdeaVim's own EditorCaretHandler.updateCaretsVisualAttributes to drop the same O(N²) walk on the local side.