### PR TITLE
VIM-4250 preserve cursor pistion with one column diff

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionDownActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionDownActionTest.kt
@@ -447,4 +447,32 @@ class MotionDownActionTest : VimTestCase() {
       Mode.NORMAL(),
     )
   }
+
+  @Test
+  fun `test preserve column position between kj`() {
+    doTest(
+      "kj", """
+      line
+      line${c}long
+    """.trimIndent(),
+      """
+      line
+      line${c}long
+    """.trimIndent()
+    )
+  }
+
+  @Test
+  fun `test preserve column position between kj 2 columns`() {
+    doTest(
+      "kj", """
+      line
+      linel${c}ong
+    """.trimIndent(),
+      """
+      line
+      linel${c}ong
+    """.trimIndent()
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionUpActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/updown/MotionUpActionTest.kt
@@ -47,6 +47,24 @@ class MotionUpActionTest : VimTestCase() {
     doTest(keys, before, after)
   }
 
+  @Test
+  fun `test preserve column when crossing line one column too short`() {
+    // VIM-4250: the caret is exactly one column past the end of the shorter line. Moving up then down must restore
+    // the intended column. The off-by-one used to be lost because the intended column matched the trailing newline's
+    // column, hiding the adjustment.
+    doTest(
+      "kj",
+      """
+        line
+        line${c}long
+      """.trimIndent(),
+      """
+        line
+        line${c}long
+      """.trimIndent(),
+    )
+  }
+
   @TestWithoutNeovim(reason = SkipNeovimReason.EDITOR_MODIFICATION)
   @Test
   fun `test caret moved outside of IdeaVim control`() {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
@@ -66,9 +66,9 @@ abstract class VimMotionGroupBase : VimMotionGroup {
 
     val newPos = VimVisualPosition(line, intendedColumn + additionalVisualColumns, false)
     val offset = editor.visualPositionToOffset(newPos)
-    val finalColumn = editor.offsetToVisualPosition(offset).column
     val bufferLine = editor.offsetToBufferPosition(offset).line
     val normalisedOffset = editor.normalizeOffset(bufferLine, offset, editor.isEndAllowed)
+    val finalColumn = editor.offsetToVisualPosition(normalisedOffset).column
     return if (intendedColumn != finalColumn) {
       normalisedOffset.toAdjustedMotionOrError(intendedColumn)
     } else {


### PR DESCRIPTION
when going jk between lines with just 1 column difference and going back it moved one column before. It was due to not normilzed offset so when doing k went to AbsoulteOffset and didn't save last column position