### PR TITLE
Trace is mouse dragging in global state

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/extension/argtextobj/VimArgTextObjExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/argtextobj/VimArgTextObjExtension.kt
@@ -236,7 +236,7 @@ class VimArgTextObjExtension : VimExtension {
         editor.nativeCarets().forEach(Consumer { caret: VimCaret ->
           val range = textObjectHandler.getRange(editor, caret, context, max(1, count0), count0)
           if (range != null) {
-            SelectionVimListenerSuppressor.lock().use { _ ->
+            SelectionVimListenerSuppressor.lock {
               if (editor.mode is VISUAL) {
                 caret.vimSetSelection(range.startOffset, range.endOffset - 1, true)
               } else {

--- a/src/main/java/com/maddyhome/idea/vim/extension/classtextobj/ClassTextObjectHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/classtextobj/ClassTextObjectHandler.kt
@@ -44,7 +44,7 @@ internal class ClassTextObjectHandler : ExtensionHandler {
   }
 
   private fun applyRange(editor: VimEditor, caret: VimCaret, range: TextRange) {
-    SelectionVimListenerSuppressor.lock().use { _ ->
+    SelectionVimListenerSuppressor.lock {
       if (editor.mode is Mode.VISUAL) {
         caret.vimSetSelection(range.startOffset, range.endOffset - 1, true)
       } else {

--- a/src/main/java/com/maddyhome/idea/vim/extension/functextobj/FuncTextObjectHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/functextobj/FuncTextObjectHandler.kt
@@ -46,7 +46,7 @@ internal class FuncTextObjectHandler(private val rangeKind: FuncRange) : Extensi
   }
 
   private fun applyRange(editor: VimEditor, caret: VimCaret, range: TextRange) {
-    SelectionVimListenerSuppressor.lock().use { _ ->
+    SelectionVimListenerSuppressor.lock {
       if (editor.mode is Mode.VISUAL) {
         caret.vimSetSelection(range.startOffset, range.endOffset - 1, true)
       } else {

--- a/src/main/java/com/maddyhome/idea/vim/extension/targets/TargetsExtension.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/targets/TargetsExtension.kt
@@ -521,7 +521,7 @@ internal class TargetsExtension : VimExtension {
       }
       editor.nativeCarets().forEach { caret ->
         val range = computeRange(editor, caret, count) ?: return@forEach
-        SelectionVimListenerSuppressor.lock().use {
+        SelectionVimListenerSuppressor.lock {
           if (editor.mode is Mode.VISUAL) {
             caret.vimSetSelection(range.startOffset, range.endOffset - 1, true)
           } else {

--- a/src/main/java/com/maddyhome/idea/vim/extension/textobjindent/VimIndentObject.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/textobjindent/VimIndentObject.kt
@@ -263,7 +263,7 @@ class VimIndentObject : VimExtension {
         val count0 = operatorArguments.count0
         editor.editor.getCaretModel().runForEachCaret { caret: Caret ->
           val range = textObjectHandler.getRange(vimEditor, IjVimCaret(caret), context, max(1, count0), count0)
-          SelectionVimListenerSuppressor.lock().use { ignored ->
+          SelectionVimListenerSuppressor.lock {
             if (editor.mode is VISUAL) {
               IjVimCaret(caret).vimSetSelection(range.startOffset, range.endOffset - 1, true)
             } else {

--- a/src/main/java/com/maddyhome/idea/vim/extension/textobjuser/TextObjUserHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/extension/textobjuser/TextObjUserHandler.kt
@@ -52,7 +52,7 @@ internal class TextObjUserHandler(
 
   private fun applyRange(editor: VimEditor, caret: VimCaret, range: TextRange) {
     val mode = editor.mode
-    SelectionVimListenerSuppressor.lock().use {
+    SelectionVimListenerSuppressor.lock {
       if (mode is Mode.VISUAL) {
         caret.vimSetSelection(range.startOffset, range.endOffset - 1, true)
         if (mode.selectionType != regionType) {

--- a/src/main/java/com/maddyhome/idea/vim/group/visual/VisualModeHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/visual/VisualModeHelper.kt
@@ -20,10 +20,10 @@ import com.maddyhome.idea.vim.listener.SelectionVimListenerSuppressor
  * Set selection without calling SelectionListener
  */
 fun SelectionModel.vimSetSystemSelectionSilently(start: Int, end: Int) =
-  SelectionVimListenerSuppressor.lock().use { setSelection(start, end) }
+  SelectionVimListenerSuppressor.lock { setSelection(start, end) }
 
 /**
  * Set selection without calling SelectionListener
  */
 fun SelectionModel.vimSetSystemBlockSelectionSilently(start: LogicalPosition, end: LogicalPosition) =
-  SelectionVimListenerSuppressor.lock().use { setBlockSelection(start, end) }
+  SelectionVimListenerSuppressor.lock { setBlockSelection(start, end) }

--- a/src/main/java/com/maddyhome/idea/vim/helper/ModeExtensions.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/ModeExtensions.kt
@@ -32,7 +32,7 @@ fun VimEditor.exitSelectMode(adjustCaretPosition: Boolean) {
   // we don't want a delayed selection change handler to override their intent.
   VimVisualTimer.drop()
   mode = mode.returnTo
-  SelectionVimListenerSuppressor.lock().use {
+  SelectionVimListenerSuppressor.lock {
     carets().forEach { vimCaret ->
       val caret = (vimCaret as IjVimCaret).caret
       // NOTE: I think it should be write action, but the exception shows only an absence of the read action

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -778,7 +778,7 @@ object VimListenerManager {
 
         if (!cutOffFixed && ComponentMouseListener.cutOffEnd) {
           cutOffFixed = true
-          SelectionVimListenerSuppressor.lock().use {
+          SelectionVimListenerSuppressor.lock {
             if (caret.selectionEnd == e.editor.document.getLineEndOffset(caret.logicalPosition.line) - 1 &&
               caret.leadSelectionOffset == caret.selectionEnd
             ) {
@@ -818,7 +818,7 @@ object VimListenerManager {
 
         val caret = e.editor.caretModel.primaryCaret
         if (onLineEnd(caret)) {
-          SelectionVimListenerSuppressor.lock().use {
+          SelectionVimListenerSuppressor.lock {
             caret.removeSelection()
             caret.forceBarCursor()
           }
@@ -870,7 +870,7 @@ object VimListenerManager {
       if (MouseEventsDataHolder.mouseDragging) {
         logger.debug("Release mouse after dragging")
         val editor = event.editor
-        SelectionVimListenerSuppressor.lock().use {
+        SelectionVimListenerSuppressor.lock {
           val predictedMode = injector.application
             .runReadAction { IdeaSelectionControl.predictMode(editor, SelectionSource.MOUSE) }
           IdeaSelectionControl.controlNonVimSelectionChange(editor, SelectionSource.MOUSE)

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -715,7 +715,7 @@ object VimListenerManager {
       }
       //endregion
 
-      if (SelectionVimListenerSuppressor.isNotLocked) {
+      if (SelectionVimListenerSuppressor.isNotLocked && !MouseEventsDataHolder.mouseDragging) {
         logger.debug("Adjust non vim selection change")
         IdeaSelectionControl.controlNonVimSelectionChange(editor)
       }
@@ -740,7 +740,6 @@ object VimListenerManager {
    */
   // TODO: Can we merge this with ComponentMouseListener to fully handle all mouse actions in one place?
   private object EditorMouseHandler : EditorMouseListener, EditorMouseMotionListener {
-    private var mouseDragging = false
     private var cutOffFixed = false
 
     override fun mouseDragged(e: EditorMouseEvent) {
@@ -750,7 +749,7 @@ object VimListenerManager {
 
       clearFirstSelectionEvents(e)
 
-      if (mouseDragging && caret.hasSelection()) {
+      if (MouseEventsDataHolder.mouseDragging && caret.hasSelection()) {
         /**
          * We force the bar caret while dragging because it matches IntelliJ's selection model better.
          * * Vim's drag selection is based on character bounding boxes. When 'selection' is set to "inclusive" (the
@@ -815,10 +814,7 @@ object VimListenerManager {
       if (MouseEventsDataHolder.dragEventCount > 0) {
         logger.debug("Mouse dragging")
         VimVisualTimer.swingTimer?.stop()
-        if (!mouseDragging) {
-          SelectionVimListenerSuppressor.lock()
-        }
-        mouseDragging = true
+        MouseEventsDataHolder.mouseDragging = true
 
         val caret = e.editor.caretModel.primaryCaret
         if (onLineEnd(caret)) {
@@ -844,7 +840,7 @@ object VimListenerManager {
         return
       }
       MouseEventsDataHolder.dragEventCount = MouseEventsDataHolder.allowedSkippedDragEvents
-      SelectionVimListenerSuppressor.reset()
+      MouseEventsDataHolder.mouseDragging = false
     }
 
     private fun isMouseMovementAllowed(): Boolean {
@@ -868,11 +864,10 @@ object VimListenerManager {
      */
     override fun mouseReleased(event: EditorMouseEvent) {
       if (event.editor.isIdeaVimDisabledHere) return
-      SelectionVimListenerSuppressor.unlock()
 
       clearFirstSelectionEvents(event)
       MouseEventsDataHolder.dragEventCount = MouseEventsDataHolder.allowedSkippedDragEvents
-      if (mouseDragging) {
+      if (MouseEventsDataHolder.mouseDragging) {
         logger.debug("Release mouse after dragging")
         val editor = event.editor
         SelectionVimListenerSuppressor.lock().use {
@@ -886,7 +881,7 @@ object VimListenerManager {
           editor.updateCaretsVisualAttributes()
         }
 
-        mouseDragging = false
+        MouseEventsDataHolder.mouseDragging = false
         cutOffFixed = false
       }
     }
@@ -1038,6 +1033,11 @@ internal object VimListenerTestObject {
 private object MouseEventsDataHolder {
   const val allowedSkippedDragEvents = 3
   var dragEventCount = allowedSkippedDragEvents
+
+  /**
+   * Ground-truth for "is a mouse drag currently in progress".
+   */
+  var mouseDragging = false
 }
 
 /**

--- a/src/main/java/com/maddyhome/idea/vim/vimscript/model/options/helpers/IdeaRefactorModeHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/vimscript/model/options/helpers/IdeaRefactorModeHelper.kt
@@ -50,7 +50,7 @@ internal object IdeaRefactorModeHelper {
           }
 
           Action.RemoveSelection -> {
-            SelectionVimListenerSuppressor.lock().use {
+            SelectionVimListenerSuppressor.lock {
               editor.selectionModel.removeSelection()
             }
           }

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -224,7 +224,7 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
       bookmarksManager.remove(bookmark)
     }
     VimListenerManager.VimLastSelectedEditorTracker.resetLastSelectedEditor(fixture.project)
-    SelectionVimListenerSuppressor.lock().use { fixture.tearDown() }
+    SelectionVimListenerSuppressor.lock { fixture.tearDown() }
     ExEntryPanel.instance?.deactivate(false)
     VimPlugin.getVariableService().clear()
     VimFuncref.lambdaCounter = 0

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -865,8 +865,8 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     key: KeyStroke,
     processResultBuilder: KeyProcessResult.KeyProcessResultBuilder,
   ): Boolean {
-    var res: Boolean
-    SelectionVimListenerSuppressor.lock().use {
+    var res = false
+    SelectionVimListenerSuppressor.lock {
       res = processKey(editor, key, processResultBuilder)
       processResultBuilder.addExecutionStep { _, lambdaEditor, lambdaContext ->
         lambdaEditor.exitSelectModeNative(false)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualGroup.kt
@@ -51,7 +51,7 @@ fun setVisualSelection(selectionStart: Int, selectionEnd: Int, caret: VimCaret) 
       // runAsAllCaretsAction fires the all-carets-action listener pair so split mode's
       // PatchEngineEditorSynchronizer batches its per-event protocol sends into one snapshot.
       // Safe here because the body doesn't run any IDE actions (only Vim-internal caret moves).
-      CaretVisualAttributesListenerSuppressor.lock().use {
+      CaretVisualAttributesListenerSuppressor.lock {
         editor.runAsAllCaretsAction {
           // This will invalidate any secondary carets, but we shouldn't have any of these cached
           // in local variables, etc. Required for correctness: setCaretsAndSelections reuses

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualModeHelper.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/group/visual/EngineVisualModeHelper.kt
@@ -15,4 +15,4 @@ import com.maddyhome.idea.vim.listener.SelectionVimListenerSuppressor
  * Set selection without calling SelectionListener
  */
 fun VimCaret.vimSetSystemSelectionSilently(start: Int, end: Int): Unit =
-  SelectionVimListenerSuppressor.lock().use { this.setSelection(start, end) }
+  SelectionVimListenerSuppressor.lock { this.setSelection(start, end) }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineModeExtensions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/helper/EngineModeExtensions.kt
@@ -21,7 +21,7 @@ import com.maddyhome.idea.vim.state.mode.selectionType
 
 fun VimEditor.exitVisualMode() {
   val selectionType = mode.selectionType ?: SelectionType.CHARACTER_WISE
-  SelectionVimListenerSuppressor.lock().use {
+  SelectionVimListenerSuppressor.lock {
     val clearAllSelections = { nativeCarets().forEach(VimCaret::removeSelection) }
     if (inBlockSelection) {
       // removeSecondaryCarets() fires N-1 caretRemoved events. In split mode those events drive

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/listener/ListenerSuppressor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/listener/ListenerSuppressor.kt
@@ -11,59 +11,60 @@ package com.maddyhome.idea.vim.listener
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.diagnostic.trace
 import com.maddyhome.idea.vim.diagnostic.vimLogger
-import java.io.Closeable
 
 /**
  * Base class for listener suppressors.
- * Children of this class have an ability to suppress editor listeners
+ * Children of this class have the ability to suppress editor listeners for the duration of a scoped block.
+ *
+ * The suppression is a re-entrant counter, but that counter is never exposed: the only way to acquire it is via
+ * [lock], which takes a block and always releases the count in a `finally`. This makes it impossible to leak a
+ * lock - there is no bare `lock()`/`unlock()` pair a caller could unbalance.
  *
  * E.g.
  * ```
- *  CaretVimListenerSuppressor.lock()
- *  caret.moveToOffset(10) // vim's caret listener will not be executed
- *  CaretVimListenerSuppressor.unlock()
- * ````
- *
- *  Locks can be nested:
+ *  CaretVimListenerSuppressor.lock {
+ *    caret.moveToOffset(10) // vim's caret listener will not be executed
+ *  }
  * ```
- * CaretVimListenerSuppressor.lock()
- * moveCaret(caret) // vim's caret listener will not be executed
- * CaretVimListenerSuppressor.unlock()
+ *
+ * Locks can be nested - the listener is re-enabled only once the outermost block completes:
+ * ```
+ * CaretVimListenerSuppressor.lock {
+ *   moveCaret(caret) // vim's caret listener will not be executed
+ * }
  *
  * fun moveCaret(caret: Caret) {
- *     CaretVimListenerSuppressor.lock()
+ *   CaretVimListenerSuppressor.lock {
  *     caret.moveToOffset(10)
- *     CaretVimListenerSuppressor.unlock()
+ *   }
  * }
- * ```
- *
- * [Locked] implements [Closeable], so you can use try-with-resources block
- *
- * java
- * ```
- * try (VimListenerSuppressor.Locked ignored = SelectionVimListenerSuppressor.INSTANCE.lock()) {
- *     ....
- * }
- * ```
- *
- * Kotlin
- * ```
- * SelectionVimListenerSuppressor.lock().use { ... }
  * ```
  */
 sealed class VimListenerSuppressor {
-  private var caretListenerSuppressor = 0
+  @PublishedApi
+  internal var caretListenerSuppressor = 0
 
-  fun lock(): Locked {
+  /**
+   * Suppress the listener for the duration of [block].
+   */
+  inline fun <T> lock(block: () -> T): T {
+    acquire()
+    try {
+      return block()
+    } finally {
+      release()
+    }
+  }
+
+  @PublishedApi
+  internal fun acquire() {
     LOG.trace("Suppressor lock")
     LOG.trace { injector.application.currentStackTrace() }
     caretListenerSuppressor++
-    return Locked()
   }
 
-  // Please try not to use lock/unlock without scoping
-  // Prefer try-with-resources
-  fun unlock() {
+  @PublishedApi
+  internal fun release() {
     LOG.trace("Suppressor unlock")
     LOG.trace { injector.application.currentStackTrace() }
     caretListenerSuppressor--
@@ -72,12 +73,10 @@ sealed class VimListenerSuppressor {
   val isNotLocked: Boolean
     get() = caretListenerSuppressor == 0
 
-  inner class Locked : Closeable {
-    override fun close(): Unit = unlock()
-  }
-
-  companion object {
-    private val LOG = vimLogger<VimListenerSuppressor>()
+  @PublishedApi
+  internal companion object {
+    @PublishedApi
+    internal val LOG = vimLogger<VimListenerSuppressor>()
   }
 }
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/listener/ListenerSuppressor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/listener/ListenerSuppressor.kt
@@ -11,7 +11,6 @@ package com.maddyhome.idea.vim.listener
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.diagnostic.trace
 import com.maddyhome.idea.vim.diagnostic.vimLogger
-import com.maddyhome.idea.vim.helper.StrictMode
 import java.io.Closeable
 
 /**
@@ -68,11 +67,6 @@ sealed class VimListenerSuppressor {
     LOG.trace("Suppressor unlock")
     LOG.trace { injector.application.currentStackTrace() }
     caretListenerSuppressor--
-  }
-
-  fun reset() {
-    StrictMode.assert(caretListenerSuppressor == 0, "Listener is not zero")
-    caretListenerSuppressor = 0
   }
 
   val isNotLocked: Boolean


### PR DESCRIPTION
During mouse dragging there could be a case where during drag the editor was closed which resulted in an invalid state in ListenerSuppressor with not removed caretListenerSuppressor. More roboust approach is to track mouseDragging as state.