### PR TITLE
VIM-4265 Restore mode in refactor keep before action

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,23 +6,24 @@
  * https://opensource.org/licenses/MIT.
  */
 
-// Set repository for snapshot versions of gradle plugin
 pluginManagement {
   repositories {
     maven {
-      url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-    maven {
-      url = uri("https://cache-redirector.jetbrains.com/packages.jetbrains.team/maven/p/ij/intellij-dependencies")
+      url = uri("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2")
     }
     maven {
       url = uri("https://cache-redirector.jetbrains.com/plugins.gradle.org/m2")
     }
     maven {
-      url = uri("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2")
+      url = uri("https://cache-redirector.jetbrains.com/packages.jetbrains.team/maven/p/ij/intellij-dependencies")
     }
     mavenCentral()
     gradlePluginPortal()
+    // Snapshot versions of gradle plugins. The legacy OSSRH endpoint below is deprecated and no longer
+    // accessible (Sonatype shut it down in July 2025), so it is kept last only as a harmless fallback.
+    maven {
+      url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
   }
 }
 

--- a/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
@@ -75,6 +75,14 @@ import javax.swing.KeyStroke
  * @author Alex Plate
  */
 internal object IdeaSpecifics {
+
+  /**
+   * The Vim mode captured in [VimActionListener.beforeActionPerformed], before the action runs and (potentially) churns
+   * the editor selection. [VimTemplateManagerListener] restores it in `currentVariableChanged` while navigating a
+   * "keep" template, so the mode survives IntelliJ's selecting/deselecting. Cleared once the action is done.
+   */
+  private var modeBeforeAction: Mode? = null
+
   class VimActionListener : AnActionListener {
     @NonNls
     private val surrounderItems = listOf("if", "if / else", "for")
@@ -89,6 +97,13 @@ internal object IdeaSpecifics {
       val hostEditor = event.dataContext.getData(CommonDataKeys.HOST_EDITOR)
       if (hostEditor != null) {
         editor = hostEditor
+      }
+
+      // Remember the mode before the action runs, while it is still correct. For 'idearefactormode' = "keep" the mode
+      // must be preserved across the template's selection churn; VimTemplateManagerListener restores this value in
+      // currentVariableChanged (which runs synchronously during the action, so the mode is not yet corrupted here).
+      if (hostEditor != null && hostEditor.vimInitialised && hostEditor.vim.isIdeaRefactorModeKeep) {
+        modeBeforeAction = hostEditor.vim.mode
       }
 
       val actionId = ActionManager.getInstance().getId(action)
@@ -167,6 +182,10 @@ internal object IdeaSpecifics {
     }
 
     override fun afterActionPerformed(action: AnAction, event: AnActionEvent, result: AnActionResult) {
+      // Release the selection listener suppression acquired in beforeActionPerformed (if any). Done before any early
+      // return so the lock can never leak - a leaked lock would silently disable selection handling everywhere.
+      modeBeforeAction = null
+
       if (VimPlugin.isNotEnabled()) return
 
       val editor = editor
@@ -338,6 +357,12 @@ internal object IdeaSpecifics {
           // $END$ (which is treated as a segment, but not a variable). If there are no variables, it is called with
           // oldIndex == newIndex == -1.
           if (vimEditor.isIdeaRefactorModeKeep) {
+            // Restore the mode captured before the current action (see IdeaSpecifics.modeBeforeAction) in case the
+            // template's selection churn drifted it. Must run before correctEditorSelection, which syncs the editor
+            // selection to whatever the current Vim mode is.
+            modeBeforeAction?.let { savedMode ->
+              if (vimEditor.mode != savedMode) vimEditor.mode = savedMode
+            }
             IdeaRefactorModeHelper.correctEditorSelection(templateState.editor)
             adjustCaretIntoTemplateRange(vimEditor)
           } else {


### PR DESCRIPTION
`IdeaSelectionControl` is executed multiple times during creating live tempalte as IJ selects and deselcts parts of text. In combination with visual timer in sometimes results in VISUAL mode at the end. To prevent being left in VISUAL mode we keep mode before action and restore in in 'idearefcatormode=keep'