### PR TITLE
VIM-4267 rename vim-indentwise to indentwise plugin

### DIFF
--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -478,7 +478,7 @@ moves are line-wise.
       <br/>
       <code>Plug 'vim-indentwise'</code>
       <br/>
-      <code>set vim-indentwise</code>
+      <code>set indentwise</code>
       </details>
 
 ### Instructions

--- a/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
+++ b/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
@@ -442,7 +442,7 @@
     </vimExtension>
 
     <vimExtension implementation="com.maddyhome.idea.vim.extension.indentwise.IndentWiseExtension"
-                  name="vim-indentwise">
+                  name="indentwise">
       <aliases>
         <alias name="https://github.com/jeetsukumaran/vim-indentwise"/>
         <alias name="jeetsukumaran/vim-indentwise"/>

--- a/src/main/java/com/maddyhome/idea/vim/extension/indentwise/IndentWiseExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/indentwise/IndentWiseExtension.kt
@@ -33,7 +33,7 @@ import com.maddyhome.idea.vim.state.mode.Mode
  * Provides motions that navigate the buffer based on the indentation level of lines.
  */
 internal class IndentWiseExtension : VimExtension {
-  override fun getName(): String = "vim-indentwise"
+  override fun getName(): String = "indentwise"
 
   data class IndentAction(
     val indentLevel: IndentLevel,
@@ -43,14 +43,14 @@ internal class IndentWiseExtension : VimExtension {
   )
 
   private val indentActions = listOf(
-    IndentAction(IndentLevel.LESSER, "<Plug>IndentWisePreviousLesserIndent", "[-", Direction.PREVIOUS),
-    IndentAction(IndentLevel.GREATER, "<Plug>IndentWisePreviousGreaterIndent", "[+", Direction.PREVIOUS),
-    IndentAction(IndentLevel.EQUAL, "<Plug>IndentWisePreviousEqualIndent", "[=", Direction.PREVIOUS),
-    IndentAction(IndentLevel.LESSER, "<Plug>IndentWiseNextLesserIndent", "]-", Direction.NEXT),
-    IndentAction(IndentLevel.GREATER, "<Plug>IndentWiseNextGreaterIndent", "]+", Direction.NEXT),
-    IndentAction(IndentLevel.EQUAL, "<Plug>IndentWiseNextEqualIndent", "]=", Direction.NEXT),
-    IndentAction(IndentLevel.BLOCK, "<Plug>IndentWiseBlockScopeBoundaryBegin", "[%", Direction.PREVIOUS),
-    IndentAction(IndentLevel.BLOCK, "<Plug>IndentWiseBlockScopeBoundaryEnd", "]%", Direction.NEXT),
+    IndentAction(IndentLevel.LESSER, "<Plug>(IndentWisePreviousLesserIndent)", "[-", Direction.PREVIOUS),
+    IndentAction(IndentLevel.GREATER, "<Plug>(IndentWisePreviousGreaterIndent)", "[+", Direction.PREVIOUS),
+    IndentAction(IndentLevel.EQUAL, "<Plug>(IndentWisePreviousEqualIndent)", "[=", Direction.PREVIOUS),
+    IndentAction(IndentLevel.LESSER, "<Plug>(IndentWiseNextLesserIndent)", "]-", Direction.NEXT),
+    IndentAction(IndentLevel.GREATER, "<Plug>(IndentWiseNextGreaterIndent)", "]+", Direction.NEXT),
+    IndentAction(IndentLevel.EQUAL, "<Plug>(IndentWiseNextEqualIndent)", "]=", Direction.NEXT),
+    IndentAction(IndentLevel.BLOCK, "<Plug>(IndentWiseBlockScopeBoundaryBegin)", "[%", Direction.PREVIOUS),
+    IndentAction(IndentLevel.BLOCK, "<Plug>(IndentWiseBlockScopeBoundaryEnd)", "]%", Direction.NEXT),
   )
 
   override fun init() {

--- a/src/main/java/com/maddyhome/idea/vim/statistic/ExtensionTracking.kt
+++ b/src/main/java/com/maddyhome/idea/vim/statistic/ExtensionTracking.kt
@@ -29,7 +29,7 @@ object ExtensionTracking {
     "matchit",
     "textobj-indent",
     "mini-ai",
-    "vim-indentwise"
+    "indentwise"
   )
   val enabledExtensions: MutableSet<String> = ConcurrentHashMap.newKeySet()
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetCommandTest.kt
@@ -179,24 +179,24 @@ class SetCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
       |--- Options ---
-      |noabolish           nohlsearch            nrformats=hex     nosurround
-      |noargtextobj          ide=IntelliJ IDEA nonumber            notargets
-      |nobomb              noideajoin            operatorfunc=     notextobj-entire
-      |nobreakindent         ideamarks         norelativenumber    notextobj-indent
-      |noCamelCaseMotion     ideawrite=all       scroll=0            textwidth=0
-      |noclasstextobj      noignorecase          scrolljump=1        timeout
-      |  cmdheight=1         inccommand=         scrolloff=0         timeoutlen=1000
-      |  colorcolumn=      noincsearch           selectmode=       notrackactionids
-      |nocommentary          langmap=            shellcmdflag=-x     undolevels=1000
-      |nocursorline          langnoremap         shellxescape=@    novim-indentwise
-      |nodigraph           nolangremap           shellxquote={     noVimEverywhere
-      |noexchange          nolist                showcmd             virtualedit=
-      |  fileformat=unix   nomatchit             showmode          novisualbell
-      |  foldlevel=1         maxmapdepth=20      sidescroll=0        visualdelay=100
-      |nofunctextobj       nomini-ai             sidescrolloff=0     whichwrap=b,s
-      |nogdefault            more              nosmartcase           wrap
-      |nohighlightedyank   nomultiple-cursors  nosneak               wrapscan
-      |  history=50        noNERDTree            startofline       noyoucompleteme
+      |noabolish           nohlsearch          noNERDTree            startofline
+      |noargtextobj          ide=IntelliJ IDEA   nrformats=hex     nosurround
+      |nobomb              noideajoin          nonumber            notargets
+      |nobreakindent         ideamarks           operatorfunc=     notextobj-entire
+      |noCamelCaseMotion     ideawrite=all     norelativenumber    notextobj-indent
+      |noclasstextobj      noignorecase          scroll=0            textwidth=0
+      |  cmdheight=1         inccommand=         scrolljump=1        timeout
+      |  colorcolumn=      noincsearch           scrolloff=0         timeoutlen=1000
+      |nocommentary        noindentwise          selectmode=       notrackactionids
+      |nocursorline          langmap=            shellcmdflag=-x     undolevels=1000
+      |nodigraph             langnoremap         shellxescape=@    noVimEverywhere
+      |noexchange          nolangremap           shellxquote={       virtualedit=
+      |  fileformat=unix   nolist                showcmd           novisualbell
+      |  foldlevel=1       nomatchit             showmode            visualdelay=100
+      |nofunctextobj         maxmapdepth=20      sidescroll=0        whichwrap=b,s
+      |nogdefault          nomini-ai             sidescrolloff=0     wrap
+      |nohighlightedyank     more              nosmartcase           wrapscan
+      |  history=50        nomultiple-cursors  nosneak             noyoucompleteme
       |  clipboard=ideaput,autoselect
       |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
       |  fileencoding=utf-8
@@ -292,6 +292,7 @@ class SetCommandTest : VimTestCase() {
     |noignorecase
     |  inccommand=
     |noincsearch
+    |noindentwise
     |  isfname=@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=
     |  iskeyword=@,48-57,_
     |  keymodel=continueselect,stopselect
@@ -339,7 +340,6 @@ class SetCommandTest : VimTestCase() {
     |  timeoutlen=1000
     |notrackactionids
     |  undolevels=1000
-    |novim-indentwise
     |novim-paragraph-motion
     |noVimEverywhere
     |  viminfo='100,<50,s10,h

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetglobalCommandTest.kt
@@ -432,25 +432,25 @@ class SetglobalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
     |--- Global option values ---
-    |noabolish           nohlsearch          nonumber            notextobj-entire
-    |noargtextobj          ide=IntelliJ IDEA   operatorfunc=     notextobj-indent
-    |nobomb              noideajoin          norelativenumber      textwidth=0
-    |nobreakindent         ideamarks           scroll=0            timeout
-    |noCamelCaseMotion     ideawrite=all       scrolljump=1        timeoutlen=1000
-    |noclasstextobj      noignorecase          scrolloff=0       notrackactionids
-    |  cmdheight=1         inccommand=         selectmode=         undolevels=1000
-    |  colorcolumn=      noincsearch           shellcmdflag=-x   novim-indentwise
-    |nocommentary          langmap=            shellxescape=@    noVimEverywhere
-    |nocursorline          langnoremap         shellxquote={       virtualedit=
-    |nodigraph           nolangremap           showcmd           novisualbell
-    |noexchange          nolist                showmode            visualdelay=100
-    |  fileencoding=     nomatchit             sidescroll=0        whichwrap=b,s
-    |  fileformat=unix     maxmapdepth=20      sidescrolloff=0     wrap
-    |  foldlevel=999     nomini-ai           nosmartcase           wrapscan
-    |nofunctextobj         more              nosneak             noyoucompleteme
-    |nogdefault          nomultiple-cursors    startofline
-    |nohighlightedyank   noNERDTree          nosurround
-    |  history=50          nrformats=hex     notargets
+    |noabolish           nohlsearch            nrformats=hex     notargets
+    |noargtextobj          ide=IntelliJ IDEA nonumber            notextobj-entire
+    |nobomb              noideajoin            operatorfunc=     notextobj-indent
+    |nobreakindent         ideamarks         norelativenumber      textwidth=0
+    |noCamelCaseMotion     ideawrite=all       scroll=0            timeout
+    |noclasstextobj      noignorecase          scrolljump=1        timeoutlen=1000
+    |  cmdheight=1         inccommand=         scrolloff=0       notrackactionids
+    |  colorcolumn=      noincsearch           selectmode=         undolevels=1000
+    |nocommentary        noindentwise          shellcmdflag=-x   noVimEverywhere
+    |nocursorline          langmap=            shellxescape=@      virtualedit=
+    |nodigraph             langnoremap         shellxquote={     novisualbell
+    |noexchange          nolangremap           showcmd             visualdelay=100
+    |  fileencoding=     nolist                showmode            whichwrap=b,s
+    |  fileformat=unix   nomatchit             sidescroll=0        wrap
+    |  foldlevel=999       maxmapdepth=20      sidescrolloff=0     wrapscan
+    |nofunctextobj       nomini-ai           nosmartcase         noyoucompleteme
+    |nogdefault            more              nosneak
+    |nohighlightedyank   nomultiple-cursors    startofline
+    |  history=50        noNERDTree          nosurround
     |  clipboard=ideaput,autoselect
     |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |  guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
@@ -546,6 +546,7 @@ class SetglobalCommandTest : VimTestCase() {
     |noignorecase
     |  inccommand=
     |noincsearch
+    |noindentwise
     |  isfname=@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=
     |  iskeyword=@,48-57,_
     |  keymodel=continueselect,stopselect
@@ -593,7 +594,6 @@ class SetglobalCommandTest : VimTestCase() {
     |  timeoutlen=1000
     |notrackactionids
     |  undolevels=1000
-    |novim-indentwise
     |novim-paragraph-motion
     |noVimEverywhere
     |  viminfo='100,<50,s10,h

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/SetlocalCommandTest.kt
@@ -484,24 +484,24 @@ class SetlocalCommandTest : VimTestCase() {
     setOsSpecificOptionsToSafeValues()
     val expected = """
     |--- Local option values ---
-    |noabolish           nohlsearch          noNERDTree            startofline
-    |noargtextobj          ide=IntelliJ IDEA   nrformats=hex     nosurround
-    |nobomb              --ideajoin          nonumber            notargets
-    |nobreakindent         ideamarks           operatorfunc=     notextobj-entire
-    |noCamelCaseMotion     idearefactormode= norelativenumber    notextobj-indent
-    |noclasstextobj        ideawrite=all       scroll=0            textwidth=0
-    |  cmdheight=1       noignorecase          scrolljump=1        timeout
-    |  colorcolumn=        inccommand=         scrolloff=-1        timeoutlen=1000
-    |nocommentary        noincsearch           selectmode=       notrackactionids
-    |nocursorline          langmap=            shellcmdflag=-x   novim-indentwise
-    |nodigraph             langnoremap         shellxescape=@    noVimEverywhere
-    |noexchange          nolangremap           shellxquote={       virtualedit=
-    |  fileformat=unix   nolist                showcmd           novisualbell
-    |  foldlevel=1       nomatchit             showmode            visualdelay=100
-    |nofunctextobj         maxmapdepth=20      sidescroll=0        whichwrap=b,s
-    |nogdefault          nomini-ai             sidescrolloff=-1    wrap
-    |nohighlightedyank     more              nosmartcase           wrapscan
-    |  history=50        nomultiple-cursors  nosneak             noyoucompleteme
+    |noabolish           nohlsearch          nomultiple-cursors  nosneak
+    |noargtextobj          ide=IntelliJ IDEA noNERDTree            startofline
+    |nobomb              --ideajoin            nrformats=hex     nosurround
+    |nobreakindent         ideamarks         nonumber            notargets
+    |noCamelCaseMotion     idearefactormode=   operatorfunc=     notextobj-entire
+    |noclasstextobj        ideawrite=all     norelativenumber    notextobj-indent
+    |  cmdheight=1       noignorecase          scroll=0            textwidth=0
+    |  colorcolumn=        inccommand=         scrolljump=1        timeout
+    |nocommentary        noincsearch           scrolloff=-1        timeoutlen=1000
+    |nocursorline        noindentwise          selectmode=       notrackactionids
+    |nodigraph             langmap=            shellcmdflag=-x   noVimEverywhere
+    |noexchange            langnoremap         shellxescape=@      virtualedit=
+    |  fileformat=unix   nolangremap           shellxquote={     novisualbell
+    |  foldlevel=1       nolist                showcmd             visualdelay=100
+    |nofunctextobj       nomatchit             showmode            whichwrap=b,s
+    |nogdefault            maxmapdepth=20      sidescroll=0        wrap
+    |nohighlightedyank   nomini-ai             sidescrolloff=-1    wrapscan
+    |  history=50          more              nosmartcase         noyoucompleteme
     |  clipboard=ideaput,autoselect
     |  comments=s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
     |  fileencoding=utf-8
@@ -597,6 +597,7 @@ class SetlocalCommandTest : VimTestCase() {
     |noignorecase
     |  inccommand=
     |noincsearch
+    |noindentwise
     |  isfname=@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=
     |  iskeyword=@,48-57,_
     |  keymodel=continueselect,stopselect
@@ -644,7 +645,6 @@ class SetlocalCommandTest : VimTestCase() {
     |  timeoutlen=1000
     |notrackactionids
     |  undolevels=-123456
-    |novim-indentwise
     |novim-paragraph-motion
     |noVimEverywhere
     |  viminfo='100,<50,s10,h

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseBlockScopeBeginTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseBlockScopeBeginTest.kt
@@ -20,7 +20,7 @@ class IndentWiseBlockScopeBeginTest : VimTestCase() {
   @BeforeEach
   override fun setUp(testInfo: TestInfo) {
     super.setUp(testInfo)
-    enableExtensions("vim-indentwise")
+    enableExtensions("indentwise")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseBlockScopeEndTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseBlockScopeEndTest.kt
@@ -20,7 +20,7 @@ class IndentWiseBlockScopeEndTest : VimTestCase() {
   @BeforeEach
   override fun setUp(testInfo: TestInfo) {
     super.setUp(testInfo)
-    enableExtensions("vim-indentwise")
+    enableExtensions("indentwise")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseExtensionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseExtensionTest.kt
@@ -20,7 +20,7 @@ class IndentWiseExtensionTest : VimTestCase() {
   @BeforeEach
   override fun setUp(testInfo: TestInfo) {
     super.setUp(testInfo)
-    enableExtensions("vim-indentwise")
+    enableExtensions("indentwise")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseNextGreaterIndentTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseNextGreaterIndentTest.kt
@@ -20,7 +20,7 @@ class IndentWiseNextGreaterIndentTest : VimTestCase() {
   @BeforeEach
   override fun setUp(testInfo: TestInfo) {
     super.setUp(testInfo)
-    enableExtensions("vim-indentwise")
+    enableExtensions("indentwise")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseNextLesserIndentTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseNextLesserIndentTest.kt
@@ -20,7 +20,7 @@ class IndentWiseNextLesserIndentTest : VimTestCase() {
   @BeforeEach
   override fun setUp(testInfo: TestInfo) {
     super.setUp(testInfo)
-    enableExtensions("vim-indentwise")
+    enableExtensions("indentwise")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseNextSameIndentTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWiseNextSameIndentTest.kt
@@ -20,7 +20,7 @@ class IndentWiseNextSameIndentTest : VimTestCase() {
   @BeforeEach
   override fun setUp(testInfo: TestInfo) {
     super.setUp(testInfo)
-    enableExtensions("vim-indentwise")
+    enableExtensions("indentwise")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWisePreviousGreaterIndentTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWisePreviousGreaterIndentTest.kt
@@ -20,7 +20,7 @@ class IndentWisePreviousGreaterIndentTest : VimTestCase() {
   @BeforeEach
   override fun setUp(testInfo: TestInfo) {
     super.setUp(testInfo)
-    enableExtensions("vim-indentwise")
+    enableExtensions("indentwise")
   }
 
   @Test

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWisePreviousSameIndentTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/indentwise/IndentWisePreviousSameIndentTest.kt
@@ -20,7 +20,7 @@ class IndentWisePreviousSameIndentTest : VimTestCase() {
   @BeforeEach
   override fun setUp(testInfo: TestInfo) {
     super.setUp(testInfo)
-    enableExtensions("vim-indentwise")
+    enableExtensions("indentwise")
   }
 
   @Test


### PR DESCRIPTION
We have convention of naming plugin without `vim-` prefix