### PR TITLE
VIM-4255 Don't record repleced mapped keystrotes

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/MacroActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/MacroActionTest.kt
@@ -58,17 +58,21 @@ class MacroActionTest : VimTestCase() {
   @Test
   @TestWithoutNeovim(reason = SkipNeovimReason.ACTION_COMMAND)
   fun testMacroWithIdeAction() {
-    configureByText("""One
+    configureByText(
+      """One
       |Two
       |Three
-      |Four""".trimMargin())
+      |Four""".trimMargin()
+    )
     enterCommand("map j <Action>(EditorDown)")
     typeText(injector.parser.parseKeys("qa" + "j" + "q"))
     typeText(injector.parser.parseKeys("@a"))
-    assertState("""One
+    assertState(
+      """One
       |Two
       |${c}Three
-      |Four""".trimMargin())
+      |Four""".trimMargin()
+    )
   }
 
   @Test
@@ -511,5 +515,15 @@ class MacroActionTest : VimTestCase() {
     setText("")
     typeText("\"ap")
     assertState("iX\nY" + '\u001B')
+  }
+
+  @Test
+  fun `should not record y twice when followed by motion`() {
+    configureByText("${c}Spider man")
+    enterCommand("map ys :echo 'hi'<CR>")
+    typeText("qa", "y")
+    Thread.sleep(2000)
+    typeText("w", "q")
+    assertRegister('a', "yw")
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -55,7 +55,7 @@ class KeyHandler {
     StartSelectRegisterConsumer(),  // Must be before command consumer, so " isn't treated as a command char
     SelectRegisterConsumer(),
     DigraphConsumer(),    // Must be before command key consumer so {char}<BS>{char} works.
-                          // Would be a problem if a command prefix requires a DIGRAPH arg (no such command exists)
+    // Would be a problem if a command prefix requires a DIGRAPH arg (no such command exists)
     CommandKeyConsumer(), // Must be before argument consumers, to handle c_CTRL-R prefix
     CharArgumentConsumer(),
     ModeInputConsumer()   // Must be last to accept the keystroke as typed input
@@ -124,6 +124,18 @@ class KeyHandler {
     val result = processKey(key, editor, allowKeyMappings, KeyProcessResult.SynchronousKeyProcessBuilder(keyState))
     if (result is KeyProcessResult.Executable) {
       result.execute(editor, context)
+    }
+  }
+
+  /**
+   * Use this to execute key handling without recording them in macro
+   */
+  fun withoutRecording(unit: () -> Unit) {
+    handleKeyRecursionCount++
+    try {
+      unit()
+    } finally {
+      handleKeyRecursionCount--
     }
   }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/MappingProcessor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/MappingProcessor.kt
@@ -149,8 +149,7 @@ internal object MappingProcessor : KeyConsumer {
       keyProcessResultBuilder.addExecutionStep { ks, _, c ->
         ks.mappingState.startMappingTimer { onUnfinishedMappingSequenceTimeout(editor, ks, c) }
       }
-    }
-    else {
+    } else {
       log.trace("'timeout' is not set. Waiting for the next keystroke")
     }
     return true
@@ -175,7 +174,9 @@ internal object MappingProcessor : KeyConsumer {
         return@invokeLater
       }
 
-      replayUnhandledKeys(unhandledKeys, editor, context, keyState)
+      KeyHandler.getInstance().withoutRecording {
+        replayUnhandledKeys(unhandledKeys, editor, context, keyState)
+      }
     }
   }
 
@@ -266,7 +267,10 @@ internal object MappingProcessor : KeyConsumer {
 
     keyProcessResultBuilder.addExecutionStep { ks, e, c ->
       log.trace("Replaying abandoned keys")
-      replayUnhandledKeys(unhandledKeyStrokes, e, c, ks)
+      val keyHandler = KeyHandler.getInstance()
+      keyHandler.withoutRecording {
+        replayUnhandledKeys(unhandledKeyStrokes, e, c, ks)
+      }
       log.trace("Abandoned keys processed. Returning true.")
     }
     return true


### PR DESCRIPTION
When user had mapping for key `onUnfinishedMappingSequenceTimeout` executed this key mapping again which resulted in duplicated key in macro. To prevent that we took simillar approach as nvim to not record mapped keystrokes