### PR TITLE
VIM-2883 Implement inccommand for dynamic replace

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/IjSearchWindowGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjSearchWindowGroup.kt
@@ -74,8 +74,7 @@ class IjSearchWindowGroup : SearchWindowGroup {
         }
       }
 
-      // Only history windows execute-and-close here; the control-chars editor commits differently.
-      VirtualBufferKind.ControlCharsEditor -> {}
+      VirtualBufferKind.ControlCharsEditor, VirtualBufferKind.SubstitutePreview -> {}
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/group/IjVirtualBufferGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjVirtualBufferGroup.kt
@@ -9,10 +9,15 @@ package com.maddyhome.idea.vim.group
 
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.fileTypes.PlainTextFileType
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.LightVirtualFile
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
@@ -31,25 +36,36 @@ class IjVirtualBufferGroup : VirtualBufferGroup {
     editor: VimEditor,
     kind: VirtualBufferKind,
     content: String,
+    focus: Boolean,
   ) {
-    if (refuseIfAlreadyOpen(context, editor)) return
-    val project = projectOf(context) ?: return
-    showFile(project, createBufferFile(editor, kind, content))
+    if (kind != VirtualBufferKind.SubstitutePreview && refuseIfAlreadyOpen(context, editor)) return
+    val project = projectOf(context) ?: (editor as IjVimEditor).editor.project ?: return
+    showFile(project, createBufferFile(editor, kind, content), kind, focus)
   }
 
   override fun close(editor: VimEditor) {
     val ijEditor = (editor as IjVimEditor).editor
     val virtualFile = ijEditor.virtualFile ?: return
     val project = ijEditor.project ?: return
-    val fem = FileEditorManagerEx.getInstanceEx(project)
-    // Close the buffer in its hosting split so the split collapses. Plain
-    // `FileEditorManager.closeFile` would leave an empty pane that the platform refills
-    // with the most-recently-active file, producing two copies of the original editor.
-    val hostingWindows = fem.windows.filter { it.selectedComposite?.file == virtualFile }
-    if (hostingWindows.isEmpty()) {
-      fem.closeFile(virtualFile)
-    } else {
-      hostingWindows.forEach { it.closeFile(virtualFile) }
+    closeFile(project, virtualFile)
+  }
+
+  override fun close(context: ExecutionContext, kind: VirtualBufferKind) {
+    val project = projectOf(context) ?: return
+    findOpenFile(project, kind)?.let { closeFile(project, it) }
+  }
+
+  override fun isOpen(context: ExecutionContext, kind: VirtualBufferKind): Boolean =
+    findOpenFile(projectOf(context), kind) != null
+
+  override fun refresh(context: ExecutionContext, kind: VirtualBufferKind, content: String) {
+    CommandProcessor.getInstance().runUndoTransparentAction {
+      ApplicationManager.getApplication().runWriteAction {
+        val project = projectOf(context) ?: return@runWriteAction
+        val file = findOpenFile(project, kind) ?: return@runWriteAction
+        val document = FileDocumentManager.getInstance().getDocument(file) ?: return@runWriteAction
+        if (!document.immutableCharSequence.contentEquals(content)) document.setText(content)
+      }
     }
   }
 
@@ -66,13 +82,22 @@ class IjVirtualBufferGroup : VirtualBufferGroup {
   private fun alreadyOpenMessage(openKind: VirtualBufferKind): String = when (openKind) {
     VirtualBufferKind.Command, is VirtualBufferKind.Search -> "E1292: Command-line window is already open"
     VirtualBufferKind.ControlCharsEditor -> "A control characters editor is already open"
+    VirtualBufferKind.SubstitutePreview -> "A substitute preview is already open"
   }
 
-  /** The kind of the currently open virtual buffer, or null if none is open. */
+  /** The kind of the currently open (nesting-restricted) virtual buffer, or null if none is open. */
   private fun openVirtualBufferKind(context: ExecutionContext): VirtualBufferKind? {
     val project = projectOf(context) ?: return null
     return FileEditorManager.getInstance(project).openFiles
-      .firstNotNullOfOrNull { it.getUserData(CmdwinKeys.KIND) }
+      .mapNotNull { it.getUserData(CmdwinKeys.KIND) }
+      // The inccommand=split preview is transient and must not block cmdwin from opening.
+      .firstOrNull { it != VirtualBufferKind.SubstitutePreview }
+  }
+
+  private fun findOpenFile(project: Project?, kind: VirtualBufferKind): VirtualFile? {
+    project ?: return null
+    return FileEditorManager.getInstance(project).openFiles
+      .firstOrNull { it.getUserData(CmdwinKeys.KIND) == kind }
   }
 
   private fun createBufferFile(editor: VimEditor, kind: VirtualBufferKind, content: String): LightVirtualFile {
@@ -82,17 +107,43 @@ class IjVirtualBufferGroup : VirtualBufferGroup {
     return file
   }
 
-  private fun showFile(project: Project, file: LightVirtualFile) {
+  private fun showFile(project: Project, file: LightVirtualFile, kind: VirtualBufferKind, focus: Boolean) {
     val fem = FileEditorManagerEx.getInstanceEx(project)
+    openSplitFile(fem, file, focus)
+    if (kind == VirtualBufferKind.SubstitutePreview) {
+      fem.getEditors(file).filterIsInstance<TextEditor>()
+        .forEach { (it.editor as? EditorEx)?.isViewer = true }
+    }
+  }
+
+  private fun openSplitFile(
+    fem: FileEditorManagerEx,
+    file: LightVirtualFile,
+    focus: Boolean,
+  ) {
+    // in unit tests there is no way to create splits
     if (ApplicationManager.getApplication().isUnitTestMode) {
       fem.openFile(file, true)
       return
     }
     val window = fem.splitters.currentWindow
-    if (window != null) {
-      window.split(SwingConstants.HORIZONTAL, true, file, true)
+    if (window == null) {
+      fem.openFile(file, focus)
+      return
+    }
+
+    window.split(SwingConstants.HORIZONTAL, true, file, focus)
+  }
+
+  // Close the buffer in its hosting split so the split collapses. Plain `FileEditorManager.closeFile` would leave an
+  // empty pane that the platform refills with the most-recently-active file, producing two copies of the original.
+  private fun closeFile(project: Project, file: VirtualFile) {
+    val fem = FileEditorManagerEx.getInstanceEx(project)
+    val hostingWindows = fem.windows.filter { it.selectedComposite?.file == file }
+    if (hostingWindows.isEmpty()) {
+      fem.closeFile(file)
     } else {
-      fem.openFile(file, true)
+      hostingWindows.forEach { it.closeFile(file) }
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/MotionGroup.kt
@@ -27,7 +27,9 @@ import com.maddyhome.idea.vim.api.VimMotionGroupBase
 import com.maddyhome.idea.vim.api.anyNonWhitespace
 import com.maddyhome.idea.vim.api.getLeadingCharacterOffset
 import com.maddyhome.idea.vim.api.getVisualLineCount
+import com.maddyhome.idea.vim.api.VirtualBufferKind
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.helper.CmdwinKeys
 import com.maddyhome.idea.vim.api.lineLength
 import com.maddyhome.idea.vim.api.normalizeOffset
 import com.maddyhome.idea.vim.api.normalizeVisualLine
@@ -349,6 +351,8 @@ class MotionGroup : VimMotionGroupBase() {
               }
 
               is Mode.CMD_LINE -> {
+                // in case of substitute preview we don't wont to close current command line
+                if (isOpeningSubstitutePreview(event)) return
                 val commandLine = injector.commandLine.getActiveCommandLine() ?: return
                 commandLine.close(refocusOwningEditor = false, resetCaret = false)
                 injector.outputPanel.getCurrentOutputPanel()?.close()
@@ -367,5 +371,8 @@ class MotionGroup : VimMotionGroupBase() {
         KeyHandler.getInstance().reset(keyHandler.keyHandlerState, state.mode)
       }
     }
+
+    private fun isOpeningSubstitutePreview(event: FileEditorManagerEvent): Boolean =
+      event.newFile?.getUserData(CmdwinKeys.KIND) == VirtualBufferKind.SubstitutePreview
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/SearchHighlightsHelper.kt
@@ -66,13 +66,14 @@ fun updateIncsearchHighlights(
   forwards: Boolean,
   caretOffset: Int,
   searchRange: LineRange?,
+  forceShowAllMatches: Boolean = false,
 ): Int {
   val searchStartOffset = if (searchRange != null && searchRange.startLine < editor.document.lineCount) {
     editor.vim.getLineStartOffset(searchRange.startLine)
   } else {
     caretOffset
   }
-  val showHighlights = injector.options(editor.vim).hlsearch
+  val showHighlights = injector.options(editor.vim).hlsearch || forceShowAllMatches
   return updateSearchHighlights(
     editor.vim,
     pattern,
@@ -101,6 +102,25 @@ fun addSubstitutionConfirmationHighlight(editor: Editor, start: Int, end: Int): 
     color,
     HighlighterTargetArea.EXACT_RANGE,
   )
+}
+
+/**
+ * Highlight a single range using the standard search-result attributes, returning the highlighter so the caller can
+ * remove it later.
+ *
+ * Unlike [highlightSearchResults], this does not touch the editor's tracked incsearch highlighters, so it is suitable
+ * for transient overlays - such as the `inccommand` preview - that manage their own highlighter lifecycle.
+ */
+fun highlightPreviewMatch(editor: Editor, start: Int, end: Int, tooltip: String): RangeHighlighter {
+  val highlighter = editor.markupModel.addRangeHighlighter(
+    EditorColors.TEXT_SEARCH_RESULT_ATTRIBUTES,
+    start,
+    end,
+    HighlighterLayer.SELECTION - 1,
+    HighlighterTargetArea.EXACT_RANGE,
+  )
+  highlighter.errorStripeTooltip = tooltip
+  return highlighter
 }
 
 /**

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
@@ -22,11 +22,13 @@ import com.maddyhome.idea.vim.KeyHandler.Companion.getInstance
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.action.VimShortcutKeyAction
 import com.maddyhome.idea.vim.api.CommandLineCompletion
+import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimCommandLine
 import com.maddyhome.idea.vim.api.VimCommandLineCaret
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimKeyGroupBase
 import com.maddyhome.idea.vim.api.VimSearchGroupBase
+import com.maddyhome.idea.vim.api.VirtualBufferKind
 import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.ex.ranges.LineRange
@@ -328,10 +330,10 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
             updateInccommandPreview(editor, update)
           }
 
-          CommandLineUpdate.ClearPreview -> inccommandPreview.clear(editor)
+          CommandLineUpdate.ClearPreview -> inccommandPreview.clearBufferPreview(editor)
 
           CommandLineUpdate.ResetIncsearch -> {
-            inccommandPreview.clear(editor)
+            inccommandPreview.clearBufferPreview(editor)
             if (isIncSearchEnabled) {
               (VimPlugin.getSearch() as VimSearchGroupBase).resetIncsearchHighlights()
               resetCaretOffsetAndScroll(editor)
@@ -427,9 +429,38 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
     val command = update.substituteCommand
     // Only preview once a replacement delimiter has been typed (e.g. `:%s/foo/` rather than just `:%s/foo`).
     if (isIncCommandEnabled && command != null && update.searchRange != null && update.searchText.contains("/")) {
-      inccommandPreview.apply(editor, command, update.searchRange)
+      val splitContent = inccommandPreview.apply(editor, command, update.searchRange)
+      updateSplitPreviewWindow(editor, splitContent)
     } else {
-      inccommandPreview.clear(editor)
+      inccommandPreview.clearBufferPreview(editor)
+    }
+  }
+
+  private fun updateSplitPreviewWindow(editor: Editor, content: String?) {
+    if (injector.globalOptions().inccommand != "split" || content == null) return
+    val vimEditor = IjVimEditor(editor)
+    val context = injector.executionContextManager.getEditorExecutionContext(vimEditor)
+    openSubstitutePreview(context, content, vimEditor)
+  }
+
+  private fun openSubstitutePreview(
+    context: ExecutionContext,
+    content: String,
+    vimEditor: IjVimEditor,
+  ) {
+    ApplicationManager.getApplication().invokeLater {
+      val virtualBufferGroup = injector.virtualBufferGroup
+      if (virtualBufferGroup.isOpen(context, VirtualBufferKind.SubstitutePreview)) {
+        virtualBufferGroup.refresh(context, VirtualBufferKind.SubstitutePreview, content)
+        return@invokeLater
+      }
+      virtualBufferGroup.open(
+        context,
+        vimEditor,
+        VirtualBufferKind.SubstitutePreview,
+        content,
+        focus = false,
+      )
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
@@ -178,9 +178,14 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
     this.context = context
     setEditor(editor)
 
+    // This is a singleton panel reused across activations. Drop any inccommand preview state left over from a previous
+    // activation that was abandoned without a clean deactivate (e.g. the editor was disposed).
+    inccommandPreview.reset()
+
     entry.document.addDocumentListener(fontListener)
-    if (this.isIncSearchEnabled) {
-      entry.document.addDocumentListener(incSearchDocumentListener)
+    // The listener drives both incsearch highlighting and the inccommand preview, so attach it if either is enabled.
+    if (this.isIncSearchEnabled || this.isIncCommandEnabled) {
+      entry.document.addDocumentListener(incrementalCommandLineListener)
       caretOffset = editor.caretModel.offset
       verticalOffset = editor.scrollingModel.verticalScrollOffset
       horizontalOffset = editor.scrollingModel.horizontalScrollOffset
@@ -219,10 +224,20 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
     activeCompletion = null
     try {
       entry.document.removeDocumentListener(fontListener)
-      // incsearch won't change in the lifetime of this activation
-      if (this.isIncSearchEnabled) {
-        entry.document.removeDocumentListener(incSearchDocumentListener)
 
+      // Revert any inccommand preview before anything else. On <CR> the command line is closed (and thus deactivated)
+      // *before* the real command executes (see CommandKeyConsumer), so reverting here guarantees the real substitution
+      // runs against the original, un-previewed document - and on <Esc> it simply restores the buffer.
+      val previewEditor = this.ijEditor
+      if (previewEditor != null && !previewEditor.isDisposed) {
+        inccommandPreview.clear(previewEditor)
+      }
+
+      // incsearch/inccommand won't change in the lifetime of this activation
+      if (this.isIncSearchEnabled || this.isIncCommandEnabled) {
+        entry.document.removeDocumentListener(incrementalCommandLineListener)
+      }
+      if (this.isIncSearchEnabled) {
         // TODO: Reduce the amount of unnecessary work here
         // If incsearch and hlsearch are enabled, and if this is a search panel, we'll have all of the results correctly
         // highlighted. But because we don't know why we're being closed, and what handler is being called next, we need
@@ -301,98 +316,133 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
   }
 
 
-  private val incSearchDocumentListener: DocumentListener = object : DocumentAdapter() {
+  // Fires on every command-line edit to update the incremental UI: incsearch highlighting (when 'incsearch' is set) and
+  // the inccommand substitute preview (when 'inccommand' is set). Named generically as it covers more than search.
+  private val incrementalCommandLineListener: DocumentListener = object : DocumentAdapter() {
     override fun textChanged(e: DocumentEvent) {
+      val editor = ijEditor ?: return
       try {
-        val editor: Editor = ijEditor ?: return
-
-        val labelText: String = myLabel.text // Either '/', '?' or ':'boolean searchCommand = false;
-
-        var searchCommand = false
-        var searchRange: LineRange? = null
-        var separator = labelText[0]
-        var searchText = text
-        if (labelText == ":") {
-          if (searchText.isEmpty()) return
-          val command = getIncsearchCommand(searchText) ?: return
-          searchCommand = true
-          searchText = ""
-          val argument = command.commandArgument
-          if (argument.length > 1) {  // E.g. skip '/' in `:%s/`. `%` is range, `s` is command, `/` is argument
-            separator = argument[0]
-            searchText = argument.substring(1)
+        when (val update = parseCommandLineForPreview(editor)) {
+          is CommandLineUpdate.Renderable -> {
+            if (isIncSearchEnabled) showIncsearchHighlights(editor, update)
+            updateInccommandPreview(editor, update)
           }
-          if (!searchText.isEmpty()) {
-            searchRange = command.getLineRangeSafe(IjVimEditor(editor))
-          }
-          if (searchText.isEmpty() || searchRange == null) {
-            // Reset back to the original search highlights after deleting a search from a substitution command.Or if
-            // there is no search range (because the user entered an invalid range, e.g. mark not set).
-            // E.g. Highlight `whatever`, type `:%s/foo` + highlight `foo`, delete back to `:%s/` and reset highlights
-            // back to `whatever`
-            (VimPlugin.getSearch() as VimSearchGroupBase).resetIncsearchHighlights()
-            resetCaretOffsetAndScroll(editor)
-            return
-          }
-        }
 
-        // Get a snapshot of the count for the in-progress command and coerce it to 1. This value will include all
-        // count components - selecting register(s), operator and motions. E.g. `2"a3"b4"c5d6/` will return 720.
-        // If we're showing highlights for an Ex command like `:s`, the command builder will be empty, but we'll still
-        // get a valid value.
-        val count1 = max(
-          1, getInstance().keyHandlerState.editorCommandBuilder
-            .calculateCount0Snapshot()
-        )
+          CommandLineUpdate.ClearPreview -> inccommandPreview.clear(editor)
 
-        if (labelText == "/" || labelText == "?" || searchCommand) {
-          val forwards = labelText != "?" // :s, :g, :v are treated as forwards
-          val patternEnd: Int = injector.searchGroup.findEndOfPattern(searchText, separator, 0)
-          val pattern = searchText.take(patternEnd)
-
-          injector.editorGroup.closeEditorSearchSession(IjVimEditor(editor))
-          val matchOffset =
-            updateIncsearchHighlights(
-              editor, pattern, count1, forwards, caretOffset,
-              searchRange
-            )
-          if (matchOffset != -1) {
-            // Moving the caret will update the Visual selection, which is only valid while performing a search. We want
-            // to remove the Visual selection when the incsearch is for a command, as this is always unrelated to the
-            // current selection.
-            // E.g. `V/foo` should update the selection to the location of the search result. But `V` followed by
-            // `:<C-U>%s/foo` should remove the selection first.
-            // We're actually in Command-line with Visual pending. Exiting Visual replaces this with just Command-line
-            if (searchCommand) {
-              IjVimEditor(editor).exitVisualMode()
+          CommandLineUpdate.ResetIncsearch -> {
+            inccommandPreview.clear(editor)
+            if (isIncSearchEnabled) {
+              (VimPlugin.getSearch() as VimSearchGroupBase).resetIncsearchHighlights()
+              resetCaretOffsetAndScroll(editor)
             }
-            IjVimCaret(editor.caretModel.primaryCaret).moveToOffset(matchOffset)
-          } else {
-            resetCaretOffsetAndScroll(editor)
           }
         }
       } catch (ex: Throwable) {
         // Make sure the exception doesn't leak out of the handler, because it can break the text entry field and
-        // require the editor to be closed/reopened. The worst that will happen is no incsearch highlights
-        logger.error("Error while trying to show incsearch highlights", ex)
+        // require the editor to be closed/reopened. The worst that will happen is no incsearch highlights or preview.
+        logger.error("Error while updating the incremental command-line UI", ex)
       }
     }
+  }
 
-    @Contract("null -> null")
-    private fun getIncsearchCommand(commandText: String?): Command? {
-      if (commandText == null) return null
-      try {
-        val exCommand = VimscriptParser.parseCommand(commandText)
-        // TODO: Add smagic and snomagic here if/when the commands are supported
-        if (exCommand is SubstituteCommand || exCommand is GlobalCommand) {
-          return exCommand
-        }
-      } catch (e: Exception) {
-        logger.error("Cannot parse command for incsearch", e)
-      }
+  /** What the current command-line text means for the incremental UI (highlighting and/or substitute preview). */
+  private sealed interface CommandLineUpdate {
+    /** A renderable search (`/`, `?`) or ex command (`:s`, `:g`) with a usable pattern. */
+    class Renderable(
+      val labelText: String,
+      val separator: Char,
+      val searchText: String,
+      val isExCommand: Boolean,
+      val searchRange: LineRange?,
+      val substituteCommand: SubstituteCommand?,
+    ) : CommandLineUpdate
 
-      return null
+    /** Nothing to render - an empty or non-previewable command line. */
+    object ClearPreview : CommandLineUpdate
+
+    /** An in-progress ex command that lost its pattern/range; restore the previous incsearch highlights. */
+    object ResetIncsearch : CommandLineUpdate
+  }
+
+  private fun parseCommandLineForPreview(editor: Editor): CommandLineUpdate {
+    val labelText = myLabel.text // Either '/', '?' or ':'
+    if (labelText != ":") {
+      // A search: '/' (forwards) or '?' (backwards). The whole entry is the pattern.
+      return CommandLineUpdate.Renderable(labelText, labelText[0], text, isExCommand = false, null, null)
     }
+
+    if (text.isEmpty()) return CommandLineUpdate.ClearPreview
+    val command = getIncsearchCommand(text) ?: return CommandLineUpdate.ClearPreview
+
+    // The argument is e.g. `/foo/bar/g` for `:%s/foo/bar/g`: the first char is the separator, the rest is the pattern
+    // (plus replacement and flags). `%` is the range, `s` the command, `/` the argument separator.
+    val argument = command.commandArgument
+    var separator = labelText[0]
+    var searchText = ""
+    if (argument.length > 1) {
+      separator = argument[0]
+      searchText = argument.substring(1)
+    }
+    val searchRange = if (searchText.isNotEmpty()) command.getLineRangeSafe(IjVimEditor(editor)) else null
+    if (searchText.isEmpty() || searchRange == null) {
+      // E.g. highlight `whatever`, type `:%s/foo` (now highlighting `foo`), then delete back to `:%s/`: restore
+      // `whatever`. A null range means the user typed an invalid range (e.g. an unset mark).
+      return CommandLineUpdate.ResetIncsearch
+    }
+    return CommandLineUpdate.Renderable(
+      labelText, separator, searchText, isExCommand = true, searchRange, command as? SubstituteCommand
+    )
+  }
+
+  private fun showIncsearchHighlights(editor: Editor, update: CommandLineUpdate.Renderable) {
+    // Get a snapshot of the count for the in-progress command and coerce it to 1. This value will include all count
+    // components - selecting register(s), operator and motions. E.g. `2"a3"b4"c5d6/` will return 720. If we're showing
+    // highlights for an Ex command like `:s`, the command builder will be empty, but we'll still get a valid value.
+    val count1 = max(1, getInstance().keyHandlerState.editorCommandBuilder.calculateCount0Snapshot())
+    val forwards = update.labelText != "?" // :s, :g, :v are treated as forwards
+    val patternEnd = injector.searchGroup.findEndOfPattern(update.searchText, update.separator, 0)
+    val pattern = update.searchText.take(patternEnd)
+
+    injector.editorGroup.closeEditorSearchSession(IjVimEditor(editor))
+    val matchOffset = updateIncsearchHighlights(editor, pattern, count1, forwards, caretOffset, update.searchRange)
+    if (matchOffset == -1) {
+      resetCaretOffsetAndScroll(editor)
+      return
+    }
+
+    // Moving the caret will update the Visual selection, which is only valid while performing a search. We want to
+    // remove the Visual selection when the incsearch is for a command, as this is always unrelated to the current
+    // selection. E.g. `V/foo` should update the selection to the search result, but `V` followed by `:<C-U>%s/foo`
+    // should remove the selection first. We're in Command-line with Visual pending; exiting Visual leaves Command-line.
+    if (update.isExCommand) IjVimEditor(editor).exitVisualMode()
+    IjVimCaret(editor.caretModel.primaryCaret).moveToOffset(matchOffset)
+  }
+
+  /** Render the inccommand preview. Called after highlighting, which must see the original (un-previewed) text. */
+  private fun updateInccommandPreview(editor: Editor, update: CommandLineUpdate.Renderable) {
+    val command = update.substituteCommand
+    // Only preview once a replacement delimiter has been typed (e.g. `:%s/foo/` rather than just `:%s/foo`).
+    if (isIncCommandEnabled && command != null && update.searchRange != null && update.searchText.contains("/")) {
+      inccommandPreview.apply(editor, command, update.searchRange)
+    } else {
+      inccommandPreview.clear(editor)
+    }
+  }
+
+  @Contract("null -> null")
+  private fun getIncsearchCommand(commandText: String?): Command? {
+    if (commandText == null) return null
+    try {
+      val exCommand = VimscriptParser.parseCommand(commandText)
+      // TODO: Add smagic and snomagic here if/when the commands are supported
+      if (exCommand is SubstituteCommand || exCommand is GlobalCommand) {
+        return exCommand
+      }
+    } catch (e: Exception) {
+      logger.error("Cannot parse command for incsearch", e)
+    }
+    return null
   }
 
   /**
@@ -566,6 +616,11 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
   private val isIncSearchEnabled: Boolean
     get() = injector.globalOptions().incsearch
 
+  // 'inccommand' is a string option: "" (off), "nosplit" or "split". We currently render both non-empty values as an
+  // in-buffer preview (the "split" preview window is not yet implemented).
+  private val isIncCommandEnabled: Boolean
+    get() = injector.globalOptions().inccommand.isNotEmpty()
+
   /**
    * Checks if the ex entry panel is currently active
    *
@@ -587,6 +642,9 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
   private var verticalOffset = 0
   private var horizontalOffset = 0
   private var caretOffset = 0
+
+  // Renders the 'inccommand' preview (live :substitute) into the buffer as the command line is edited.
+  private val inccommandPreview = InccommandPreview()
 
   init {
 

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
@@ -405,7 +405,10 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
     val pattern = update.searchText.take(patternEnd)
 
     injector.editorGroup.closeEditorSearchSession(IjVimEditor(editor))
-    val matchOffset = updateIncsearchHighlights(editor, pattern, count1, forwards, caretOffset, update.searchRange)
+    // A substitute/global command highlights every match in its range, even without 'hlsearch'.
+    val matchOffset = updateIncsearchHighlights(
+      editor, pattern, count1, forwards, caretOffset, update.searchRange, forceShowAllMatches = update.isExCommand
+    )
     if (matchOffset == -1) {
       resetCaretOffsetAndScroll(editor)
       return

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/InccommandPreview.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/InccommandPreview.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.ui.ex
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.api.SubstitutePreviewChange
+import com.maddyhome.idea.vim.api.VimSearchGroupBase
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.ex.ranges.LineRange
+import com.maddyhome.idea.vim.newapi.IjVimEditor
+import com.maddyhome.idea.vim.vimscript.model.Script
+import com.maddyhome.idea.vim.vimscript.model.commands.SubstituteCommand
+
+/**
+ * Renders Vim's 'inccommand' preview: a live, throwaway preview of a `:substitute` applied directly to the document as
+ * the user types the command line. The preview is purely visual - it is always fully reverted before the real command
+ * runs (on `<CR>`) or the command line is cancelled (on `<Esc>`), so it never commits a change itself.
+ *
+ * The preview is applied incrementally: only the matched ranges are touched, and reverting/re-applying happen inside a
+ * single undo-transparent write action so the editor repaints once (only the net difference is visible - no flicker)
+ * and the throwaway edits never pollute the user's undo stack.
+ *
+ * One instance is held per command-line panel. It is not thread-safe; all calls must happen on the EDT.
+ */
+internal class InccommandPreview {
+  /** The replacements currently applied to the document as a preview, in the order they were made. */
+  private var changes: List<SubstitutePreviewChange> = emptyList()
+
+  /** A copy-free snapshot of the document taken before the preview was applied, used only as a revert fallback. */
+  private var snapshot: CharSequence? = null
+
+  /**
+   * Render a preview of [command] over [range], replacing whatever the previous preview showed.
+   */
+  fun apply(editor: Editor, command: SubstituteCommand, range: LineRange) {
+    val vimEditor = IjVimEditor(editor)
+    val context = injector.executionContextManager.getEditorExecutionContext(vimEditor)
+    CommandProcessor.getInstance().runUndoTransparentAction {
+      ApplicationManager.getApplication().runWriteAction {
+        revert(editor)
+        snapshot = editor.document.immutableCharSequence
+        // A command parsed purely for preview has no vimContext; give it a root so `\=expr` replacements can evaluate.
+        command.vimContext = Script()
+        changes = (VimPlugin.getSearch() as VimSearchGroupBase)
+          .substitutePreview(vimEditor, context, range, command.command, command.argument, command)
+      }
+    }
+  }
+
+  /** Revert any active preview, restoring the document to its original state. */
+  fun clear(editor: Editor) {
+    if (changes.isEmpty() && snapshot == null) return
+    CommandProcessor.getInstance().runUndoTransparentAction {
+      ApplicationManager.getApplication().runWriteAction {
+        revert(editor)
+      }
+    }
+  }
+
+  /**
+   * Drop any tracked preview state *without* reverting it.
+   *
+   * Used when a command-line panel is (re)activated: the panel is a reused singleton, so it may still hold preview
+   * state from a previous activation that was abandoned without a clean [clear] (e.g. the editor was disposed). Those
+   * offsets refer to a now-stale document and must not be replayed, so we simply forget them.
+   */
+  fun reset() {
+    changes = emptyList()
+    snapshot = null
+  }
+
+  /**
+   * Undo the tracked preview replacements, restoring the original text. Must be called inside a write action.
+   *
+   * Replacements are reverted in descending offset order so that reverting a later change (which changes the document
+   * length) never invalidates the stored offset of an earlier one.
+   */
+  private fun revert(editor: Editor) {
+    val changes = this.changes
+    val snapshot = this.snapshot
+    this.changes = emptyList()
+    this.snapshot = null
+    if (changes.isEmpty()) return
+
+    val document = editor.document
+    try {
+      for (change in changes.sortedByDescending { it.startOffset }) {
+        document.replaceString(change.startOffset, change.startOffset + change.replacementLength, change.originalText)
+      }
+    } catch (e: Throwable) {
+      // Defensive fallback: the tracked offsets somehow diverged from the document. Restore the snapshot wholesale.
+      if (snapshot != null) document.setText(snapshot)
+      logger.warn("inccommand preview: incremental revert failed; restored snapshot", e)
+    }
+  }
+
+  private companion object {
+    private val logger = Logger.getInstance(InccommandPreview::class.java)
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/InccommandPreview.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/InccommandPreview.kt
@@ -11,11 +11,13 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.SubstitutePreviewChange
 import com.maddyhome.idea.vim.api.VimSearchGroupBase
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.ex.ranges.LineRange
+import com.maddyhome.idea.vim.helper.highlightPreviewMatch
 import com.maddyhome.idea.vim.newapi.IjVimEditor
 import com.maddyhome.idea.vim.vimscript.model.Script
 import com.maddyhome.idea.vim.vimscript.model.commands.SubstituteCommand
@@ -38,6 +40,9 @@ internal class InccommandPreview {
   /** A copy-free snapshot of the document taken before the preview was applied, used only as a revert fallback. */
   private var snapshot: CharSequence? = null
 
+  /** Highlighters drawn over the replacement text so the user can see what changed. Removed alongside [changes]. */
+  private var highlighters: List<RangeHighlighter> = emptyList()
+
   /**
    * Render a preview of [command] over [range], replacing whatever the previous preview showed.
    */
@@ -52,13 +57,18 @@ internal class InccommandPreview {
         command.vimContext = Script()
         changes = (VimPlugin.getSearch() as VimSearchGroupBase)
           .substitutePreview(vimEditor, context, range, command.command, command.argument, command)
+        // Highlight the replacement text in place so the change is visible, like Vim/Neovim's inccommand preview.
+        highlighters = changes.map { change ->
+          val end = change.startOffset + change.replacementLength
+          highlightPreviewMatch(editor, change.startOffset, end, change.originalText)
+        }
       }
     }
   }
 
   /** Revert any active preview, restoring the document to its original state. */
   fun clear(editor: Editor) {
-    if (changes.isEmpty() && snapshot == null) return
+    if (changes.isEmpty() && snapshot == null && highlighters.isEmpty()) return
     CommandProcessor.getInstance().runUndoTransparentAction {
       ApplicationManager.getApplication().runWriteAction {
         revert(editor)
@@ -76,6 +86,7 @@ internal class InccommandPreview {
   fun reset() {
     changes = emptyList()
     snapshot = null
+    highlighters = emptyList()
   }
 
   /**
@@ -87,8 +98,12 @@ internal class InccommandPreview {
   private fun revert(editor: Editor) {
     val changes = this.changes
     val snapshot = this.snapshot
+    val highlighters = this.highlighters
     this.changes = emptyList()
     this.snapshot = null
+    this.highlighters = emptyList()
+
+    highlighters.forEach { editor.markupModel.removeHighlighter(it) }
     if (changes.isEmpty()) return
 
     val document = editor.document

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/InccommandPreview.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/InccommandPreview.kt
@@ -12,9 +12,13 @@ import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.intellij.openapi.util.TextRange
 import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.SubstitutePreviewChange
 import com.maddyhome.idea.vim.api.VimSearchGroupBase
+import com.maddyhome.idea.vim.api.VirtualBufferKind
+import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.ex.ranges.LineRange
 import com.maddyhome.idea.vim.helper.highlightPreviewMatch
@@ -45,10 +49,14 @@ internal class InccommandPreview {
 
   /**
    * Render a preview of [command] over [range], replacing whatever the previous preview showed.
+   *
+   * @return split-window content when `inccommand=split` and there are affected lines, otherwise null
    */
-  fun apply(editor: Editor, command: SubstituteCommand, range: LineRange) {
+  fun apply(editor: Editor, command: SubstituteCommand, range: LineRange): String? {
     val vimEditor = IjVimEditor(editor)
     val context = injector.executionContextManager.getEditorExecutionContext(vimEditor)
+    val splitMode = injector.globalOptions().inccommand == "split"
+    var windowContent: String? = null
     CommandProcessor.getInstance().runUndoTransparentAction {
       ApplicationManager.getApplication().runWriteAction {
         revert(editor)
@@ -62,18 +70,45 @@ internal class InccommandPreview {
           val end = change.startOffset + change.replacementLength
           highlightPreviewMatch(editor, change.startOffset, end, change.originalText)
         }
+        if (splitMode && changes.isNotEmpty()) windowContent = buildAffectedLinesPreview(editor)
       }
     }
+    return windowContent
   }
 
-  /** Revert any active preview, restoring the document to its original state. */
-  fun clear(editor: Editor) {
+  /** Revert the in-buffer preview without closing the split window. */
+  fun clearBufferPreview(editor: Editor) {
     if (changes.isEmpty() && snapshot == null && highlighters.isEmpty()) return
     CommandProcessor.getInstance().runUndoTransparentAction {
       ApplicationManager.getApplication().runWriteAction {
         revert(editor)
       }
     }
+  }
+
+  /** Revert any active preview, restoring the document to its original state and closing the preview window. */
+  fun clear(editor: Editor) {
+    val vimEditor = IjVimEditor(editor)
+    val context = injector.executionContextManager.getEditorExecutionContext(vimEditor)
+    ApplicationManager.getApplication().invokeLater {
+      injector.virtualBufferGroup.close(context, VirtualBufferKind.SubstitutePreview)
+    }
+    clearBufferPreview(editor)
+  }
+
+  /**
+   * Build the `inccommand=split` window content: one entry per affected line, in line order, each prefixed with its
+   * 1-based line number and showing the replacement already applied (the document is in its previewed state here).
+   */
+  private fun buildAffectedLinesPreview(editor: Editor): String {
+    val document = editor.document
+    return changes.map { document.getLineNumber(it.startOffset) }
+      .distinct()
+      .sorted()
+      .joinToString("\n") { line ->
+        val text = document.getText(TextRange(document.getLineStartOffset(line), document.getLineEndOffset(line)))
+        "${line + 1}: $text"
+      }
   }
 
   /**

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -179,23 +179,23 @@ class SetCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
       |--- Options ---
-      |noabolish             history=50          operatorfunc=     notargets
-      |noargtextobj        nohlsearch          norelativenumber    notextobj-entire
-      |nobomb                ide=IntelliJ IDEA   scroll=0          notextobj-indent
-      |nobreakindent       noideajoin            scrolljump=1        textwidth=0
-      |noCamelCaseMotion     ideamarks           scrolloff=0         timeout
-      |noclasstextobj        ideawrite=all       selectmode=         timeoutlen=1000
-      |  cmdheight=1       noignorecase          shellcmdflag=-x   notrackactionids
-      |  colorcolumn=      noincsearch           shellxescape=@      undolevels=1000
-      |nocommentary        nolist                shellxquote={     noVimEverywhere
-      |nocursorline        nomatchit             showcmd             virtualedit=
-      |nodigraph             maxmapdepth=20      showmode          novisualbell
-      |noexchange          nomini-ai             sidescroll=0        visualdelay=100
-      |  fileformat=unix     more                sidescrolloff=0     whichwrap=b,s
-      |  foldlevel=1       nomultiple-cursors  nosmartcase           wrap
-      |nofunctextobj       noNERDTree          nosneak               wrapscan
-      |nogdefault            nrformats=hex       startofline       noyoucompleteme
-      |nohighlightedyank   nonumber            nosurround
+      |noabolish             history=50        nonumber            nosurround
+      |noargtextobj        nohlsearch            operatorfunc=     notargets
+      |nobomb                ide=IntelliJ IDEA norelativenumber    notextobj-entire
+      |nobreakindent       noideajoin            scroll=0          notextobj-indent
+      |noCamelCaseMotion     ideamarks           scrolljump=1        textwidth=0
+      |noclasstextobj        ideawrite=all       scrolloff=0         timeout
+      |  cmdheight=1       noignorecase          selectmode=         timeoutlen=1000
+      |  colorcolumn=        inccommand=         shellcmdflag=-x   notrackactionids
+      |nocommentary        noincsearch           shellxescape=@      undolevels=1000
+      |nocursorline        nolist                shellxquote={     noVimEverywhere
+      |nodigraph           nomatchit             showcmd             virtualedit=
+      |noexchange            maxmapdepth=20      showmode          novisualbell
+      |  fileformat=unix   nomini-ai             sidescroll=0        visualdelay=100
+      |  foldlevel=1         more                sidescrolloff=0     whichwrap=b,s
+      |nofunctextobj       nomultiple-cursors  nosmartcase           wrap
+      |nogdefault          noNERDTree          nosneak               wrapscan
+      |nohighlightedyank     nrformats=hex       startofline       noyoucompleteme
       |  clipboard=ideaput,autoselect
       |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
       |  fileencoding=utf-8
@@ -289,6 +289,7 @@ class SetCommandTest : VimTestCase() {
     |  ideavimsupport=dialog
     |  ideawrite=all
     |noignorecase
+    |  inccommand=
     |noincsearch
     |  isfname=@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=
     |  iskeyword=@,48-57,_

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
@@ -432,23 +432,24 @@ class SetglobalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
     |--- Global option values ---
-    |noabolish           nohighlightedyank   nonumber            nosurround
-    |noargtextobj          history=50          operatorfunc=     notargets
-    |nobomb              nohlsearch          norelativenumber    notextobj-entire
-    |nobreakindent         ide=IntelliJ IDEA   scroll=0          notextobj-indent
-    |noCamelCaseMotion   noideajoin            scrolljump=1        textwidth=0
-    |noclasstextobj        ideamarks           scrolloff=0         timeout
-    |  cmdheight=1         ideawrite=all       selectmode=         timeoutlen=1000
-    |  colorcolumn=      noignorecase          shellcmdflag=-x   notrackactionids
-    |nocommentary        noincsearch           shellxescape=@      undolevels=1000
-    |nocursorline        nolist                shellxquote={     noVimEverywhere
-    |nodigraph           nomatchit             showcmd             virtualedit=
-    |noexchange            maxmapdepth=20      showmode          novisualbell
-    |  fileencoding=     nomini-ai             sidescroll=0        visualdelay=100
-    |  fileformat=unix     more                sidescrolloff=0     whichwrap=b,s
-    |  foldlevel=999     nomultiple-cursors  nosmartcase           wrap
-    |nofunctextobj       noNERDTree          nosneak               wrapscan
-    |nogdefault            nrformats=hex       startofline       noyoucompleteme
+    |noabolish             history=50          operatorfunc=     notextobj-entire
+    |noargtextobj        nohlsearch          norelativenumber    notextobj-indent
+    |nobomb                ide=IntelliJ IDEA   scroll=0            textwidth=0
+    |nobreakindent       noideajoin            scrolljump=1        timeout
+    |noCamelCaseMotion     ideamarks           scrolloff=0         timeoutlen=1000
+    |noclasstextobj        ideawrite=all       selectmode=       notrackactionids
+    |  cmdheight=1       noignorecase          shellcmdflag=-x     undolevels=1000
+    |  colorcolumn=        inccommand=         shellxescape=@    noVimEverywhere
+    |nocommentary        noincsearch           shellxquote={       virtualedit=
+    |nocursorline        nolist                showcmd           novisualbell
+    |nodigraph           nomatchit             showmode            visualdelay=100
+    |noexchange            maxmapdepth=20      sidescroll=0        whichwrap=b,s
+    |  fileencoding=     nomini-ai             sidescrolloff=0     wrap
+    |  fileformat=unix     more              nosmartcase           wrapscan
+    |  foldlevel=999     nomultiple-cursors  nosneak             noyoucompleteme
+    |nofunctextobj       noNERDTree            startofline
+    |nogdefault            nrformats=hex     nosurround
+    |nohighlightedyank   nonumber            notargets
     |  clipboard=ideaput,autoselect
     |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
@@ -542,6 +543,7 @@ class SetglobalCommandTest : VimTestCase() {
     |  ideavimsupport=dialog
     |  ideawrite=all
     |noignorecase
+    |  inccommand=
     |noincsearch
     |  isfname=@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=
     |  iskeyword=@,48-57,_

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
@@ -484,23 +484,23 @@ class SetlocalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
     |--- Local option values ---
-    |noabolish             history=50        nonumber            nosurround
-    |noargtextobj        nohlsearch            operatorfunc=     notargets
-    |nobomb                ide=IntelliJ IDEA norelativenumber    notextobj-entire
-    |nobreakindent       --ideajoin            scroll=0          notextobj-indent
-    |noCamelCaseMotion     ideamarks           scrolljump=1        textwidth=0
-    |noclasstextobj        idearefactormode=   scrolloff=-1        timeout
-    |  cmdheight=1         ideawrite=all       selectmode=         timeoutlen=1000
-    |  colorcolumn=      noignorecase          shellcmdflag=-x   notrackactionids
-    |nocommentary        noincsearch           shellxescape=@    noVimEverywhere
-    |nocursorline        nolist                shellxquote={       virtualedit=
-    |nodigraph           nomatchit             showcmd           novisualbell
-    |noexchange            maxmapdepth=20      showmode            visualdelay=100
-    |  fileformat=unix   nomini-ai             sidescroll=0        whichwrap=b,s
-    |  foldlevel=1         more                sidescrolloff=-1    wrap
-    |nofunctextobj       nomultiple-cursors  nosmartcase           wrapscan
-    |nogdefault          noNERDTree          nosneak             noyoucompleteme
-    |nohighlightedyank     nrformats=hex       startofline
+    |noabolish             history=50          nrformats=hex       startofline
+    |noargtextobj        nohlsearch          nonumber            nosurround
+    |nobomb                ide=IntelliJ IDEA   operatorfunc=     notargets
+    |nobreakindent       --ideajoin          norelativenumber    notextobj-entire
+    |noCamelCaseMotion     ideamarks           scroll=0          notextobj-indent
+    |noclasstextobj        idearefactormode=   scrolljump=1        textwidth=0
+    |  cmdheight=1         ideawrite=all       scrolloff=-1        timeout
+    |  colorcolumn=      noignorecase          selectmode=         timeoutlen=1000
+    |nocommentary          inccommand=         shellcmdflag=-x   notrackactionids
+    |nocursorline        noincsearch           shellxescape=@    noVimEverywhere
+    |nodigraph           nolist                shellxquote={       virtualedit=
+    |noexchange          nomatchit             showcmd           novisualbell
+    |  fileformat=unix     maxmapdepth=20      showmode            visualdelay=100
+    |  foldlevel=1       nomini-ai             sidescroll=0        whichwrap=b,s
+    |nofunctextobj         more                sidescrolloff=-1    wrap
+    |nogdefault          nomultiple-cursors  nosmartcase           wrapscan
+    |nohighlightedyank   noNERDTree          nosneak             noyoucompleteme
     |  clipboard=ideaput,autoselect
     |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |  fileencoding=utf-8
@@ -594,6 +594,7 @@ class SetlocalCommandTest : VimTestCase() {
     |  ideavimsupport=dialog
     |  ideawrite=all
     |noignorecase
+    |  inccommand=
     |noincsearch
     |  isfname=@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=
     |  iskeyword=@,48-57,_

--- a/src/test/java/org/jetbrains/plugins/ideavim/group/search/InccommandSplitTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/group/search/InccommandSplitTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.group.search
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.PlatformTestUtil
+import com.maddyhome.idea.vim.api.VirtualBufferKind
+import com.maddyhome.idea.vim.helper.CmdwinKeys
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests for `inccommand=split`, which - on top of the in-buffer preview that `nosplit` provides - opens a preview
+ * window listing every line a `:substitute` will change.
+ *
+ * The preview window is a virtual buffer named [PREVIEW_WINDOW_NAME]. Its content is one entry per *affected* line
+ * (lines without a match are omitted), prefixed with the 1-based line number and showing the replacement applied, e.g.
+ * `3: zero ventilation and no plumbing are doing Xir job. That's right, it stinks.`
+ */
+@Suppress("SpellCheckingInspection")
+class InccommandSplitTest : VimTestCase() {
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand split opens preview window listing affected lines`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=split")
+
+    // No <CR> - the preview window should be open while still typing the command
+    typeText(":", "%s/the/X/g")
+
+    val preview = openedSubstitutePreview()
+    assertNotNull(preview, "expected the substitute preview window to be open")
+    assertEquals(
+      """
+        |1: My name is Cezary Baryka, and for X last 20 minutes I have been X owner of this glass house.
+        |2: I'm slowly starting to regret X purchase, freezing cold at night, sweltering heat by day,
+        |3: zero ventilation and no plumbing are doing Xir job. That's right, it stinks.
+        |4: Ehhh..... I lied.... I didn't buy this pigsty, I won it from my faXr in a game of cards:
+      """.trimMargin(),
+      preview.readContent(),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand split preview lists only lines that actually match`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=split")
+
+    // "and" only appears on lines 1 and 3, so lines 2 and 4 must be omitted from the preview.
+    typeText(":", "%s/and/X/g")
+
+    assertEquals(
+      """
+        |1: My name is Cezary Baryka, X for the last 20 minutes I have been the owner of this glass house.
+        |3: zero ventilation X no plumbing are doing their job. That's right, it stinks.
+      """.trimMargin(),
+      openedSubstitutePreview()?.readContent(),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand split preview is limited to the command range`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=split")
+
+    typeText(":", "2,3s/the/X/g")
+
+    assertEquals(
+      """
+        |2: I'm slowly starting to regret X purchase, freezing cold at night, sweltering heat by day,
+        |3: zero ventilation and no plumbing are doing Xir job. That's right, it stinks.
+      """.trimMargin(),
+      openedSubstitutePreview()?.readContent(),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand split closes the preview window on escape`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=split")
+
+    typeText(":", "%s/the/X/g", "<Esc>")
+
+    assertNull(openedSubstitutePreview(), "the preview window should be closed after cancelling the command")
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand nosplit does not open a preview window`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=nosplit")
+
+    typeText(":", "%s/the/X/g")
+
+    assertNull(openedSubstitutePreview(), "nosplit must preview in the buffer only, never open a preview window")
+  }
+
+  private fun openedSubstitutePreview(): VirtualFile? {
+    var preview: VirtualFile? = null
+    ApplicationManager.getApplication().invokeAndWait {
+      repeat(10) {
+        PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
+        preview = ReadAction.compute<VirtualFile?, RuntimeException> {
+          FileEditorManager.getInstance(fixture.project).openFiles
+            .firstOrNull { it.getUserData(CmdwinKeys.KIND) == VirtualBufferKind.SubstitutePreview }
+        }
+        if (preview != null) return@invokeAndWait
+      }
+    }
+    return preview
+  }
+
+  // The preview window is refreshed in place via its document, so read what is actually displayed (the document),
+  // falling back to the VFS content.
+  private fun VirtualFile.readContent(): String = ApplicationManager.getApplication().runReadAction<String> {
+    val document = FileDocumentManager.getInstance().getDocument(this)
+    document?.text ?: String(contentsToByteArray(), charset)
+  }
+
+  companion object {
+    private const val PREVIEW_WINDOW_NAME = "[Preview Substitute]"
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/group/search/InccommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/group/search/InccommandTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2003-2024 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.group.search
+
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+@Suppress("SpellCheckingInspection")
+class InccommandTest : VimTestCase() {
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand nosplit previews replacement in whole file`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=nosplit")
+
+    // No <CR> - the preview should be visible while still typing the command
+    typeText(":", "%s/the/X/g")
+
+    assertState(
+      """My name is Cezary Baryka, and for X last 20 minutes I have been X owner of this glass house.
+         |I'm slowly starting to regret X purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing Xir job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my faXr in a game of cards:
+      """.trimMargin(),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand nosplit previews replacement in current line with no range`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=nosplit")
+
+    typeText(":", "s/the/X/g")
+
+    assertState(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |I'm slowly starting to regret X purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand nosplit previews replacement only in range`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |${c}Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=nosplit")
+
+    typeText(":", "2,3s/the/X/g")
+
+    assertState(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |I'm slowly starting to regret X purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing Xir job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand nosplit updates preview after each key press`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=nosplit")
+
+    // Without the /g flag only the first match per line is previewed (note line 1's second "the" is left untouched)
+    typeText(":", "%s/the/X")
+    assertState(
+      """My name is Cezary Baryka, and for X last 20 minutes I have been the owner of this glass house.
+         |I'm slowly starting to regret X purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing Xir job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my faXr in a game of cards:
+      """.trimMargin(),
+    )
+
+    // Continue typing - the preview should follow the new replacement text
+    typeText("YZ")
+    assertState(
+      """My name is Cezary Baryka, and for XYZ last 20 minutes I have been the owner of this glass house.
+         |I'm slowly starting to regret XYZ purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing XYZir job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my faXYZr in a game of cards:
+      """.trimMargin(),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand nosplit restores original text on escape`() {
+    val original =
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin()
+    configureByText(original)
+    enterCommand("set inccommand=nosplit")
+
+    typeText(":", "%s/the/X/g", "<Esc>")
+
+    assertState(original)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand nosplit applies replacement on enter`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=nosplit")
+
+    typeText(":", "%s/the/X/g", "<CR>")
+
+    assertState(
+      """My name is Cezary Baryka, and for X last 20 minutes I have been X owner of this glass house.
+         |I'm slowly starting to regret X purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing Xir job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my faXr in a game of cards:
+      """.trimMargin(),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test inccommand empty value does not preview replacement`() {
+    val original =
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin()
+    configureByText(original)
+    enterCommand("set inccommand=")
+
+    // With no inccommand preview, the document is unchanged while typing
+    typeText(":", "%s/the/X/g")
+
+    assertState(original)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `should not replace until pass replaced test`() {
+    val original =
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin()
+    configureByText(original)
+    enterCommand("set inccommand=nosplit")
+
+    typeText(":", "%s/the")
+
+    assertState(original)
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/group/search/InccommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/group/search/InccommandTest.kt
@@ -17,6 +17,31 @@ import org.junit.jupiter.api.Test
 class InccommandTest : VimTestCase() {
   @TestWithoutNeovim(SkipNeovimReason.OPTION)
   @Test
+  fun `test inccommand nosplit highlights replaced text`() {
+    configureByText(
+      """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
+         |${c}I'm slowly starting to regret the purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing their job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my father in a game of cards:
+      """.trimMargin(),
+    )
+    enterCommand("set inccommand=nosplit")
+
+    typeText(":", "%s/the/X/g")
+
+    // The replacement text in the previewed buffer should be highlighted so the user can see what changed.
+    assertSearchHighlights(
+      "the",
+      """My name is Cezary Baryka, and for «X» last 20 minutes I have been «X» owner of this glass house.
+         |I'm slowly starting to regret «X» purchase, freezing cold at night, sweltering heat by day,
+         |zero ventilation and no plumbing are doing «X»ir job. That's right, it stinks.
+         |Ehhh..... I lied.... I didn't buy this pigsty, I won it from my fa«X»r in a game of cards:
+      """.trimMargin(),
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
   fun `test inccommand nosplit previews replacement in whole file`() {
     configureByText(
       """My name is Cezary Baryka, and for the last 20 minutes I have been the owner of this glass house.
@@ -133,6 +158,8 @@ class InccommandTest : VimTestCase() {
     typeText(":", "%s/the/X/g", "<Esc>")
 
     assertState(original)
+    // Cancelling must also remove the preview highlights.
+    assertNoSearchHighlights()
   }
 
   @TestWithoutNeovim(SkipNeovimReason.OPTION)

--- a/src/test/java/org/jetbrains/plugins/ideavim/group/search/IncsearchSubstituteTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/group/search/IncsearchSubstituteTest.kt
@@ -24,6 +24,48 @@ class IncsearchSubstituteTest : VimTestCase() {
   }
 
   @Test
+  fun `test incsearch highlights all matches for substitute command without hlsearch`() {
+    configureByText(
+      """I found it in a legendary land
+           |${c}all rocks and lavender and tufted grass,
+           |where it was settled on some sodden sand
+           |hard by the torrent of a mountain pass.
+      """.trimMargin(),
+    )
+    // Note: incsearch only, no hlsearch. A substitute command should still highlight *all* matches in its range, not
+    // just the current one (this matches Vim/Neovim's incremental substitute preview).
+    enterCommand("set incsearch")
+
+    typeText(":", "%s/and")
+
+    assertSearchHighlights(
+      "and",
+      """I found it in a legendary l‷and‴
+           |all rocks «and» lavender «and» tufted grass,
+           |where it was settled on some sodden s«and»
+           |hard by the torrent of a mountain pass.
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test cancelling substitute command clears all-match highlights without hlsearch`() {
+    configureByText(
+      """I found it in a legendary land
+           |${c}all rocks and lavender and tufted grass,
+           |where it was settled on some sodden sand
+           |hard by the torrent of a mountain pass.
+      """.trimMargin(),
+    )
+    enterCommand("set incsearch")
+
+    typeText(":", "%s/and", "<Esc>")
+
+    // Without hlsearch there are no persistent highlights to fall back to, so cancelling must clear everything.
+    assertNoSearchHighlights()
+  }
+
+  @Test
   fun `test incsearch highlights for substitute command`() {
     configureByText(
       """I found it in a legendary land

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
@@ -27,6 +27,7 @@ open class GlobalOptions(scope: OptionAccessScope) : OptionsPropertiesBase(scope
   var hlsearch: Boolean by optionProperty(Options.hlsearch)
   var ignorecase: Boolean by optionProperty(Options.ignorecase)
   var incsearch: Boolean by optionProperty(Options.incsearch)
+  var inccommand: String by optionProperty(Options.inccommand)
   val keymodel: StringListOptionValue by optionProperty(Options.keymodel)
   var maxmapdepth: Int by optionProperty(Options.maxmapdepth)
   var maxsearchcount: Int by optionProperty(Options.maxsearchcount)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -216,6 +216,15 @@ object Options {
   val startofline: ToggleOption = addOption(ToggleOption("startofline", GLOBAL, "sol", true))
   val timeout: ToggleOption = addOption(ToggleOption("timeout", GLOBAL, "to", true))
   val timeoutlen: UnsignedNumberOption = addOption(UnsignedNumberOption("timeoutlen", GLOBAL, "tm", 1000))
+  val inccommand: StringOption = addOption(
+    StringOption(
+      "inccommand",
+      GLOBAL,
+      "icm",
+      "",
+      setOf("nosplit", "split")
+    )
+  )
   val undolevels: NumberOption = addOption(
     // -1 means no undo. Vim uses -123456 as "unset". See `:help undolevels`
     // TODO: This option doesn't appear to be used anywhere...

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimSearchGroupBase.kt
@@ -37,6 +37,22 @@ import javax.swing.KeyStroke
 import kotlin.math.max
 import kotlin.math.min
 
+/**
+ * A single replacement applied by an `inccommand` substitute preview.
+ *
+ * The offsets are in the live document, captured at the moment the replacement was applied. To revert a list of
+ * changes, restore them in descending [startOffset] order so reverting a later change doesn't shift the offset of an
+ * earlier one.
+ */
+data class SubstitutePreviewChange(
+  /** Offset in the (live) document where the replacement text starts. */
+  val startOffset: Int,
+  /** Length of the inserted replacement text. */
+  val replacementLength: Int,
+  /** The original text that was replaced, used to restore the document on revert. */
+  val originalText: String,
+)
+
 abstract class VimSearchGroupBase : VimSearchGroup {
 
   protected companion object {
@@ -594,12 +610,50 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     exarg: String,
     parent: VimLContext,
   ): Boolean {
+    return runSubstitute(editor, caret, context, range, excmd, exarg, parent, collector = null)
+  }
+
+  /**
+   * Apply a substitute command as an `inccommand` preview, mutating the document but suppressing all the persistent
+   * side effects of a real substitution (search history, last-used pattern/replacement, messages, jumps, caret moves,
+   * `:s///c` confirmation). Returns the list of changes applied, in the order they were made, so the caller can revert
+   * them (see [SubstitutePreviewChange]).
+   */
+  fun substitutePreview(
+    editor: VimEditor,
+    context: ExecutionContext,
+    range: LineRange,
+    excmd: String,
+    exarg: String,
+    parent: VimLContext,
+  ): List<SubstitutePreviewChange> {
+    val collector = mutableListOf<SubstitutePreviewChange>()
+    runSubstitute(editor, editor.primaryCaret(), context, range, excmd, exarg, parent, collector)
+    return collector
+  }
+
+  /**
+   * Shared implementation for both a real substitution and an `inccommand` preview. Passing a [collector] switches on
+   * preview mode: the replacements are recorded into it and all persistent side effects (messages, history, jumps,
+   * caret moves, confirmation) are suppressed. A `null` collector performs a normal, committing substitution.
+   */
+  private fun runSubstitute(
+    editor: VimEditor,
+    caret: VimCaret,
+    context: ExecutionContext,
+    range: LineRange,
+    excmd: String,
+    exarg: String,
+    parent: VimLContext,
+    collector: MutableList<SubstitutePreviewChange>?,
+  ): Boolean {
+    val preview = collector != null
     // Explicitly exit visual mode here, so that visual mode marks don't change when we move the cursor to a match.
     val exceptions: MutableList<ExException> = ArrayList()
-    if (editor.inVisualMode) editor.exitVisualMode()
+    if (!preview && editor.inVisualMode) editor.exitVisualMode()
 
     // Parse Ex command and arguments to extract the pattern, substitute string, and line range
-    val substituteCommandParse = parseSubstituteCommand(editor, range, excmd, exarg) ?: return false
+    val substituteCommandParse = parseSubstituteCommand(editor, range, excmd, exarg, preview) ?: return false
     val pattern = substituteCommandParse.pattern
     val substituteString = substituteCommandParse.substituteString
     val line1 = substituteCommandParse.range.startLine
@@ -612,21 +666,24 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     val regex: VimRegex = try {
       VimRegex(pattern)
     } catch (e: VimRegexException) {
-      injector.messages.showErrorMessage(editor, e.message)
+      if (!preview) injector.messages.showErrorMessage(editor, e.message)
       return false
     }
 
     val hasExpression = substituteString.length >= 2 && substituteString[0] == '\\' && substituteString[1] == '='
 
     val oldLastSubstituteString: String = lastSubstituteString ?: ""
-    if (substituteString != "~") {
+    if (!preview && substituteString != "~") {
       lastSubstituteString = substituteString
     }
 
-    setShouldShowSearchHighlights()
-    updateSearchHighlights(true)
+    if (!preview) {
+      setShouldShowSearchHighlights()
+      updateSearchHighlights(true)
+    }
 
-    if (!doAsk) {
+    // A preview always behaves like a non-confirming substitution - we preview every match, ignoring the `c` flag.
+    if (!doAsk || preview) {
       performSubstituteInLines(
         editor,
         caret,
@@ -641,7 +698,8 @@ abstract class VimSearchGroupBase : VimSearchGroup {
         hasExpression,
         substituteString,
         exceptions,
-        options
+        options,
+        collector,
       )
     } else {
       val lineToNextSubstitute = getNextSubstitute(
@@ -712,6 +770,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     hasExpression: Boolean,
     substituteString: String,
     options: EnumSet<VimRegexOptions>,
+    preview: Boolean,
   ): SubstitutePreparationResult {
     val substituteResult =
       regex.substitute(editor, substituteString, oldLastSubstituteString, line, column, hasExpression, options)
@@ -719,7 +778,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     val matchRange = substituteResult.first.range
     val match = substituteResult.second
 
-    injector.jumpService.saveJumpLocation(editor)
+    if (!preview) injector.jumpService.saveJumpLocation(editor)
     return SubstitutePreparationResult.Prepared(match, matchRange, endLine, doReplace = true, gotQuit = false)
   }
 
@@ -749,7 +808,9 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     substituteString: String,
     exceptions: MutableList<ExException>,
     options: EnumSet<VimRegexOptions>,
+    collector: MutableList<SubstitutePreviewChange>?,
   ) {
+    val preview = collector != null
     var column = startColumn
     var line = startLine
     var line2 = endLine
@@ -764,7 +825,8 @@ abstract class VimSearchGroupBase : VimSearchGroup {
         column,
         hasExpression,
         substituteString,
-        options
+        options,
+        preview
       )
       if (preparationResult is SubstitutePreparationResult.Skip) {
         line = preparationResult.newLine
@@ -786,13 +848,14 @@ abstract class VimSearchGroupBase : VimSearchGroup {
         preparationResult.newEndLine,
         hasExpression,
         substituteString,
-        exceptions
+        exceptions,
+        collector
       )
       line = replaceResult.line
       column = replaceResult.column
       line2 = replaceResult.endLine
     }
-    postSubstitute(editor, caret, pattern, gotQuit = false, lastMatchLine, exceptions)
+    postSubstitute(editor, caret, pattern, gotQuit = false, lastMatchLine, exceptions, preview)
   }
 
   private fun performReplace(
@@ -808,9 +871,12 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     hasExpression: Boolean,
     substituteString: String,
     exceptions: MutableList<ExException>,
+    collector: MutableList<SubstitutePreviewChange>?,
   ): ReplaceResult {
-    caret.moveToOffset(matchRange.startOffset)
-    setLatestMatch(editor.getText(TextRange(matchRange.startOffset, matchRange.endOffset)))
+    val preview = collector != null
+    if (!preview) caret.moveToOffset(matchRange.startOffset)
+    val originalText = editor.getText(TextRange(matchRange.startOffset, matchRange.endOffset))
+    setLatestMatch(originalText)
     val finalMatch = if (hasExpression) evaluateExpression(
       substituteString.substring(2),
       editor,
@@ -831,6 +897,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
       injector.application.runWriteAction {
         (editor as MutableVimEditor).replaceString(matchRange.startOffset, matchRange.endOffset, finalMatch)
       }
+      collector?.add(SubstitutePreviewChange(matchRange.startOffset, finalMatch.length, originalText))
       didReplace = true
 
       val endPositionWithReplace = editor.offsetToBufferPosition(matchRange.startOffset + finalMatch.length)
@@ -865,7 +932,14 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     gotQuit: Boolean,
     lastMatchLine: Int,
     exceptions: List<ExException>,
+    preview: Boolean,
   ) {
+    // A preview must not move the caret or report errors - it's purely a visual, throwaway rendering.
+    if (preview) {
+      setLatestMatch("")
+      return
+    }
+
     if (!gotQuit) {
       if (lastMatchLine != -1) {
         caret.moveToOffset(injector.motion.moveCaretToLineStartSkipLeading(editor, lastMatchLine))
@@ -944,7 +1018,8 @@ abstract class VimSearchGroupBase : VimSearchGroup {
               hasExpression,
               substituteString,
               exceptions,
-              options
+              options,
+              collector = null
             )
             closeModalInputPrompt()
             return@executeCommand
@@ -974,7 +1049,8 @@ abstract class VimSearchGroupBase : VimSearchGroup {
           endLine,
           hasExpression,
           substituteString,
-          exceptions
+          exceptions,
+          collector = null
         )
         line = replaceResult.line
         endLine = replaceResult.endLine
@@ -1029,7 +1105,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     }
 
     private fun afterAllSubstitutes() {
-      postSubstitute(editor, caret, pattern, gotQuit, lastMatchLine, exceptions)
+      postSubstitute(editor, caret, pattern, gotQuit, lastMatchLine, exceptions, preview = false)
       closeModalInputPrompt()
     }
   }
@@ -1060,6 +1136,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     range: LineRange,
     excmd: String,
     exarg: String,
+    preview: Boolean = false,
   ): SubstituteCommandArguments? {
     var patternType = if ("~" == excmd) {
       // use last used regexp
@@ -1078,7 +1155,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     ) {
       // don't accept alphanumeric for separator
       if (exarg.first().isLetter()) {
-        injector.messages.showStatusBarMessage(null, "E146: Regular expressions can't be delimited by letters")
+        if (!preview) injector.messages.showStatusBarMessage(null, "E146: Regular expressions can't be delimited by letters")
         return null
       }
 
@@ -1090,7 +1167,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
       var substituteStringStartIndex = 0
       if (exarg.first() == '\\') {
         if (exarg.length < 2 || !"/?&".contains(exarg[1])) {
-          injector.messages.showStatusBarMessage(null, "E10: \\ should be followed by /, ? or &")
+          if (!preview) injector.messages.showStatusBarMessage(null, "E10: \\ should be followed by /, ? or &")
           return null
         }
         if (exarg[1] != '&') {
@@ -1130,7 +1207,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
       // use previous pattern and substitution
       if (lastSubstituteString == null) {
         // there is no previous command
-        injector.messages.showStatusBarMessage(null, "E33: No previous substitute regular expression")
+        if (!preview) injector.messages.showStatusBarMessage(null, "E33: No previous substitute regular expression")
         return null
       }
       pattern = null
@@ -1192,7 +1269,7 @@ abstract class VimSearchGroupBase : VimSearchGroup {
         trailingOptionsEndIndex++
       }
       if (count <= 0 && doError) {
-        injector.messages.showStatusBarMessage(null, injector.messages.message("command.substitute.zero.count"))
+        if (!preview) injector.messages.showStatusBarMessage(null, injector.messages.message("command.substitute.zero.count"))
         return null
       }
       line1 = line2
@@ -1202,14 +1279,14 @@ abstract class VimSearchGroupBase : VimSearchGroup {
     // check for trailing command or garbage
     if (trailingOptionsEndIndex < exarg.length && exarg[trailingOptionsEndIndex] != '"') {
       // if not end-of-line or comment
-      injector.messages.showStatusBarMessage(null, injector.messages.message("command.substitute.trailing.characters"))
+      if (!preview) injector.messages.showStatusBarMessage(null, injector.messages.message("command.substitute.trailing.characters"))
       return null
     }
 
     // check for trailing command or garbage
     if (trailingOptionsEndIndex < exarg.length && exarg[trailingOptionsEndIndex] != '"') {
       // if not end-of-line or comment
-      injector.messages.showStatusBarMessage(null, injector.messages.message("command.substitute.trailing.characters"))
+      if (!preview) injector.messages.showStatusBarMessage(null, injector.messages.message("command.substitute.trailing.characters"))
       return null
     }
 
@@ -1233,14 +1310,17 @@ abstract class VimSearchGroupBase : VimSearchGroup {
 
       // Pattern was never defined
       if (pattern == null) {
-        injector.messages.showStatusBarMessage(null, errorMessage)
+        if (!preview) injector.messages.showStatusBarMessage(null, errorMessage)
         return null
       }
     }
 
-    // Set last substitute pattern, but only for explicitly typed patterns. Reused patterns are not saved/updated
-    setLastUsedPattern(pattern, PatternType.SUBSTITUTE, isNewPattern)
-    lastReplaceString = sub
+    // Set last substitute pattern, but only for explicitly typed patterns. Reused patterns are not saved/updated.
+    // A preview is throwaway, so it must not touch the search history, registers, or last-used pattern/replacement.
+    if (!preview) {
+      setLastUsedPattern(pattern, PatternType.SUBSTITUTE, isNewPattern)
+      lastReplaceString = sub
+    }
 
     // Always reset after checking, only set for nv_ident
     lastIgnoreSmartCase = false

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VirtualBufferGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VirtualBufferGroup.kt
@@ -8,15 +8,38 @@
 package com.maddyhome.idea.vim.api
 
 /**
- * Manages IdeaVim's virtual buffers (the command-line / search history windows and the control-chars
- * editor) — light in-memory editors that are not backed by a real file.
+ * Manages IdeaVim's virtual buffers (the command-line / search history windows, the control-chars
+ * editor, and the `inccommand=split` substitute preview) — light in-memory editors that are not
+ * backed by a real file.
  */
 interface VirtualBufferGroup {
 
   /**
-   * Opens a virtual buffer of [kind] populated with [content]. Refused (with an error) if any
-   * virtual buffer is already open, since these buffers cannot be nested (`:help cmdwin`).
+   * Opens a virtual buffer of [kind] populated with [content].
+   *
+   * Command-line / search history buffers and the control-chars editor refuse to open while another
+   * such buffer is already open, since these buffers cannot be nested (`:help cmdwin`). The
+   * substitute preview is transient and does not participate in that restriction.
+   *
+   * @param focus when false, the buffer is shown without stealing focus (used by `inccommand=split`).
    */
-  fun open(context: ExecutionContext, editor: VimEditor, kind: VirtualBufferKind, content: String)
+  fun open(
+    context: ExecutionContext,
+    editor: VimEditor,
+    kind: VirtualBufferKind,
+    content: String,
+    focus: Boolean = true,
+  )
+
+  /** Closes the virtual buffer hosted in [editor] (typically the cmdwin editor itself). */
   fun close(editor: VimEditor)
+
+  /** Closes the open virtual buffer of [kind] in the project associated with [context]. */
+  fun close(context: ExecutionContext, kind: VirtualBufferKind)
+
+  /** Returns whether a virtual buffer of [kind] is currently open in the project associated with [context]. */
+  fun isOpen(context: ExecutionContext, kind: VirtualBufferKind): Boolean
+
+  /** Replaces the content of an already-open virtual buffer of [kind] in place. */
+  fun refresh(context: ExecutionContext, kind: VirtualBufferKind, content: String)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VirtualBufferKind.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VirtualBufferKind.kt
@@ -11,7 +11,7 @@ import com.maddyhome.idea.vim.common.Direction
 
 /**
  * Identifies which kind of virtual buffer the editor is hosting: a command-line / search history
- * window (`q:`, `q/`, `q?`) or the control-chars editor.
+ * window (`q:`, `q/`, `q?`), the control-chars editor, or the `inccommand=split` substitute preview.
  */
 sealed class VirtualBufferKind {
   abstract val fileName: String
@@ -26,5 +26,9 @@ sealed class VirtualBufferKind {
 
   data object ControlCharsEditor : VirtualBufferKind() {
     override val fileName: String = "[Control Chars Editor]"
+  }
+
+  data object SubstitutePreview : VirtualBufferKind() {
+    override val fileName: String = "[Preview Substitute]"
   }
 }


### PR DESCRIPTION
Added option `incommand` with option `nosplit` and `split`
When it's set during replace text that will be replaced is dynamiclly highlihgted and replaced on esc it returns to old state
with option split there is addition window showing modified lines