### PR TITLE
Allow to always preview whats new page

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/NotificationService.kt
@@ -21,7 +21,6 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.KeyboardShortcut
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.options.ShowSettingsUtil
@@ -29,7 +28,6 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.SystemInfo
-import com.intellij.util.ui.StartupUiUtil
 import com.maddyhome.idea.vim.VimPlugin
 import com.maddyhome.idea.vim.action.editor.OpenControlCharsEditorAction
 import com.maddyhome.idea.vim.api.VimEditor
@@ -46,7 +44,6 @@ import com.maddyhome.idea.vim.statistic.ActionTracker
 import com.maddyhome.idea.vim.ui.VimEmulationConfigurable
 import com.maddyhome.idea.vim.vimscript.services.VimRcService
 import java.awt.datatransfer.StringSelection
-import java.nio.charset.StandardCharsets
 import javax.swing.KeyStroke
 import kotlin.io.path.Path
 import kotlin.io.path.appendText
@@ -244,20 +241,9 @@ internal class NotificationService(private val project: Project?) : VimNotificat
 
     notification.addAction(object : DumbAwareAction("See What's New") {
       override fun actionPerformed(e: AnActionEvent) {
-        if (project == null) return
-        val theme = if (StartupUiUtil.isDarkTheme) "dark" else "light"
-        val html = getVersionHtml(theme) ?: return
-        HTMLEditorProvider.openEditor(project, "What's new in $version", html)
+        WhatsNewHelper.showWhatsNew(project, version)
       }
 
-      private fun getVersionHtml(theme: String): String? =
-        (loadHtml("whatsnew-$version.html") ?: loadHtml("whatsnew-tbr.html"))
-          ?.replace("__THEME__", theme)
-          ?.replace("__VERSION__", version)
-
-      private fun loadHtml(resource: String): String? = javaClass.classLoader
-        .getResourceAsStream(resource)
-        ?.use { it.readBytes().toString(StandardCharsets.UTF_8) }
     })
 
     notification.notify(project)

--- a/src/main/java/com/maddyhome/idea/vim/group/WhatsNewHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/WhatsNewHelper.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.group
+
+import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
+import com.intellij.openapi.project.Project
+import com.intellij.util.ui.StartupUiUtil
+import java.nio.charset.StandardCharsets
+
+class WhatsNewHelper {
+
+  companion object {
+    fun showWhatsNew(project: Project?, version: String) {
+      if (project == null) return
+      val theme = if (StartupUiUtil.isDarkTheme) "dark" else "light"
+      val html = getVersionHtml(theme, version) ?: return
+      HTMLEditorProvider.openEditor(project, "What's new in $version", html)
+    }
+
+    private fun getVersionHtml(theme: String, version: String): String? =
+      (loadHtml("whatsnew-$version.html") ?: loadHtml("whatsnew-tbr.html"))
+        ?.replace("__THEME__", theme)
+        ?.replace("__VERSION__", version)
+
+    private fun loadHtml(resource: String): String? = javaClass.classLoader
+      .getResourceAsStream(resource)
+      ?.use { it.readBytes().toString(StandardCharsets.UTF_8) }
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/ui/StatusBar.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/StatusBar.kt
@@ -44,6 +44,7 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.group.IjOptionConstants
 import com.maddyhome.idea.vim.group.IjOptions
 import com.maddyhome.idea.vim.group.NotificationService
+import com.maddyhome.idea.vim.group.WhatsNewHelper
 import com.maddyhome.idea.vim.helper.MessageHelper
 import com.maddyhome.idea.vim.icons.VimIcons
 import com.maddyhome.idea.vim.newapi.globalIjOptions
@@ -204,6 +205,7 @@ private object VimActionsPopup {
         AllIcons.Actions.IntentionBulb,
       ),
     )
+    actionGroup.add(WhatsNewIdeaVimAction())
     actionGroup.addSeparator(MessageHelper.message("widget.vim.actions.popup.eap.choice.active.text"))
 
     actionGroup.add(JoinEap)
@@ -266,6 +268,13 @@ private class TutorAction : DumbAwareAction("Tutor") {
     PsiManager.getInstance(project).findFile(file)?.let {
       ProjectView.getInstance(project).selectPsiElement(it, false)
     }
+  }
+}
+
+private class WhatsNewIdeaVimAction : DumbAwareAction("What's New") {
+  override fun actionPerformed(e: AnActionEvent) {
+    val project = e.project ?: return
+    WhatsNewHelper.showWhatsNew(project, VimPlugin.getVersion())
   }
 }
 


### PR DESCRIPTION
After initial notification there was no way to view whats new page again so we've added it to vim toolbar