### PR TITLE
VIM-4245 Fix carret offsets on intelij actions

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
@@ -43,13 +43,16 @@ import com.maddyhome.idea.vim.action.VimShortcutKeyAction
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimKeyGroupBase
 import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.api.normalizeOffset
 import com.maddyhome.idea.vim.api.options
 import com.maddyhome.idea.vim.group.NotificationService
 import com.maddyhome.idea.vim.group.visual.IdeaSelectionControl
 import com.maddyhome.idea.vim.helper.exitSelectMode
 import com.maddyhome.idea.vim.helper.exitVisualMode
 import com.maddyhome.idea.vim.helper.hasVisualSelection
+import com.maddyhome.idea.vim.helper.isEndAllowed
 import com.maddyhome.idea.vim.helper.isIdeaVimDisabledHere
+import com.maddyhome.idea.vim.helper.vimInitialised
 import com.maddyhome.idea.vim.ide.isClionNova
 import com.maddyhome.idea.vim.ide.isRider
 import com.maddyhome.idea.vim.newapi.globalIjOptions
@@ -91,7 +94,7 @@ internal object IdeaSpecifics {
         saveJumpBeforeGoto(event, editor)
       }
 
-      val isVimAction = (action as? AnActionWrapper)?.delegate is VimShortcutKeyAction
+      val isVimAction = isVimAction(action)
       if (!isVimAction && injector.vimState.mode == Mode.INSERT && action !is EnterAction) {
         val undoService = injector.undo as VimTimestampBasedUndoService
         val nanoTime = System.nanoTime()
@@ -184,10 +187,32 @@ internal object IdeaSpecifics {
       }
       //endregion
 
+      if (!isVimAction(action)) {
+        normalizeCarets(editor)
+      }
+
       this.editor = null
 
       this.completionData?.dispose()
       this.completionData = null
+    }
+
+    private fun isVimAction(action: AnAction): Boolean = (action as? AnActionWrapper)?.delegate is VimShortcutKeyAction
+
+    private fun normalizeCarets(editor: Editor?) {
+      editor?.let { ij ->
+        if (!ij.vimInitialised) return@let
+        val vimEditor = ij.vim
+        if (vimEditor.isEndAllowed) {
+          return
+        }
+        for (caret in ij.caretModel.allCarets) {
+          val normalized = vimEditor.normalizeOffset(caret.offset, false)
+          if (normalized != caret.offset) {
+            caret.moveToOffset(normalized)
+          }
+        }
+      }
     }
 
     private fun isGotoAction(actionId: String?): Boolean =

--- a/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
@@ -17,6 +17,7 @@ import com.intellij.codeInsight.template.Template
 import com.intellij.codeInsight.template.TemplateEditingAdapter
 import com.intellij.codeInsight.template.TemplateManagerListener
 import com.intellij.codeInsight.template.impl.TemplateImpl
+import com.intellij.codeInsight.template.impl.TemplateManagerImpl
 import com.intellij.codeInsight.template.impl.TemplateState
 import com.intellij.find.FindModelListener
 import com.intellij.ide.actions.ApplyIntentionAction
@@ -30,6 +31,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.IdeActions
 import com.intellij.openapi.actionSystem.ex.AnActionListener
 import com.intellij.openapi.actionSystem.impl.ProxyShortcutSet
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.RangeMarker
 import com.intellij.openapi.editor.actions.EnterAction
@@ -337,6 +339,7 @@ internal object IdeaSpecifics {
           // oldIndex == newIndex == -1.
           if (vimEditor.isIdeaRefactorModeKeep) {
             IdeaRefactorModeHelper.correctEditorSelection(templateState.editor)
+            adjustCaretIntoTemplateRange(vimEditor)
           } else {
             // The editor places the caret at the exclusive end of the variable. For Visual, unless we've enabled
             // exclusive selection, move it to the inclusive end.
@@ -374,6 +377,17 @@ internal object IdeaSpecifics {
                   vimEditor.mode = Mode.NORMAL()
                 }
               }
+            }
+          }
+        }
+
+        private fun adjustCaretIntoTemplateRange(vimEditor: VimEditor) {
+          ApplicationManager.getApplication().invokeLater {
+            if (editor.isDisposed) return@invokeLater
+            if (vimEditor.mode !is Mode.NORMAL) return@invokeLater
+            val range = TemplateManagerImpl.getTemplateState(editor)?.currentVariableRange ?: return@invokeLater
+            if (!range.isEmpty && editor.caretModel.offset >= range.endOffset) {
+              editor.caretModel.moveToOffset(range.endOffset - 1)
             }
           }
         }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/ActionsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/ActionsTest.kt
@@ -35,7 +35,7 @@ class ActionsTest : VimTestCase() {
       """
       Lorem Ipsum
 
-      Lorem ipsum dolor sit amet,$c
+      Lorem ipsum dolor sit amet$c,
        consectetur adipiscing elit
       Sed in orci mauris.
       Cras id tellus in ex imperdiet egestas.

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/CreateConstructorTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/CreateConstructorTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package org.jetbrains.plugins.ideavim.action
+
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimJavaTestCase
+import org.junit.jupiter.api.Test
+
+class CreateConstructorTest : VimJavaTestCase() {
+  @TestWithoutNeovim(SkipNeovimReason.ACTION_COMMAND)
+  @Test
+  fun testSimpleConstructor() {
+    configureByJavaText(
+      """
+      class MyClass {
+          private int ${c}value;
+      }
+      """.trimIndent(),
+    )
+    enterCommand("action GenerateConstructor")
+    assertState(
+      """
+      class MyClass {
+          public MyClass(int value) ${c}{
+              this.value = value;
+          }
+
+          private int value;
+      }
+      """.trimIndent(),
+    )
+  }
+}

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/group/visual/TemplateTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/group/visual/TemplateTest.kt
@@ -19,6 +19,9 @@ import com.intellij.ide.DataManager
 import com.intellij.injected.editor.EditorWindow
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.refactoring.introduceVariable.IntroduceVariableHandler
 import com.intellij.refactoring.rename.inplace.VariableInplaceRenameHandler
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.CodeInsightTestUtil.doInlineRename
@@ -31,6 +34,7 @@ import org.jetbrains.plugins.ideavim.VimJavaTestCase
 import org.jetbrains.plugins.ideavim.assertModeDoesNotChange
 import org.jetbrains.plugins.ideavim.waitAndAssertMode
 import org.jetbrains.plugins.ideavim.waitUntilSelectionUpdated
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -1330,6 +1334,40 @@ class TemplateTest : VimJavaTestCase() {
     assertTemplateFinished()
   }
 
+  @Test
+  fun `test introduce variable with keep option places caret on last char of refactor box`() {
+    configureByJavaText(
+      """
+        |class Hello {
+        |  public static void main() {
+        |    System.out.println(${c}42);
+        |  }
+        |}
+      """.trimMargin()
+    )
+    enterCommand("set idearefactormode=keep")
+
+    ApplicationManager.getApplication().invokeAndWait {
+      var expression: PsiExpression? = null
+      ApplicationManager.getApplication().runReadAction {
+        val element = fixture.file.findElementAt(fixture.editor.caretModel.offset)
+        expression = PsiTreeUtil.getParentOfType(element, PsiExpression::class.java, false)
+      }
+      IntroduceVariableHandler().invoke(fixture.project, fixture.editor, expression!!)
+      PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+    }
+
+    assertModeDoesNotChange(fixture.editor, Mode.NORMAL())
+    assertTemplateActive()
+
+    val templateState = TemplateManagerImpl.getTemplateState(fixture.editor)!!
+    val variableRange = templateState.currentVariableRange!!
+    // Caret must be on the last character of the variable name (inside the box), not after it
+    ApplicationManager.getApplication().runReadAction {
+      assertEquals(variableRange.endOffset - 1, fixture.editor.caretModel.offset)
+    }
+  }
+
   private fun startRenaming(handler: VariableInplaceRenameHandler) {
     val editor = if (fixture.editor is EditorWindow) (fixture.editor as EditorWindow).delegate else fixture.editor
 
@@ -1361,11 +1399,9 @@ class TemplateTest : VimJavaTestCase() {
     waitUntilSelectionUpdated(fixture.editor)
   }
 
-  private fun assertTemplateActive() =
-    assertNotNull(TemplateManagerImpl.getTemplateState(fixture.editor))
+  private fun assertTemplateActive() = assertNotNull(TemplateManagerImpl.getTemplateState(fixture.editor))
 
-  private fun assertTemplateFinished() =
-    assertNull(TemplateManagerImpl.getTemplateState(fixture.editor))
+  private fun assertTemplateFinished() = assertNull(TemplateManagerImpl.getTemplateState(fixture.editor))
 
   private val dataContext
     get() = DataManager.getInstance().getDataContext(fixture.editor.component)

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/group/visual/TemplateTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/group/visual/TemplateTest.kt
@@ -1123,7 +1123,7 @@ class TemplateTest : VimJavaTestCase() {
 
     moveToNextVariable()
     assertMode(Mode.NORMAL())
-    assertState("var foo = 239;${c}")
+    assertState("var foo = 239${c};")
     assertTemplateFinished()
   }
 
@@ -1191,7 +1191,7 @@ class TemplateTest : VimJavaTestCase() {
     moveToNextVariable()  // V2 -> End
 
     assertMode(Mode.NORMAL())
-    assertState("var foo = 239;${c}")
+    assertState("var foo = 239${c};")
     assertTemplateFinished()
   }
 
@@ -1259,7 +1259,7 @@ class TemplateTest : VimJavaTestCase() {
 
     moveToNextVariable()
     assertMode(Mode.NORMAL())
-    assertState("var foo = 239;${c}")
+    assertState("var foo = 239${c};")
     assertTemplateFinished()
   }
 


### PR DESCRIPTION
- Don't place cursor on last char (\n) after intelij actions
- place cursor on last char of template when idearefactormode=keep and normal mode