### PR TITLE
Show blogpost with changes on new release

### DIFF
--- a/.github/workflows/prepareWhatsNewClaude.yml
+++ b/.github/workflows/prepareWhatsNewClaude.yml
@@ -112,3 +112,45 @@ jobs:
 
           # Changelog needs the skill + git/gh/web; the page generation needs file read/write.
           claude_args: '--allowed-tools "Skill,Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*),WebSearch,WebFetch(domain:plugins.jetbrains.com),WebFetch(domain:youtrack.jetbrains.com),WebFetch(domain:github.com)"'
+
+      - name: Comment rendered preview link on the PR
+        if: ${{ always() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Only ever preview the page this workflow updates: whatsnew-tbr.html.
+            const branch = 'whatsnew-tbr';
+            const file = 'src/main/resources/whatsnew-tbr.html';
+            const { owner, repo } = context.repo;
+
+            const prs = await github.rest.pulls.list({ owner, repo, state: 'open', head: `${owner}:${branch}` });
+            if (prs.data.length === 0) {
+              core.info(`No open PR for ${branch}; nothing to preview.`);
+              return;
+            }
+            const pr = prs.data[0];
+
+            // The page is self-contained (inline CSS), so raw.githack.com renders it directly.
+            const url = `https://raw.githack.com/${owner}/${repo}/${branch}/${file}`;
+            const marker = '<!-- whatsnew-preview -->';
+            const body = [
+              marker,
+              "### 📰 What's New preview",
+              '',
+              `Rendered via raw.githack.com: [\`${file}\`](${url})`,
+              '',
+              '> Note: the live page follows the **IDE** theme. This preview follows your ' +
+              '**OS** theme (the `__THEME__` token is unresolved here), and `__VERSION__` ' +
+              'shows literally — both are substituted by the IDE at runtime.',
+            ].join('\n');
+
+            // Upsert a single sticky comment instead of spamming on re-runs.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pr.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+            }

--- a/.github/workflows/prepareWhatsNewClaude.yml
+++ b/.github/workflows/prepareWhatsNewClaude.yml
@@ -1,0 +1,114 @@
+name: Prepare What's New with Claude
+
+on:
+  workflow_dispatch:  # Manually triggered by a maintainer
+
+jobs:
+  prepare-whats-new:
+    runs-on: ubuntu-latest
+    if: github.repository == 'JetBrains/ideavim'
+
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+      issues: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history so the changelog can be analyzed and the PR branch pushed
+
+      - name: Run Claude Code to update the changelog and prepare the What's New page
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.PROXY_URL }}
+          ANTHROPIC_CUSTOM_HEADERS: |
+            Grazie-Agent: {"name":"ideavim-claude-code-action","version":"github-actions"}
+            Grazie-Authenticate-JWT: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          prompt: |
+            Do TWO things in order, in this single run, then open ONE pull request that
+            contains both changes. The What's New page is derived from the changelog, so the
+            changelog MUST be brought up to date first.
+
+            ## Step 1 — Update the changelog first
+            - Use the `changelog` skill to load the maintenance rules, then follow them.
+            - Review commits since the last documented version and add any missing
+              user-facing entries to the `## [To Be Released]` section of `CHANGES.md`
+              (under `### Features:`, `### Fixes:`, `### Changes:`, `### Merged PRs:`).
+            - Respect every skill rule: exclusions (Dependabot/Claude PRs, internal
+              refactors, test-only/doc-only changes, the `api` module, and the Vim Everywhere
+              / Hints project), the writing style, and "each change in exactly one subsection".
+            - Only EDIT `CHANGES.md` in the working tree here. Do NOT open a separate PR for it.
+
+            ## Step 2 — Create or update the What's New page (whatsnew-tbr.html)
+            The page for the upcoming release lives at `src/main/resources/whatsnew-tbr.html`.
+            After each release it is promoted to `whatsnew-<version>.html` and the `tbr` file is
+            gone, so USUALLY it does NOT exist when this workflow runs — only the version-specific
+            pages for older releases (`whatsnew-<version>.html`) remain.
+
+            Read the now-updated `## [To Be Released]` section of `CHANGES.md` (everything between
+            that heading and the next dated release heading, e.g. `## 2.39.0, ...`). Use only its
+            Features and Fixes; you may skip Merged PRs.
+
+            First decide what to do by checking the working tree:
+            - List `src/main/resources/whatsnew-*.html`.
+            - **If `whatsnew-tbr.html` does NOT exist (the normal case):** create it fresh,
+              describing every Feature and Fix currently under `## [To Be Released]`.
+            - **If `whatsnew-tbr.html` ALREADY exists (it was generated earlier this cycle):**
+              do NOT rebuild it from scratch. Diff it against the current `## [To Be Released]`
+              section — work out which changelog entries are NOT yet represented on the page — and
+              update the page to incorporate ONLY those new/changed items, preserving the existing
+              sections, ordering and wording already present. This is an incremental update, not a
+              rewrite. (If nothing in the changelog is new relative to the page, make no changes
+              and do not open a PR.)
+
+            - If, after Step 1, `## [To Be Released]` still has no Features or Fixes, STOP:
+              do not create or change the HTML and do not open a PR. Explain why in your final message.
+
+            ### Style — match the existing pages EXACTLY
+            Use the NEWEST version-specific page as the canonical style reference: pick
+            `src/main/resources/whatsnew-<highest-version>.html` (fall back to `whatsnew-tbr.html`
+            only if no version-specific page exists) and read it first. It is a terminal-window
+            "blog post": monospace font, a title bar with traffic-light dots, `❯`-prefixed `<h2>`
+            headings, `#`-prefixed `.kicker` labels, a `.grid` of `.mini` cards, syntax-colored
+            `<pre>` blocks (`.cm` comments, `.str` strings, `.key` keys), and a footer prompt with links.
+
+            Copy its `<head>` and entire `<style>` block VERBATIM. You MUST keep, unchanged:
+            - the `data-theme="__THEME__"` attribute on `<html>` and the `__VERSION__` token —
+              the IDE replaces both at runtime; never remove or rename them,
+            - the `:root`, `:root[data-theme="dark"]`, and
+              `@media (prefers-color-scheme: dark)` variable blocks,
+            - every existing CSS class (`.term`, `.titlebar`, `.kicker`, `.section`, `.mini`,
+              `.grid`, `pre .cm/.str/.key`, `.caret`, `footer`, etc.).
+
+            Only change the human content: the `<title>`, the title-bar `.title`, the intro
+            `.runline`/`.out` block, the feature `.section`s, the "polish & fixes" list, and
+            the footer. Lead with the most interesting Features as full `.section`s (kicker +
+            `<h2>` + paragraph, plus a `<pre>` example when the entry shows commands or
+            `set`/`map` syntax); group smaller items into a `.grid` of `.mini` cards. Render
+            the Fixes as a final "polish & fixes" `<ul>`, each `<li>` with a short bolded lead.
+            Rewrite changelog lines into concise, friendly, user-facing prose — do NOT put
+            `VIM-####` ids or raw issue URLs on the page. Escape HTML correctly inside
+            `code`/`kbd`/`pre` (`&lt;` `&gt;` `&amp;`).
+
+            ## Do NOT set the version
+            - Never hard-code a version anywhere in the page. Leave the `__VERSION__` token
+              exactly as-is wherever it appears — the release pipeline (TeamCity) and the IDE
+              substitute the real version at build/runtime.
+
+            ## Open ONE pull request
+            - Create a branch named `whatsnew-tbr` (reset it if it already exists).
+            - Include BOTH the `CHANGES.md` update and the `whatsnew-tbr.html` change.
+            - Open it against `master` with:
+              - Title: "Prepare What's New for the upcoming release"
+              - Body: a short summary of the changelog entries added and the What's New highlights.
+
+          # Changelog needs the skill + git/gh/web; the page generation needs file read/write.
+          claude_args: '--allowed-tools "Skill,Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*),WebSearch,WebFetch(domain:plugins.jetbrains.com),WebFetch(domain:youtrack.jetbrains.com),WebFetch(domain:github.com)"'

--- a/.teamcity/_Self/buildTypes/ReleasePlugin.kt
+++ b/.teamcity/_Self/buildTypes/ReleasePlugin.kt
@@ -120,13 +120,29 @@ sealed class ReleasePlugin(private val releaseType: String) : IdeaVimBuildType({
       """.trimIndent()
     }
     script {
+      name = "Update what's new"
+      scriptContent = """
+        set -e
+        version=${'$'}(echo "%build.number%" | tr '[:upper:]' '[:lower:]')
+        tbr="src/main/resources/whatsnew-tbr.html"
+        target="src/main/resources/whatsnew-${'$'}version.html"
+        if [ -f "${'$'}tbr" ]; then
+          cp "${'$'}tbr" "${'$'}target"
+          git add "${'$'}target"
+          echo "Promoted whatsnew-tbr.html to whatsnew-${'$'}version.html"
+        else
+          echo "WARN: ${'$'}tbr not found; skipping What's New promotion"
+        fi
+      """.trimIndent()
+    }
+    script {
       name = "Commit preparation changes"
       scriptContent = """
         set -e
         git config user.name "IdeaVim Bot"
         git config user.email "maintainers@ideavim.dev"
-        if git diff --quiet; then
-          echo "No changelog changes to commit"
+        if git diff --quiet && git diff --cached --quiet; then
+          echo "No preparation changes to commit"
         else
           git commit -am "Preparation to %build.number% release"
         fi
@@ -153,17 +169,25 @@ sealed class ReleasePlugin(private val releaseType: String) : IdeaVimBuildType({
       jdkHome = "/usr/lib/jvm/java-21-amazon-corretto"
     }
     script {
-      name = "Sync changelog to master"
+      name = "Sync changelog and what's new to master"
       scriptContent = """
         set -e
         git checkout master
         cd scripts-ts
         npx tsx src/promoteChangelog.ts "%build.number%" "%env.ORG_GRADLE_PROJECT_releaseType%" ..
         cd ..
+        version=${'$'}(echo "%build.number%" | tr '[:upper:]' '[:lower:]')
+        tbr="src/main/resources/whatsnew-tbr.html"
+        target="src/main/resources/whatsnew-${'$'}version.html"
+        if [ -f "${'$'}tbr" ] && [ ! -f "${'$'}target" ]; then
+          cp "${'$'}tbr" "${'$'}target"
+          git add "${'$'}target"
+          echo "Promoted whatsnew-tbr.html to whatsnew-${'$'}version.html on master"
+        fi
         git config user.name "IdeaVim Bot"
         git config user.email "maintainers@ideavim.dev"
-        if git diff --quiet; then
-          echo "No changelog changes to commit on master"
+        if git diff --quiet && git diff --cached --quiet; then
+          echo "No changes to commit on master"
         else
           git commit -am "Preparation to %build.number% release"
         fi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
   compileOnly("org.jetbrains:annotations:26.1.0")
   ksp(project(":annotation-processors"))
   compileOnly(project(":annotation-processors"))
+
   kotlinCompilerPluginClasspath("org.jetbrains.kotlin:kotlin-serialization-compiler-plugin:$kotlinVersion")
   kotlinCompilerPluginClasspath("com.jetbrains.fleet:rpc-compiler-plugin:$fleetRpcVersion")
 
@@ -243,7 +244,7 @@ tasks {
 
   val runWebstorm by intellijPlatformTesting.runIde.registering {
     type = IntelliJPlatformType.WebStorm
-    version = "2025.3.2"
+    version = "2026.1"
   }
 
   val runClion by intellijPlatformTesting.runIde.registering {

--- a/src/main/java/com/maddyhome/idea/vim/VimPlugin.java
+++ b/src/main/java/com/maddyhome/idea/vim/VimPlugin.java
@@ -182,6 +182,11 @@ public class VimPlugin implements PersistentStateComponent<Element>, Disposable 
     return plugin != null ? plugin.getVersion() : "SNAPSHOT";
   }
 
+  public static @NotNull Boolean isPreRelease() {
+    var version = getVersion().toLowerCase();
+    return version.contains("dev") || version.contains("eap") || version.contains("snapshot");
+  }
+
   public static boolean isEnabled() {
     final VimPlugin instance = ApplicationManager.getApplication().getService(VimPlugin.class);
     return instance != null && instance.enabled;

--- a/src/main/java/com/maddyhome/idea/vim/config/VimState.kt
+++ b/src/main/java/com/maddyhome/idea/vim/config/VimState.kt
@@ -20,6 +20,7 @@ class VimState {
   var isIdeaPutNotified by StateProperty("idea-put")
   var wasSubscribedToEAPAutomatically by StateProperty("was-automatically-subscribed-to-eap")
   var firstIdeaVimVersion: String? by StringProperty("first-ideavim-version", null)
+  var lastIdeaVimVersion: String? by StringProperty("last-ideavim-version", null)
 
   fun readData(element: Element) {
     val notifications = element.getChild("notifications")

--- a/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
@@ -21,15 +21,15 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.KeyboardShortcut
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.keymap.KeymapUtil
-import com.intellij.openapi.keymap.ex.KeymapManagerEx
-import com.intellij.openapi.keymap.impl.ui.KeymapPanel
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.SystemInfo
+import com.intellij.util.ui.StartupUiUtil
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.action.editor.OpenControlCharsEditorAction
 import com.maddyhome.idea.vim.api.VimEditor
@@ -46,6 +46,7 @@ import com.maddyhome.idea.vim.statistic.ActionTracker
 import com.maddyhome.idea.vim.ui.VimEmulationConfigurable
 import com.maddyhome.idea.vim.vimscript.services.VimRcService
 import java.awt.datatransfer.StringSelection
+import java.nio.charset.StandardCharsets
 import javax.swing.KeyStroke
 import kotlin.io.path.Path
 import kotlin.io.path.appendText
@@ -230,6 +231,36 @@ internal class NotificationService(private val project: Project?) : VimNotificat
 
   override fun notifyActionId(id: String?, candidates: List<String>?, intentionName: String?) {
     ActionIdNotifier.notifyActionId(id, project, candidates, intentionName)
+  }
+
+  override fun notifyAboutNewVersion(version: String) {
+    val notification = Notification(
+      IDEAVIM_NOTIFICATION_ID,
+      IDEAVIM_NOTIFICATION_TITLE,
+      "Welcome to IdeaVim $version see what's new in",
+      NotificationType.INFORMATION,
+    )
+    notification.icon = VimIcons.IDEAVIM
+
+    notification.addAction(object : DumbAwareAction("See What's New") {
+      override fun actionPerformed(e: AnActionEvent) {
+        if (project == null) return
+        val theme = if (StartupUiUtil.isDarkTheme) "dark" else "light"
+        val html = getVersionHtml(theme) ?: return
+        HTMLEditorProvider.openEditor(project, "What's new in $version", html)
+      }
+
+      private fun getVersionHtml(theme: String): String? =
+        (loadHtml("whatsnew-$version.html") ?: loadHtml("whatsnew-tbr.html"))
+          ?.replace("__THEME__", theme)
+          ?.replace("__VERSION__", version)
+
+      private fun loadHtml(resource: String): String? = javaClass.classLoader
+        .getResourceAsStream(resource)
+        ?.use { it.readBytes().toString(StandardCharsets.UTF_8) }
+    })
+
+    notification.notify(project)
   }
 
   object ActionIdNotifier {

--- a/src/main/java/com/maddyhome/idea/vim/group/VimNotifications.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/VimNotifications.kt
@@ -33,4 +33,5 @@ interface VimNotifications {
   fun notifyEapFinished()
   fun showReenableNotification(project: Project)
   fun notifyActionId(id: String?, candidates: List<String>? = null, intentionName: String?)
+  fun notifyAboutNewVersion(version: String)
 }

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEnabler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEnabler.kt
@@ -10,6 +10,7 @@ package com.maddyhome.idea.vim.newapi
 
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.api.VimEnabler
+import com.maddyhome.idea.vim.api.injector
 
 class IjVimEnabler : VimEnabler {
   private var isNewUser = false
@@ -26,5 +27,12 @@ class IjVimEnabler : VimEnabler {
       VimPlugin.getVimState().firstIdeaVimVersion = VimPlugin.getVersion()
       this.isNewUser = true
     }
+
+    val lastVersion = VimPlugin.getVimState().lastIdeaVimVersion
+    val currentVersion = VimPlugin.getVersion().lowercase()
+    if (currentVersion != "snapshot" && (VimPlugin.isPreRelease() || lastVersion == currentVersion)) return
+    VimPlugin.getVimState().lastIdeaVimVersion = currentVersion
+    VimPlugin.getNotifications(injector.editorGroup.getSelectedEditor()?.ij?.project)
+      .notifyAboutNewVersion(currentVersion)
   }
 }

--- a/src/main/resources/whatsnew-tbr.html
+++ b/src/main/resources/whatsnew-tbr.html
@@ -1,0 +1,521 @@
+<!--
+  ~ Copyright 2003-2026 The IdeaVim authors
+  ~
+  ~ Use of this source code is governed by an MIT-style
+  ~ license that can be found in the LICENSE.txt file or at
+  ~ https://opensource.org/licenses/MIT.
+  -->
+
+<!doctype html>
+<html data-theme="__THEME__" lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta content="width=device-width, initial-scale=1" name="viewport">
+  <title>What's New in IdeaVim __VERSION__</title>
+  <style>
+      /* Light theme (default). The IDE theme is injected as data-theme on <html>;
+         prefers-color-scheme is the fallback when the page is viewed standalone. */
+      :root {
+          --bg: #eceef1;
+          --term-bg: #ffffff;
+          --titlebar: #e3e6ea;
+          --border: #d7dbe0;
+          --fg: #1a1c1f;
+          --fg-dim: #5b6168;
+          --prompt: #067d17; /* green prompt */
+          --accent: #871094; /* magenta */
+          --link: #0033b3;
+          --key: #0d6efd;
+          --string: #067d17;
+          --comment: #8c8c8c;
+          --code-bg: #f4f5f7;
+          --code-border: #e3e6ea;
+          --dot1: #ff5f56;
+          --dot2: #ffbd2e;
+          --dot3: #27c93f;
+          --shadow: 0 10px 40px rgba(0, 0, 0, 0.12);
+      }
+
+      :root[data-theme="dark"] {
+          --bg: #131417;
+          --term-bg: #1e1f22;
+          --titlebar: #2b2d30;
+          --border: #393b40;
+          --fg: #dfe1e5;
+          --fg-dim: #9aa0a6;
+          --prompt: #57965c;
+          --accent: #c77dbb;
+          --link: #56a8f5;
+          --key: #2aacb8;
+          --string: #6aab73;
+          --comment: #7a7e85;
+          --code-bg: #16171a;
+          --code-border: #393b40;
+          --dot1: #ff5f56;
+          --dot2: #ffbd2e;
+          --dot3: #27c93f;
+          --shadow: 0 12px 48px rgba(0, 0, 0, 0.55);
+      }
+
+      @media (prefers-color-scheme: dark) {
+          :root:not([data-theme="light"]) {
+              --bg: #131417;
+              --term-bg: #1e1f22;
+              --titlebar: #2b2d30;
+              --border: #393b40;
+              --fg: #dfe1e5;
+              --fg-dim: #9aa0a6;
+              --prompt: #57965c;
+              --accent: #c77dbb;
+              --link: #56a8f5;
+              --key: #2aacb8;
+              --string: #6aab73;
+              --comment: #7a7e85;
+              --code-bg: #16171a;
+              --code-border: #393b40;
+              --dot1: #ff5f56;
+              --dot2: #ffbd2e;
+              --dot3: #27c93f;
+              --shadow: 0 12px 48px rgba(0, 0, 0, 0.55);
+          }
+      }
+
+      * {
+          box-sizing: border-box;
+      }
+
+      body {
+          margin: 0;
+          background: var(--bg);
+          color: var(--fg);
+          font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+          font-size: 14.5px;
+          line-height: 1.7;
+          -webkit-font-smoothing: antialiased;
+          padding: 32px 16px 64px;
+      }
+
+      /* Terminal window -------------------------------------------------- */
+      .term {
+          max-width: 760px;
+          margin: 0 auto;
+          background: var(--term-bg);
+          border: 1px solid var(--border);
+          border-radius: 12px;
+          box-shadow: var(--shadow);
+          overflow: hidden;
+      }
+
+      .titlebar {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          padding: 11px 14px;
+          background: var(--titlebar);
+          border-bottom: 1px solid var(--border);
+      }
+
+      .dot {
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+      }
+
+      .dot.r {
+          background: var(--dot1);
+      }
+
+      .dot.y {
+          background: var(--dot2);
+      }
+
+      .dot.g {
+          background: var(--dot3);
+      }
+
+      .titlebar .title {
+          flex: 1 1 auto;
+          text-align: center;
+          font-size: 12.5px;
+          color: var(--fg-dim);
+          margin-right: 44px; /* balance the dots */
+      }
+
+      .body {
+          padding: 26px 30px 30px;
+      }
+
+      /* The intro "command" --------------------------------------------- */
+      .runline {
+          margin: 0 0 6px;
+      }
+
+      .runline .p {
+          color: var(--prompt);
+          font-weight: 700;
+      }
+
+      .runline .cmd {
+          color: var(--fg);
+      }
+
+      .runline .flag {
+          color: var(--key);
+      }
+
+      .out {
+          color: var(--fg-dim);
+          margin: 0 0 28px;
+      }
+
+      .out .v {
+          color: var(--accent);
+          font-weight: 700;
+      }
+
+      /* Blog content ----------------------------------------------------- */
+      h2 {
+          font-size: 17px;
+          font-weight: 700;
+          margin: 34px 0 4px;
+          color: var(--fg);
+          letter-spacing: -0.01em;
+      }
+
+      h2::before {
+          content: "❯ ";
+          color: var(--prompt);
+          font-weight: 700;
+      }
+
+      .kicker {
+          font-size: 12px;
+          color: var(--accent);
+          text-transform: lowercase;
+          letter-spacing: 0.04em;
+          margin: 0 0 10px;
+      }
+
+      .kicker::before {
+          content: "# ";
+          color: var(--comment);
+      }
+
+      p {
+          margin: 0 0 14px;
+      }
+
+      p.note {
+          color: var(--fg-dim);
+      }
+
+      .section {
+          margin-bottom: 30px;
+      }
+
+      .section + .section {
+          border-top: 1px dashed var(--border);
+          padding-top: 4px;
+      }
+
+      /* Inline tokens ---------------------------------------------------- */
+      code, kbd {
+          font-family: inherit;
+          font-size: 13px;
+          background: var(--code-bg);
+          border: 1px solid var(--code-border);
+          border-radius: 5px;
+          padding: 1px 6px;
+          white-space: nowrap;
+      }
+
+      kbd {
+          color: var(--key);
+      }
+
+      code {
+          color: var(--accent);
+      }
+
+      /* Terminal output / code blocks ----------------------------------- */
+      pre {
+          background: var(--code-bg);
+          border: 1px solid var(--code-border);
+          border-radius: 8px;
+          padding: 14px 16px;
+          margin: 0 0 14px;
+          overflow-x: auto;
+          line-height: 1.7;
+          font-size: 13px;
+      }
+
+      pre .cm {
+          color: var(--comment);
+      }
+
+      pre .str {
+          color: var(--string);
+      }
+
+      pre .key {
+          color: var(--key);
+      }
+
+      pre .p {
+          color: var(--prompt);
+      }
+
+      /* "Also worth a look" grid ---------------------------------------- */
+      .grid {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 14px;
+          margin-top: 6px;
+      }
+
+      @media (max-width: 560px) {
+          .grid {
+              grid-template-columns: 1fr;
+          }
+      }
+
+      .mini {
+          border: 1px solid var(--border);
+          border-radius: 8px;
+          padding: 14px 16px;
+      }
+
+      .mini h3 {
+          margin: 0 0 6px;
+          font-size: 14px;
+      }
+
+      .mini h3::before {
+          content: "$ ";
+          color: var(--prompt);
+      }
+
+      .mini p {
+          margin: 0;
+          font-size: 13px;
+          color: var(--fg-dim);
+      }
+
+      /* Fixes list ------------------------------------------------------- */
+      ul {
+          margin: 4px 0 0;
+          padding: 0;
+          list-style: none;
+      }
+
+      li {
+          margin-bottom: 8px;
+          color: var(--fg-dim);
+          padding-left: 1.6em;
+          text-indent: -1.6em;
+      }
+
+      li::before {
+          content: "+ ";
+          color: var(--prompt);
+          font-weight: 700;
+      }
+
+      li strong {
+          color: var(--fg);
+          font-weight: 700;
+      }
+
+      /* Footer prompt ---------------------------------------------------- */
+      footer {
+          margin-top: 34px;
+          padding-top: 18px;
+          border-top: 1px solid var(--border);
+          color: var(--fg-dim);
+          font-size: 13px;
+      }
+
+      footer .p {
+          color: var(--prompt);
+          font-weight: 700;
+      }
+
+      footer a {
+          color: var(--link);
+          text-decoration: none;
+      }
+
+      footer a:hover {
+          text-decoration: underline;
+      }
+
+      .caret {
+          display: inline-block;
+          width: 0.6em;
+          height: 1.05em;
+          background: var(--fg);
+          vertical-align: text-bottom;
+          animation: blink 1.1s steps(1) infinite;
+      }
+
+      @keyframes blink {
+          50% {
+              background: transparent;
+          }
+      }
+  </style>
+</head>
+<body>
+
+<div class="term">
+  <div class="titlebar">
+    <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+    <span class="title">ideavim — whats-new — 80×24</span>
+  </div>
+
+  <div class="body">
+    <p class="runline"><span class="p">~ $</span> <span class="cmd">ideavim</span> <span class="flag">--whats-new</span>
+    </p>
+    <p class="out">Welcome to a new way of hearing about IdeaVim.<br>
+      Instead of digging through <code>CHANGES.md</code>, the highlights now come to you —
+      right here in the IDE, every release. Here's what landed in <span class="v">__VERSION__</span>.</p>
+
+    <!-- VimEverywhere — the star -->
+    <div class="section">
+      <p class="kicker">new plugin · vim everywhere</p>
+      <h2>VimEverywhere — Vim keys for the whole IDE</h2>
+      <p>Modal, keyboard-first navigation has always stopped at the edge of the editor. <strong>VimEverywhere</strong>
+        takes it everywhere else — tool windows, trees, and clickable UI all bend to the keyboard, no mouse required.
+        It's brand new and we'd love more people to kick the tyres.</p>
+      <pre><span class="str">set VimEverywhere</span>   <span
+          class="cm">" add this to ~/.ideavimrc and restart</span></pre>
+      <p>Three things come bundled the moment it's on:</p>
+      <div class="grid">
+        <div class="mini">
+          <h3>Hints — jump anywhere</h3>
+          <p>Press <kbd>Ctrl+Shift+\</kbd> (<kbd>Ctrl+Cmd+\</kbd> on macOS) and every clickable target gets a
+            short <code>A&#8201;S&#8201;D&#8201;F</code> label — type it to jump straight there. Buttons, tabs,
+            tool-window controls, even inside dialogs like the IdeaVim settings.</p>
+        </div>
+        <div class="mini">
+          <h3>NERDTree, everywhere</h3>
+          <p>The NERDTree keys you already know — <kbd>o</kbd>, <kbd>t</kbd>, <kbd>s</kbd>, <kbd>i</kbd>,
+            <kbd>gs</kbd>, <kbd>gi</kbd> — now work in <em>any</em> tree, not just the Project tool window.</p>
+        </div>
+        <div class="mini">
+          <h3>Hop between tool windows</h3>
+          <p><kbd>&lt;C-W&gt;h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd> moves focus directionally across
+            tool windows and the editor — fired from inside any tool window, just like window motions.</p>
+        </div>
+        <div class="mini">
+          <h3>Spread the word</h3>
+          <p>It's young and we want it in more hands. Turn it on, live in it for a day, and tell us what
+            should come next — feedback shapes where it goes.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Headline features -->
+    <div class="section">
+      <p class="kicker">window management</p>
+      <h2>Resize splits from the keyboard</h2>
+      <p>Stop reaching for the mouse to balance your layout. A full set of Vim window-resize
+        commands has landed, so your splits bend to your will.</p>
+      <pre><span class="key">&lt;C-W&gt;+</span>   <span class="key">&lt;C-W&gt;-</span>     <span class="cm">" taller / shorter</span>
+<span class="key">&lt;C-W&gt;&gt;</span>   <span class="key">&lt;C-W&gt;&lt;</span>     <span class="cm">" wider / narrower</span>
+<span class="key">&lt;C-W&gt;=</span>              <span class="cm">" equalize every window</span>
+<span class="str">:resize 20</span>          <span class="cm">" or  :resize +5 / -5</span>
+<span class="str">:vertical resize 80</span> <span class="cm">" width, absolute or relative</span></pre>
+      <p class="note">Counts work too — <kbd>5&lt;C-W&gt;+</kbd> grows the window by five lines at once.</p>
+    </div>
+
+    <div class="section">
+      <p class="kicker">editing · live preview</p>
+      <h2>See your :substitute before you run it</h2>
+      <p>The new <code>'inccommand'</code> option previews replacements as you type the command —
+        and quietly reverts everything if you bail out with <kbd>Esc</kbd>.</p>
+      <pre><span class="str">set inccommand=nosplit</span>  <span class="cm">" preview inline, in the buffer</span>
+<span class="str">set inccommand=split</span>    <span class="cm">" inline preview + a window listing</span>
+                        <span class="cm">" every affected line</span></pre>
+      <p class="note">No more squinting at a regex and hoping for the best.</p>
+    </div>
+
+    <div class="section">
+      <p class="kicker">text objects</p>
+      <h2>targets.vim, built in</h2>
+      <p>Welle's beloved <code>targets.vim</code> is now bundled. It supercharges text objects with
+        <em>seeking</em> — operate on the next or last pair, quote, or argument without moving first.</p>
+      <pre><span class="str">Plug 'wellle/targets.vim'</span>
+
+<span class="key">cin)</span>   <span class="cm">" change inside the NEXT ( )</span>
+<span class="key">da,</span>    <span class="cm">" delete an argument, comma and all</span>
+<span class="key">ci"</span>    <span class="cm">" change inside the nearest quotes, even</span>
+       <span class="cm">" if the cursor isn't on them yet</span></pre>
+      <p class="note">Pairs, quotes, separators, arguments and tags — with <code>i</code>/<code>a</code>/<code>I</code>/<code>A</code>
+        modifiers and <code>n</code>/<code>l</code> next/last qualifiers.</p>
+    </div>
+
+    <div class="section">
+      <p class="kicker">search</p>
+      <h2>Always know where you are</h2>
+      <p>After <kbd>/</kbd>, <kbd>?</kbd>, <kbd>n</kbd>, <kbd>N</kbd>, <kbd>*</kbd> or <kbd>#</kbd>,
+        IdeaVim now shows the match index and total — <code>[2/4]</code> — just like Vim.
+        Tune the ceiling with <code>'maxsearchcount'</code> (it shows <code>[2/&gt;3]</code> when exceeded).</p>
+    </div>
+
+    <!-- Also worth a look -->
+    <div class="section">
+      <p class="kicker">also worth a look</p>
+      <div class="grid">
+        <div class="mini">
+          <h3>YouCompleteMe popup</h3>
+          <p>Enable <code>set youcompleteme</code> and cycle the popup with <kbd>Tab</kbd> /
+            <kbd>S-Tab</kbd> — normal tabbing stays untouched when no popup is open.</p>
+        </div>
+        <div class="mini">
+          <h3>IDE completion keys</h3>
+          <p><kbd>C-Y</kbd> accepts the selected completion item and <kbd>C-E</kbd> closes the
+            popup — the Vim muscle memory you already have.</p>
+        </div>
+        <div class="mini">
+          <h3>Edit control characters</h3>
+          <p>The new <em>IdeaVim: Edit Control Characters</em> action opens an editor for registers
+            and macros containing control chars (<code>^M</code>, <code>^[</code>).</p>
+        </div>
+        <div class="mini">
+          <h3>Roomier messages</h3>
+          <p><code>'cmdheight'</code> and <code>'messagesopt'</code> arrived: multi-line messages get
+            their own space, and single-line messages auto-hide after a timeout.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Polish & fixes -->
+    <div class="section">
+      <p class="kicker">polish &amp; fixes</p>
+      <ul>
+        <li><strong>Modeless selection</strong> in the output panel and command line — select with the mouse, copy with
+          <kbd>C-Y</kbd>.
+        </li>
+        <li><strong>Tab is free again</strong> — <code>sethandler &lt;Tab&gt; a:ide</code> can hand it to the IDE.</li>
+        <li><strong>Smarter * search</strong> now respects <code>smartcase</code>.</li>
+        <li><strong>Steadier cursor</strong> — fixed column drift on <kbd>j</kbd>/<kbd>k</kbd>, centering with inlay
+          hints, and double-scroll after incremental search.
+        </li>
+        <li>Plus the <code>g&lt;</code> command, a scroll-back more-prompt pager, and a long list of smaller fixes.</li>
+      </ul>
+    </div>
+
+    <footer>
+      <p><span class="p">~ $</span> # thanks for using IdeaVim — happy editing<span class="caret"></span></p>
+      <p>
+        <a href="https://github.com/JetBrains/ideavim/blob/master/CHANGES.md">full-changelog</a> ·
+        <a href="https://youtrack.jetbrains.com/issues/VIM">report-an-issue</a> ·
+        <a href="https://jb.gg/ideavim-eap">join-the-eap</a>
+      </p>
+    </footer>
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
When user installs new version of the IdeaVim we will show dialog that will open blogpost with changes in ideaVim.
Process work in two steps:
1. Manual workflow that will create PR with new blogpost html using claude for latest `To be released`. There will be generated link to preview of that post.
2. Release pipeline will bump tbr to latest version that will be picked up by ideavim in runtime and shown to user