### PR TITLE
VIM-989 Implement write command with file argument

### DIFF
--- a/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
+++ b/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApiImpl.kt
@@ -58,7 +58,7 @@ internal class FileRemoteApiImpl : FileRemoteApi {
 
   override suspend fun openFile(filename: String, projectId: ProjectId?, focusEditor: Boolean): String? = onEdt {
     val project = projectId?.findProjectOrNull() ?: return@onEdt "No project found"
-    var file = findFile(filename, project) ?: createFile(filename, project)
+    val file = findFile(filename, project) ?: createFile(filename, project)
 
     if (file != null) {
       FileEditorManager.getInstance(project)
@@ -155,6 +155,20 @@ internal class FileRemoteApiImpl : FileRemoteApi {
     FileCompletionHelper.listMatchingFiles(pathPrefix, basePath)
   }
 
+  override suspend fun createFile(
+    filename: String,
+    projectId: ProjectId?,
+    content: String?,
+  ) {
+    val project = projectId?.findProjectOrNull() ?: return
+    onEdt {
+      WriteCommandAction.runWriteCommandAction(project) {
+        val file = createFile(filename, project)
+        content?.toByteArray()?.let { file?.setBinaryContent(it) }
+      }
+    }
+  }
+
   // ======================== Private helpers ========================
   private fun findFile(filename: String, project: Project): VirtualFile? {
     if (filename.startsWith("~/") || filename.startsWith("~\\")) {
@@ -245,6 +259,7 @@ internal class FileRemoteApiImpl : FileRemoteApi {
         val home = System.getProperty("user.home")
         Path(home, filename.substring(2))
       }
+
       Path(filename).isAbsolute -> Path(filename)
       else -> {
         val basePath = project.basePath ?: return null

--- a/ideavim-common/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApi.kt
+++ b/ideavim-common/src/main/java/com/maddyhome/idea/vim/group/file/FileRemoteApi.kt
@@ -44,6 +44,7 @@ interface FileRemoteApi : RemoteApi<Unit> {
   suspend fun buildFileInfoMessage(editorId: EditorId, fullPath: Boolean): String?
   suspend fun selectEditor(projectId: ProjectId, documentPath: String, protocol: String): Boolean
   suspend fun listFilesForCompletion(pathPrefix: String, projectId: ProjectId?): List<String>
+  suspend fun createFile(filename: String, projectId: ProjectId?, content: String?)
 
   companion object {
     @JvmStatic

--- a/src/main/java/com/maddyhome/idea/vim/group/IjFileGroup.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjFileGroup.kt
@@ -134,6 +134,15 @@ class IjFileGroup : VimFileBase() {
     }
   }
 
+  override fun createFile(
+    filename: String,
+    context: ExecutionContext,
+    content: String?,
+    editor: VimEditor,
+  ) {
+    rpc { FileRemoteApi.getInstance().createFile(filename, extractProjectId(context), content) }
+  }
+
   override fun selectPreviousTab(context: ExecutionContext): Boolean {
     val project = PlatformDataKeys.PROJECT.getData(context.context as DataContext) ?: return false
     val vf = LastTabService.getInstance(project).lastTab

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/WriteCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/WriteCommandTest.kt
@@ -8,16 +8,102 @@
 
 package org.jetbrains.plugins.ideavim.ex.implementation.commands
 
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.vimscript.model.commands.WriteCommand
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class WriteCommandTest : VimTestCase() {
+
+  @TempDir
+  lateinit var tempDir: Path
+
   @Test
   fun `command parsing`() {
     val command = injector.vimscriptParser.parseCommand("write")
     assertTrue(command is WriteCommand)
+  }
+
+  @Test
+  fun `write buffer to new file creates it with buffer content`() {
+    val target = tempDir.resolve("written.txt").absolutePathString()
+    configureByText("hello world\nsecond line\n")
+
+    enterCommand("write $target")
+
+    assertPluginError(false)
+    assertEquals("hello world\nsecond line\n", readFile(target))
+  }
+
+  @Test
+  fun `write ignores trailing whitespace in filename`() {
+    val target = tempDir.resolve("trailing.txt").absolutePathString()
+    configureByText("content\n")
+
+    // Trailing spaces after the filename must not become part of the name.
+    enterCommand("write $target   ")
+
+    assertPluginError(false)
+    assertEquals("content\n", readFile(target))
+    // The path with trailing spaces must not exist as a separate file.
+    assertNull(LocalFileSystem.getInstance().refreshAndFindFileByPath("$target   "))
+  }
+
+  @Test
+  fun `write with range writes only the given lines`() {
+    val target = tempDir.resolve("range.txt").absolutePathString()
+    configureByText("line1\nline2\nline3\nline4\n")
+
+    enterCommand("1,2write $target")
+
+    assertPluginError(false)
+    assertEquals("line1\nline2\n", readFile(target))
+  }
+
+  @Test
+  fun `write without bang to existing file reports error and does not overwrite`() {
+    val target = tempDir.resolve("existing.txt")
+    Files.writeString(target, "original\n")
+    val targetPath = target.absolutePathString()
+    LocalFileSystem.getInstance().refreshAndFindFileByPath(targetPath)
+    configureByText("new content\n")
+
+    enterCommand("write $targetPath")
+
+    // Vim: E13 File exists (add ! to override)
+    assertPluginError(true)
+    assertEquals("original\n", readFile(targetPath), "File must not be overwritten without !")
+  }
+
+  @Test
+  fun `write with bang overwrites existing file`() {
+    val target = tempDir.resolve("overwrite.txt")
+    Files.writeString(target, "original\n")
+    val targetPath = target.absolutePathString()
+    LocalFileSystem.getInstance().refreshAndFindFileByPath(targetPath)
+    configureByText("new content\n")
+
+    enterCommand("write! $targetPath")
+
+    assertPluginError(false)
+    assertEquals("new content\n", readFile(targetPath))
+  }
+
+  private fun readFile(path: String): String {
+    val file: VirtualFile = assertNotNull(
+      LocalFileSystem.getInstance().refreshAndFindFileByPath(path),
+      "Expected file to exist on disk: $path",
+    )
+    return String(file.contentsToByteArray())
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimFile.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimFile.kt
@@ -28,6 +28,7 @@ interface VimFile {
   fun closeFile(number: Int, context: ExecutionContext)
   fun selectFile(count: Int, context: ExecutionContext): Boolean
   fun selectNextFile(count: Int, context: ExecutionContext)
+  fun createFile(filename: String, context: ExecutionContext, content: String?, editor: VimEditor)
 
   /**
    * Opens a file by name or path.

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/WriteCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/WriteCommand.kt
@@ -11,16 +11,15 @@ package com.maddyhome.idea.vim.vimscript.model.commands
 import com.intellij.vim.annotations.ExCommand
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.getText
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.ex.ranges.Range
+import com.maddyhome.idea.vim.ex.ranges.toTextRange
 import com.maddyhome.idea.vim.vimscript.model.ExecutionResult
 
 /**
  * see "h :write"
- *
- * XXX: [argument] is currently unused. When `:write {file}` support is added, expand [argument] using
- * [VimPathExpansion.expandPath] to support environment variables (`$VAR`, `${VAR}`) and tilde (`~`, `~/`).
  */
 @ExCommand(command = "w[rite]")
 data class WriteCommand(val range: Range, val modifier: CommandModifier, val argument: String) :
@@ -34,7 +33,25 @@ data class WriteCommand(val range: Range, val modifier: CommandModifier, val arg
     context: ExecutionContext,
     operatorArguments: OperatorArguments,
   ): ExecutionResult {
-    injector.file.saveFile(editor, context)
+    if (argument.isEmpty()) {
+      injector.file.saveFile(editor, context)
+      return ExecutionResult.Success
+    }
+    val path = injector.pathExpansion.expandPath(argument.trim())
+    val fileExists = injector.file.findFile(path, context) != null
+    if (modifier != CommandModifier.BANG && fileExists) {
+      injector.messages.showMessage(editor, "E37: File exists")
+      return ExecutionResult.Error
+    }
+    injector.file.createFile(path, context, getText(editor), editor)
     return ExecutionResult.Success
+  }
+
+  private fun getText(editor: VimEditor): String {
+    if (range.size() != 0) {
+      val tr = getLineRange(editor).toTextRange(editor)
+      return editor.getText(tr.startOffset, tr.endOffset)
+    }
+    return editor.text().toString()
   }
 }


### PR DESCRIPTION
Now when argument is passed to `:w {arg}` content will be saved to newly created file