### PR TITLE
VIM-4272 use published PRIMARY content when we own the selection

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjClipboardManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjClipboardManager.kt
@@ -20,9 +20,9 @@ import com.intellij.openapi.editor.richcopy.view.RtfTransferableData
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.psi.PsiDocumentManager
-import com.intellij.util.ui.EmptyClipboardOwner
 import com.maddyhome.idea.vim.api.ExecutionContext
 import com.maddyhome.idea.vim.api.ImmutableVimCaret
+import com.maddyhome.idea.vim.api.OwnedPrimaryContent
 import com.maddyhome.idea.vim.api.VimClipboardManager
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
@@ -40,10 +40,12 @@ import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 import java.awt.datatransfer.UnsupportedFlavorException
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicReference
 
 
 internal class IjClipboardManager : VimClipboardManager {
   private val primaryWriter: PrimarySelectionWriter = primarySelectionWriter()
+  private val publishedToPrimary = AtomicReference<OwnedPrimaryContent?>()
 
   override fun getPrimaryContent(editor: VimEditor, context: ExecutionContext): IjVimCopiedText? {
     val clipboard = Toolkit.getDefaultToolkit()?.systemSelection ?: return null
@@ -108,16 +110,23 @@ internal class IjClipboardManager : VimClipboardManager {
     editor: VimEditor,
     context: ExecutionContext,
     textData: VimCopiedText,
+    selectionType: SelectionType,
   ): Boolean {
     require(textData is IjVimCopiedText)
-    return primaryWriter.write(textData.text, textData.transferableData)
+    val published = primaryWriter.write(textData.text, textData.transferableData)
+    publishedToPrimary.set(if (published) OwnedPrimaryContent(textData, selectionType) else null)
+    return published
   }
+
+  override fun getOwnedPrimaryContent(): OwnedPrimaryContent? =
+    publishedToPrimary.get()?.takeIf { primaryWriter.ownsSelection() }
 
   override fun onVisualSelectionChange(editor: VimEditor, caret: ImmutableVimCaret) {
     if (!shouldRepublishVisualSelection(editor)) return
     val text = readVisualSelectionText(editor, caret) ?: return
     val context = injector.executionContextManager.getEditorExecutionContext(editor)
-    setPrimaryContent(editor, context, dumbCopiedText(text))
+    val selectionType = editor.mode.selectionType ?: SelectionType.CHARACTER_WISE
+    setPrimaryContent(editor, context, dumbCopiedText(text), selectionType)
   }
 
   // vim-engine invokes setVisualSelection transiently from operators (yy, dd, c…), text-object

--- a/src/main/java/com/maddyhome/idea/vim/newapi/PrimarySelectionWriter.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/PrimarySelectionWriter.kt
@@ -10,11 +10,13 @@ package com.maddyhome.idea.vim.newapi
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
-import com.intellij.util.ui.EmptyClipboardOwner
 import com.maddyhome.idea.vim.diagnostic.debug
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import java.awt.HeadlessException
 import java.awt.Toolkit
+import java.awt.datatransfer.Clipboard
+import java.awt.datatransfer.ClipboardOwner
+import java.awt.datatransfer.Transferable
 import java.io.File
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -27,6 +29,14 @@ import java.util.concurrent.atomic.AtomicReference
 internal interface PrimarySelectionWriter {
   /** `true` if the write was performed or reliably scheduled; `false` if PRIMARY isn't reachable here. */
   fun write(text: String, transferableData: List<Any>): Boolean
+
+  /**
+   * `true` while nothing else has claimed PRIMARY since our last [write], meaning the selection still
+   * holds exactly the text we put there.
+   *
+   * @see com.maddyhome.idea.vim.api.VimClipboardManager.ownsPrimaryContent
+   */
+  fun ownsSelection(): Boolean
 }
 
 internal fun primarySelectionWriter(): PrimarySelectionWriter {
@@ -35,14 +45,39 @@ internal fun primarySelectionWriter(): PrimarySelectionWriter {
 }
 
 internal class AwtPrimarySelectionWriter : PrimarySelectionWriter {
+  private val latestClaim = AtomicReference<SelectionClaim?>()
+
   override fun write(text: String, transferableData: List<Any>): Boolean {
-    val clipboard = Toolkit.getDefaultToolkit()?.systemSelection ?: return false
     return try {
-      val content = buildIjTextTransferable(text, text, transferableData)
-      clipboard.setContents(content, EmptyClipboardOwner.INSTANCE)
+      val clipboard = Toolkit.getDefaultToolkit()?.systemSelection ?: return noClaim()
+      claimSelection(clipboard, buildIjTextTransferable(text, text, transferableData))
       true
     } catch (_: HeadlessException) {
-      false
+      noClaim()
+    }
+  }
+
+  override fun ownsSelection(): Boolean = latestClaim.get()?.isStillHeld == true
+
+  private fun noClaim(): Boolean {
+    latestClaim.set(null)
+    return false
+  }
+
+  private fun claimSelection(clipboard: Clipboard, content: Transferable) {
+    val claim = SelectionClaim()
+    latestClaim.set(claim)
+    clipboard.setContents(content, claim)
+  }
+
+  /** Per-write, because AWT revokes a superseded claim asynchronously — a shared one would be cleared late. */
+  private class SelectionClaim : ClipboardOwner {
+    @Volatile
+    var isStillHeld: Boolean = true
+      private set
+
+    override fun lostOwnership(clipboard: Clipboard?, contents: Transferable?) {
+      isStillHeld = false
     }
   }
 }
@@ -52,6 +87,7 @@ internal class AwtPrimarySelectionWriter : PrimarySelectionWriter {
  */
 internal class XclipPrimarySelectionWriter private constructor() : PrimarySelectionWriter {
   private val pendingText = AtomicReference<String?>()
+  private val selectionHolder = AtomicReference<Process?>()
   private val executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { runnable ->
     Thread(runnable, "IdeaVim-PrimarySelection").apply { isDaemon = true }
   }
@@ -65,20 +101,42 @@ internal class XclipPrimarySelectionWriter private constructor() : PrimarySelect
     return true
   }
 
+  override fun ownsSelection(): Boolean = hasUnflushedWrite() || isHoldingSelection()
+
+  private fun hasUnflushedWrite(): Boolean = pendingText.get() != null
+
+  private fun isHoldingSelection(): Boolean = selectionHolder.get()?.isAlive == true
+
   private fun drain() {
     val text = pendingText.getAndSet(null) ?: return
+    var process: Process? = null
     try {
-      val process = ProcessBuilder(XCLIP_ARGV).redirectErrorStream(true).start()
+      process = ProcessBuilder(XCLIP_ARGV)
+        // A foreground xclip chatters about selection requests; an unread pipe would fill and block it.
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        .redirectError(ProcessBuilder.Redirect.DISCARD)
+        .start()
+      // Closing stdin is what makes xclip claim the selection; the previous holder then releases it
+      // and exits by itself.
       process.outputStream.use { it.write(text.toByteArray(Charsets.UTF_8)) }
     } catch (e: Exception) {
+      // The write can fail after the process started, leaving xclip to claim PRIMARY with truncated
+      // text. Kill it rather than orphan a holder we no longer track.
+      process?.destroy()
+      process = null
       logger.debug { "xclip failed: ${e.message}" }
     }
+    selectionHolder.set(process)
   }
 
   companion object {
     private const val DEBOUNCE_MS = 20L
     private val logger = vimLogger<XclipPrimarySelectionWriter>()
-    private val XCLIP_ARGV = listOf("xclip", "-selection", "primary")
+
+    // Detached, xclip outlives the Process we hold, leaving us blind to ownership. In the
+    // foreground the Process *is* the owner: alive while it holds PRIMARY, gone once it loses it.
+    private const val STAY_IN_FOREGROUND = "-quiet"
+    private val XCLIP_ARGV = listOf("xclip", "-selection", "primary", STAY_IN_FOREGROUND)
 
     fun tryCreate(): XclipPrimarySelectionWriter? {
       if (!isExecutableInPath()) {

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/RegistersCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/RegistersCommandTest.kt
@@ -457,7 +457,7 @@ class RegistersCommandTest : VimTestCase() {
         |  c  "y   Hello world y
         |  c  "z   Hello world z
         |  c  "-   s
-        |  c  "*   mall delete register
+        |  l  "*   mall delete register^J
         |  c  "+   clipboard content
         |  c  ":   ascii
         |  c  "/   search pattern
@@ -485,7 +485,7 @@ class RegistersCommandTest : VimTestCase() {
     assertExOutput(
       """
         |Type Name Content
-        |  c  "*   line 0 
+        |  l  "*   line 0 ^J
         |  c  "+   clipboard content
       """.trimMargin(),
     )

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimClipboardManager.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimClipboardManager.kt
@@ -11,7 +11,11 @@ package com.maddyhome.idea.vim.api
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.common.VimCopiedText
 import com.maddyhome.idea.vim.helper.VimLockLabel
+import com.maddyhome.idea.vim.state.mode.SelectionType
 import java.awt.datatransfer.Transferable
+
+/** Text published to the PRIMARY selection, paired with the selection type PRIMARY itself cannot store. */
+data class OwnedPrimaryContent(val copiedText: VimCopiedText, val selectionType: SelectionType)
 
 /**
  * Interface representing a clipboard manager for the Vim text editor.
@@ -25,7 +29,34 @@ interface VimClipboardManager {
   fun getClipboardContent(editor: VimEditor, context: ExecutionContext): VimCopiedText?
 
   fun setClipboardContent(editor: VimEditor, context: ExecutionContext, textData: VimCopiedText): Boolean
-  fun setPrimaryContent(editor: VimEditor, context: ExecutionContext, textData: VimCopiedText): Boolean
+
+  /**
+   * Publishes [textData] to PRIMARY. [selectionType] is remembered alongside it, because the windowing
+   * system stores text only and cannot carry it — see [getOwnedPrimaryContent].
+   */
+  fun setPrimaryContent(
+    editor: VimEditor,
+    context: ExecutionContext,
+    textData: VimCopiedText,
+    selectionType: SelectionType,
+  ): Boolean
+
+  /**
+   * What we last published via [setPrimaryContent], or `null` once anything else has claimed PRIMARY.
+   *
+   * A register read back out of PRIMARY has to re-guess its selection type from the text, which turns
+   * line-wise into character-wise whenever the text is reformatted or re-published on the way. While
+   * the selection is still ours, what we published is by definition what it holds — and we still know
+   * its type. Neovim's clipboard provider works the same way, reusing the `[lines, regtype]` it last
+   * handed out for as long as the `xclip`/`wl-copy` job it spawned is alive.
+   *
+   * This deliberately reports what was *published*, not what any register happens to cache: several
+   * call sites write PRIMARY without updating the `*` register, and conflating the two hands back
+   * content the selection never held.
+   *
+   * Default: `null` — platforms without a PRIMARY selection never own one.
+   */
+  fun getOwnedPrimaryContent(): OwnedPrimaryContent? = null
 
   /**
    * Fired when the user's visible visual selection changes. Whether to republish the new

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
@@ -221,12 +221,12 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
     if (register == CLIPBOARD_REGISTER) {
       injector.clipboardManager.setClipboardContent(editor, context, copiedText)
       if (!isRegisterSpecifiedExplicitly && !isDelete && isPrimaryRegisterSupported() && OptionConstants.clipboard_unnamedplus in injector.globalOptions().clipboard) {
-        injector.clipboardManager.setPrimaryContent(editor, context, copiedText)
+        injector.clipboardManager.setPrimaryContent(editor, context, copiedText, type)
       }
     }
     if (register == PRIMARY_REGISTER) {
       if (isPrimaryRegisterSupported()) {
-        injector.clipboardManager.setPrimaryContent(editor, context, copiedText)
+        injector.clipboardManager.setPrimaryContent(editor, context, copiedText, type)
         if (!isRegisterSpecifiedExplicitly && !isDelete && OptionConstants.clipboard_unnamed in injector.globalOptions().clipboard) {
           injector.clipboardManager.setClipboardContent(editor, context, copiedText)
         }
@@ -416,11 +416,16 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
     return myRegisters[r.lowercaseChar()]
   }
 
-  private fun setSystemPrimaryRegisterText(editor: VimEditor, context: ExecutionContext, copiedText: VimCopiedText) {
+  private fun setSystemPrimaryRegisterText(
+    editor: VimEditor,
+    context: ExecutionContext,
+    copiedText: VimCopiedText,
+    selectionType: SelectionType,
+  ) {
     logger.trace("Setting text: $copiedText to primary selection...")
     if (isPrimaryRegisterSupported()) {
       try {
-        injector.clipboardManager.setPrimaryContent(editor, context, copiedText)
+        injector.clipboardManager.setPrimaryContent(editor, context, copiedText, selectionType)
       } catch (e: Exception) {
         logger.warn("False positive X11 primary selection support")
         logger.trace("Setting text to primary selection failed. Setting it to clipboard selection instead")
@@ -436,11 +441,9 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
     injector.clipboardManager.setClipboardContent(editor, context, copiedText)
   }
 
-  // Wayland's clipboard reader strips trailing newlines, so a line-wise yank cached as "foo\n"
-  // re-reads from PRIMARY as "foo". Treat the missing-trailing-newline variant as a match too,
-  // otherwise every poll of PRIMARY would overwrite our cached line-wise register with a
-  // character-wise one.
-  private fun cachedRegisterMatchesClipboard(cached: Register, clipboard: VimCopiedText): Boolean {
+  // Fallback for when getOwnedPrimaryContent reports a false negative; Wayland's reader strips the
+  // trailing newline, so a line-wise "foo\n" comes back as "foo".
+  private fun matchesIgnoringStrippedTrailingNewline(cached: Register, clipboard: VimCopiedText): Boolean {
     return clipboard.text == cached.text || clipboard.text + "\n" == cached.text
   }
 
@@ -451,15 +454,23 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
       return refreshClipboardRegister(editor, context)
     }
     try {
+      val ourContent = injector.clipboardManager.getOwnedPrimaryContent()
+      if (ourContent != null) {
+        logger.trace("PRIMARY still holds what we published; reusing it instead of re-guessing its type")
+        return Register(PRIMARY_REGISTER, ourContent.copiedText, ourContent.selectionType)
+      }
       val clipboardData = injector.clipboardManager.getPrimaryContent(editor, context)
       if (clipboardData == null || clipboardData.text.isEmpty()) {
         // Wayland/XWayland clears PRIMARY on focus change; prefer the last IdeaVim-written value over
         // an empty result. Differs from Vim only when the user deliberately clears PRIMARY externally.
         logger.trace("PRIMARY selection is unavailable or empty; falling back to in-memory register value")
         return myRegisters[PRIMARY_REGISTER]
+          // Nothing cached either: a readable-but-empty PRIMARY is still a register, and reporting it
+          // as absent hides the `*` row from `:registers` entirely.
+          ?: clipboardData?.let { Register(PRIMARY_REGISTER, it, SelectionType.CHARACTER_WISE) }
       }
       val currentRegister = myRegisters[PRIMARY_REGISTER]
-      if (currentRegister != null && cachedRegisterMatchesClipboard(currentRegister, clipboardData)) {
+      if (currentRegister != null && matchesIgnoringStrippedTrailingNewline(currentRegister, clipboardData)) {
         return currentRegister
       }
       return Register(PRIMARY_REGISTER, clipboardData, guessSelectionType(clipboardData.text))
@@ -518,7 +529,7 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
         }
 
         PRIMARY_REGISTER -> {
-          setSystemPrimaryRegisterText(editor, context, register.copiedText)
+          setSystemPrimaryRegisterText(editor, context, register.copiedText, register.type)
         }
       }
     }


### PR DESCRIPTION
On Linux with clipboard=unnamed the `*` register is backed by the system PRIMARY selection, which stores text only, so its type was re-guessed from the text on every read. The selection can come back with trailing whitespace stripped, so a line-wise "foo   \n" reads back as "foo" and gets downgraded to character-wise. We now reuse the text and type we published while we still own the selection, and only read and guess once another app claims it.