### PR TITLE
VIM-4283 Fix dw in jupyter notebook cell

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimDocument.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimDocument.kt
@@ -43,4 +43,8 @@ class IjVimDocument(val document: Document) : VimDocument {
   override fun getOffsetGuard(offset: Int): LiveRange? {
     return document.getOffsetGuard(offset)?.vim
   }
+
+  override fun getRangeGuard(start: Int, end: Int): LiveRange? {
+    return document.getRangeGuard(start, end)?.vim
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/GuardedBlocksTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/GuardedBlocksTest.kt
@@ -8,11 +8,13 @@
 
 package org.jetbrains.plugins.ideavim.action
 
+import com.intellij.openapi.application.ApplicationManager
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.state.mode.Mode
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
+import org.jetbrains.plugins.ideavim.rangeOf
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -25,6 +27,32 @@ class GuardedBlocksTest : VimTestCase() {
     assertDoesNotThrow {
       typeText(injector.parser.parseKeys("x"))
     }
+  }
+
+  @TestWithoutNeovim(reason = SkipNeovimReason.GUARDED_BLOCKS)
+  @Test
+  fun `test delete word does not expand into guarded collapsed fold`() {
+    // Simulate a Jupyter notebook cell: the `#%%` delimiter is rendered as a collapsed fold and is also a
+    // guarded block. A char-wise `dw` on the editable cell content must not be expanded to cover the fold,
+    // otherwise the whole delete would overlap the guard and be rejected, leaving the text untouched.
+    configureAndFold(
+      """
+      [#%%
+      ]${c}test()asdf sd
+      """.trimIndent(),
+      "",
+    )
+    val guardRange = "#%%\ntest()asdf sd" rangeOf "#%%\n"
+    ApplicationManager.getApplication().runReadAction {
+      fixture.editor.document.createGuardedBlock(guardRange.startOffset, guardRange.endOffset)
+    }
+    typeText(injector.parser.parseKeys("dw"))
+    assertState(
+      """
+      #%%
+      ${c}()asdf sd
+      """.trimIndent(),
+    )
   }
 
   @TestWithoutNeovim(reason = SkipNeovimReason.GUARDED_BLOCKS)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDocument.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimDocument.kt
@@ -15,4 +15,5 @@ interface VimDocument {
   fun addChangeListener(listener: ChangesListener)
   fun removeChangeListener(listener: ChangesListener)
   fun getOffsetGuard(offset: Int): LiveRange?
+  fun getRangeGuard(start: Int, end: Int): LiveRange?
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMotionGroupBase.kt
@@ -461,6 +461,10 @@ abstract class VimMotionGroupBase : VimMotionGroup {
         rangeEndLine
       ) ?: return TextRange(start, end)
 
+    if (editor.document.getRangeGuard(collapsedFold.startOffset, collapsedFold.endOffset) != null) {
+      return TextRange(start, end)
+    }
+
     val shouldExpand = linewise || start + 1 >= collapsedFold.startOffset
     if (!shouldExpand) {
       return TextRange(start, end)


### PR DESCRIPTION
cells had guarded blocks which prevents from modifing document at such place and they are treated as collapsed regions. So after adding expanding collapsed regions it was included in motion range and as it is guarded block we couldn't delete in such way