### PR TITLE
Fix output of maps when prefix match fails

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MapCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/MapCommandTest.kt
@@ -378,6 +378,7 @@ class MapCommandTest : VimTestCase() {
   fun `test map reports when no existing mappings match prefix`() {
     configureByText("\n")
     enterCommand("map quux bar")
+    enterCommand("map fop bop")
     assertCommandOutput("map foo", "No mapping found")
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyStrokeTrie.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/KeyStrokeTrie.kt
@@ -155,8 +155,8 @@ class KeyStrokeTrie<T>(private val name: String) {
     if (prefix?.isNotEmpty() == true) {
       // For prefix matching, yield all nodes along the path that have data, then yield the children
       prefix.forEach {
-        if (!node.children.isInitialized()) return@forEach
-        node = node.children.value[it] ?: return@forEach
+        if (!node.children.isInitialized()) return@sequence
+        node = node.children.value[it] ?: return@sequence
         if (node.data != null && includePrefixNodes) {
           yield(node)
         }


### PR DESCRIPTION
This PR fixes a bug where the `:map {prefix}` command would list maps that matched part of the prefix, when the prefix fails. For example, in the scenario that `:map <Plug>(ab` doesn't have a prefix (there are no maps beginning with `<Plug>(ab`), then `:map` would list all maps that begin with what however much of the prefix that did match _something_. This might be any map beginning with `<Plug>(` or just `<Plug>`.