### PR TITLE
VIM-2649 Move carret on enter after C-G/C-t

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExEntryPanel.kt
@@ -102,6 +102,10 @@ class ExEntryPanel private constructor() : JPanel(), VimCommandLine {
     return getLabel().startsWith(":")
   }
 
+  override fun getIncsearchMatchOffset(): Int {
+    return incsearchMatchOffset
+  }
+
   override fun showCompletionBar(completion: CommandLineCompletion) {
     if (ApplicationManager.getApplication().isUnitTestMode) return
     val editor = this.ijEditor ?: return

--- a/src/test/java/org/jetbrains/plugins/ideavim/group/search/IncsearchTests.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/group/search/IncsearchTests.kt
@@ -1151,4 +1151,180 @@ class IncsearchTests : VimTestCase() {
       """.trimMargin()
     )
   }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test enter after ctrl+g lands on the advanced match`() {
+    configureByText(
+      """
+        |${c}one
+        |two
+        |one
+        |two
+        |one
+      """.trimMargin(),
+    )
+    enterCommand("set incsearch")
+    // /two -> line 1, <C-G> -> line 3. Pressing <CR> must accept the advanced match, not jump back to line 1.
+    typeText("/", "two")
+    typeText("<C-G>")
+    typeText("<CR>")
+    assertState(
+      """
+        |one
+        |two
+        |one
+        |${c}two
+        |one
+      """.trimMargin()
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test enter after ctrl+t lands on the previous match`() {
+    configureByText(
+      """
+        |${c}one
+        |two
+        |one
+        |two
+        |one
+      """.trimMargin(),
+    )
+    enterCommand("set incsearch")
+    // /two -> line 1, <C-T> wraps backwards to line 3. Pressing <CR> must accept that match.
+    typeText("/", "two")
+    typeText("<C-T>")
+    typeText("<CR>")
+    assertState(
+      """
+        |one
+        |two
+        |one
+        |${c}two
+        |one
+      """.trimMargin()
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test enter after multiple ctrl+g lands on the correct match`() {
+    configureByText(
+      """
+        |${c}one
+        |two
+        |one
+        |two
+        |one
+        |two
+        |one
+      """.trimMargin(),
+    )
+    enterCommand("set incsearch")
+    // /two -> line 1, <C-G> -> line 3, <C-G> -> line 5. Pressing <CR> must accept the twice-advanced match.
+    typeText("/", "two")
+    typeText("<C-G>")
+    typeText("<C-G>")
+    typeText("<CR>")
+    assertState(
+      """
+        |one
+        |two
+        |one
+        |two
+        |one
+        |${c}two
+        |one
+      """.trimMargin()
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test enter after ctrl+g then ctrl+t lands on the first match`() {
+    configureByText(
+      """
+        |${c}one
+        |two
+        |one
+        |two
+        |one
+      """.trimMargin(),
+    )
+    enterCommand("set incsearch")
+    // /two -> line 1, <C-G> -> line 3, <C-T> -> back to line 1. Pressing <CR> must accept line 1.
+    typeText("/", "two")
+    typeText("<C-G>")
+    typeText("<C-T>")
+    typeText("<CR>")
+    assertState(
+      """
+        |one
+        |${c}two
+        |one
+        |two
+        |one
+      """.trimMargin()
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test enter after ctrl+g during backwards incsearch lands on the advanced match`() {
+    configureByText(
+      """
+        |one
+        |two
+        |one
+        |two
+        |${c}one
+      """.trimMargin(),
+    )
+    enterCommand("set incsearch")
+    // ?two -> line 3 (first match backwards), <C-G> -> next match, i.e. line 1. Pressing <CR> must accept line 1.
+    typeText("?", "two")
+    typeText("<C-G>")
+    typeText("<CR>")
+    assertState(
+      """
+        |one
+        |${c}two
+        |one
+        |two
+        |one
+      """.trimMargin()
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.OPTION)
+  @Test
+  fun `test enter after wrapping ctrl+t with nowrapscan leaves caret unmoved`() {
+    configureByText(
+      """
+        |${c}one
+        |two
+        |one
+        |two
+        |one
+      """.trimMargin(),
+    )
+    enterCommand("set incsearch nowrapscan")
+    // Known limitation: /two -> line 1, <C-T> would wrap backwards past the first match to line 3, which the preview
+    // shows (its match count wraps unconditionally). But on <CR> the search runs in the reverse direction, and with
+    // 'nowrapscan' it cannot wrap around, so it finds nothing and the caret is left where it started (line 0).
+    typeText("/", "two")
+    typeText("<C-T>")
+    typeText("<CR>")
+    assertState(
+      """
+        |${c}one
+        |two
+        |one
+        |two
+        |one
+      """.trimMargin()
+    )
+  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ProcessExEntryActions.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/ex/ProcessExEntryActions.kt
@@ -106,25 +106,15 @@ class ProcessSearchEntryAction(private val parentAction: ProcessExEntryAction) :
     operatorArguments: OperatorArguments,
   ): Motion {
     if (argument !is Argument.ExString) return Motion.Error
-    val offsetAndMotion = when (argument.label) {
-      '/' -> injector.searchGroup.processSearchCommand(
-        editor,
-        argument.string,
-        caret.offset,
-        operatorArguments.count1,
-        Direction.FORWARDS
-      )
+    val originalDirection = if (argument.label == '/') Direction.FORWARDS else Direction.BACKWARDS
 
-      '?' -> injector.searchGroup.processSearchCommand(
-        editor,
-        argument.string,
-        caret.offset,
-        operatorArguments.count1,
-        Direction.BACKWARDS
-      )
+    val effectiveCount = operatorArguments.count1 + argument.incSearchOffset
+    val direction = if (effectiveCount >= 1) originalDirection else originalDirection.reverse()
+    val count = if (effectiveCount >= 1) effectiveCount else 1 - effectiveCount
 
-      else -> throw ExException("Unexpected search label ${argument.label}")
-    }
+    val offsetAndMotion = injector.searchGroup.processSearchCommand(
+      editor, argument.string, caret.offset, count, direction
+    )
     // Vim doesn't treat not finding something as an error, although it might report either an error or warning message
     if (offsetAndMotion == null) return Motion.NoMotion
     parentAction.motionType = offsetAndMotion.second

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimCommandLine.kt
@@ -137,6 +137,8 @@ interface VimCommandLine {
    */
   fun advanceIncsearchMatch(next: Boolean) {}
 
+  fun getIncsearchMatchOffset(): Int = 0
+
   /**
    * TODO remove me, close is safer
    */

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/Argument.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/command/Argument.kt
@@ -27,7 +27,8 @@ sealed class Argument {
   class Character(val character: Char) : Argument()
 
   /** An argument representing the user's input from the Ex command line, typically a search string */
-  class ExString(val label: Char, val string: String, val processing: ((String) -> Unit)?) : Argument()
+  class ExString(val label: Char, val string: String, val incSearchOffset: Int, val processing: ((String) -> Unit)?) :
+    Argument()
 
   /**
    * Represents an argument that is a motion. Used by operator commands

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandKeyConsumer.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/key/consumers/CommandKeyConsumer.kt
@@ -150,9 +150,10 @@ internal class CommandKeyConsumer : KeyConsumer {
         val label = commandLine.getLabel()
         val text = commandLine.text
         val processing = commandLine.inputProcessing
+        val incSearchOffset = commandLine.getIncsearchMatchOffset()
         commandLine.close(refocusOwningEditor = true, resetCaret = true)
 
-        commandBuilder.addArgument(Argument.ExString(label[0], text, processing))
+        commandBuilder.addArgument(Argument.ExString(label[0], text, incSearchOffset, processing))
       }
     }
   }


### PR DESCRIPTION
during serach and moving through searches using C-G/C-T we didn't move caret to this search after enter