### PR TITLE
VIM-1346 Implement undo all line command

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/LineChangeGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/LineChangeGroup.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.group
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.TextRange
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.newapi.ij
+import com.maddyhome.idea.vim.undo.LineChange
+
+/**
+ * IntelliJ implementation of [LineChange] — Vim's "U" command ("undo line").
+ *
+ * The saved line (Vim's `b_u_line_ptr` / `b_u_line_lnum` / `b_u_line_colnr`) is stored as user data
+ * on the `Document`, so it lives and dies with the document and is naturally per-buffer.
+ *
+ * Snapshotting is driven by the document-change listener (see `VimListenerManager.VimDocumentListener`),
+ * which figures out which line is about to change and calls [snapshotLine] before the edit is applied.
+ */
+object LineChangeGroup : LineChange {
+  private data class LineSnapshot(val line: Int, val text: String, val col: Int)
+
+  private val SNAPSHOT_KEY = Key.create<LineSnapshot>("IdeaVim.LineChangeSnapshot")
+
+  override fun snapshotLine(line: Int, editor: VimEditor): Boolean {
+    val doc = editor.ij.document
+    if (line < 0 || line >= doc.lineCount) return false
+
+    val existing = doc.getUserData(SNAPSHOT_KEY)
+    if (existing != null && existing.line == line) {
+      // Line is already saved: keep the pre-first-change copy (u_saveline's early return).
+      return false
+    }
+
+    val lineStart = doc.getLineStartOffset(line)
+    val lineEnd = doc.getLineEndOffset(line)
+    val text = doc.getText(TextRange(lineStart, lineEnd))
+    doc.putUserData(SNAPSHOT_KEY, LineSnapshot(line, text, caretColumn(editor, line, lineStart)))
+    return true
+  }
+
+  override fun undoLineChange(editor: VimEditor, context: ExecutionContext): Boolean {
+    val ijEditor = editor.ij
+    val doc = ijEditor.document
+    val snapshot = doc.getUserData(SNAPSHOT_KEY) ?: return false
+    if (snapshot.line >= doc.lineCount) return false
+
+    val lineStart = doc.getLineStartOffset(snapshot.line)
+    val lineEnd = doc.getLineEndOffset(snapshot.line)
+    val currentText = doc.getText(TextRange(lineStart, lineEnd))
+    val currentCol = caretColumn(editor, snapshot.line, lineStart)
+
+    WriteCommandAction.runWriteCommandAction(ijEditor.project) {
+      doc.replaceString(lineStart, lineEnd, snapshot.text)
+    }
+
+    // Store what we just replaced so a second `U` toggles back ("U can be undone with the next U").
+    doc.putUserData(SNAPSHOT_KEY, LineSnapshot(snapshot.line, currentText, currentCol))
+
+    val newLineStart = doc.getLineStartOffset(snapshot.line)
+    val newLineEnd = doc.getLineEndOffset(snapshot.line)
+    ijEditor.caretModel.primaryCaret.moveToOffset((newLineStart + snapshot.col).coerceIn(newLineStart, newLineEnd))
+    return true
+  }
+
+  private fun caretColumn(editor: VimEditor, line: Int, lineStart: Int): Int {
+    val doc = editor.ij.document
+    val caretOffset = editor.ij.caretModel.primaryCaret.offset
+    return if (doc.getLineNumber(caretOffset) == line) caretOffset - lineStart else 0
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -427,6 +427,7 @@ object VimListenerManager {
   class VimDocumentListener : DocumentListener {
     override fun beforeDocumentChange(event: DocumentEvent) {
       MarkUpdater.beforeDocumentChange(event)
+      snapshotChangedLine(event)
       IjVimSearchGroup.DocumentSearchListener.INSTANCE.beforeDocumentChange(event)
       IjVimRedrawService.RedrawListener.beforeDocumentChange(event)
     }
@@ -435,6 +436,21 @@ object VimListenerManager {
       MarkUpdater.documentChanged(event)
       IjVimSearchGroup.DocumentSearchListener.INSTANCE.documentChanged(event)
       IjVimRedrawService.RedrawListener.documentChanged(event)
+    }
+
+    /**
+     * Saves the pristine line for the "U" command before it is changed. We only work out which line
+     * is about to change here; the snapshot itself is owned by [injector.lineChange]. Only single-line
+     * changes are tracked, mirroring Vim's `u_save` (which calls `u_saveline` only for a 1-line range).
+     */
+    private fun snapshotChangedLine(event: DocumentEvent) {
+      if (VimPlugin.isNotEnabled()) return
+      val doc = event.document
+      val startLine = doc.getLineNumber(event.offset)
+      val endLine = doc.getLineNumber(event.offset + event.oldLength)
+      if (startLine != endLine || event.newFragment.contains('\n')) return
+      val editor = EditorFactory.getInstance().getEditors(doc).firstOrNull()?.let { IjVimEditor(it) } ?: return
+      injector.lineChange.snapshotLine(startLine, editor)
     }
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
@@ -72,6 +72,7 @@ import com.maddyhome.idea.vim.extension.JsonExtensionProvider
 import com.maddyhome.idea.vim.group.EffectiveIjOptions
 import com.maddyhome.idea.vim.group.GlobalIjOptions
 import com.maddyhome.idea.vim.group.IjVimOptionGroup
+import com.maddyhome.idea.vim.group.LineChangeGroup
 import com.maddyhome.idea.vim.group.TabService
 import com.maddyhome.idea.vim.group.VimWindowGroup
 import com.maddyhome.idea.vim.history.VimHistory
@@ -80,6 +81,7 @@ import com.maddyhome.idea.vim.put.VimPut
 import com.maddyhome.idea.vim.register.VimRegisterGroup
 import com.maddyhome.idea.vim.thinapi.VimHighlightingService
 import com.maddyhome.idea.vim.thinapi.VimPluginService
+import com.maddyhome.idea.vim.undo.LineChange
 import com.maddyhome.idea.vim.undo.VimUndoRedo
 import com.maddyhome.idea.vim.vimscript.services.VariableService
 import com.maddyhome.idea.vim.yank.VimYankGroup
@@ -148,6 +150,8 @@ internal class IjVimInjector : VimInjectorBase() {
     get() = service()
   override val undo: VimUndoRedo
     get() = service()
+  override val lineChange: LineChange
+    get() = LineChangeGroup
   override val psiService: VimPsiService
     get() = service()
   override val nativeActionManager: NativeActionManager

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/LineUndoActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/LineUndoActionTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action.change
+
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the "U" command ("undo line").
+ *
+ * `:help U` -> "Undo all latest changes on one line, the line where the latest change was made."
+ *
+ * Unlike `u`, which steps back one change at a time through the undo tree, `U` restores the most
+ * recently changed line to the state it had *before the first change was made to it*, no matter how
+ * many edits happened on that line. A second `U` toggles the change back. See `u_saveline` /
+ * `u_undoline` in Neovim's `undo.c`.
+ */
+class LineUndoActionTest : VimTestCase() {
+
+  @Test
+  fun `test U restores line after multiple changes`() {
+    configureByText("${c}one two three")
+    // Three separate changes, all on the same line, cursor never leaves the line.
+    typeText("cwA<Esc>")   // "A two three"
+    typeText("wcwB<Esc>")  // "A B three"
+    typeText("wcwC<Esc>")  // "A B C"
+    assertState("A B ${c}C")
+
+    typeText("U")
+    assertState("${c}one two three")
+  }
+
+  @Test
+  fun `test U differs from lowercase u`() {
+    configureByText("${c}one two three")
+    typeText("cwA<Esc>")   // "A two three"
+    typeText("wcwB<Esc>")  // "A B three"
+    typeText("wcwC<Esc>")  // "A B C"
+    assertState("A B ${c}C")
+
+    // Lowercase u only reverts the most recent change, not the whole line.
+    typeText("u")
+    assertState("A B ${c}three")
+  }
+
+  @Test
+  fun `test U after a single change restores the line`() {
+    configureByText("${c}one two three")
+    typeText("cwA<Esc>")
+    assertState("${c}A two three")
+
+    typeText("U")
+    assertState("${c}one two three")
+  }
+
+  @Test
+  fun `test U toggles back when pressed twice`() {
+    configureByText("${c}one two three")
+    typeText("cwA<Esc>")   // "A two three"
+    typeText("wcwB<Esc>")  // "A B three"
+    assertState("A ${c}B three")
+
+    // First U restores the line.
+    typeText("U")
+    assertState("${c}one two three")
+
+    // Second U toggles the changes back ("U can be undone with the next U").
+    typeText("U")
+    assertState("A B three")
+  }
+
+  @Test
+  fun `test U toggles repeatedly`() {
+    configureByText("${c}one two three")
+    typeText("cwA<Esc>")
+    assertState("${c}A two three")
+
+    typeText("U")
+    assertState("${c}one two three")
+    typeText("U")
+    assertState("A two three")
+    typeText("U")
+    assertState("${c}one two three")
+  }
+
+  @Test
+  fun `test U does nothing when the line was not changed`() {
+    configureByText("${c}one two three")
+    typeText("U")
+    assertState("${c}one two three")
+  }
+
+  @Test
+  fun `test U restores deletions made within the line`() {
+    configureByText("${c}hello world")
+    typeText("xxx")  // deletes "hel" -> "lo world"
+    assertState("${c}lo world")
+
+    typeText("U")
+    assertState("${c}hello world")
+  }
+
+  @Test
+  fun `test U restores insertions made within the line`() {
+    configureByText("${c}hello")
+    typeText("iABC<Esc>")  // "ABChello"
+    assertState("AB${c}Chello")
+
+    typeText("U")
+    assertState("${c}hello")
+  }
+
+  @Test
+  fun `test U restores the cursor column of the first change`() {
+    configureByText("hello ${c}world")
+    typeText("cwX<Esc>")  // "hello X"
+    assertState("hello ${c}X")
+
+    typeText("U")
+    assertState("hello ${c}world")
+  }
+
+  @Test
+  fun `test U restores only the most recently changed line`() {
+    configureByText(
+      """
+        ${c}one
+        two
+        three
+      """.trimIndent(),
+    )
+    typeText("cwX<Esc>")    // line 0 -> "X"
+    typeText("jcwY<Esc>")   // line 1 -> "Y"
+    assertState(
+      """
+        X
+        ${c}Y
+        three
+      """.trimIndent(),
+    )
+
+    // U restores the line where the latest change was made (line 1), leaving line 0 changed.
+    typeText("U")
+    assertState(
+      """
+        X
+        ${c}two
+        three
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `test plain u undoes a U`() {
+    configureByText("${c}one two")
+    typeText("cwX<Esc>")  // "X two"
+    assertState("${c}X two")
+
+    typeText("U")
+    assertState("${c}one two")
+
+    // U is a normal, undoable change, so plain u reverts it.
+    typeText("u")
+    assertState("${c}X two")
+  }
+
+  @Test
+  fun `test U after switching lines back and forth`() {
+    configureByText(
+      """
+        ${c}alpha
+        beta
+      """.trimIndent(),
+    )
+    typeText("cwX<Esc>")   // line 0 -> "X"
+    typeText("jcwY<Esc>")  // line 1 -> "Y"
+    typeText("kcwZ<Esc>")  // back to line 0, change again -> "Z"
+    assertState(
+      """
+        ${c}Z
+        Y
+      """.trimIndent(),
+    )
+
+    // The latest change was on line 0, and its snapshot was retaken when we returned to it,
+    // so U restores line 0 to the state it had right before that latest change ("X").
+    typeText("U")
+    assertState(
+      """
+        ${c}X
+        Y
+      """.trimIndent(),
+    )
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/LineUndoAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/LineUndoAction.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2003-2023 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package com.maddyhome.idea.vim.action.change
+
+import com.intellij.vim.annotations.CommandOrMotion
+import com.intellij.vim.annotations.Mode
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.handler.VimActionHandler
+
+@CommandOrMotion(keys = ["U"], modes = [Mode.NORMAL])
+class LineUndoAction : VimActionHandler.SingleExecution() {
+  override val type: Command.Type = Command.Type.OTHER_SELF_SYNCHRONIZED
+
+  override fun execute(
+    editor: VimEditor,
+    context: ExecutionContext,
+    cmd: Command,
+    operatorArguments: OperatorArguments,
+  ): Boolean {
+    val result = injector.lineChange.undoLineChange(editor, context)
+    injector.scroll.scrollCaretIntoView(editor)
+    return result
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
@@ -21,6 +21,7 @@ import com.maddyhome.idea.vim.register.VimRegisterGroup
 import com.maddyhome.idea.vim.state.VimStateMachine
 import com.maddyhome.idea.vim.thinapi.VimHighlightingService
 import com.maddyhome.idea.vim.thinapi.VimPluginService
+import com.maddyhome.idea.vim.undo.LineChange
 import com.maddyhome.idea.vim.undo.VimUndoRedo
 import com.maddyhome.idea.vim.vimscript.services.VariableService
 import com.maddyhome.idea.vim.yank.VimYankGroup
@@ -126,6 +127,8 @@ interface VimInjector {
   val macro: VimMacro
 
   val undo: VimUndoRedo
+
+  val lineChange: LineChange
 
   val psiService: VimPsiService
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/undo/LineChange.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/undo/LineChange.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.undo
+
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimEditor
+
+/**
+ * Implements Vim's "U" command ("undo line"). See `u_saveline` / `u_undoline` in Neovim's `undo.c`.
+ *
+ * Unlike `u`, `U` does not walk the undo tree. Vim keeps a single saved copy of one line and `U`
+ * swaps that copy with the current line, reverting *all* changes made to it since it was first
+ * touched (and a second `U` toggles back).
+ */
+interface LineChange {
+
+  /**
+   * Saves the pristine text of [line] so it can later be restored by [undoLineChange] (mirrors
+   * `u_saveline`). Must be called *before* the line is modified. While the same line keeps being
+   * edited the original snapshot is preserved, which is what makes `U` revert every change on it.
+   *
+   * @return `true` if a new snapshot was taken, `false` if the line was already saved or invalid.
+   */
+  fun snapshotLine(line: Int, editor: VimEditor): Boolean
+
+  /**
+   * Restores the saved line, swapping it with the current line content (mirrors `u_undoline`).
+   * @return `false` when there is nothing to restore, so the caller can beep like Vim does.
+   */
+  fun undoLineChange(editor: VimEditor, context: ExecutionContext): Boolean
+}

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -1276,6 +1276,11 @@
   },
   {
     "keys": "U",
+    "class": "com.maddyhome.idea.vim.action.change.LineUndoAction",
+    "modes": "N"
+  },
+  {
+    "keys": "U",
     "class": "com.maddyhome.idea.vim.action.change.change.ChangeCaseUpperVisualAction",
     "modes": "X"
   },


### PR DESCRIPTION
"U" undoes all changes and most recently edited line. Implemented in simmilar way as nvim does by tracking snapshot of last edited line and then just restoring that snapshot.