### PR TITLE
VIM-4302 initlize vim editor for run in python console

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -48,6 +48,7 @@ public class EditorHelper {
   // Code Vision)
   public static final String PYTHON_CONSOLE_FILE_NAME = "Python Console.py";
   public static final String PYTHON_CONSOLE_TOOL_WINDOW_ID = "Python Console";
+  private static final String PYDEV_CONSOLE_KEY_NAME = "PYDEV_CONSOLE_KEY";
 
   private static final int BLOCK_INLAY_MAX_LINE_HEIGHT = 3;
 
@@ -359,7 +360,8 @@ public class EditorHelper {
     final int screenHeight = visibleArea.height;
     final int lineHeight = editor.getLineHeight();
 
-    final int offset = y - getStickyLinesPanelHeight(editor) - ((screenHeight - lineHeight) / lineHeight / 2 * lineHeight);
+    final int offset =
+      y - getStickyLinesPanelHeight(editor) - ((screenHeight - lineHeight) / lineHeight / 2 * lineHeight);
     final @NotNull VimEditor editor1 = new IjVimEditor(editor);
     final int lastVisualLine = EngineEditorHelperKt.getVisualLineCount(editor1) - 1;
     final int offsetForLastLineAtBottom = getOffsetToScrollVisualLineToBottomOfScreen(editor, lastVisualLine);
@@ -399,8 +401,9 @@ public class EditorHelper {
     final int lineHeight = editor.getLineHeight();
     // Use the full viewport height for bottom placement. Sticky lines reduce the content area at the top, but the
     // bottom of the window is still the physical bottom of the viewport (minus ex command line and scrollbar).
-    final int screenHeight = editor.getScrollingModel().getVisibleAreaOnScrollingFinished().height
-      - getExEntryHeight() - getHorizontalScrollbarHeight(editor);
+    final int screenHeight = editor.getScrollingModel().getVisibleAreaOnScrollingFinished().height -
+                             getExEntryHeight() -
+                             getHorizontalScrollbarHeight(editor);
     final int inlayHeight = EditorUtil.getInlaysHeight(editor, nonNormalisedVisualLine, false);
     final int maxInlayHeight = BLOCK_INLAY_MAX_LINE_HEIGHT * lineHeight;
     final int y = editor.visualLineToY(nonNormalisedVisualLine) + lineHeight + min(inlayHeight, maxInlayHeight);
@@ -416,8 +419,7 @@ public class EditorHelper {
 
   private static int getExEntryHeight() {
     Integer height = injector.getCommandLine().getActiveCommandLineHeight();
-    if (height != null)
-      return height;
+    if (height != null) return height;
     height = injector.getOutputPanel().getActiveOutputPanelHeight();
     return height != null ? height : 0;
   }
@@ -715,13 +717,29 @@ public class EditorHelper {
   /**
    * Checks if the editor is the Python console, so we can enable Vim features while still applying the special
    * Enter/arrow key handling it requires.
+   * <p>
+   * The console's virtual file is a light file named after the console title. That title is only "Python Console" for
+   * consoles started from the tool window - "Run file in Python Console" names the console after the run
+   * configuration, and the title is localised. So we primarily look for the marker the Python plugin puts on the
+   * console's virtual file ({@code PythonConsoleView.CONSOLE_KEY}), and fall back to the name.
+   * <p>
+   * The name check is still needed: the console's input editor is created inside {@code LanguageConsoleImpl}'s
+   * constructor, i.e. before {@code PythonConsoleView} gets a chance to set the marker. See
+   * {@code VimEditorFactoryListener.scheduleDeferredInitialisation} for how consoles that aren't recognisable at
+   * creation time are picked up.
    */
   public static boolean isPythonConsole(@NotNull Editor editor) {
     var file = EditorHelper.getVirtualFile(editor);
     if (file == null) return false;
+    if (isMarkedAsPythonConsole(file)) return true;
     // In split mode, the projected VirtualFile may have a different getName() result,
     // so we also check getPath() to reliably detect the Python console.
     return file.getName().contains(PYTHON_CONSOLE_FILE_NAME) || file.getPath().contains(PYTHON_CONSOLE_FILE_NAME);
+  }
+
+  private static boolean isMarkedAsPythonConsole(@NotNull VirtualFile file) {
+    @SuppressWarnings("deprecation") Key<?> consoleKey = Key.findKeyByName(PYDEV_CONSOLE_KEY_NAME);
+    return consoleKey != null && Boolean.TRUE.equals(file.getUserData(consoleKey));
   }
 
   /**
@@ -737,17 +755,17 @@ public class EditorHelper {
   /**
    * Checks if the editor is a Kotlin class file decompiled to a Java file, so we can enable Vim features
    * <p>
-   *   The platform changed the implementation of decompiling a Kotlin .class file to Java in 2026.2. Previously, it
-   *   used a dummy virtual file implementation. Now it uses an instance of {@link LightVirtualFile}. Typically, this
-   *   means an in-memory file that we don't want to have Vim features for, but in this case, we do.
+   * The platform changed the implementation of decompiling a Kotlin .class file to Java in 2026.2. Previously, it
+   * used a dummy virtual file implementation. Now it uses an instance of {@link LightVirtualFile}. Typically, this
+   * means an in-memory file that we don't want to have Vim features for, but in this case, we do.
    * </p>
    * <p>
-   *   To test, open a .class file generated from a Kotlin file. Then use the "Decompile to Java" action to create a
-   *   separate (in-memory) `.decompiled.java` file. Java-based .class files are decompiled directly in the document for
-   *   the .class file, so the editor is always backed by a valid file.
+   * To test, open a .class file generated from a Kotlin file. Then use the "Decompile to Java" action to create a
+   * separate (in-memory) `.decompiled.java` file. Java-based .class files are decompiled directly in the document for
+   * the .class file, so the editor is always backed by a valid file.
    * </p>
    * <p>
-   *   Perhaps a future implementation would have an allow-list for {@link VirtualFile#getFileType()} and allow "JAVA"?
+   * Perhaps a future implementation would have an allow-list for {@link VirtualFile#getFileType()} and allow "JAVA"?
    * </p>
    */
   public static boolean isKotlinClassDecompiledToJavaFile(@NotNull Editor editor) {

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -61,6 +61,7 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.testFramework.LightVirtualFile
 import com.intellij.util.ExceptionUtil
 import com.intellij.util.SlowOperations
 import com.maddyhome.idea.vim.EventFacade
@@ -522,8 +523,13 @@ object VimListenerManager {
 
     private val openingEditorKey: Key<OpeningEditor> = Key("IdeaVim::OpeningEditor")
 
+    private const val PYTHON_EXTENSION = "py"
+
     override fun editorCreated(event: EditorFactoryEvent) {
-      if (vimDisabled(event.editor)) return
+      if (vimDisabled(event.editor)) {
+        scheduleDeferredInitialisation(event.editor)
+        return
+      }
 
       // This callback is called when an editor is created, but we cannot completely rely on it to initialise options.
       // We can find the currently selected editor, which we can use as the opening editor, and we're given the new
@@ -539,19 +545,8 @@ object VimListenerManager {
           event.editor
         )
       ) {
-        // If we don't have an opening editor, use the fallback window. If it's the first time, use the FALLBACK
-        // scenario and make a full copy to get everything set in `~/.ideavimrc`. If it's not, then use EDIT, as if we
-        // still had a current window and we are just replacing the buffer. If we do have an opening window, it's NEW.
         // Preview and reused tabs are handled below
-        val scenario = when {
-          openingEditor == null && !firstEditorInitialised -> LocalOptionInitialisationScenario.FALLBACK
-          openingEditor == null -> LocalOptionInitialisationScenario.EDIT
-          else -> LocalOptionInitialisationScenario.NEW
-        }
-        SlowOperations.knownIssue("VIM-3648").use {
-          EditorListeners.add(event.editor, openingEditor?.vim ?: injector.fallbackWindow, scenario)
-        }
-        firstEditorInitialised = true
+        initialiseFromOpeningEditor(event.editor, openingEditor)
       } else {
         // We've got a virtual file, so FileOpenedSyncListener will be called. Save data
         val project = openingEditor.project ?: return
@@ -577,6 +572,49 @@ object VimListenerManager {
           openingEditorKey,
           OpeningEditor(openingEditor, owningEditorWindow, isPreview, canBeReused)
         )
+      }
+    }
+
+    private fun initialiseFromOpeningEditor(editor: Editor, openingEditor: Editor?) {
+      // If we don't have an opening editor, use the fallback window. If it's the first time, use the FALLBACK scenario
+      // and make a full copy to get everything set in `~/.ideavimrc`. If it's not, then use EDIT, as if we still had a
+      // current window and we are just replacing the buffer. If we do have an opening window, it's NEW.
+      val scenario = when {
+        openingEditor == null && !firstEditorInitialised -> LocalOptionInitialisationScenario.FALLBACK
+        openingEditor == null -> LocalOptionInitialisationScenario.EDIT
+        else -> LocalOptionInitialisationScenario.NEW
+      }
+      SlowOperations.knownIssue("VIM-3648").use {
+        EditorListeners.add(editor, openingEditor?.vim ?: injector.fallbackWindow, scenario)
+      }
+      firstEditorInitialised = true
+    }
+
+    /**
+     * Retries initialisation for editors that can only be recognised as supported after they've been created.
+     *
+     * The Python console's input editor is created inside `LanguageConsoleImpl`'s constructor, before
+     * `PythonConsoleView` marks the console's virtual file with `PYDEV_CONSOLE_KEY`. Consoles started by
+     * "Run file in Python Console" are named after the run configuration rather than "Python Console" (see
+     * `PydevConsoleRunnerFactory.createConsoleRunnerWithFile`), so at [editorCreated] time there is nothing to identify
+     * them by and [vimDisabled] rejects them. The console is fully constructed within a single EDT runnable, so
+     * re-checking in `invokeLater` sees the marker.
+     *
+     * Only light Python files are considered, to keep this from queueing work for every unsupported editor. Anything
+     * that still isn't supported on the second look (e.g. a Python code fragment in the debugger's evaluate window) is
+     * dropped, exactly as before.
+     */
+    private fun scheduleDeferredInitialisation(editor: Editor) {
+      if (editor.isDisposed) return
+      val file = EditorHelper.getVirtualFile(editor) ?: return
+      if (file !is LightVirtualFile || file.extension != PYTHON_EXTENSION) return
+
+      // Capture the opening editor now rather than in the callback - by then the selected editor might have changed
+      val openingEditor = getOpeningEditor(editor)
+
+      ApplicationManager.getApplication().invokeLater {
+        if (editor.isDisposed || vimDisabled(editor)) return@invokeLater
+        initialiseFromOpeningEditor(editor, openingEditor?.takeUnless { it.isDisposed })
       }
     }
 


### PR DESCRIPTION
When running python script in python console name of console isn't "Python Console" so we need to check that by KEY.