### PR TITLE
VIM-2178 Use original mapping in multi-cursor extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,9 @@ usual beta standards.
 ### Fixes:
 * [VIM-4265](https://youtrack.jetbrains.com/issue/VIM-4265) Fixed being left in Visual mode after a refactoring (e.g. rename) with `idearefactormode=keep` — the mode active before the action is now restored once the template's selection changes settle
 
+### Changes:
+* [VIM-2178](https://youtrack.jetbrains.com/issue/VIM-2178) The `multiple-cursors` extension now maps its default shortcuts to match the original [vim-multiple-cursors](https://github.com/terryma/vim-multiple-cursors) plugin: `<C-n>`/`g<C-n>` add the next occurrence (whole word / any match), `<A-n>`/`g<A-n>` select all occurrences in the file, and `<C-x>`/`<C-p>` skip and remove selections. This is a breaking change from the previous `<A-n>`/`g<A-n>`/`<A-x>`/`<A-p>` mappings — set `let g:multi_cursor_use_default_mapping = 0` to disable the defaults and bind the `<Plug>` mappings yourself (for example, back to the old `<A-n>` based keys)
+
 ### Merged PRs:
 * [1890](https://github.com/JetBrains/ideavim/pull/1890) by [1grzyb1](https://github.com/1grzyb1): VIM-2694 Add C-G and C-T  action during incsearch
 

--- a/doc/IdeaVim Plugins.md
+++ b/doc/IdeaVim Plugins.md
@@ -570,24 +570,48 @@ Original plugin: [vim-multiple-cursors](https://github.com/terryma/vim-multiple-
 
 ### Instructions
 
-At the moment, the default key binds for this plugin do not get mapped correctly in IdeaVim (see [VIM-2178](https://youtrack.jetbrains.com/issue/VIM-2178)). To enable the default key binds, add the following to your `.ideavimrc` file...
+The default key bindings match the original terryma/vim-multiple-cursors plugin:
+
+| Action                                            | Shortcut  |
+|---------------------------------------------------|-----------|
+| Start / add next occurrence (whole word)          | `<C-n>`   |
+| Start / add next occurrence (not whole word)      | `g<C-n>`  |
+| Select all occurrences in file (whole word)       | `<A-n>`   |
+| Select all occurrences in file (not whole word)   | `g<A-n>`  |
+| Skip current and select next (during selection)   | `<C-x>`   |
+| Remove current selection (during selection)       | `<C-p>`   |
+
+These map to the following `<Plug>` mappings:
 
 ```
-" Remap multiple-cursors shortcuts to match terryma/vim-multiple-cursors
 nmap <C-n> <Plug>NextWholeOccurrence
 xmap <C-n> <Plug>NextWholeOccurrence
 nmap g<C-n> <Plug>NextOccurrence
 xmap g<C-n> <Plug>NextOccurrence
+nmap <A-n> <Plug>AllWholeOccurrences
+xmap <A-n> <Plug>AllWholeOccurrences
+nmap g<A-n> <Plug>AllOccurrences
+xmap g<A-n> <Plug>AllOccurrences
 xmap <C-x> <Plug>SkipOccurrence
 xmap <C-p> <Plug>RemoveOccurrence
+```
 
-" Note that the default <A-n> and g<A-n> shortcuts don't work on Mac due to dead keys.
+### Custom mappings
+
+To use your own mappings instead of the defaults, set `g:multi_cursor_use_default_mapping` to `0` and bind the
+`<Plug>` mappings yourself. This is also how you restore the old IdeaVim `<A-n>` based mappings:
+
+```
+let g:multi_cursor_use_default_mapping = 0
+
+" Note that the <A-n> and g<A-n> shortcuts don't work on Mac due to dead keys.
 " <A-n> is used to enter accented text e.g. ñ
-" Feel free to pick your own mappings that are not affected. I like to use <leader>
-nmap <leader><C-n> <Plug>AllWholeOccurrences
-xmap <leader><C-n> <Plug>AllWholeOccurrences
-nmap <leader>g<C-n> <Plug>AllOccurrences
-xmap <leader>g<C-n> <Plug>AllOccurrences
+nmap <A-n> <Plug>NextWholeOccurrence
+xmap <A-n> <Plug>NextWholeOccurrence
+nmap g<A-n> <Plug>NextOccurrence
+xmap g<A-n> <Plug>NextOccurrence
+xmap <A-x> <Plug>SkipOccurrence
+xmap <A-p> <Plug>RemoveOccurrence
 ```
 
 </details>

--- a/src/main/java/com/maddyhome/idea/vim/extension/multiplecursors/VimMultipleCursorsExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/multiplecursors/VimMultipleCursorsExtension.kt
@@ -62,6 +62,14 @@ private const val ALL_WHOLE_OCCURRENCES = "<Plug>AllWholeOccurrences"
 @NlsSafe
 private const val ALL_OCCURRENCES = "<Plug>AllOccurrences"
 
+/**
+ * When set to `0`, the default key mappings are not created, allowing the user to map the `<Plug>` mappings to keys of
+ * their own choosing (e.g. mapping back to the old `<A-n>` based mappings). This matches the
+ * `g:multi_cursor_use_default_mapping` option of the original vim-multiple-cursors plugin.
+ */
+@NlsSafe
+private const val USE_DEFAULT_MAPPING = "multi_cursor_use_default_mapping"
+
 private var Editor.vimMultipleCursorsWholeWord: Boolean? by userData()
 private var Editor.vimMultipleCursorsLastSelection: TextRange? by userData()
 
@@ -115,34 +123,52 @@ internal class VimMultipleCursorsExtension : VimExtension {
       RemoveOccurrenceHandler(), false
     )
 
-    putKeyMappingIfMissing(
-      MappingMode.NXO,
-      injector.parser.parseKeys("<A-n>"),
-      owner,
-      injector.parser.parseKeys(NEXT_WHOLE_OCCURRENCE),
-      true
-    )
-    putKeyMappingIfMissing(
-      MappingMode.NXO,
-      injector.parser.parseKeys("g<A-n>"),
-      owner,
-      injector.parser.parseKeys(NEXT_OCCURRENCE),
-      true
-    )
-    putKeyMappingIfMissing(
-      MappingMode.X,
-      injector.parser.parseKeys("<A-x>"),
-      owner,
-      injector.parser.parseKeys(SKIP_OCCURRENCE),
-      true
-    )
-    putKeyMappingIfMissing(
-      MappingMode.X,
-      injector.parser.parseKeys("<A-p>"),
-      owner,
-      injector.parser.parseKeys(REMOVE_OCCURRENCE),
-      true
-    )
+    val useDefaultMapping =
+      VimPlugin.getVariableService().getGlobalVariableValue(USE_DEFAULT_MAPPING)?.toVimNumber()?.booleanValue ?: true
+    if (useDefaultMapping) {
+      putKeyMappingIfMissing(
+        MappingMode.NXO,
+        injector.parser.parseKeys("<C-n>"),
+        owner,
+        injector.parser.parseKeys(NEXT_WHOLE_OCCURRENCE),
+        true
+      )
+      putKeyMappingIfMissing(
+        MappingMode.NXO,
+        injector.parser.parseKeys("g<C-n>"),
+        owner,
+        injector.parser.parseKeys(NEXT_OCCURRENCE),
+        true
+      )
+      putKeyMappingIfMissing(
+        MappingMode.NXO,
+        injector.parser.parseKeys("<A-n>"),
+        owner,
+        injector.parser.parseKeys(ALL_WHOLE_OCCURRENCES),
+        true
+      )
+      putKeyMappingIfMissing(
+        MappingMode.NXO,
+        injector.parser.parseKeys("g<A-n>"),
+        owner,
+        injector.parser.parseKeys(ALL_OCCURRENCES),
+        true
+      )
+      putKeyMappingIfMissing(
+        MappingMode.X,
+        injector.parser.parseKeys("<C-x>"),
+        owner,
+        injector.parser.parseKeys(SKIP_OCCURRENCE),
+        true
+      )
+      putKeyMappingIfMissing(
+        MappingMode.X,
+        injector.parser.parseKeys("<C-p>"),
+        owner,
+        injector.parser.parseKeys(REMOVE_OCCURRENCE),
+        true
+      )
+    }
   }
 
   abstract class WriteActionHandler : ExtensionHandler {

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionTest.kt
@@ -41,7 +41,7 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
     """.trimMargin()
     configureByText(before)
 
-    typeText(injector.parser.parseKeys("g<A-n>" + "<A-n>".repeat(before.count { it == '\n' } - 1)))
+    typeText(injector.parser.parseKeys("g<C-n>" + "<C-n>".repeat(before.count { it == '\n' } - 1)))
 
     val after = """${s}Int$se
       |Integer
@@ -63,7 +63,7 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
     """.trimMargin()
     configureByText(before)
 
-    typeText(injector.parser.parseKeys("g<A-n>".repeat(3)))
+    typeText(injector.parser.parseKeys("g<C-n>".repeat(3)))
 
     val after = """${s}qwe$se
       |asd${s}qwe${se}asd
@@ -84,7 +84,7 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
     """.trimMargin()
     configureByText(before)
 
-    typeText(injector.parser.parseKeys("<A-n>".repeat(4)))
+    typeText(injector.parser.parseKeys("<C-n>".repeat(4)))
 
     val after = """${s}qwe$se
       |asd
@@ -106,7 +106,7 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
     """.trimMargin()
     configureByText(before)
 
-    typeText(injector.parser.parseKeys("<A-n>"))
+    typeText(injector.parser.parseKeys("<C-n>"))
     assertState(before)
   }
 
@@ -194,7 +194,7 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
       editor.vim.mode = Mode.VISUAL(SelectionType.CHARACTER_WISE)
     }
 
-    typeText(injector.parser.parseKeys("<A-p>"))
+    typeText(injector.parser.parseKeys("<C-p>"))
 
     val after = """qwe
       |dsgkldfjs ldfl gkjsdsl kj
@@ -212,7 +212,7 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
     """.trimMargin()
     configureByText(before)
 
-    typeText(injector.parser.parseKeys("g<A-n>" + "<A-n>".repeat(2) + "<A-p>"))
+    typeText(injector.parser.parseKeys("g<C-n>" + "<C-n>".repeat(2) + "<C-p>"))
 
     val after = """${s}Int$se
       |kek${s}Int${se}eger
@@ -231,11 +231,11 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
     """.trimMargin()
     configureByText(before)
 
-    typeText(injector.parser.parseKeys("<A-n>".repeat(3)))
+    typeText(injector.parser.parseKeys("<C-n>".repeat(3)))
     assertMode(Mode.VISUAL(SelectionType.CHARACTER_WISE))
-    typeText(injector.parser.parseKeys("<A-p>".repeat(3)))
+    typeText(injector.parser.parseKeys("<C-p>".repeat(3)))
     assertMode(Mode.NORMAL())
-    typeText(injector.parser.parseKeys("<A-n>".repeat(2)))
+    typeText(injector.parser.parseKeys("<C-n>".repeat(2)))
 
     val after = """${s}qwe$se
       |asd
@@ -256,7 +256,7 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
     """.trimMargin()
     configureByText(before)
 
-    typeText(injector.parser.parseKeys("g<A-n>" + "<A-x>" + "<A-n>".repeat(2)))
+    typeText(injector.parser.parseKeys("g<C-n>" + "<C-x>" + "<C-n>".repeat(2)))
 
     val after = """qwe
       |asd${s}qwe${se}asd
@@ -279,7 +279,7 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
       editor.vim.mode = Mode.VISUAL(SelectionType.CHARACTER_WISE)
     }
 
-    typeText(injector.parser.parseKeys("<A-x>"))
+    typeText(injector.parser.parseKeys("<C-x>"))
     assertMode(Mode.VISUAL(SelectionType.CHARACTER_WISE))
     assertState(before)
   }
@@ -292,7 +292,7 @@ class VimMultipleCursorsExtensionTest : VimTestCase() {
     """.trimMargin()
     configureByText(before)
 
-    typeText(injector.parser.parseKeys("vjl" + "<A-n>"))
+    typeText(injector.parser.parseKeys("vjl" + "<C-n>"))
     val after = """jdfsg sdf${c}dfkgjhfkgkldfjsg
                         |dfkjghdfs${c}gs
                         |dflsgsdfgh
@@ -317,7 +317,7 @@ fun getCellType(${c}pos: VisualPosition): CellType {
     configureByText(before)
 
     typeText(commandToKeys("set ignorecase"))
-    typeText(injector.parser.parseKeys("g<A-n><A-n><A-n>"))
+    typeText(injector.parser.parseKeys("g<C-n><C-n><C-n>"))
     val after = """@TestWithoutNeovim(reason = SkipNeovimReason.PLUGIN)
 fun getCellType(${s}pos$se: VisualPosition): CellType {
     if (${s}pos$se in snakeCells) {
@@ -342,7 +342,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
   ...all it was settled on some sodden sand
   ...all by the torrent of a mountain pass
     """.trimIndent().dotToTab()
-    val keys = listOf("vll", "<A-N>", "<A-N>")
+    val keys = listOf("vll", "<C-N>", "<C-N>")
     val after = """
   I found it in a legendary land
   ...${s}al${c}l$se rocks and lavender and tufted grass,
@@ -358,7 +358,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
     configureByText(before)
 
     typeText(commandToKeys("set ignorecase"))
-    typeText(injector.parser.parseKeys("<A-n><A-n><A-n><A-n>"))
+    typeText(injector.parser.parseKeys("<C-n><C-n><C-n><C-n>"))
     val after = """test ${s}Test$se tEst TeSt tEST ${s}Test$se test ${s}Test$se test"""
     assertState(after)
   }
@@ -371,7 +371,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       editor.vim.mode = Mode.VISUAL(SelectionType.CHARACTER_WISE)
     }
 
-    typeText(injector.parser.parseKeys("<A-n><A-n>"))
+    typeText(injector.parser.parseKeys("<C-n><C-n>"))
     val after = "test ${s}t.*st$se toast tallest ${s}t.*st$se"
     assertState(after)
   }
@@ -384,7 +384,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       editor.vim.mode = Mode.VISUAL(SelectionType.CHARACTER_WISE)
     }
 
-    typeText(injector.parser.parseKeys("<A-n>"))
+    typeText(injector.parser.parseKeys("<C-n>"))
     val after = "Fields${s}\\IntegerField$se('ID') ssssIntegerField Fields${s}\\IntegerField$se('ENTITY_ID')"
     assertState(after)
   }
@@ -397,7 +397,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       editor.vim.mode = Mode.VISUAL(SelectionType.CHARACTER_WISE)
     }
 
-    typeText(injector.parser.parseKeys("<A-n>"))
+    typeText(injector.parser.parseKeys("<C-n>"))
     val after = "test ${s}\\\\hello$se world ${s}\\\\hello$se again"
     assertState(after)
   }
@@ -410,7 +410,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       editor.vim.mode = Mode.VISUAL(SelectionType.CHARACTER_WISE)
     }
 
-    typeText(injector.parser.parseKeys("<A-n>"))
+    typeText(injector.parser.parseKeys("<C-n>"))
     val after = "path${s}test\\$se file path ${s}test\\$se dir"
     assertState(after)
   }
@@ -443,7 +443,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       ${c}Sed in orci mauris.
       Cras id tellus in ex imperdiet egestas. 
     """.trimIndent()
-    doTest("Vjj<A-n>", before, after)
+    doTest("Vjj<C-n>", before, after)
   }
 
   @Test
@@ -460,7 +460,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       ${c}Sed in orci mauris.
       ${c}Cras id tellus in ex imperdiet egestas. 
     """.trimIndent()
-    doTest("Vjjj<A-n>", before, after)
+    doTest("Vjjj<C-n>", before, after)
   }
 
   @Test
@@ -478,7 +478,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       ${c}Sed in orci mauris.
       Cras id tellus in ex imperdiet egestas.
     """.trimIndent()
-    doTest("Vkk<A-n>", before, after)
+    doTest("Vkk<C-n>", before, after)
   }
 
   @Test
@@ -496,7 +496,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       ${c}Sed in orci mauris.
       ${c}Cras id tellus in ex imperdiet egestas.
     """.trimIndent()
-    doTest("Vkk<A-n>", before, after)
+    doTest("Vkk<C-n>", before, after)
   }
 
   @Test
@@ -520,7 +520,7 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       ${c}Sed in orci mauris.
       ${c}Cras id tellus in ex imperdiet egestas.
     """.trimIndent()
-    doTest("Vkkk<A-n>", before, after)
+    doTest("Vkkk<C-n>", before, after)
   }
 
   @Test
@@ -544,6 +544,218 @@ fun getCellType(${s}pos$se: VisualPosition): CellType {
       Sed in orci mauris.
       Cras id tellus in ex imperdiet egestas.
     """.trimIndent()
-    doTest("Vjjj<A-n>", before, after)
+    doTest("Vjjj<C-n>", before, after)
+  }
+
+  // Default key mappings. These match the original terryma/vim-multiple-cursors plugin.
+
+  @Test
+  fun `test ctrl-n default mapping starts and adds next whole occurrence`() {
+    val before = """q${c}we
+      |asd
+      |qwe
+      |asd
+      |qwe
+    """.trimMargin()
+    configureByText(before)
+
+    typeText(injector.parser.parseKeys("<C-n><C-n>"))
+
+    val after = """${s}qwe$se
+      |asd
+      |${s}qwe$se
+      |asd
+      |qwe
+    """.trimMargin()
+    assertState(after)
+  }
+
+  @Test
+  fun `test g ctrl-n default mapping adds next occurrence without word boundaries`() {
+    val before = """q${c}we
+      |asdqweasd
+      |qwe
+      |asd
+    """.trimMargin()
+    configureByText(before)
+
+    typeText(injector.parser.parseKeys("g<C-n>".repeat(3)))
+
+    val after = """${s}qwe$se
+      |asd${s}qwe${se}asd
+      |${s}qwe$se
+      |asd
+    """.trimMargin()
+    assertState(after)
+  }
+
+  @Test
+  fun `test alt-n default mapping selects all whole occurrences`() {
+    val before = """qwe
+      |asd
+      |q${c}we
+      |asd
+      |qwe
+    """.trimMargin()
+    configureByText(before)
+
+    typeText(injector.parser.parseKeys("<A-n>"))
+
+    val after = """${s}qwe$se
+      |asd
+      |${s}qwe$se
+      |asd
+      |${s}qwe$se
+    """.trimMargin()
+    assertState(after)
+  }
+
+  @Test
+  fun `test g alt-n default mapping selects all occurrences without word boundaries`() {
+    val before = """Int
+      |Integer
+      |I${c}nt
+      |Integer
+      |Integer
+      |Int
+      |Intger
+    """.trimMargin()
+    configureByText(before)
+
+    typeText(injector.parser.parseKeys("g<A-n>"))
+
+    val after = """${s}Int$se
+      |${s}Int${se}eger
+      |${s}Int$se
+      |${s}Int${se}eger
+      |${s}Int${se}eger
+      |${s}Int$se
+      |${s}Int${se}ger
+    """.trimMargin()
+    assertState(after)
+  }
+
+  @Test
+  fun `test ctrl-p default mapping removes occurrence`() {
+    val before = """q${c}we
+      |asd
+      |qwe
+      |asd
+      |qwe
+    """.trimMargin()
+    configureByText(before)
+
+    // Add three cursors, then remove the last one
+    typeText(injector.parser.parseKeys("<C-n>".repeat(3) + "<C-p>"))
+
+    val after = """${s}qwe$se
+      |asd
+      |${s}qwe$se
+      |asd
+      |qwe
+    """.trimMargin()
+    assertState(after)
+  }
+
+  @Test
+  fun `test ctrl-x default mapping skips occurrence`() {
+    val before = """q${c}we
+      |asd
+      |qwe
+      |asd
+      |qwe
+    """.trimMargin()
+    configureByText(before)
+
+    // Select the first occurrence, skip it to the second, then add the third
+    typeText(injector.parser.parseKeys("<C-n>" + "<C-x>" + "<C-n>"))
+
+    val after = """qwe
+      |asd
+      |${s}qwe$se
+      |asd
+      |${s}qwe$se
+    """.trimMargin()
+    assertState(after)
+  }
+
+  // g:multi_cursor_use_default_mapping
+
+  /**
+   * Re-runs the extension's [init] with `g:multi_cursor_use_default_mapping = 0` so that the default key mappings are
+   * not created. Toggling the option off and on again is what causes `init()` to re-read the variable.
+   */
+  private fun disableDefaultMappings() {
+    enterCommand("set nomultiple-cursors")
+    enterCommand("let g:multi_cursor_use_default_mapping = 0")
+    enterCommand("set multiple-cursors")
+  }
+
+  @Test
+  fun `test default mappings are not created when multi_cursor_use_default_mapping is zero`() {
+    val before = """q${c}we
+      |asd
+      |qwe
+    """.trimMargin()
+    configureByText(before)
+    disableDefaultMappings()
+
+    // Without the default mapping, <C-n> must not start a multiple-cursors session (which would enter Visual mode)
+    typeText(injector.parser.parseKeys("<C-n>"))
+    assertMode(Mode.NORMAL())
+
+    // The same applies to the select-all mapping
+    typeText(injector.parser.parseKeys("<A-n>"))
+    assertMode(Mode.NORMAL())
+  }
+
+  @Test
+  fun `test plug mappings still available when default mappings disabled`() {
+    val before = """qwe
+      |asd
+      |q${c}we
+      |asd
+      |qwe
+    """.trimMargin()
+    configureByText(before)
+    disableDefaultMappings()
+
+    // The <Plug> mappings are always registered, so the user can still bind them manually
+    typeText(injector.parser.parseKeys("<Plug>AllWholeOccurrences"))
+
+    val after = """${s}qwe$se
+      |asd
+      |${s}qwe$se
+      |asd
+      |${s}qwe$se
+    """.trimMargin()
+    assertState(after)
+  }
+
+  @Test
+  fun `test can restore old alt based mappings when default mappings disabled`() {
+    val before = """q${c}we
+      |asd
+      |qwe
+      |asd
+      |qwe
+    """.trimMargin()
+    configureByText(before)
+    disableDefaultMappings()
+
+    // Map the alt-based keys back to the "next" behaviour, as they were before the defaults changed
+    enterCommand("nmap <A-n> <Plug>NextWholeOccurrence")
+    enterCommand("xmap <A-n> <Plug>NextWholeOccurrence")
+
+    typeText(injector.parser.parseKeys("<A-n><A-n>"))
+    assertMode(Mode.VISUAL(SelectionType.CHARACTER_WISE))
+
+    val after = """${s}qwe$se
+      |asd
+      |${s}qwe$se
+      |asd
+      |qwe
+    """.trimMargin()
+    assertState(after)
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterNewTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterNewTest.kt
@@ -589,7 +589,7 @@ class ReplaceWithRegisterNewTest : VimTestCase() {
     """.trimIndent()
     configureByText(text)
     enterCommand("set clipboard+=unnamedplus")
-    typeText(injector.parser.parseKeys("ye" + "j" + "<A-n><A-n><A-n><A-n>" + "gr"))
+    typeText(injector.parser.parseKeys("ye" + "j" + "<C-n><C-n><C-n><C-n>" + "gr"))
     assertState(
       """
         copyMe
@@ -620,7 +620,7 @@ class ReplaceWithRegisterNewTest : VimTestCase() {
     enableExtensions("multiple-cursors")
     enterCommand("set clipboard+=unnamed")
 
-    typeText(injector.parser.parseKeys("yiw" + "j" + "griw" + "jj" + "<A-n><A-n><A-n><A-n>" + "gr"))
+    typeText(injector.parser.parseKeys("yiw" + "j" + "griw" + "jj" + "<C-n><C-n><C-n><C-n>" + "gr"))
     assertState(
       """
       test

--- a/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/extension/replacewithregister/ReplaceWithRegisterTest.kt
@@ -579,7 +579,7 @@ class ReplaceWithRegisterTest : VimTestCase() {
     """.trimIndent()
     configureByText(text)
     enterCommand("set clipboard+=unnamedplus")
-    typeText(injector.parser.parseKeys("ye" + "j" + "<A-n><A-n><A-n><A-n>" + "gr"))
+    typeText(injector.parser.parseKeys("ye" + "j" + "<C-n><C-n><C-n><C-n>" + "gr"))
     assertState(
       """
         copyMe
@@ -610,7 +610,7 @@ class ReplaceWithRegisterTest : VimTestCase() {
     enableExtensions("multiple-cursors")
     enterCommand("set clipboard+=unnamed")
 
-    typeText(injector.parser.parseKeys("yiw" + "j" + "griw" + "jj" + "<A-n><A-n><A-n><A-n>" + "gr"))
+    typeText(injector.parser.parseKeys("yiw" + "j" + "griw" + "jj" + "<C-n><C-n><C-n><C-n>" + "gr"))
     assertState(
       """
       test

--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionJavaTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/extension/multiplecursors/VimMultipleCursorsExtensionJavaTest.kt
@@ -41,7 +41,7 @@ class VimMultipleCursorsExtensionJavaTest : VimJavaTestCase() {
 }"""
     configureByJavaText(before)
 
-    typeText(injector.parser.parseKeys("<A-n>".repeat(3)))
+    typeText(injector.parser.parseKeys("<C-n>".repeat(3)))
 
     val after = """public class ChangeLineAction extends EditorAction {
   public ChangeLineAction() {
@@ -81,7 +81,7 @@ class VimMultipleCursorsExtensionJavaTest : VimJavaTestCase() {
 }"""
     configureByJavaText(before)
 
-    typeText(injector.parser.parseKeys("<A-n>".repeat(6)))
+    typeText(injector.parser.parseKeys("<C-n>".repeat(6)))
 
     val after = """public class ChangeLineAction extends EditorAction {
   public ChangeLineAction() {
@@ -112,7 +112,7 @@ class VimMultipleCursorsExtensionJavaTest : VimJavaTestCase() {
     """.trimMargin()
     configureByJavaText(before)
 
-    typeText(injector.parser.parseKeys("<A-n>" + "<A-n>".repeat(3) + "<A-p>"))
+    typeText(injector.parser.parseKeys("<C-n>" + "<C-n>".repeat(3) + "<C-p>"))
 
     val after = """private ${s}int$se a = 0;
       |private ${s}int$se b = 1;
@@ -131,7 +131,7 @@ class VimMultipleCursorsExtensionJavaTest : VimJavaTestCase() {
     """.trimMargin()
     configureByJavaText(before)
 
-    typeText(injector.parser.parseKeys("<A-n>" + "<A-x>" + "<A-n>"))
+    typeText(injector.parser.parseKeys("<C-n>" + "<C-x>" + "<C-n>"))
 
     val after = """private int a = 0;
       |${s}private$se int b = 1;
@@ -149,7 +149,7 @@ class VimMultipleCursorsExtensionJavaTest : VimJavaTestCase() {
     """.trimMargin()
     configureByJavaText(before)
 
-    typeText(injector.parser.parseKeys("<A-n>" + "<A-x>" + "<A-n>".repeat(3)))
+    typeText(injector.parser.parseKeys("<C-n>" + "<C-x>" + "<C-n>".repeat(3)))
 
     val after = """${s}private$se int a = 0;
       |${s}private$se int b = 1;
@@ -175,7 +175,7 @@ class VimMultipleCursorsExtensionJavaTest : VimJavaTestCase() {
     """.trimMargin()
     configureByJavaText(before)
 
-    typeText(injector.parser.parseKeys("<A-n>" + "<A-x>" + "<A-n>" + "<A-n>" + "<A-n>" + "<A-p>" + "<A-n>" + "<A-x>"))
+    typeText(injector.parser.parseKeys("<C-n>" + "<C-x>" + "<C-n>" + "<C-n>" + "<C-n>" + "<C-p>" + "<C-n>" + "<C-x>"))
 
     val after = """public class Main {
       |  public static void main(String[] args) {


### PR DESCRIPTION
We had discreppancy between ideavim implementation of multi-cursor plugin and original one as we defined different mappings. Here we restore original mapping and add flag to switch to old IdeaVim alt-based mappings