### PR TITLE
VIM-330 Add missing spellchecker methods

### DIFF
--- a/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
+++ b/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
@@ -209,6 +209,8 @@
     <applicationService serviceImplementation="com.maddyhome.idea.vim.ui.widgets.mode.ModeWidgetSettings"/>
     <applicationService serviceImplementation="com.maddyhome.idea.vim.group.IjStatisticsService"
                         serviceInterface="com.maddyhome.idea.vim.api.VimStatistics"/>
+    <applicationService serviceImplementation="com.maddyhome.idea.vim.group.IjSpellcheckerService"
+                        serviceInterface="com.maddyhome.idea.vim.api.SpellcheckerService"/>
     <applicationService serviceImplementation="com.maddyhome.idea.vim.vimscript.services.FunctionStorage"
                         serviceInterface="com.maddyhome.idea.vim.api.VimscriptFunctionService"/>
     <applicationService serviceImplementation="com.maddyhome.idea.vim.vimscript.Executor"

--- a/src/main/java/com/maddyhome/idea/vim/group/IjSpellcheckerService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjSpellcheckerService.kt
@@ -46,4 +46,12 @@ class IjSpellcheckerService : SpellcheckerService {
       .createPopup()
       .showInBestPositionFor(editor.ij)
   }
+
+  override fun removeWordFromDictionary(word: String, editor: VimEditor) {
+    val project = editor.ij.project ?: return
+    val manager = SpellCheckerManager.getInstance(project)
+    var dictionaryWords = manager.userDictionaryWords
+    dictionaryWords = dictionaryWords - word
+    manager.updateUserDictionary(dictionaryWords)
+  }
 }

--- a/src/main/java/com/maddyhome/idea/vim/group/IjSpellcheckerService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjSpellcheckerService.kt
@@ -8,9 +8,14 @@
 
 package com.maddyhome.idea.vim.group
 
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.spellchecker.SpellCheckerManager
+import com.maddyhome.idea.vim.api.MutableVimEditor
 import com.maddyhome.idea.vim.api.SpellcheckerService
+import com.maddyhome.idea.vim.api.VimCaret
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.newapi.ij
 
 class IjSpellcheckerService : SpellcheckerService {
@@ -18,5 +23,27 @@ class IjSpellcheckerService : SpellcheckerService {
     val project = editor.ij.project ?: return
     val manager = SpellCheckerManager.getInstance(project)
     manager.acceptWordAsCorrect(word, project = project)
+  }
+
+  override fun selectSuggestion(word: String, editor: VimEditor, caret: VimCaret) {
+    val project = editor.ij.project ?: return
+    val range = injector.searchHelper.findWordAtOrFollowingCursor(editor, caret, isBigWord = false) ?: return
+
+    val suggestions = SpellCheckerManager.getInstance(project).getSuggestions(word)
+    if (suggestions.isEmpty()) {
+      injector.messages.showMessage(editor, "No spelling suggestions for '$word'")
+      return
+    }
+
+    JBPopupFactory.getInstance()
+      .createPopupChooserBuilder(suggestions)
+      .setTitle("Change '$word' to")
+      .setItemChosenCallback { chosen ->
+        WriteCommandAction.runWriteCommandAction(project) {
+          (editor as MutableVimEditor).replaceString(range.startOffset, range.endOffset, chosen)
+        }
+      }
+      .createPopup()
+      .showInBestPositionFor(editor.ij)
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/group/IjSpellcheckerService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/IjSpellcheckerService.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.group
+
+import com.intellij.spellchecker.SpellCheckerManager
+import com.maddyhome.idea.vim.api.SpellcheckerService
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.newapi.ij
+
+class IjSpellcheckerService : SpellcheckerService {
+  override fun addWordToDictionary(word: String, editor: VimEditor) {
+    val project = editor.ij.project ?: return
+    val manager = SpellCheckerManager.getInstance(project)
+    manager.acceptWordAsCorrect(word, project = project)
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
@@ -18,6 +18,7 @@ import com.maddyhome.idea.vim.api.ExecutionContextManager
 import com.maddyhome.idea.vim.api.LocalOptionInitialisationScenario
 import com.maddyhome.idea.vim.api.NativeActionManager
 import com.maddyhome.idea.vim.api.SearchWindowGroup
+import com.maddyhome.idea.vim.api.SpellcheckerService
 import com.maddyhome.idea.vim.api.SystemInfoService
 import com.maddyhome.idea.vim.api.VimAbbreviationGroup
 import com.maddyhome.idea.vim.api.VimActionExecutor
@@ -190,6 +191,8 @@ internal class IjVimInjector : VimInjectorBase() {
   override val visualMotionGroup: VimVisualMotionGroup
     get() = service()
   override val statisticsService: VimStatistics
+    get() = service()
+  override val spellcheckerService: SpellcheckerService
     get() = service()
   override val commandGroup: VimCommandGroup
     get() = service()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -47,6 +47,10 @@
   <depends>com.intellij.modules.platform</depends>
   <resource-bundle>messages.IdeaVimBundle</resource-bundle>
 
+  <dependencies>
+    <module name="intellij.spellchecker"/>
+  </dependencies>
+
   <content>
     <module name="IdeaVIM.ideavim-common" loading="embedded"/>
     <module name="IdeaVIM.ideavim-frontend"/>

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/AddGoodWordToDictionaryActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/AddGoodWordToDictionaryActionTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action.motion.text
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.testFramework.replaceService
+import com.maddyhome.idea.vim.api.SpellcheckerService
+import com.maddyhome.idea.vim.api.VimEditor
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+
+/**
+ * Tests for the `zg` command (add the word under the cursor to the dictionary as a good word).
+ *
+ * `zg` is Vim's "good word" command: it takes the word under the caret and hands it to the IDE spellchecker so it is
+ * no longer reported as misspelled.
+ */
+@Suppress("SpellCheckingInspection")
+class AddGoodWordToDictionaryActionTest : VimTestCase() {
+
+  private class FakeSpellcheckerService : SpellcheckerService {
+    val addedWords = mutableListOf<String>()
+
+    override fun addWordToDictionary(word: String, editor: VimEditor) {
+      addedWords.add(word)
+    }
+  }
+
+  private lateinit var fakeSpellcheckerService: FakeSpellcheckerService
+
+  @BeforeEach
+  override fun setUp(testInfo: TestInfo) {
+    super.setUp(testInfo)
+    fakeSpellcheckerService = FakeSpellcheckerService()
+    ApplicationManager.getApplication()
+      .replaceService(SpellcheckerService::class.java, fakeSpellcheckerService, fixture.testRootDisposable)
+  }
+
+  @Test
+  fun `test add word under cursor to dictionary`() {
+    configureByText("I have a ${c}xqwzptu here")
+
+    typeText("zg")
+
+    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.addedWords)
+  }
+
+  @Test
+  fun `test add word to dictionary with caret in the middle of the word`() {
+    configureByText("Some qzw${c}xytp text")
+
+    typeText("zg")
+
+    assertEquals(listOf("qzwxytp"), fakeSpellcheckerService.addedWords, "the whole word under the cursor should be added, not just a fragment")
+  }
+
+  @Test
+  fun `test add word to dictionary with caret at the end of the word`() {
+    configureByText("Some vqxzpt${c}w text")
+
+    typeText("zg")
+
+    assertEquals(listOf("vqxzptw"), fakeSpellcheckerService.addedWords)
+  }
+
+  @Test
+  fun `test add word to dictionary does not change the buffer`() {
+    configureByText("I have a ${c}xqwzptu here")
+
+    typeText("zg")
+
+    assertState("I have a ${c}xqwzptu here")
+  }
+
+  @Test
+  fun `test only the word under the cursor is added`() {
+    configureByText("I have a ${c}xqwzptu and vqxzptw here")
+
+    typeText("zg")
+
+    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.addedWords, "only the word under the cursor should be added")
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/MotionMisspelledWordNextActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/MotionMisspelledWordNextActionTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action.motion.text
+
+import com.intellij.lang.LanguageAnnotators
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileTypes.PlainTextLanguage
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.spellchecker.SpellCheckerSeveritiesProvider
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the `]s` motion (jump to the next misspelled word).
+ *
+ * The motion finds the next word marked with a [SpellCheckerSeveritiesProvider.TYPO] highlight. In a running IDE
+ * those highlights are produced by the spellchecker inspection, but that inspection's implementation lives in a
+ * plugin that isn't on the test classpath. To keep the tests deterministic and independent of any dictionary, we
+ * register a small annotator that marks a fixed set of "misspelled" words with TYPO severity, then force a
+ * highlighting pass before running the motion. This exercises the exact same code path the real motion uses.
+ */
+@Suppress("SpellCheckingInspection", "RemoveCurlyBracesFromTemplate")
+class MotionMisspelledWordNextActionTest : VimTestCase() {
+
+  private class TypoAnnotator : Annotator {
+    private val misspelledWords = setOf("recieve", "teh", "mispell", "typpo", "wolrd")
+
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+      if (element !is PsiFile) return
+      Regex("""\w+""").findAll(element.text).forEach { match ->
+        if (match.value in misspelledWords) {
+          holder.newSilentAnnotation(SpellCheckerSeveritiesProvider.TYPO)
+            .range(TextRange(match.range.first, match.range.last + 1))
+            .create()
+        }
+      }
+    }
+  }
+
+  private fun markTypos(@Suppress("UNUSED_PARAMETER") editor: Editor) {
+    LanguageAnnotators.INSTANCE.addExplicitExtension(
+      PlainTextLanguage.INSTANCE,
+      TypoAnnotator(),
+      fixture.testRootDisposable,
+    )
+    fixture.doHighlighting()
+  }
+
+  @Test
+  fun `test move to next misspelled word`() {
+    doTest(
+      "]s",
+      "${c}I recieve teh mispell here",
+      "I ${c}recieve teh mispell here",
+      afterEditorInitialized = ::markTypos,
+    )
+  }
+
+  @Test
+  fun `test move to next misspelled word from within a misspelled word`() {
+    doTest(
+      "]s",
+      "I rec${c}ieve teh mispell here",
+      "I recieve ${c}teh mispell here",
+      afterEditorInitialized = ::markTypos,
+    )
+  }
+
+  @Test
+  fun `test move to next misspelled word with count`() {
+    doTest(
+      "2]s",
+      "${c}I recieve teh mispell here",
+      "I recieve ${c}teh mispell here",
+      afterEditorInitialized = ::markTypos,
+    )
+  }
+
+  @Test
+  fun `test count larger than remaining misspelled words stops at last`() {
+    doTest(
+      "9]s",
+      "${c}I recieve teh mispell here",
+      "I recieve teh ${c}mispell here",
+      afterEditorInitialized = ::markTypos,
+    )
+  }
+
+  @Test
+  fun `test move to next misspelled word across lines`() {
+    doTest(
+      "]s",
+      """
+        |${c}This line is fine
+        |But this one has a typpo
+      """.trimMargin(),
+      """
+        |This line is fine
+        |But this one has a ${c}typpo
+      """.trimMargin(),
+      afterEditorInitialized = ::markTypos,
+    )
+  }
+
+  @Test
+  fun `test no motion when no misspelled words after caret`() {
+    doTest(
+      "]s",
+      "I recieve teh mispell ${c}here",
+      "I recieve teh mispell ${c}here",
+      afterEditorInitialized = ::markTypos,
+    )
+  }
+
+  @Test
+  fun `test no motion when text has no misspelled words`() {
+    doTest(
+      "]s",
+      "${c}the quick brown fox",
+      "${c}the quick brown fox",
+      afterEditorInitialized = ::markTypos,
+    )
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/RemoveWordFromDictionaryActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/RemoveWordFromDictionaryActionTest.kt
@@ -20,25 +20,22 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 
 /**
- * Tests for the `zg` command (add the word under the cursor to the dictionary as a good word).
- *
- * `zg` is Vim's "good word" command: it takes the word under the caret and hands it to the IDE spellchecker so it is
- * no longer reported as misspelled.
+ * Tests for the `zw` command (remove the word under the cursor from the dictionary, marking it as spelled wrong).
  */
 @Suppress("SpellCheckingInspection")
-class AddGoodWordToDictionaryActionTest : VimTestCase() {
+class RemoveWordFromDictionaryActionTest : VimTestCase() {
 
   private class FakeSpellcheckerService : SpellcheckerService {
-    val addedWords = mutableListOf<String>()
+    val removedWords = mutableListOf<String>()
 
     override fun addWordToDictionary(word: String, editor: VimEditor) {
-      addedWords.add(word)
     }
 
     override fun selectSuggestion(word: String, editor: VimEditor, caret: VimCaret) {
     }
 
     override fun removeWordFromDictionary(word: String, editor: VimEditor) {
+      removedWords.add(word)
     }
   }
 
@@ -53,47 +50,47 @@ class AddGoodWordToDictionaryActionTest : VimTestCase() {
   }
 
   @Test
-  fun `test add word under cursor to dictionary`() {
+  fun `test remove word under cursor from dictionary`() {
     configureByText("I have a ${c}xqwzptu here")
 
-    typeText("zg")
+    typeText("zw")
 
-    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.addedWords)
+    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.removedWords)
   }
 
   @Test
-  fun `test add word to dictionary with caret in the middle of the word`() {
+  fun `test remove word from dictionary with caret in the middle of the word`() {
     configureByText("Some qzw${c}xytp text")
 
-    typeText("zg")
+    typeText("zw")
 
-    assertEquals(listOf("qzwxytp"), fakeSpellcheckerService.addedWords, "the whole word under the cursor should be added, not just a fragment")
+    assertEquals(listOf("qzwxytp"), fakeSpellcheckerService.removedWords, "the whole word under the cursor should be removed, not just a fragment")
   }
 
   @Test
-  fun `test add word to dictionary with caret at the end of the word`() {
+  fun `test remove word from dictionary with caret at the end of the word`() {
     configureByText("Some vqxzpt${c}w text")
 
-    typeText("zg")
+    typeText("zw")
 
-    assertEquals(listOf("vqxzptw"), fakeSpellcheckerService.addedWords)
+    assertEquals(listOf("vqxzptw"), fakeSpellcheckerService.removedWords)
   }
 
   @Test
-  fun `test add word to dictionary does not change the buffer`() {
+  fun `test remove word from dictionary does not change the buffer`() {
     configureByText("I have a ${c}xqwzptu here")
 
-    typeText("zg")
+    typeText("zw")
 
     assertState("I have a ${c}xqwzptu here")
   }
 
   @Test
-  fun `test only the word under the cursor is added`() {
+  fun `test only the word under the cursor is removed`() {
     configureByText("I have a ${c}xqwzptu and vqxzptw here")
 
-    typeText("zg")
+    typeText("zw")
 
-    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.addedWords, "only the word under the cursor should be added")
+    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.removedWords, "only the word under the cursor should be removed")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/SelectMisspelledWordSuggestionActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/SelectMisspelledWordSuggestionActionTest.kt
@@ -20,22 +20,25 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 
 /**
- * Tests for the `zg` command (add the word under the cursor to the dictionary as a good word).
+ * Tests for the `z=` command (offer suggested replacements for the misspelled word under the cursor).
  *
- * `zg` is Vim's "good word" command: it takes the word under the caret and hands it to the IDE spellchecker so it is
- * no longer reported as misspelled.
+ * `z=` is Vim's "spelling suggestions" command: it takes the word under the caret and asks the IDE spellchecker for
+ * replacement suggestions, which are then offered to the user. Gathering and presenting suggestions is host-specific
+ * (see [SpellcheckerService], backed by `SpellCheckerManager`); here we stub that boundary with a fake so we can verify
+ * - fast and without the IDE's spellchecker engine - that `z=` identifies the correct word under the caret and asks
+ * for suggestions for it.
  */
 @Suppress("SpellCheckingInspection")
-class AddGoodWordToDictionaryActionTest : VimTestCase() {
+class SelectMisspelledWordSuggestionActionTest : VimTestCase() {
 
   private class FakeSpellcheckerService : SpellcheckerService {
-    val addedWords = mutableListOf<String>()
+    val suggestionRequests = mutableListOf<String>()
 
     override fun addWordToDictionary(word: String, editor: VimEditor) {
-      addedWords.add(word)
     }
 
     override fun selectSuggestion(word: String, editor: VimEditor, caret: VimCaret) {
+      suggestionRequests.add(word)
     }
   }
 
@@ -50,47 +53,47 @@ class AddGoodWordToDictionaryActionTest : VimTestCase() {
   }
 
   @Test
-  fun `test add word under cursor to dictionary`() {
+  fun `test suggest replacements for word under cursor`() {
     configureByText("I have a ${c}xqwzptu here")
 
-    typeText("zg")
+    typeText("z=")
 
-    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.addedWords)
+    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.suggestionRequests)
   }
 
   @Test
-  fun `test add word to dictionary with caret in the middle of the word`() {
+  fun `test suggest replacements with caret in the middle of the word`() {
     configureByText("Some qzw${c}xytp text")
 
-    typeText("zg")
+    typeText("z=")
 
-    assertEquals(listOf("qzwxytp"), fakeSpellcheckerService.addedWords, "the whole word under the cursor should be added, not just a fragment")
+    assertEquals(listOf("qzwxytp"), fakeSpellcheckerService.suggestionRequests, "suggestions should be requested for the whole word under the cursor, not just a fragment")
   }
 
   @Test
-  fun `test add word to dictionary with caret at the end of the word`() {
+  fun `test suggest replacements with caret at the end of the word`() {
     configureByText("Some vqxzpt${c}w text")
 
-    typeText("zg")
+    typeText("z=")
 
-    assertEquals(listOf("vqxzptw"), fakeSpellcheckerService.addedWords)
+    assertEquals(listOf("vqxzptw"), fakeSpellcheckerService.suggestionRequests)
   }
 
   @Test
-  fun `test add word to dictionary does not change the buffer`() {
+  fun `test suggest replacements does not change the buffer`() {
     configureByText("I have a ${c}xqwzptu here")
 
-    typeText("zg")
+    typeText("z=")
 
     assertState("I have a ${c}xqwzptu here")
   }
 
   @Test
-  fun `test only the word under the cursor is added`() {
+  fun `test suggestions are requested only for the word under the cursor`() {
     configureByText("I have a ${c}xqwzptu and vqxzptw here")
 
-    typeText("zg")
+    typeText("z=")
 
-    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.addedWords, "only the word under the cursor should be added")
+    assertEquals(listOf("xqwzptu"), fakeSpellcheckerService.suggestionRequests, "suggestions should be requested only for the word under the cursor")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/SelectMisspelledWordSuggestionActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/text/SelectMisspelledWordSuggestionActionTest.kt
@@ -40,6 +40,9 @@ class SelectMisspelledWordSuggestionActionTest : VimTestCase() {
     override fun selectSuggestion(word: String, editor: VimEditor, caret: VimCaret) {
       suggestionRequests.add(word)
     }
+
+    override fun removeWordFromDictionary(word: String, editor: VimEditor) {
+    }
   }
 
   private lateinit var fakeSpellcheckerService: FakeSpellcheckerService

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/text/AddMisspelledWordAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/text/AddMisspelledWordAction.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.action.motion.text
+
+import com.intellij.vim.annotations.CommandOrMotion
+import com.intellij.vim.annotations.Mode
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimCaret
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.getText
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.Command.Type
+import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.handler.VimActionHandler
+
+@CommandOrMotion(keys = ["zg"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
+class AddMisspelledWordAction : VimActionHandler.ForEachCaret() {
+
+  override fun execute(
+    editor: VimEditor,
+    caret: VimCaret,
+    context: ExecutionContext,
+    cmd: Command,
+    operatorArguments: OperatorArguments,
+  ): Boolean {
+    val range = injector.searchHelper.findWordAtOrFollowingCursor(editor, caret, isBigWord = false)
+      ?: return false
+    val word = editor.getText(range.startOffset, range.endOffset)
+    injector.spellcheckerService.addWordToDictionary(word, editor)
+    return true
+  }
+
+  override val type: Type
+    get() = Type.OTHER_READONLY
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/text/RemoveMisspelledWordAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/text/RemoveMisspelledWordAction.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.action.motion.text
+
+import com.intellij.vim.annotations.CommandOrMotion
+import com.intellij.vim.annotations.Mode
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimCaret
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.getText
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.Command.Type
+import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.handler.VimActionHandler
+
+@CommandOrMotion(keys = ["zw"], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
+class RemoveMisspelledWordAction : VimActionHandler.ForEachCaret() {
+
+  override fun execute(
+    editor: VimEditor,
+    caret: VimCaret,
+    context: ExecutionContext,
+    cmd: Command,
+    operatorArguments: OperatorArguments,
+  ): Boolean {
+    val range = injector.searchHelper.findWordAtOrFollowingCursor(editor, caret, isBigWord = false)
+      ?: return false
+    val word = editor.getText(range.startOffset, range.endOffset)
+    injector.spellcheckerService.removeWordFromDictionary(word, editor)
+    return true
+  }
+
+  override val type: Type
+    get() = Type.OTHER_READONLY
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/text/SelectMisspelledWordSuggestionAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/motion/text/SelectMisspelledWordSuggestionAction.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.action.motion.text
+
+import com.intellij.vim.annotations.CommandOrMotion
+import com.intellij.vim.annotations.Mode
+import com.maddyhome.idea.vim.api.ExecutionContext
+import com.maddyhome.idea.vim.api.VimCaret
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.getText
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.command.Command
+import com.maddyhome.idea.vim.command.Command.Type
+import com.maddyhome.idea.vim.command.OperatorArguments
+import com.maddyhome.idea.vim.handler.VimActionHandler
+
+@CommandOrMotion(keys = ["z="], modes = [Mode.NORMAL, Mode.VISUAL, Mode.OP_PENDING])
+class SelectMisspelledWordSuggestionAction : VimActionHandler.ForEachCaret() {
+
+  override fun execute(
+    editor: VimEditor,
+    caret: VimCaret,
+    context: ExecutionContext,
+    cmd: Command,
+    operatorArguments: OperatorArguments,
+  ): Boolean {
+    val range = injector.searchHelper.findWordAtOrFollowingCursor(editor, caret, isBigWord = false) ?: return false
+    val word = editor.getText(range.startOffset, range.endOffset)
+    if (word.isEmpty()) return false
+    injector.spellcheckerService.selectSuggestion(word, editor, caret)
+    return true
+  }
+
+  override val type: Type
+    get() = Type.OTHER_WRITABLE
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/SpellcheckerService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/SpellcheckerService.kt
@@ -11,4 +11,6 @@ package com.maddyhome.idea.vim.api
 interface SpellcheckerService {
 
   fun addWordToDictionary(word: String, editor: VimEditor)
+
+  fun selectSuggestion(word: String, editor: VimEditor, caret: VimCaret)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/SpellcheckerService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/SpellcheckerService.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.api
+
+interface SpellcheckerService {
+
+  fun addWordToDictionary(word: String, editor: VimEditor)
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/SpellcheckerService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/SpellcheckerService.kt
@@ -13,4 +13,6 @@ interface SpellcheckerService {
   fun addWordToDictionary(word: String, editor: VimEditor)
 
   fun selectSuggestion(word: String, editor: VimEditor, caret: VimCaret)
+
+  fun removeWordFromDictionary(word: String, editor: VimEditor)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
@@ -118,6 +118,8 @@ interface VimInjector {
 
   val statisticsService: VimStatistics
 
+  val spellcheckerService: SpellcheckerService
+
   val put: VimPut
 
   val window: VimWindowGroup

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -2230,6 +2230,11 @@
     "modes": "NXO"
   },
   {
+    "keys": "z=",
+    "class": "com.maddyhome.idea.vim.action.motion.text.SelectMisspelledWordSuggestionAction",
+    "modes": "NXO"
+  },
+  {
     "keys": "zA",
     "class": "com.maddyhome.idea.vim.action.fold.VimToggleRegionRecursively",
     "modes": "NX"

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -2310,6 +2310,11 @@
     "modes": "X"
   },
   {
+    "keys": "zg",
+    "class": "com.maddyhome.idea.vim.action.motion.text.AddMisspelledWordAction",
+    "modes": "NXO"
+  },
+  {
     "keys": "zh",
     "class": "com.maddyhome.idea.vim.action.motion.scroll.MotionScrollColumnRightAction",
     "modes": "NXO"

--- a/vim-engine/src/main/resources/ksp-generated/engine_commands.json
+++ b/vim-engine/src/main/resources/ksp-generated/engine_commands.json
@@ -2365,6 +2365,11 @@
     "modes": "NXO"
   },
   {
+    "keys": "zw",
+    "class": "com.maddyhome.idea.vim.action.motion.text.RemoveMisspelledWordAction",
+    "modes": "NXO"
+  },
+  {
     "keys": "zz",
     "class": "com.maddyhome.idea.vim.action.motion.scroll.MotionScrollMiddleScreenLineAction",
     "modes": "NXO"


### PR DESCRIPTION
- zg - Add word under the cursor to dictionary as a good word.
- z= - For mispelled word under the cursor, offer suggested replacements.
- zw - Remove word under the cursor from dictionary. (It is spelled wrong.)