### PR TITLE
Refresh VFS after running external shell command

### DIFF
--- a/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/process/ProcessGroup.kt
+++ b/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/process/ProcessGroup.kt
@@ -19,6 +19,9 @@ import com.intellij.openapi.progress.ProgressIndicatorProvider
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.platform.project.ProjectId
 import com.intellij.platform.project.findProjectOrNull
 import com.intellij.util.execution.ParametersListUtil
@@ -148,6 +151,11 @@ class ProcessGroup : VimProcessGroupBase() {
           throw ProcessCanceledException()
         }
 
+        // If the process writes to the filesystem, refresh the VFS so that the changes are visible
+        if (project != null) {
+          refreshVfs(project)
+        }
+
         ProcessResult(
           output = (output.stderr + output.stdout).replace("\u001B\\[[;\\d]*m".toRegex(), ""),
           exitCode = handler.exitCode,
@@ -173,6 +181,15 @@ class ProcessGroup : VimProcessGroupBase() {
     while ((from.read(buf).also { cnt = it }) != -1) {
       to.write(buf, 0, cnt)
     }
+  }
+
+  private fun refreshVfs(project: Project) {
+    val roots = buildList {
+      project.guessProjectDir()?.let(::add)
+      addAll(ProjectRootManager.getInstance(project).contentRoots)
+    }.distinct()
+
+    VfsUtil.markDirtyAndRefresh(true, true, true, *roots.toTypedArray())
   }
 
   companion object {

--- a/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/process/ProcessGroup.kt
+++ b/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/process/ProcessGroup.kt
@@ -10,8 +10,8 @@ package com.maddyhome.idea.vim.group.process
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProcessCanceledException
@@ -32,8 +32,6 @@ import com.maddyhome.idea.vim.api.VimProcessGroupBase
 import java.io.BufferedWriter
 import java.io.IOException
 import java.io.OutputStreamWriter
-import java.io.Reader
-import java.io.Writer
 
 
 class ProcessGroup : VimProcessGroupBase() {
@@ -128,12 +126,12 @@ class ProcessGroup : VimProcessGroupBase() {
         }
         val handler = CapturingProcessHandler(commandLine)
         if (input != null) {
-          handler.addProcessListener(object : ProcessAdapter() {
+          handler.addProcessListener(object : ProcessListener {
             override fun startNotified(event: ProcessEvent) {
               try {
                 val charSequenceReader = CharSequenceReader(input)
                 val outputStreamWriter = BufferedWriter(OutputStreamWriter(handler.processInput))
-                copy(charSequenceReader, outputStreamWriter)
+                charSequenceReader.transferTo(outputStreamWriter)
                 outputStreamWriter.close()
               } catch (e: IOException) {
                 logger.error(e)
@@ -171,16 +169,6 @@ class ProcessGroup : VimProcessGroupBase() {
       result = result.replace("" + c, escapeChar + c)
     }
     return result
-  }
-
-  // TODO: Java 10 has a transferTo method we could use instead
-  @Throws(IOException::class)
-  private fun copy(from: Reader, to: Writer) {
-    val buf = CharArray(2048)
-    var cnt: Int
-    while ((from.read(buf).also { cnt = it }) != -1) {
-      to.write(buf, 0, cnt)
-    }
   }
 
   private fun refreshVfs(project: Project) {


### PR DESCRIPTION
After running a shell command such as `:!echo "foo" > foo` or `:!rm foo`, the Project view would not be updated with the newly created or removed file. This PR will refresh VFS for all project roots after executing a command, meaning the Project view is up to date.

Fixes [VIM-4240](https://youtrack.jetbrains.com/issue/VIM-4240). 