### PR TITLE
VIM-4301 fix native undo action

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/IdeaSpecifics.kt
@@ -208,7 +208,13 @@ internal object IdeaSpecifics {
       }
       //endregion
 
-      if (!isVimAction(action)) {
+      // Do not normalize carets after native undo/redo. The platform undo (UndoRedo.execute) treats caret movement as a
+      // separate undo step by default ('ide.undo.transparent.caret.movement' = false): before reverting the document it
+      // checks whether the caret matches the state recorded with the edit, and if not, it only restores that caret and
+      // consumes the keypress. Moving the caret here, in afterActionPerformed of the undo action itself, keeps the caret
+      // perpetually mismatched, so every subsequent Ctrl+Z is spent restoring the caret and the text is never reverted
+      // (VIM-4287). Vim's own `u` is unaffected because it calls UndoManager directly with that registry flag forced on.
+      if (!isVimAction(action) && !isUndoRedoAction(ActionManager.getInstance().getId(action))) {
         normalizeCarets(editor)
       }
 
@@ -238,6 +244,9 @@ internal object IdeaSpecifics {
 
     private fun isGotoAction(actionId: String?): Boolean =
       actionId == IdeActions.ACTION_GOTO_BACK || actionId == IdeActions.ACTION_GOTO_FORWARD
+
+    private fun isUndoRedoAction(actionId: String?): Boolean =
+      actionId == IdeActions.ACTION_UNDO || actionId == IdeActions.ACTION_REDO
 
     private fun saveJumpBeforeGoto(event: AnActionEvent, editor: Editor?) {
       val project = event.dataContext.getData(CommonDataKeys.PROJECT)

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/NativeUndoAfterChangeTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/NativeUndoAfterChangeTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action.change
+
+import com.intellij.idea.TestFor
+import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.openapi.application.ApplicationManager
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+/**
+ * Native IDE undo (Ctrl+Z, the `$Undo` action) after a `S`/`C` change must restore the original content.
+ *
+ * Regression from VIM-4245, which normalized carets after every non-IdeaVim IDE action. That normalization ran in
+ * `afterActionPerformed` of the undo action itself and moved the caret off the position recorded with the edit. The
+ * platform undo treats caret movement as a separate undo step by default, so every Ctrl+Z was consumed restoring the
+ * caret and the text was never reverted (VIM-4287).
+ */
+class NativeUndoAfterChangeTest : VimTestCase() {
+  @Test
+  @TestFor(issues = ["VIM-4287"])
+  @TestWithoutNeovim(SkipNeovimReason.ACTION_COMMAND)
+  fun `native undo after S restores original line`() {
+    configureByText("Lorem ${c}ipsum dolor sit amet")
+    typeText("S", "replacement", "<Esc>")
+    assertState("replacemen${c}t")
+
+    performNativeUndo("Lorem ipsum dolor sit amet")
+
+    assertState("Lorem ${c}ipsum dolor sit amet")
+  }
+
+  @Test
+  @TestFor(issues = ["VIM-4287"])
+  @TestWithoutNeovim(SkipNeovimReason.ACTION_COMMAND)
+  fun `native undo after C restores original text to end of line`() {
+    configureByText("Lorem ${c}ipsum dolor sit amet")
+    typeText("C", "replacement", "<Esc>")
+    assertState("Lorem replacemen${c}t")
+
+    performNativeUndo("Lorem ipsum dolor sit amet")
+
+    assertState("Lorem ${c}ipsum dolor sit amet")
+  }
+
+  /**
+   * Presses native undo (`$Undo`) until the document is restored to [expected], dispatched through the action system so
+   * [com.maddyhome.idea.vim.listener.IdeaSpecifics.VimActionListener] fires, exactly like a real Ctrl+Z. The guard
+   * bounds the loop: with the regression present the text is never reverted, so the loop must terminate on its own and
+   * let the assertion fail rather than hang. It also stops as soon as the text matches, so it never over-undoes into
+   * the file-setup commands.
+   */
+  private fun performNativeUndo(expected: String) {
+    ApplicationManager.getApplication().invokeAndWait {
+      var guard = 0
+      while (fixture.editor.document.text != expected && guard++ < 20) {
+        fixture.performEditorAction(IdeActions.ACTION_UNDO)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Do not normalize carets after native undo/redo. The platform undo (UndoRedo.execute) treats caret movement as a separate undo step by default