### PR TITLE
VIM-3936 enable vim in python console

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -51,7 +51,6 @@ import com.maddyhome.idea.vim.key.KeySource
 import com.maddyhome.idea.vim.key.ShortcutOwner
 import com.maddyhome.idea.vim.key.ShortcutOwnerInfo
 import com.maddyhome.idea.vim.listener.AceJumpService
-import com.maddyhome.idea.vim.newapi.IjNativeAction
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.newapi.initInjector
 import com.maddyhome.idea.vim.newapi.vim
@@ -84,8 +83,8 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
     val editor = getEditor(e)
     val keyStroke = getKeyStroke(e)
     if (editor != null && keyStroke != null) {
-      // In the Python console, Enter executes and Up/Down navigate command history in every Vim mode, rather than
-      // being handled as Vim commands (newline / caret motion).
+      // In the Python console, Enter/Up/Down should drive the console's own actions (execute / history) in every Vim
+      // mode, with the console's native context-aware behaviour.
       if (handlePythonConsoleKey(editor, keyStroke, e)) return
 
       val owner = VimPlugin.getKey().savedShortcutConflicts[keyStroke]
@@ -113,14 +112,18 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
 
   /**
    * In the Python console, Enter and Up/Down should drive the console's own behaviour in every Vim mode, rather than
-   * being handled as Vim commands. These are implemented by per-console actions:
+   * being handled as Vim commands. These are implemented by per-console actions (the corresponding global action ids
+   * `Console.History.*` / `Console.Execute` are only [com.intellij.openapi.actionSystem.impl.EmptyAction] keymap stubs):
    *  - Up/Down: history navigation, created by [ConsoleHistoryController] (Up -> `historyNext`, Down -> `historyPrev`).
    *  - Enter: [com.intellij.execution.console.ConsoleExecuteAction], registered on the console editor component.
    *
-   * The corresponding global action ids (`Console.History.*`, `Console.Execute`) are only keymap stubs (`EmptyAction`)
-   * with no behaviour, so we resolve the console via [LangDataKeys.CONSOLE_VIEW] and invoke the real action instances.
+   * We invoke the real action instance via [ActionManager.tryToExecute], passing the original key event so the
+   * action's own `update` decides enablement. This preserves the console's context-aware behaviour: Up/Down only
+   * navigate history at the first/last line (moving the caret otherwise), and Enter executes or inserts a newline for
+   * an incomplete block. If the console action is disabled for the current caret position, `tryToExecute` rejects and
+   * we return false so Vim performs the normal caret movement.
    *
-   * @return true if the keystroke was handled by the console (and Vim should not process it further).
+   * @return true if the console handled the keystroke (and Vim should not process it further).
    */
   private fun handlePythonConsoleKey(editor: Editor, keyStroke: KeyStroke, e: AnActionEvent): Boolean {
     if (keyStroke.modifiers != 0) return false
@@ -132,13 +135,16 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
       KeyEvent.VK_ENTER -> consoleExecuteAction(consoleView)
       else -> null
     } ?: return false
-    return injector.actionExecutor.executeAction(editor.vim, IjNativeAction(action), e.dataContext.vim)
+    val result = ActionManager.getInstance()
+      .tryToExecute(action, e.inputEvent, consoleView.consoleEditor.contentComponent, e.place, true)
+    result.waitFor(1000)
+    return result.isDone
   }
 
   /**
-   * Finds the console's own execute action (bound to Enter). [ConsoleExecuteAction] is registered directly on the
-   * console editor component and carries a [ProxyShortcutSet] pointing at the `Console.Execute` keymap stub, so we
-   * match on that id.
+   * Finds the console's own execute action (bound to Enter). [com.intellij.execution.console.ConsoleExecuteAction] is
+   * registered directly on the console editor component and carries a [ProxyShortcutSet] pointing at the
+   * `Console.Execute` keymap stub, so we match on that id.
    */
   private fun consoleExecuteAction(consoleView: LanguageConsoleView): AnAction? {
     return ActionUtil.getActions(consoleView.consoleEditor.component)

--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -19,6 +19,8 @@ import com.intellij.openapi.actionSystem.AnActionWrapper
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.actionSystem.ex.ActionUtil
+import com.intellij.openapi.actionSystem.impl.ProxyShortcutSet
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Editor
@@ -82,7 +84,9 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
     val editor = getEditor(e)
     val keyStroke = getKeyStroke(e)
     if (editor != null && keyStroke != null) {
-      if (navigatePythonConsoleHistory(editor, keyStroke, e)) return
+      // In the Python console, Enter executes and Up/Down navigate command history in every Vim mode, rather than
+      // being handled as Vim commands (newline / caret motion).
+      if (handlePythonConsoleKey(editor, keyStroke, e)) return
 
       val owner = VimPlugin.getKey().savedShortcutConflicts[keyStroke]
       if ((owner as? ShortcutOwnerInfo.AllModes)?.owner == ShortcutOwner.UNDEFINED) {
@@ -108,26 +112,37 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
   }
 
   /**
-   * In the Python console, Up/Down should navigate command history in every Vim mode, matching the console's native
-   * behaviour. History navigation is implemented by a per-console action created by [ConsoleHistoryController] (the
-   * global `Console.History.*` action ids are only keymap stubs with no behaviour), so we resolve the console via
-   * [LangDataKeys.CONSOLE_VIEW] and invoke the controller's real action directly. The platform binds Up to
-   * `historyNext` and Down to `historyPrev`.
+   * In the Python console, Enter and Up/Down should drive the console's own behaviour in every Vim mode, rather than
+   * being handled as Vim commands. These are implemented by per-console actions:
+   *  - Up/Down: history navigation, created by [ConsoleHistoryController] (Up -> `historyNext`, Down -> `historyPrev`).
+   *  - Enter: [com.intellij.execution.console.ConsoleExecuteAction], registered on the console editor component.
    *
-   * @return true if the keystroke was handled as history navigation (and Vim should not process it further).
+   * The corresponding global action ids (`Console.History.*`, `Console.Execute`) are only keymap stubs (`EmptyAction`)
+   * with no behaviour, so we resolve the console via [LangDataKeys.CONSOLE_VIEW] and invoke the real action instances.
+   *
+   * @return true if the keystroke was handled by the console (and Vim should not process it further).
    */
-  private fun navigatePythonConsoleHistory(editor: Editor, keyStroke: KeyStroke, e: AnActionEvent): Boolean {
+  private fun handlePythonConsoleKey(editor: Editor, keyStroke: KeyStroke, e: AnActionEvent): Boolean {
     if (keyStroke.modifiers != 0) return false
-    val next = when (keyStroke.keyCode) {
-      KeyEvent.VK_UP -> true
-      KeyEvent.VK_DOWN -> false
-      else -> return false
-    }
     if (!EditorHelper.isPythonConsole(editor)) return false
     val consoleView = LangDataKeys.CONSOLE_VIEW.getData(e.dataContext) as? LanguageConsoleView ?: return false
-    val controller = ConsoleHistoryController.getController(consoleView) ?: return false
-    val action = if (next) controller.historyNext else controller.historyPrev
+    val action = when (keyStroke.keyCode) {
+      KeyEvent.VK_UP -> ConsoleHistoryController.getController(consoleView)?.historyNext
+      KeyEvent.VK_DOWN -> ConsoleHistoryController.getController(consoleView)?.historyPrev
+      KeyEvent.VK_ENTER -> consoleExecuteAction(consoleView)
+      else -> null
+    } ?: return false
     return injector.actionExecutor.executeAction(editor.vim, IjNativeAction(action), e.dataContext.vim)
+  }
+
+  /**
+   * Finds the console's own execute action (bound to Enter). [ConsoleExecuteAction] is registered directly on the
+   * console editor component and carries a [ProxyShortcutSet] pointing at the `Console.Execute` keymap stub, so we
+   * match on that id.
+   */
+  private fun consoleExecuteAction(consoleView: LanguageConsoleView): AnAction? {
+    return ActionUtil.getActions(consoleView.consoleEditor.component)
+      .firstOrNull { (it.shortcutSet as? ProxyShortcutSet)?.actionId == CONSOLE_EXECUTE_ACTION_ID }
   }
 
   // There is a chance that we can use BGT, but we call for isCell inside the update.
@@ -321,6 +336,10 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
   }
 
   companion object {
+    // Keymap id of the console execute action (com.intellij.execution.console.ConsoleExecuteAction). The id constant
+    // itself is not public in the platform, so we mirror it here.
+    private const val CONSOLE_EXECUTE_ACTION_ID = "Console.Execute"
+
     @JvmField
     val VIM_ONLY_EDITOR_KEYS: Set<KeyStroke> =
       ImmutableSet.builder<KeyStroke>().addAll(getKeyStrokes(KeyEvent.VK_ENTER, 0))

--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -9,12 +9,15 @@ package com.maddyhome.idea.vim.action
 
 import com.google.common.collect.ImmutableSet
 import com.intellij.codeInsight.lookup.LookupManager
+import com.intellij.execution.console.ConsoleHistoryController
+import com.intellij.execution.console.LanguageConsoleView
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.AnActionWrapper
 import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.diagnostic.logger
@@ -46,6 +49,7 @@ import com.maddyhome.idea.vim.key.KeySource
 import com.maddyhome.idea.vim.key.ShortcutOwner
 import com.maddyhome.idea.vim.key.ShortcutOwnerInfo
 import com.maddyhome.idea.vim.listener.AceJumpService
+import com.maddyhome.idea.vim.newapi.IjNativeAction
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.newapi.initInjector
 import com.maddyhome.idea.vim.newapi.vim
@@ -78,6 +82,8 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
     val editor = getEditor(e)
     val keyStroke = getKeyStroke(e)
     if (editor != null && keyStroke != null) {
+      if (navigatePythonConsoleHistory(editor, keyStroke, e)) return
+
       val owner = VimPlugin.getKey().savedShortcutConflicts[keyStroke]
       if ((owner as? ShortcutOwnerInfo.AllModes)?.owner == ShortcutOwner.UNDEFINED) {
         VimPlugin.getNotifications(editor.project).notifyAboutShortcutConflict(keyStroke)
@@ -99,6 +105,29 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
         LOG.error(e)
       }
     }
+  }
+
+  /**
+   * In the Python console, Up/Down should navigate command history in every Vim mode, matching the console's native
+   * behaviour. History navigation is implemented by a per-console action created by [ConsoleHistoryController] (the
+   * global `Console.History.*` action ids are only keymap stubs with no behaviour), so we resolve the console via
+   * [LangDataKeys.CONSOLE_VIEW] and invoke the controller's real action directly. The platform binds Up to
+   * `historyNext` and Down to `historyPrev`.
+   *
+   * @return true if the keystroke was handled as history navigation (and Vim should not process it further).
+   */
+  private fun navigatePythonConsoleHistory(editor: Editor, keyStroke: KeyStroke, e: AnActionEvent): Boolean {
+    if (keyStroke.modifiers != 0) return false
+    val next = when (keyStroke.keyCode) {
+      KeyEvent.VK_UP -> true
+      KeyEvent.VK_DOWN -> false
+      else -> return false
+    }
+    if (!EditorHelper.isPythonConsole(editor)) return false
+    val consoleView = LangDataKeys.CONSOLE_VIEW.getData(e.dataContext) as? LanguageConsoleView ?: return false
+    val controller = ConsoleHistoryController.getController(consoleView) ?: return false
+    val action = if (next) controller.historyNext else controller.historyPrev
+    return injector.actionExecutor.executeAction(editor.vim, IjNativeAction(action), e.dataContext.vim)
   }
 
   // There is a chance that we can use BGT, but we call for isCell inside the update.
@@ -227,6 +256,8 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
       injector.globalIjOptions().ideavimsupport.contains(IjOptionConstants.ideavimsupport_dialog)
     return editor.isPrimaryEditor() ||
       EditorHelper.isFileEditor(editor) && !editor.vim.mode.inNormalMode ||
+      // The Python console has full Vim support, so Escape must leave Insert/Visual mode instead of defocusing it.
+      EditorHelper.isPythonConsole(editor) && !editor.vim.mode.inNormalMode ||
       ideaVimSupportDialog && !editor.vim.mode.inNormalMode
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -119,9 +119,9 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
    *
    * We invoke the real action instance via [ActionManager.tryToExecute], passing the original key event so the
    * action's own `update` decides enablement. This preserves the console's context-aware behaviour: Up/Down only
-   * navigate history at the first/last line (moving the caret otherwise), and Enter executes or inserts a newline for
-   * an incomplete block. If the console action is disabled for the current caret position, `tryToExecute` rejects and
-   * we return false so Vim performs the normal caret movement.
+   * navigate history at the first/last line (moving the caret otherwise), and in Insert mode Enter executes or inserts
+   * a newline for an incomplete block. If the console action is disabled for the current caret position,
+   * `tryToExecute` rejects and we return false so Vim performs the normal caret movement.
    *
    * @return true if the console handled the keystroke (and Vim should not process it further).
    */
@@ -132,7 +132,15 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
     val action = when (keyStroke.keyCode) {
       KeyEvent.VK_UP -> ConsoleHistoryController.getController(consoleView)?.historyNext
       KeyEvent.VK_DOWN -> ConsoleHistoryController.getController(consoleView)?.historyPrev
-      KeyEvent.VK_ENTER -> consoleExecuteAction(consoleView)
+      KeyEvent.VK_ENTER -> {
+        // in normal mode we move caret to end of command so it will always execute command
+        if (editor.vim.mode.inNormalMode) {
+          val consoleEditor = consoleView.consoleEditor
+          consoleEditor.caretModel.moveToOffset(consoleEditor.document.textLength)
+        }
+        consoleExecuteAction(consoleView)
+      }
+
       else -> null
     } ?: return false
     val result = ActionManager.getInstance()

--- a/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -107,9 +107,10 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
 
     if (EditorHelper.isPythonConsole(ijEditor)) {
       // The Python console handles the horizontal arrow keys (caret movement within the input) itself, so we must not
-      // let Vim claim those. Enter and Up/Down are intentionally left registered so Vim receives them:
-      // VimShortcutKeyAction redirects them to the console's own actions (execute / history navigation) in every mode.
-      // Every other key - including Escape to leave Insert mode - is registered so Vim works normally in the console.
+      // let Vim claim those. Enter and Up/Down are intentionally left registered so Vim receives them, and
+      // VimShortcutKeyAction redirects them to the console's own actions (execute / history navigation) with native,
+      // context-aware behaviour. Every other key - including Escape to leave Insert mode - is registered so Vim works
+      // normally in the console.
       final List<RequiredShortcut> filtered = new ArrayList<>();
       for (RequiredShortcut shortcut : shortcuts) {
         if (!isPythonConsoleReservedKey(shortcut.getKeyStroke())) filtered.add(shortcut);
@@ -125,8 +126,8 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
   /**
    * The Python console natively uses the horizontal arrow keys (caret movement within the input line), so Vim must
    * leave these unmodified keystrokes to the console rather than claiming them as shortcuts. Enter and Up/Down are
-   * deliberately NOT reserved here so Vim receives them and VimShortcutKeyAction can delegate to the console's own
-   * actions (execute / history navigation) in every mode.
+   * deliberately NOT reserved here so Vim receives them and VimShortcutKeyAction can redirect them to the console's
+   * own actions (execute / history navigation).
    */
   private static boolean isPythonConsoleReservedKey(@NotNull KeyStroke keyStroke) {
     if (keyStroke.getModifiers() != 0) return false;

--- a/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -106,10 +106,10 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
     Collection<RequiredShortcut> shortcuts = getRequiredShortcutKeys();
 
     if (EditorHelper.isPythonConsole(ijEditor)) {
-      // The Python console handles Enter (Console.Execute) and the horizontal arrow keys (caret movement within the
-      // input) itself, so we must not let Vim claim those. Up/Down are intentionally left registered so Vim receives
-      // them: VimShortcutKeyAction redirects them to the console's history navigation in every mode. Every other key
-      // - including Escape to leave Insert mode - is registered so Vim works normally in the console.
+      // The Python console handles the horizontal arrow keys (caret movement within the input) itself, so we must not
+      // let Vim claim those. Enter and Up/Down are intentionally left registered so Vim receives them:
+      // VimShortcutKeyAction redirects them to the console's own actions (execute / history navigation) in every mode.
+      // Every other key - including Escape to leave Insert mode - is registered so Vim works normally in the console.
       final List<RequiredShortcut> filtered = new ArrayList<>();
       for (RequiredShortcut shortcut : shortcuts) {
         if (!isPythonConsoleReservedKey(shortcut.getKeyStroke())) filtered.add(shortcut);
@@ -123,16 +123,15 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
   }
 
   /**
-   * The Python console natively uses Enter (execute) and the horizontal arrow keys (caret movement within the input
-   * line) for its own behaviour, so Vim must leave these unmodified keystrokes to the console rather than claiming
-   * them as shortcuts. Up/Down are deliberately excluded here so Vim receives them and VimShortcutKeyAction can
-   * delegate to the console's history navigation.
+   * The Python console natively uses the horizontal arrow keys (caret movement within the input line), so Vim must
+   * leave these unmodified keystrokes to the console rather than claiming them as shortcuts. Enter and Up/Down are
+   * deliberately NOT reserved here so Vim receives them and VimShortcutKeyAction can delegate to the console's own
+   * actions (execute / history navigation) in every mode.
    */
   private static boolean isPythonConsoleReservedKey(@NotNull KeyStroke keyStroke) {
     if (keyStroke.getModifiers() != 0) return false;
     final int code = keyStroke.getKeyCode();
-    return code == KeyEvent.VK_ENTER
-           || code == KeyEvent.VK_LEFT
+    return code == KeyEvent.VK_LEFT
            || code == KeyEvent.VK_RIGHT;
   }
 

--- a/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
+++ b/src/main/java/com/maddyhome/idea/vim/group/KeyGroup.java
@@ -103,12 +103,37 @@ public class KeyGroup extends VimKeyGroupBase implements PersistentStateComponen
     Editor ijEditor = ((IjVimEditor)editor).getEditor();
     if (EditorHelperRt.isIdeaVimDisabledHere(ijEditor)) return;
 
-    var vf = editor.getVirtualFile();
-    if (vf != null && vf.getPath().contains(EditorHelper.PYTHON_CONSOLE_FILE_NAME)) return;
+    Collection<RequiredShortcut> shortcuts = getRequiredShortcutKeys();
+
+    if (EditorHelper.isPythonConsole(ijEditor)) {
+      // The Python console handles Enter (Console.Execute) and the horizontal arrow keys (caret movement within the
+      // input) itself, so we must not let Vim claim those. Up/Down are intentionally left registered so Vim receives
+      // them: VimShortcutKeyAction redirects them to the console's history navigation in every mode. Every other key
+      // - including Escape to leave Insert mode - is registered so Vim works normally in the console.
+      final List<RequiredShortcut> filtered = new ArrayList<>();
+      for (RequiredShortcut shortcut : shortcuts) {
+        if (!isPythonConsoleReservedKey(shortcut.getKeyStroke())) filtered.add(shortcut);
+      }
+      shortcuts = filtered;
+    }
 
     EventFacade.getInstance().registerCustomShortcutSet(VimShortcutKeyAction.getInstance(),
-                                                        ShortcutHelper.toShortcutSet(getRequiredShortcutKeys()),
+                                                        ShortcutHelper.toShortcutSet(shortcuts),
                                                         ijEditor.getContentComponent());
+  }
+
+  /**
+   * The Python console natively uses Enter (execute) and the horizontal arrow keys (caret movement within the input
+   * line) for its own behaviour, so Vim must leave these unmodified keystrokes to the console rather than claiming
+   * them as shortcuts. Up/Down are deliberately excluded here so Vim receives them and VimShortcutKeyAction can
+   * delegate to the console's history navigation.
+   */
+  private static boolean isPythonConsoleReservedKey(@NotNull KeyStroke keyStroke) {
+    if (keyStroke.getModifiers() != 0) return false;
+    final int code = keyStroke.getKeyCode();
+    return code == KeyEvent.VK_ENTER
+           || code == KeyEvent.VK_LEFT
+           || code == KeyEvent.VK_RIGHT;
   }
 
   @Override

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -713,7 +713,8 @@ public class EditorHelper {
   }
 
   /**
-   * Checks if the editor is the Python console, so we can disable Vim features
+   * Checks if the editor is the Python console, so we can enable Vim features while still applying the special
+   * Enter/arrow key handling it requires.
    */
   public static boolean isPythonConsole(@NotNull Editor editor) {
     var file = EditorHelper.getVirtualFile(editor);

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
@@ -114,6 +114,7 @@ internal fun Editor.isTerminalEditor(): Boolean {
     && !EditorHelper.isFileEditor(this)
     && !EditorHelper.isDiffEditor(this)
     && !EditorHelper.isCommandHistoryWindow(this)
+    && !EditorHelper.isPythonConsole(this)
 }
 
 // Optimized clone of com.intellij.ide.ui.laf.darcula.DarculaUIUtil.isTableCellEditor

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
@@ -53,7 +53,7 @@ internal val Editor.isIdeaVimDisabledHere: Boolean
   }
 
 /**
- * Almost every non-file-based editor should not use Vim mode. These editors are debug watch, Python console, AI chats,
+ * Almost every non-file-based editor should not use Vim mode. These editors are debug watch, AI chats,
  *   and other fields that are smart.
  *
  * We may support IdeaVim in these editors, but this will require a focused work and a lot of testing.
@@ -61,19 +61,18 @@ internal val Editor.isIdeaVimDisabledHere: Boolean
  * Here are issues when non-file editors were supported:
  * AI Chat – VIM-3786
  * Debug evaluate console – VIM-3929
- * Python console - VIM-4172
  *
- * We do want to support Vim actions in some windows, such as the commit window, diff windows, and decompiled Java
- * files. We don't support the Python console.
+ * We do want to support Vim actions in some windows, such as the commit window, diff windows, decompiled Java
+ * files, and the Python console. Note that the Python console still needs special handling so it doesn't lose the
+ * Enter and arrow keys (see KeyGroup and ToolWindowNavEverywhere).
  */
 private fun Editor.isAllowedFileEditor(): Boolean {
-  if (EditorHelper.isPythonConsole(this)) return false
-
   return EditorHelper.isCommitWindowEditor(this)
     || EditorHelper.isKotlinClassDecompiledToJavaFile(this)
     || EditorHelper.isDiffEditor(this)
     || EditorHelper.isFileEditor(this)
     || EditorHelper.isCommandHistoryWindow(this)
+    || EditorHelper.isPythonConsole(this)
 }
 
 private fun ideaVimDisabledInDialog(ideaVimSupportValue: StringListOptionValue): Boolean {

--- a/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IJEditorFocusListener.kt
@@ -17,6 +17,7 @@ import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.common.EditorListener
+import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.inInsertMode
 import com.maddyhome.idea.vim.helper.isTerminalEditor
 import com.maddyhome.idea.vim.newapi.ij
@@ -76,6 +77,8 @@ class IJEditorFocusListener : EditorListener {
     }
     ApplicationManager.getApplication().invokeLater {
       if (ijEditor.isDisposed) return@invokeLater
+      // The Python console keeps the user's current Vim mode on focus, so don't force Insert mode here either.
+      if (EditorHelper.isPythonConsole(ijEditor)) return@invokeLater
       val consoleView: ConsoleViewImpl? = ijEditor.getUserData(ConsoleViewImpl.CONSOLE_VIEW_IN_EDITOR_VIEW)
       if (consoleView != null && consoleView.isRunning && !ijEditor.inInsertMode) {
         // Switch to Insert mode, but make sure we reset the editor to actually make it apply


### PR DESCRIPTION
Enable again vim in python console
most issues in that were related to way how we handle keys in python console
easiest way of fixing it was passing some keys directly to python console bypassing vim emulation layer: up/down/enter