### PR TITLE
Fix undo in macro replay

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/IjActionExecutor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/IjActionExecutor.kt
@@ -160,6 +160,12 @@ class IjActionExecutor : VimActionExecutor {
     context: ExecutionContext,
     operatorArguments: OperatorArguments,
   ) {
+    if (cmd.executesNestedCommands) {
+      // Macro-like actions replay keystrokes that must each form their own undoable command, so they must not run
+      // inside an outer command. See [EditorActionHandlerBase.executesNestedCommands].
+      cmd.execute(editor, context, operatorArguments)
+      return
+    }
     CommandProcessor.getInstance()
       .executeCommand(
         editor.ij.project,

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/MacroActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/MacroActionTest.kt
@@ -331,8 +331,8 @@ class MacroActionTest : VimTestCase() {
       undoCount++
     }
     assertState(initialText)
-    // Verify that multiple undos were needed (one for each macro execution)
-    assertTrue(undoCount == 2, "Expected 2 undos for 2 macro executions, but needed $undoCount")
+    // Each replayed keystroke is its own undoable change, as in Vim: 1 for the recorded `dw` plus 3 for `3@a`.
+    assertTrue(undoCount == 4, "Expected 4 undos (recording + 3 macro executions), but needed $undoCount")
   }
 
   @Test
@@ -525,5 +525,13 @@ class MacroActionTest : VimTestCase() {
     Thread.sleep(2000)
     typeText("w", "q")
     assertRegister('a', "yw")
+  }
+
+  @Test
+  fun `should execute undo in macro`() {
+    configureByText("${c}Spongebob Squarepants")
+    typeText("qa", "dwu", "q")
+    typeText("@a")
+    assertState("Spongebob Squarepants")
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/KeyHandler.kt
@@ -330,7 +330,13 @@ class KeyHandler {
     val action: Runnable = ActionRunner(editor, context, command, keyState, operatorArguments, isSingleCommandFromInsert)
     val cmdAction = command.action
     val name = cmdAction.id
-    injector.actionExecutor.executeCommand(editor, action, name, action)
+    if (cmdAction.executesNestedCommands) {
+      // Macro-like actions must not hold an open command while replaying keystrokes, otherwise a replayed `u` can't
+      // undo an earlier change made by the same macro. See [EditorActionHandlerBase.executesNestedCommands].
+      action.run()
+    } else {
+      injector.actionExecutor.executeCommand(editor, action, name, action)
+    }
   }
 
   /**

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/macro/PlaybackRegisterAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/macro/PlaybackRegisterAction.kt
@@ -24,6 +24,9 @@ class PlaybackRegisterAction : VimActionHandler.SingleExecution() {
   override val type: Command.Type = Command.Type.OTHER_SELF_SYNCHRONIZED
   override val argumentType: Argument.Type = Argument.Type.REGISTER
 
+  // Replay each macro keystroke as its own command so a `u` inside the macro can undo earlier macro changes
+  override val executesNestedCommands: Boolean = true
+
   override fun execute(
     editor: VimEditor,
     context: ExecutionContext,
@@ -37,7 +40,12 @@ class PlaybackRegisterAction : VimActionHandler.SingleExecution() {
         try {
           var success = false
           for (i in 0 until cmd.count) {
-            success = injector.vimscriptExecutor.executeLastCommand(editor, context)
+            // Unlike `@reg`, the last-command path doesn't replay keystrokes through the key handler, so it isn't
+            // wrapped in a command by anyone (this action runs without an outer command, see [executesNestedCommands]).
+            // Give each execution its own command so the document write is valid and independently undoable, as in Vim.
+            injector.actionExecutor.executeCommand(editor, {
+              success = injector.vimscriptExecutor.executeLastCommand(editor, context)
+            }, id, null)
             if (!success) break
           }
           if (reg != '@') { // @ is not a register itself, it just tells vim to use the last register

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/EditorActionHandlerBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/EditorActionHandlerBase.kt
@@ -57,6 +57,20 @@ abstract class EditorActionHandlerBase(private val myRunForEachCaret: Boolean) {
    */
   abstract val type: Command.Type
 
+  /**
+   * Macro-like actions replay other keystrokes, and each replayed keystroke must form its own undoable command.
+   *
+   * If such an action were itself wrapped in an outer [com.intellij.openapi.command.CommandProcessor] command, every
+   * change made during playback would be merged into that single still-open command. A `u` replayed inside the macro
+   * could then not undo an earlier change made by the same macro: the earlier change has not been committed as a
+   * separate undo entry yet, so IntelliJ throws `UnexpectedUndoException` ("Unexpected document state") and disposes
+   * the editor.
+   *
+   * Returning `true` tells the key handler to execute this action without an outer command wrapper, so the replayed
+   * keystrokes each open their own top-level command and can be undone independently (as in Vim).
+   */
+  open val executesNestedCommands: Boolean = false
+
   open val argumentType: Argument.Type? = null
 
   /**


### PR DESCRIPTION
When undo was in macro it couldn't be replayed as it was already in single command executiion. So other commands modified editor and when undo was trying execute those commands didn't yet commit and in UndoManager in Ij there is
```
    if (document.getTextLength() != fromLength) throw new UnexpectedUndoException("Unexpected document state");

```

So we have to execute each command separately during macro execution