### PR TITLE
Restore plugin compatibility for Argument.Type

### DIFF
--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/Argument.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/Argument.kt
@@ -97,6 +97,20 @@ sealed class Argument {
      * which means the handler will allow `<C-K>`, `<C-V>` and `<C-Q>` to start the digraph/literal state machine.
      * The final character will not be mapped by `'langmap'`.
      */
-    CHARACTER
+    CHARACTER;
+
+    companion object {
+      /**
+       * Backwards-compatible alias for [CHARACTER].
+       *
+       * Returns the [CHARACTER] constant so that Java code comparing with `== Argument.Type.DIGRAPH` continues to work
+       * after the `DIGRAPH` enum value was merged into `CHARACTER`.
+       *
+       * Note: this does NOT work as a `case` label in a Java `switch` statement, which requires a true enum constant.
+       */
+      @JvmField
+      @Deprecated("Use CHARACTER instead", ReplaceWith("CHARACTER"))
+      val DIGRAPH: Type = CHARACTER
+    }
   }
 }


### PR DESCRIPTION
The recent change to enable `'langmap'` support refactored argument types, including removing `Argument.Type.DIGRAPH`. Unfortunately, `DIGRAPH` is being used by [TheBlob42/idea-which-key](https://github.com/TheBlob42/idea-which-key) and I missed this break in compatibility. See TheBlob42/idea-which-key#113.

This PR adds back a static field to `Argument.Type` called `DIGRAPH`. It is set to the same value as `Argument.Type.CHARACTER` (which replaced `DIGRAPH`) and marked as deprecated.

Paging @1grzyb1 for a hopefully speedy point release. Apologies for missing this!