### PR TITLE
Allow releasing minor without eap first

### DIFF
--- a/.teamcity/_Self/buildTypes/ReleasePlugin.kt
+++ b/.teamcity/_Self/buildTypes/ReleasePlugin.kt
@@ -80,14 +80,12 @@ sealed class ReleasePlugin(private val releaseType: String) : IdeaVimBuildType({
       scriptContent = """
         if [ "major" = "$releaseType" ] || [ "minor" = "$releaseType" ]
         then
-          echo Resetting the release branch because the release type is $releaseType
+          echo Resetting the release branch to the latest master because the release type is $releaseType
           git checkout master
-          latest_eap=${'$'}(git describe --tags --match="[0-9].[0-9]*.[0-9]-eap.[0-9]*" --abbrev=0 HEAD)
-          echo Latest EAP: ${'$'}latest_eap
-          commit_of_latest_eap=${'$'}(git rev-list -n 1 ${'$'}latest_eap)
-          echo Commit of latest EAP: ${'$'}commit_of_latest_eap
+          master_commit=${'$'}(git rev-parse HEAD)
+          echo Master commit: ${'$'}master_commit
           git checkout release
-          git reset --hard ${'$'}commit_of_latest_eap
+          git reset --hard ${'$'}master_commit
         else
           git checkout release
           echo Do not reset the release branch because the release type is $releaseType

--- a/scripts/src/main/kotlin/scripts/releaseActions.kt
+++ b/scripts/src/main/kotlin/scripts/releaseActions.kt
@@ -23,7 +23,7 @@ fun performReleaseActions(version: String, releaseType: String?) = runBlocking {
     return@runBlocking
   }
 
-  val tickets = getYoutrackTicketsByQuery("#{Ready To Release} and tag: {IdeaVim Released In EAP}")
+  val tickets = getYoutrackTicketsByQuery("#{Ready To Release}")
   
   if (tickets.isNotEmpty()) {
     println("Updating statuses for tickets: $tickets")


### PR DESCRIPTION
Each time we wanted to do minor release we had to do eap first which commented youtrack issues as resolved in eap. So we've simplified this process and we can release minro directly now.