### PR TITLE
Allow Setting Custom `.ideavimrc` Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ have `-Duser.home=/my/alternate/home` then IdeaVim will source
 Alternatively, you can set up initialization commands using [XDG](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) standard.
 Put your settings to `$XDG_CONFIG_HOME/ideavim/ideavimrc` file.
 
+You can also set a custom path for your `.ideavimrc` file using the
+`IDEA_VIM_CUSTOM_VIMRC` environment variable. If set, IdeaVim will use this path
+instead of the default locations.
+
 
 IdeaVim Plugins
 --------------------

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/services/VimRcService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/services/VimRcService.kt
@@ -66,6 +66,15 @@ object VimRcService {
   }
 
   private fun findIdeaVimRc(homeVimrcPaths: Array<String>, xdgVimrcPath: String): Path? {
+    val customVimrc = System.getenv("IDEA_VIM_CUSTOM_VIMRC")
+    if (!customVimrc.isNullOrEmpty()) {
+      val file = Path(customVimrc)
+      if (file.exists()) {
+        logger.debug { "Found ideavimrc file: $file" }
+        return file
+      }
+    }
+
     // Check whether file exists in home dir
     val homeDirName = System.getProperty("user.home")
     if (homeDirName != null) {


### PR DESCRIPTION
Currently, IdeaVIM looks for `.ideavimrc` in the user's home directory and in `$XDG_CONFIG_HOME`.

However, sometimes it's desirable to tell IdeaVIM to look for `.ideavimrc` in a specific custom path.

This change allows the user to specify a custom path in the `$IDEA_VIM_CUSTOM_VIMRC` environment variable.

My specific usecase for this:

I use the Nix package manager. Nix makes it easy to "wrap" programs along with their configuration. It basically creates a wrapper shell script that sets the needed options and environment variables then launches the software. I can already wrap IntelliJ by setting a custom `$XDG_CONFIG_HOME`, but then whenever anything in IntelliJ (including other plugins) looks for something in `$XDG_CONFIG_HOME`, it will look in the custom directory. This is a bit too much, I need a way to only change the location of the `.ideavimrc` file.