### PR TITLE
VIM-4275 implement modeless selection for the 'mouse' option

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/VimTypedActionHandler.kt
+++ b/src/main/java/com/maddyhome/idea/vim/VimTypedActionHandler.kt
@@ -20,6 +20,7 @@ import com.maddyhome.idea.vim.helper.inInsertMode
 import com.maddyhome.idea.vim.helper.isIdeaVimDisabledHere
 import com.maddyhome.idea.vim.key.KeyHandlerKeeper
 import com.maddyhome.idea.vim.key.KeySource
+import com.maddyhome.idea.vim.listener.ModelessSelection
 import com.maddyhome.idea.vim.newapi.vim
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
@@ -80,6 +81,8 @@ class VimTypedActionHandler(origHandler: TypedActionHandler) : TypedActionHandle
 
     try {
       LOG.trace("Executing typed action")
+      // Vim removes a modeless selection as soon as a command is typed
+      ModelessSelection.clearIfOwned(editor)
       val modifiers = if (charTyped == ' ' && VimKeyListener.isSpaceShift) KeyEvent.SHIFT_DOWN_MASK else 0
       val keyStroke = KeyStroke.getKeyStroke(charTyped, modifiers)
       val startTime = if (traceTime) System.currentTimeMillis() else null

--- a/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
+++ b/src/main/java/com/maddyhome/idea/vim/action/VimShortcutKeyAction.kt
@@ -51,6 +51,7 @@ import com.maddyhome.idea.vim.key.KeySource
 import com.maddyhome.idea.vim.key.ShortcutOwner
 import com.maddyhome.idea.vim.key.ShortcutOwnerInfo
 import com.maddyhome.idea.vim.listener.AceJumpService
+import com.maddyhome.idea.vim.listener.ModelessSelection
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.newapi.initInjector
 import com.maddyhome.idea.vim.newapi.vim
@@ -94,6 +95,8 @@ class VimShortcutKeyAction : AnAction(), DumbAware/*, LightEditCompatible*/ {
       // Should we use HelperKt.getTopLevelEditor(editor) here, as we did in former EditorKeyHandler?
       try {
         val start = if (traceTime) System.currentTimeMillis() else null
+        // Vim removes a modeless selection as soon as a command is typed
+        ModelessSelection.clearIfOwned(editor)
         val keyHandler = KeyHandler.getInstance()
         keyHandler.handleKey(editor.vim, keyStroke, KeySource.TYPED, e.dataContext.vim, keyHandler.keyHandlerState)
         if (start != null) {

--- a/src/main/java/com/maddyhome/idea/vim/listener/ModelessSelection.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/ModelessSelection.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.listener
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseEventArea
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.removeUserData
+import com.maddyhome.idea.vim.api.coerceOffset
+import com.maddyhome.idea.vim.api.globalOptions
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.helper.hasVisualSelection
+import com.maddyhome.idea.vim.newapi.IjVimEditor
+import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.state.mode.Mode
+import java.awt.event.InputEvent
+import javax.swing.SwingUtilities
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Implements Vim's `modeless-selection` for mouse gestures that Vim itself does not handle.
+ *
+ * When `'mouse'` does not include the current mode, Vim does not use the mouse for cursor positioning or for Visual
+ * mode. It still lets the mouse select text, so that the selection can be copied - Vim calls this a modeless selection
+ * (`:help modeless-selection`). Such a selection does not change the mode, does not move the caret, and Vim's operators
+ * cannot act on it. It goes away as soon as a command is typed or another selection is started.
+ *
+ * We get the "caret does not move" part by consuming the mouse press, which is the only way the platform offers - the
+ * caret is placed inline in `EditorImpl.processMousePressed`, with nothing between it and the single `isConsumed` check
+ * in `runMousePressedCommand`. A consumed press also makes the platform ignore the rest of the gesture
+ * (`runMouseDraggedCommand` bails out on it), so we make the selection ourselves in [extendSelection].
+ *
+ * We consume as little as possible: only a plain left-button press over text. The context menu, middle-click paste,
+ * gutter clicks, folding arrows, ctrl+click navigation and alt+click carets are IDE features that `'mouse'` has no
+ * business disabling, so those gestures are left to the platform untouched. See [appliesTo].
+ *
+ * That narrowing has a deliberate consequence: "the caret does not move" only holds for the plain left button. The
+ * platform's caret placement depends on the mouse event's area, not on its button, so a right, middle, ctrl+ or shift+
+ * click still moves the caret even when `'mouse'` is empty, and a shift+click additionally creates a native selection
+ * that IdeaVim turns into Visual mode. We accept this: those gestures are IDE navigation rather than Vim's use of the
+ * mouse, and disabling them (as consuming every press used to) breaks the context menu, breakpoints and go-to-declaration
+ * for no benefit Vim asks for.
+ */
+internal object ModelessSelection {
+  /**
+   * The offset a gesture started at, i.e. the anchor of the modeless selection being made, if any.
+   *
+   * Also acts as the "we consumed this press" flag. Stored per editor rather than globally: a gesture belongs to one
+   * editor, and several editors (splits, diff panes) can be in play.
+   */
+  private val anchorKey = Key.create<Int>("IdeaVim.mouse.modelessSelectionAnchor")
+
+  /**
+   * The range of a modeless selection that we made.
+   *
+   * We only ever remove a selection that still matches this range, so we cannot destroy a selection that something else
+   * has taken ownership of in the meantime.
+   *
+   * A [RangeMarker] rather than plain offsets, because the selection is itself document-tracking: an edit that doesn't
+   * come from a Vim key (a menu-invoked Reformat Code, say) shifts the selection, and raw offsets would then stop
+   * matching, leaving the selection on screen with nothing able to remove it.
+   */
+  private val ownedRangeKey = Key.create<RangeMarker>("IdeaVim.mouse.modelessSelectionRange")
+
+  /**
+   * Is the mouse enabled for the current mode, as described by the `'mouse'` option?
+   *
+   * Note that IdeaVim's mode is global rather than per-editor ([com.maddyhome.idea.vim.api.VimEditorBase.mode]
+   * delegates to the state machine), so [editor] does not narrow the mode - it is only used for the option scope.
+   */
+  fun isMouseEnabled(editor: Editor): Boolean {
+    val mouseOption = injector.globalOptions().mouse
+    if (mouseOption.contains("a")) return true
+    return when (editor.vim.mode) {
+      is Mode.INSERT, is Mode.REPLACE -> mouseOption.contains("i")
+      // Vim has no flag for operator-pending; `:help 'mouse'` treats it as Normal
+      is Mode.NORMAL, is Mode.OP_PENDING -> mouseOption.contains("n")
+      is Mode.VISUAL, is Mode.SELECT -> mouseOption.contains("v")
+      is Mode.CMD_LINE -> mouseOption.contains("c")
+      // Vim's 'r' flag (hit-enter and more-prompt) is not modelled
+      else -> true
+    }
+  }
+
+  /**
+   * Is this a gesture that `'mouse'` governs, i.e. a plain left-button gesture over text?
+   */
+  fun appliesTo(event: EditorMouseEvent): Boolean {
+    if (event.area != EditorMouseEventArea.EDITING_AREA) return false
+    if (!SwingUtilities.isLeftMouseButton(event.mouseEvent)) return false
+    val modifiers = InputEvent.SHIFT_DOWN_MASK or InputEvent.CTRL_DOWN_MASK or
+      InputEvent.ALT_DOWN_MASK or InputEvent.META_DOWN_MASK
+    return event.mouseEvent.modifiersEx and modifiers == 0
+  }
+
+  /**
+   * Start a gesture that Vim does not handle. Any modeless selection left from the previous gesture goes away, as it
+   * does in Vim.
+   */
+  fun beginGesture(editor: Editor, offset: Int) {
+    clearIfOwned(editor)
+    editor.putUserData(anchorKey, offset)
+  }
+
+  /**
+   * Finish the gesture. The modeless selection stays on screen until a command is typed or another gesture starts.
+   */
+  fun endGesture(editor: Editor) {
+    editor.removeUserData(anchorKey)
+  }
+
+  /**
+   * Is a gesture that Vim does not handle in progress in this editor, i.e. did we consume its press?
+   */
+  fun isGestureInProgress(editor: Editor): Boolean = editor.getUserData(anchorKey) != null
+
+  /**
+   * Extend the modeless selection to [offset], the position the mouse has been dragged to.
+   *
+   * Does nothing when the current mode owns a selection. Vim draws a modeless selection on top of the Visual area and
+   * keeps both; IdeaVim has one selection per caret, and the Visual area has to win, because operators and Insert mode
+   * act on the native selection - letting the drag win would make `d` delete the dragged text instead.
+   */
+  fun extendSelection(editor: Editor, offset: Int) {
+    val anchor = editor.getUserData(anchorKey) ?: return
+    // Note that Command-line mode keeps the Visual selection on screen, so its `returnTo` has to be checked as well -
+    // `hasVisualSelection` alone is false for CMD_LINE. See IdeaSelectionControl, which makes the same distinction
+    if (editor.vim.mode.hasVisualSelection || editor.vim.mode.returnTo.hasVisualSelection) return
+
+    val vimEditor = IjVimEditor(editor)
+    val start = vimEditor.coerceOffset(min(anchor, offset))
+    val end = vimEditor.coerceOffset(max(anchor, offset))
+    if (start == end) {
+      // Dragged back onto the anchor. Every other drag-select in the IDE collapses here, rather than leaving the last
+      // non-empty range on screen
+      clearIfOwned(editor)
+      return
+    }
+
+    // The suppressor stops IdeaSelectionControl from turning this into a Visual selection
+    SelectionVimListenerSuppressor.lock {
+      editor.caretModel.primaryCaret.setSelection(start, end)
+    }
+    setOwnedRange(editor, start, end)
+  }
+
+  private fun setOwnedRange(editor: Editor, start: Int, end: Int) {
+    disposeOwnedRange(editor)
+    editor.putUserData(ownedRangeKey, editor.document.createRangeMarker(start, end))
+  }
+
+  private fun disposeOwnedRange(editor: Editor) {
+    editor.getUserData(ownedRangeKey)?.dispose()
+    editor.removeUserData(ownedRangeKey)
+  }
+
+  /**
+   * Drop a modeless selection that we made. Called when a Vim command is about to run, matching Vim, where any command
+   * removes the modeless selection.
+   *
+   * Does nothing unless the selection still is exactly the one we made, so a Visual selection, an IDE selection or a
+   * template selection is never touched.
+   */
+  fun clearIfOwned(editor: Editor) {
+    val owned = editor.getUserData(ownedRangeKey) ?: return
+    val caret = editor.caretModel.primaryCaret
+    val isOurs = owned.isValid &&
+      caret.hasSelection() &&
+      caret.selectionStart == owned.startOffset &&
+      caret.selectionEnd == owned.endOffset
+
+    if (isOurs) {
+      SelectionVimListenerSuppressor.lock {
+        caret.removeSelection()
+      }
+    }
+    // Only drop ownership once we know the selection is no longer ours to remove, so that a selection we made can never
+    // be orphaned on screen with nothing able to clear it
+    disposeOwnedRange(editor)
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -76,7 +76,6 @@ import com.maddyhome.idea.vim.api.VirtualBufferKind
 import com.maddyhome.idea.vim.api.coerceOffset
 import com.maddyhome.idea.vim.api.getLineEndForOffset
 import com.maddyhome.idea.vim.api.getLineStartForOffset
-import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.autocmd.AutoCmdEvent
 import com.maddyhome.idea.vim.autocmd.IjFileTypeMapping
@@ -785,6 +784,16 @@ object VimListenerManager {
     override fun mouseDragged(e: EditorMouseEvent) {
       val editor = e.editor
       if (editor.isIdeaVimDisabledHere) return
+
+      if (ModelessSelection.isGestureInProgress(editor)) {
+        // We consumed the press, so the platform ignores the drag - make the modeless selection ourselves. Note that we
+        // deliberately don't touch the drag bookkeeping: leaving dragEventCount alone keeps the end-of-line correction
+        // in EditorSelectionHandler away from a selection that isn't Vim's
+        ModelessSelection.extendSelection(editor, e.offset)
+        e.consume()
+        return
+      }
+
       val caret = editor.caretModel.primaryCaret
 
       clearFirstSelectionEvents(e)
@@ -875,24 +884,19 @@ object VimListenerManager {
 
     override fun mousePressed(event: EditorMouseEvent) {
       if (event.editor.isIdeaVimDisabledHere) return
-      if (!isMouseMovementAllowed()) {
-        event.consume()
-        return
-      }
+
+      // Unconditional bookkeeping first - it is not 'mouse'-dependent, and leaving it out of any early return is what
+      // keeps a stale mouseDragging from disabling IdeaSelectionControl for the rest of the session
       MouseEventsDataHolder.dragEventCount = MouseEventsDataHolder.allowedSkippedDragEvents
       MouseEventsDataHolder.mouseDragging = false
-    }
 
-    private fun isMouseMovementAllowed(): Boolean {
-      val mouseOption = injector.globalOptions().mouse
-      val mode = injector.editorGroup.getSelectedEditor()?.mode
-      if (mouseOption.contains("a")) return true
-      return when (mode) {
-        is Mode.INSERT, is Mode.REPLACE -> mouseOption.contains("i")
-        is Mode.NORMAL -> mouseOption.contains("n")
-        is Mode.VISUAL, is Mode.SELECT -> mouseOption.contains("v")
-        is Mode.CMD_LINE -> mouseOption.contains("c")
-        else -> true
+      if (!ModelessSelection.isMouseEnabled(event.editor) && ModelessSelection.appliesTo(event)) {
+        // Vim doesn't use the mouse in this mode, so the caret must not move. Consuming the press is the only way to
+        // stop the platform from placing it, which also means we make any selection ourselves. See [ModelessSelection]
+        ModelessSelection.beginGesture(event.editor, event.offset)
+        event.consume()
+      } else {
+        ModelessSelection.endGesture(event.editor)
       }
     }
 
@@ -904,6 +908,24 @@ object VimListenerManager {
      */
     override fun mouseReleased(event: EditorMouseEvent) {
       if (event.editor.isIdeaVimDisabledHere) return
+
+      if (ModelessSelection.isGestureInProgress(event.editor)) {
+        // Everything below is for turning a mouse selection into a Vim one, which is exactly what must not happen here.
+        // The modeless selection stays until a command is typed or the next gesture starts.
+        //
+        // Consume the release as well, or the platform's processMouseReleased can drop our selection: it ends with a
+        // `removeSelection()` guarded by `myKeepSelectionOnMousePress` and `myDragStarted`, and because we consumed the
+        // press, neither of those was recomputed for this gesture. Not for a popup trigger though - on Windows that is
+        // the release, and consuming it would swallow the context menu
+        if (!event.mouseEvent.isPopupTrigger) {
+          event.consume()
+        }
+        MouseEventsDataHolder.dragEventCount = MouseEventsDataHolder.allowedSkippedDragEvents
+        MouseEventsDataHolder.mouseDragging = false
+        cutOffFixed = false
+        ModelessSelection.endGesture(event.editor)
+        return
+      }
 
       clearFirstSelectionEvents(event)
       MouseEventsDataHolder.dragEventCount = MouseEventsDataHolder.allowedSkippedDragEvents
@@ -990,6 +1012,9 @@ object VimListenerManager {
     override fun mousePressed(e: MouseEvent?) {
       val editor = (e?.component as? EditorComponentImpl)?.editor ?: return
       if (editor.isIdeaVimDisabledHere) return
+      // AWT delivers consumed events to component listeners too, but everything below fixes up what the platform's own
+      // press handling did - and that was skipped for a consumed press
+      if (e.isConsumed) return
       val predictedMode = injector.application.runReadAction {
         IdeaSelectionControl.predictMode(editor, SelectionSource.MOUSE)
       }

--- a/src/main/java/com/maddyhome/idea/vim/ui/OutputPanel.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/OutputPanel.kt
@@ -41,6 +41,7 @@ import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.requestFocus
 import com.maddyhome.idea.vim.helper.selectEditorFont
 import com.maddyhome.idea.vim.helper.vimMorePanel
+import com.maddyhome.idea.vim.listener.ModelessSelection
 import com.maddyhome.idea.vim.newapi.IjVimEditor
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.register.RegisterConstants
@@ -658,6 +659,9 @@ internal class OutputPanel private constructor(private val editor: Editor) : JBP
    * versions of control characters and Enter, etc.
    */
   internal fun handleKey(key: KeyStroke) {
+    // Like the command line, this bypasses VimTypedActionHandler and VimShortcutKeyAction, so a modeless selection in
+    // the owning editor has to be dropped here too
+    ModelessSelection.clearIfOwned(editor)
     // Note that it is normally invalid to compare a virtual key code and a Unicode codepoint; however, these virtual
     // key codes are explicitly defined to match ASCII values
     if (key.keyChar.code == KeyEvent.VK_ENTER

--- a/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.kt
+++ b/src/main/java/com/maddyhome/idea/vim/ui/ex/ExTextField.kt
@@ -18,6 +18,7 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.helper.EngineStringHelper.isPrintableCharacter
 import com.maddyhome.idea.vim.helper.selectEditorFont
 import com.maddyhome.idea.vim.key.KeySource
+import com.maddyhome.idea.vim.listener.ModelessSelection
 import com.maddyhome.idea.vim.newapi.IjEditorExecutionContext
 import com.maddyhome.idea.vim.options.helpers.GuiCursorAttributes
 import com.maddyhome.idea.vim.options.helpers.GuiCursorMode
@@ -229,6 +230,9 @@ class ExTextField internal constructor(private val myParentPanel: ExEntryPanel) 
     // handle them separately, as key presses, but not as typed characters.
     if (isAllowedPressedEvent(e) || isAllowedTypedEvent(e)) {
       val editor = myParentPanel.editor
+      // Keys typed here bypass VimTypedActionHandler and VimShortcutKeyAction, so this is where a modeless selection in
+      // the owning editor has to be dropped. Without it, `:d` after a mouse drag would act on the dragged range
+      myParentPanel.ijEditor?.let { ModelessSelection.clearIfOwned(it) }
       val keyHandler = KeyHandler.getInstance()
       val keyStroke = KeyStroke.getKeyStrokeForEvent(e)
       keyHandler.handleKey(

--- a/src/test/java/org/jetbrains/plugins/ideavim/listener/MouseDragSelectionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/listener/MouseDragSelectionTest.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.listener
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.impl.EditorImpl
+import com.intellij.testFramework.fixtures.EditorMouseFixture
+import com.maddyhome.idea.vim.state.mode.Mode
+import com.maddyhome.idea.vim.state.mode.SelectionType
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.jetbrains.plugins.ideavim.waitUntilSelectionUpdated
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for selecting with the mouse, as governed by the 'mouse' option.
+ *
+ * When the mouse is enabled for the current mode, dragging creates a selection and IdeaVim switches to Visual mode.
+ *
+ * When it is not enabled, Vim makes a `modeless-selection` (`:help modeless-selection`): the text is still selected so
+ * that it can be copied, but the mode is not changed, the caret does not move, and Vim's operators cannot act on the
+ * selection, which goes away as soon as a command is typed. This is why people set `mouse=` in the first place - so
+ * that selecting with the mouse keeps working the "old" way.
+ *
+ * The gestures are simulated with the platform [EditorMouseFixture], which dispatches real Swing mouse events to the
+ * editor component. Note that [EditorMouseFixture.dragTo] requires a non-empty visible area.
+ *
+ * Only plain left-button gestures are covered here. [EditorMouseFixture] adds a modifier to the release event of every
+ * other button (ALT for the middle button, META for the right one, plus a popup trigger for the right one), so the
+ * platform reacts with alt-click / cmd-click / context-menu behaviour whose side effects leak into unrelated tests
+ * sharing this JVM. The button and area filtering therefore has to be verified by hand - see
+ * `ModelessSelection.appliesTo`.
+ */
+@TestWithoutNeovim(SkipNeovimReason.NOT_VIM_TESTING)
+class MouseDragSelectionTest : VimTestCase() {
+  private companion object {
+    const val TEXT = "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit"
+
+    /**
+     * 'mouse' does not change *what* a drag selects, only what Vim does about it - a modeless selection covers the same
+     * text as the Visual selection the same gesture would make.
+     *
+     * Note that the drag has to send more than one event to get this. On the very first drag event the caret is still a
+     * block caret, and `EditorImpl.getTargetPosition` then subtracts a column when the mouse is in the first half of a
+     * cell, so a single-event drag to column 5 selects only four characters. A real drag always sends many events, by
+     * which point IdeaVim has forced a bar caret and the adjustment no longer applies.
+     */
+    const val SELECTED = "Lorem"
+  }
+
+  @Test
+  fun `mouse=a -- drag selects text and enters Visual mode`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=a")
+
+    dragOverFirstWord()
+
+    assertSelection(SELECTED)
+    assertMode(Mode.VISUAL(SelectionType.CHARACTER_WISE))
+  }
+
+  @Test
+  fun `mouse= (empty) -- drag still selects text, but the mode does not change`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=")
+
+    dragOverFirstWord()
+
+    assertSelection(SELECTED)
+    assertMode(Mode.NORMAL())
+  }
+
+  @Test
+  fun `mouse= (empty) -- drag does not move the caret`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=")
+    typeText("w") // Move off offset 0, so that "the caret did not move" is meaningful
+
+    val before = caretOffset()
+    dragOverFirstWord()
+
+    assertSelection(SELECTED)
+    assertEquals(before, caretOffset(), "A modeless selection must not move the caret")
+  }
+
+  @Test
+  fun `mouse= (empty) -- a Vim command removes the modeless selection`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=")
+
+    dragOverFirstWord()
+    assertSelection(SELECTED)
+
+    // Vim drops a modeless selection as soon as a command is typed. It must not survive as an operator target
+    typeText("l")
+
+    assertSelection(null)
+    assertMode(Mode.NORMAL())
+  }
+
+  @Test
+  fun `mouse= (empty) -- click keeps a Visual selection made with the keyboard`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=")
+    typeText("ve")
+
+    ApplicationManager.getApplication().invokeAndWait {
+      EditorMouseFixture(fixture.editor as EditorImpl).clickAt(1, 3)
+    }
+    waitUntilSelectionUpdated(fixture.editor)
+
+    // Vim ignores the click entirely, so neither the selection nor the mode may change
+    assertSelection("Lorem")
+    assertMode(Mode.VISUAL(SelectionType.CHARACTER_WISE))
+  }
+
+  @Test
+  fun `mouse=n -- drag in Visual mode does not replace the Visual selection`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=n") // No 'v', so the mouse is disabled in Visual mode
+    typeText("ve")
+
+    // Drag over a different part of the file. Vim would show a modeless selection on top of the Visual area; IdeaVim
+    // has one selection per caret, and the Visual area has to win - operators act on the native selection
+    ApplicationManager.getApplication().invokeAndWait {
+      EditorMouseFixture(fixture.editor as EditorImpl).pressAt(1, 0).dragTo(1, 8).release()
+    }
+    waitUntilSelectionUpdated(fixture.editor)
+
+    assertSelection("Lorem")
+    assertMode(Mode.VISUAL(SelectionType.CHARACTER_WISE))
+  }
+
+  @Test
+  fun `mouse= (empty) -- a special key removes the modeless selection`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=")
+    typeText("w")
+
+    dragOverFirstWord()
+
+    // Special keys take a different route into the key handler than typed characters do (VimShortcutKeyAction rather
+    // than VimTypedActionHandler), and the selection has to be dropped on both
+    typeText("<Left>")
+
+    assertSelection(null)
+  }
+
+  @Test
+  fun `mouse= (empty) -- an operator does not act on the modeless selection`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=")
+    typeText("w") // Caret on "ipsum", away from the dragged range
+
+    dragOverFirstWord()
+    typeText("yiw")
+
+    // Vim's operators cannot see a modeless selection, so this yanks the word under the caret
+    assertRegister('"', "ipsum")
+  }
+
+  @Test
+  fun `mouse= (empty) -- typing in Insert mode does not replace the selected text`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=n") // Mouse disabled in Insert mode too, since 'i' is absent
+    typeText("i")
+
+    dragOverFirstWord()
+    typeText("X")
+
+    // The platform's typed action replaces a native selection, so the modeless selection has to be gone by then
+    assertState("X${TEXT}")
+  }
+
+  @Test
+  fun `mouse=nvi -- drag with the command line open keeps the Visual selection`() {
+    configureByText(TEXT)
+    typeText("ve") // Visual, "Lorem"
+    typeText(":") // Command-line mode. The default 'mouse' has no 'c', so the mouse is disabled here
+
+    // IdeaVim keeps the Visual selection on screen while the command line is open, so a drag must not replace it
+    dragOverSecondLine()
+
+    assertSelection("Lorem")
+
+    // Leave the command line closed. VimTestCase.tearDown deactivates the panel but does not reset the Vim mode, so an
+    // open command line here would make the next test in this JVM run its `:` command outside Normal mode.
+    // <C-C> is what VimExTestCase.deactivateExEntry uses
+    typeText("<C-C>")
+  }
+
+  @Test
+  fun `mouse= (empty) -- dragging back to the anchor collapses the selection`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=")
+
+    ApplicationManager.getApplication().invokeAndWait {
+      EditorMouseFixture(fixture.editor as EditorImpl)
+        .pressAt(0, 0)
+        .dragTo(0, 3)
+        .dragTo(0, 5)
+        .dragTo(0, 0)
+        .release()
+    }
+    waitUntilSelectionUpdated(fixture.editor)
+
+    assertSelection(null)
+  }
+
+  @Test
+  fun `mouse= (empty) -- a second drag replaces the first modeless selection`() {
+    configureByText(TEXT)
+    enterCommand("set mouse=")
+
+    dragOverFirstWord()
+    dragOverSecondLine()
+
+    assertSelection("consec")
+  }
+
+  private fun dragOverSecondLine() {
+    ApplicationManager.getApplication().invokeAndWait {
+      EditorMouseFixture(fixture.editor as EditorImpl)
+        .pressAt(1, 0)
+        .dragTo(1, 3)
+        .dragTo(1, 6)
+        .release()
+    }
+    waitUntilSelectionUpdated(fixture.editor)
+  }
+
+  private fun dragOverFirstWord() {
+    ApplicationManager.getApplication().invokeAndWait {
+      EditorMouseFixture(fixture.editor as EditorImpl)
+        .pressAt(0, 0)
+        .dragTo(0, 3)
+        .dragTo(0, 5)
+        .release()
+    }
+    waitUntilSelectionUpdated(fixture.editor)
+  }
+
+  private fun caretOffset(): Int {
+    var offset = 0
+    ApplicationManager.getApplication().invokeAndWait {
+      offset = fixture.editor.caretModel.primaryCaret.offset
+    }
+    return offset
+  }
+}


### PR DESCRIPTION
'mouse' should stop Vim from interpreting the mouse rather than disable the mouse, so we now consume only the plain left-button press over text. the platform's single hook for suppressing caret placement - and build Vim's modeless selection ourselves, leaving the context menu, gutter clicks and modifier gestures
  to the IDE