### PR TITLE
VIM-4256 handle empty guicursor

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/CaretVisualAttributesHelper.kt
@@ -146,6 +146,8 @@ private object AttributesCache {
         GuiCursorType.BLOCK -> CaretVisualAttributes.Shape.BLOCK
         GuiCursorType.VER -> CaretVisualAttributes.Shape.BAR
         GuiCursorType.HOR -> CaretVisualAttributes.Shape.UNDERSCORE
+        // 'guicursor' is empty - don't override the caret, use the IDE's native (e.g. blinking) caret
+        null -> return@getOrPut CaretVisualAttributes.getDefault()
       }
       val colour: Color? = null // Support highlight group?
       CaretVisualAttributes(colour, CaretVisualAttributes.Weight.NORMAL, shape, attributes.thickness / 100F)

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.kt
@@ -339,7 +339,8 @@ class ExTextField internal constructor(private val myParentPanel: ExEntryPanel) 
       // See VIM-2562
 
       mode = attributes.type
-      thickness = if (mode == GuiCursorType.BLOCK) 100 else attributes.thickness
+      // A null type means 'guicursor' is empty. The command line has no IDE-native caret, so fall back to a block
+      thickness = if (mode == GuiCursorType.BLOCK || mode == null) 100 else attributes.thickness
     }
 
     override fun focusGained(e: FocusEvent?) {

--- a/src/test/java/org/jetbrains/plugins/ideavim/helper/CaretVisualAttributesHelperTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/helper/CaretVisualAttributesHelperTest.kt
@@ -261,6 +261,35 @@ class CaretVisualAttributesHelperTest : VimTestCase() {
 
   @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
   @Test
+  fun `test empty guicursor leaves caret to the ide`() {
+    configureByText("Lorem ipsum dolor sit amet,")
+    enterCommand("set guicursor=")
+    // An empty 'guicursor' should not override the caret - we use the IDE's native default caret
+    assertCaretVisualAttributes(CaretVisualAttributes.getDefault().shape, CaretVisualAttributes.getDefault().thickness)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
+  @Test
+  fun `test empty guicursor leaves caret to the ide in insert mode`() {
+    configureByText("Lorem ipsum dolor sit amet,")
+    enterCommand("set guicursor=")
+    typeText("i")
+    assertCaretVisualAttributes(CaretVisualAttributes.getDefault().shape, CaretVisualAttributes.getDefault().thickness)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
+  @Test
+  fun `test caret restored after clearing and resetting guicursor`() {
+    configureByText("Lorem ipsum dolor sit amet,")
+    enterCommand("set guicursor=")
+    enterCommand("set guicursor&")
+    assertCaretVisualAttributes(CaretVisualAttributes.Shape.BLOCK, 0F)
+    typeText("i")
+    assertCaretVisualAttributes(CaretVisualAttributes.Shape.BAR, 0.25F)
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
+  @Test
   fun `test 'all' guicursor option`() {
     configureByText("Lorem ipsum dolor sit amet,")
     enterCommand("set guicursor+=a:ver25")

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/GuiCursorOptionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/GuiCursorOptionTest.kt
@@ -173,4 +173,21 @@ class GuiCursorOptionTest : VimTestCase() {
     assertEquals(75, attributes.thickness)
     assertEquals("OtherCursor", attributes.highlightGroup)
   }
+
+  @Test
+  fun `test allow empty guicursor`() {
+    enterCommand("set guicursor=")
+    assertPluginError(false)
+    assertEquals("", options().guicursor.value)
+  }
+
+  @Test
+  fun `test empty guicursor has unspecified attributes for all modes`() {
+    enterCommand("set guicursor=")
+    GuiCursorMode.entries.filter { it != GuiCursorMode.ALL }.forEach { mode ->
+      val attributes = GuiCursorOptionHelper.getAttributes(mode)
+      // A null type signals that the caret shape is not specified and should be left to the IDE
+      assertEquals(null, attributes.type, "Expected unspecified caret shape for mode $mode")
+    }
+  }
 }

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -806,18 +806,26 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
         assertEquals(CaretVisualAttributes.Shape.BAR, caret.visualAttributes.shape)
         assertEquals(0F, caret.visualAttributes.thickness)
       } else {
-        val shape = when (attributes.type) {
-          GuiCursorType.BLOCK -> CaretVisualAttributes.Shape.BLOCK
-          GuiCursorType.VER -> CaretVisualAttributes.Shape.BAR
-          GuiCursorType.HOR -> CaretVisualAttributes.Shape.UNDERSCORE
-        }
-        assertEquals(shape, editor.caretModel.primaryCaret.visualAttributes.shape)
-        assertEquals(
-          attributes.thickness / 100.0F,
-          editor.caretModel.primaryCaret.visualAttributes.thickness,
-        )
-        editor.caretModel.primaryCaret.visualAttributes.color?.let {
-          assertEquals(colour, it)
+        val type = attributes.type
+        if (type == null) {
+          // 'guicursor' is empty - the caret is left to the IDE (its native default caret)
+          val default = CaretVisualAttributes.getDefault()
+          assertEquals(default.shape, editor.caretModel.primaryCaret.visualAttributes.shape)
+          assertEquals(default.thickness, editor.caretModel.primaryCaret.visualAttributes.thickness)
+        } else {
+          val shape = when (type) {
+            GuiCursorType.BLOCK -> CaretVisualAttributes.Shape.BLOCK
+            GuiCursorType.VER -> CaretVisualAttributes.Shape.BAR
+            GuiCursorType.HOR -> CaretVisualAttributes.Shape.UNDERSCORE
+          }
+          assertEquals(shape, editor.caretModel.primaryCaret.visualAttributes.shape)
+          assertEquals(
+            attributes.thickness / 100.0F,
+            editor.caretModel.primaryCaret.visualAttributes.thickness,
+          )
+          editor.caretModel.primaryCaret.visualAttributes.color?.let {
+            assertEquals(colour, it)
+          }
         }
       }
     }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/helpers/GuiCursorOptionHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/options/helpers/GuiCursorOptionHelper.kt
@@ -81,6 +81,11 @@ object GuiCursorOptionHelper {
   fun getAttributes(mode: GuiCursorMode): GuiCursorAttributes {
     val attributes = injector.optionGroup.getParsedEffectiveOptionValue(Options.guicursor, null, ::parseGuicursor)
 
+    // An empty 'guicursor' means "don't change the cursor" - we leave the caret to the IDE rather than forcing a shape
+    if (attributes.isEmpty()) {
+      return GuiCursorAttributes.UNSPECIFIED
+    }
+
     // `ve` falls back to `v` if not specified
     return attributes[mode]
       ?: (if (mode == GuiCursorMode.VISUAL_EXCLUSIVE) attributes[GuiCursorMode.VISUAL] else null)
@@ -88,7 +93,11 @@ object GuiCursorOptionHelper {
   }
 
   private fun parseGuicursor(guicursor: VimString) = GuiCursorAttributeBuilders().also { builders ->
-    // Split into entries. Each entry has a list of modes and various attributes and adds to/overrides current values
+    // An empty 'guicursor' produces no entries - getAttributes() maps the empty result to GuiCursorAttributes.UNSPECIFIED
+    if (guicursor.value.isEmpty()) {
+      return@also
+    }
+    // Split into entries. Each entry has a list of modes and various attributes and adds to/overrides current values.
     Options.guicursor.split(guicursor.value).map { convertToken(it) }
       .forEach { entry ->
         entry.modes.forEach {
@@ -209,15 +218,26 @@ class GuiCursorEntry(
 )
 
 data class GuiCursorAttributes(
-  val type: GuiCursorType,
+  /** The cursor shape, or `null` when no shape is specified and the IDE's native caret should be used */
+  val type: GuiCursorType?,
   val thickness: Int,
   val highlightGroup: String,
   val lmapHighlightGroup: String,
   val blinkModes: List<String>,
 ) {
   companion object {
+    /** Fallback for a mode with no entry in a non-empty 'guicursor'. Like Vim's GUI default, this is a block cursor */
     val DEFAULT: GuiCursorAttributes = GuiCursorAttributes(
       GuiCursorType.BLOCK,
+      thickness = 0,
+      highlightGroup = "",
+      lmapHighlightGroup = "",
+      blinkModes = emptyList()
+    )
+
+    /** Used when 'guicursor' is empty. The caret shape is not overridden, but left to the IDE */
+    val UNSPECIFIED: GuiCursorAttributes = GuiCursorAttributes(
+      type = null,
       thickness = 0,
       highlightGroup = "",
       lmapHighlightGroup = "",


### PR DESCRIPTION
When guicursor is set to empty we fallback to default ij caret shape