### PR TITLE
VIM-4272 recover the register type when PRIMARY comes back stripped

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjClipboardManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjClipboardManager.kt
@@ -17,6 +17,7 @@ import com.intellij.openapi.editor.CaretStateTransferableData
 import com.intellij.openapi.editor.RawText
 import com.intellij.openapi.editor.richcopy.view.HtmlTransferableData
 import com.intellij.openapi.editor.richcopy.view.RtfTransferableData
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.psi.PsiDocumentManager
@@ -43,9 +44,17 @@ import java.io.IOException
 import java.util.concurrent.atomic.AtomicReference
 
 
-internal class IjClipboardManager : VimClipboardManager {
+// Disposable so the PRIMARY writer's background thread and helper process are released when the
+// service goes away. That covers plugin unload as well as shutdown: IdeaVim's extension points are
+// all dynamic, so an un-disposed executor would pin the plugin classloader across a reload.
+internal class IjClipboardManager : VimClipboardManager, Disposable {
   private val primaryWriter: PrimarySelectionWriter = primarySelectionWriter()
   private val publishedToPrimary = AtomicReference<OwnedPrimaryContent?>()
+
+  override fun dispose() {
+    primaryWriter.dispose()
+    publishedToPrimary.set(null)
+  }
 
   override fun getPrimaryContent(editor: VimEditor, context: ExecutionContext): IjVimCopiedText? {
     val clipboard = Toolkit.getDefaultToolkit()?.systemSelection ?: return null
@@ -120,6 +129,8 @@ internal class IjClipboardManager : VimClipboardManager {
 
   override fun getOwnedPrimaryContent(): OwnedPrimaryContent? =
     publishedToPrimary.get()?.takeIf { primaryWriter.ownsSelection() }
+
+  override fun getLastPublishedPrimaryContent(): OwnedPrimaryContent? = publishedToPrimary.get()
 
   override fun onVisualSelectionChange(editor: VimEditor, caret: ImmutableVimCaret) {
     if (!shouldRepublishVisualSelection(editor)) return

--- a/src/main/java/com/maddyhome/idea/vim/newapi/PrimarySelectionWriter.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/PrimarySelectionWriter.kt
@@ -34,9 +34,12 @@ internal interface PrimarySelectionWriter {
    * `true` while nothing else has claimed PRIMARY since our last [write], meaning the selection still
    * holds exactly the text we put there.
    *
-   * @see com.maddyhome.idea.vim.api.VimClipboardManager.ownsPrimaryContent
+   * @see com.maddyhome.idea.vim.api.VimClipboardManager.getOwnedPrimaryContent
    */
   fun ownsSelection(): Boolean
+
+  /** Releases anything held on behalf of the selection. Default: nothing to release. */
+  fun dispose() {}
 }
 
 internal fun primarySelectionWriter(): PrimarySelectionWriter {
@@ -46,13 +49,18 @@ internal fun primarySelectionWriter(): PrimarySelectionWriter {
 
 internal class AwtPrimarySelectionWriter : PrimarySelectionWriter {
   private val latestClaim = AtomicReference<SelectionClaim?>()
+  private val logger = vimLogger<AwtPrimarySelectionWriter>()
 
   override fun write(text: String, transferableData: List<Any>): Boolean {
     return try {
       val clipboard = Toolkit.getDefaultToolkit()?.systemSelection ?: return noClaim()
       claimSelection(clipboard, buildIjTextTransferable(text, text, transferableData))
       true
-    } catch (_: HeadlessException) {
+    } catch (e: Exception) {
+      // Any failure, not just headless: AWT throws IllegalStateException when the selection cannot be
+      // opened. Claiming optimistically and leaving the claim behind would report ownership of a write
+      // that never happened, and nothing would ever revoke it.
+      logger.debug { "Could not claim PRIMARY: ${e.message}" }
       noClaim()
     }
   }
@@ -66,8 +74,9 @@ internal class AwtPrimarySelectionWriter : PrimarySelectionWriter {
 
   private fun claimSelection(clipboard: Clipboard, content: Transferable) {
     val claim = SelectionClaim()
-    latestClaim.set(claim)
+    // Published only once `setContents` has accepted it, so a throw leaves no claim to get stuck on.
     clipboard.setContents(content, claim)
+    latestClaim.set(claim)
   }
 
   /** Per-write, because AWT revokes a superseded claim asynchronously — a shared one would be cleared late. */
@@ -94,10 +103,18 @@ internal class XclipPrimarySelectionWriter private constructor() : PrimarySelect
 
   override fun write(text: String, transferableData: List<Any>): Boolean {
     pendingText.set(text)
-    ApplicationManager.getApplication().invokeLater(
-      { executor.schedule(::drain, DEBOUNCE_MS, TimeUnit.MILLISECONDS) },
-      ModalityState.any(),
-    )
+    try {
+      ApplicationManager.getApplication().invokeLater(
+        { executor.schedule(::drain, DEBOUNCE_MS, TimeUnit.MILLISECONDS) },
+        ModalityState.any(),
+      )
+    } catch (e: Exception) {
+      // Nothing will drain the pending write now, and a pending write counts as ownership — leaving it
+      // set would report that we own PRIMARY for the rest of the session.
+      pendingText.set(null)
+      logger.debug { "Could not schedule the PRIMARY write: ${e.message}" }
+      return false
+    }
     return true
   }
 
@@ -106,6 +123,12 @@ internal class XclipPrimarySelectionWriter private constructor() : PrimarySelect
   private fun hasUnflushedWrite(): Boolean = pendingText.get() != null
 
   private fun isHoldingSelection(): Boolean = selectionHolder.get()?.isAlive == true
+
+  override fun dispose() {
+    executor.shutdownNow()
+    pendingText.set(null)
+    selectionHolder.getAndSet(null)?.destroy()
+  }
 
   private fun drain() {
     val text = pendingText.getAndSet(null) ?: return
@@ -119,6 +142,13 @@ internal class XclipPrimarySelectionWriter private constructor() : PrimarySelect
       // Closing stdin is what makes xclip claim the selection; the previous holder then releases it
       // and exits by itself.
       process.outputStream.use { it.write(text.toByteArray(Charsets.UTF_8)) }
+      if (hasFailedImmediately(process)) {
+        // xclip treats an unrecognised argument as a filename and exits without claiming anything, so
+        // this is how a bad argv or an unreachable display surfaces — both output streams are
+        // discarded, and a small payload fits the pipe buffer, so nothing else would report it.
+        logger.warn("xclip exited with ${process.exitValue()} without taking PRIMARY; is `$STAY_IN_FOREGROUND` supported?")
+        process = null
+      }
     } catch (e: Exception) {
       // The write can fail after the process started, leaving xclip to claim PRIMARY with truncated
       // text. Kill it rather than orphan a holder we no longer track.
@@ -129,8 +159,15 @@ internal class XclipPrimarySelectionWriter private constructor() : PrimarySelect
     selectionHolder.set(process)
   }
 
+  /** A healthy foreground xclip stays alive holding the selection; a quick exit means it took nothing. */
+  private fun hasFailedImmediately(process: Process): Boolean =
+    process.waitFor(STARTUP_GRACE_MS, TimeUnit.MILLISECONDS)
+
   companion object {
     private const val DEBOUNCE_MS = 20L
+
+    /** Long enough for a rejected argv or an unreachable display to exit, short enough not to stall a yank. */
+    private const val STARTUP_GRACE_MS = 50L
     private val logger = vimLogger<XclipPrimarySelectionWriter>()
 
     // Detached, xclip outlives the Process we hold, leaving us blind to ownership. In the

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimClipboardManager.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimClipboardManager.kt
@@ -42,21 +42,21 @@ interface VimClipboardManager {
   ): Boolean
 
   /**
-   * What we last published via [setPrimaryContent], or `null` once anything else has claimed PRIMARY.
-   *
-   * A register read back out of PRIMARY has to re-guess its selection type from the text, which turns
-   * line-wise into character-wise whenever the text is reformatted or re-published on the way. While
-   * the selection is still ours, what we published is by definition what it holds — and we still know
-   * its type. Neovim's clipboard provider works the same way, reusing the `[lines, regtype]` it last
-   * handed out for as long as the `xclip`/`wl-copy` job it spawned is alive.
-   *
-   * This deliberately reports what was *published*, not what any register happens to cache: several
-   * call sites write PRIMARY without updating the `*` register, and conflating the two hands back
-   * content the selection never held.
+   * What we last published via [setPrimaryContent], while the selection is provably still ours, so the
+   * type survives instead of being guessed from the text. Neovim's clipboard provider does the same,
+   * reusing the `[lines, regtype]` it last handed out while its `xclip`/`wl-copy` job is alive.
    *
    * Default: `null` — platforms without a PRIMARY selection never own one.
    */
   fun getOwnedPrimaryContent(): OwnedPrimaryContent? = null
+
+  /**
+   * The same value, but claiming nothing about who owns PRIMARY now — for recognising our own content
+   * after a lossy round trip. Callers must confirm the text before trusting it.
+   *
+   * Default: `null`.
+   */
+  fun getLastPublishedPrimaryContent(): OwnedPrimaryContent? = null
 
   /**
    * Fired when the user's visible visual selection changes. Whether to republish the new

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/register/VimRegisterGroupBase.kt
@@ -441,44 +441,86 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
     injector.clipboardManager.setClipboardContent(editor, context, copiedText)
   }
 
-  // Fallback for when getOwnedPrimaryContent reports a false negative; Wayland's reader strips the
-  // trailing newline, so a line-wise "foo\n" comes back as "foo".
-  private fun matchesIgnoringStrippedTrailingNewline(cached: Register, clipboard: VimCopiedText): Boolean {
-    return clipboard.text == cached.text || clipboard.text + "\n" == cached.text
-  }
-
+  /**
+   * Resolves the `*` register, whose backing store is the windowing system's PRIMARY selection.
+   *
+   * PRIMARY holds text and nothing else, so the selection type has to be found elsewhere. Each source
+   * below is less trustworthy than the one before it, ending in a guess made from the text alone.
+   */
   private fun refreshPrimaryRegister(editor: VimEditor, context: ExecutionContext): Register? {
-    logger.trace("Syncing cached primary selection value..")
     if (!isPrimaryRegisterSupported()) {
       logger.trace("X11 primary selection is not supported. Syncing clipboard selection..")
       return refreshClipboardRegister(editor, context)
     }
-    try {
-      val ourContent = injector.clipboardManager.getOwnedPrimaryContent()
-      if (ourContent != null) {
-        logger.trace("PRIMARY still holds what we published; reusing it instead of re-guessing its type")
-        return Register(PRIMARY_REGISTER, ourContent.copiedText, ourContent.selectionType)
-      }
-      val clipboardData = injector.clipboardManager.getPrimaryContent(editor, context)
-      if (clipboardData == null || clipboardData.text.isEmpty()) {
-        // Wayland/XWayland clears PRIMARY on focus change; prefer the last IdeaVim-written value over
-        // an empty result. Differs from Vim only when the user deliberately clears PRIMARY externally.
-        logger.trace("PRIMARY selection is unavailable or empty; falling back to in-memory register value")
-        return myRegisters[PRIMARY_REGISTER]
-          // Nothing cached either: a readable-but-empty PRIMARY is still a register, and reporting it
-          // as absent hides the `*` row from `:registers` entirely.
-          ?: clipboardData?.let { Register(PRIMARY_REGISTER, it, SelectionType.CHARACTER_WISE) }
-      }
-      val currentRegister = myRegisters[PRIMARY_REGISTER]
-      if (currentRegister != null && matchesIgnoringStrippedTrailingNewline(currentRegister, clipboardData)) {
-        return currentRegister
-      }
-      return Register(PRIMARY_REGISTER, clipboardData, guessSelectionType(clipboardData.text))
+    return try {
+      registerWeStillOwn() ?: registerFor(injector.clipboardManager.getPrimaryContent(editor, context))
     } catch (e: Exception) {
       logger.warn("False positive X11 primary selection support")
-      logger.trace("Syncing primary selection failed. Syncing clipboard selection instead")
-      return refreshClipboardRegister(editor, context)
+      refreshClipboardRegister(editor, context)
     }
+  }
+
+  private fun registerWeStillOwn(): Register? =
+    injector.clipboardManager.getOwnedPrimaryContent()
+      ?.let { Register(PRIMARY_REGISTER, it.copiedText, it.selectionType) }
+
+  private fun registerFor(selection: VimCopiedText?): Register? {
+    if (selection == null || selection.text.isEmpty()) return registerForUnreadableSelection(selection)
+    // What we published is asked first: it is the record of what actually went to the selection,
+    // whereas the `*` register is only updated by the paths that write it explicitly.
+    return publishedRegisterHolding(selection)
+      ?: cachedRegisterHolding(selection)
+      ?: Register(PRIMARY_REGISTER, selection, guessSelectionType(selection.text))
+  }
+
+  /**
+   * Wayland/XWayland clears PRIMARY on focus change, so an unreadable selection is far more likely to
+   * be that than a deliberate clear — prefer the last value we held. A readable-but-empty selection is
+   * still a register: reporting it as absent would drop the `*` row from `:registers` altogether.
+   */
+  private fun registerForUnreadableSelection(selection: VimCopiedText?): Register? =
+    myRegisters[PRIMARY_REGISTER]
+      ?: selection?.let { Register(PRIMARY_REGISTER, it, SelectionType.CHARACTER_WISE) }
+
+  /**
+   * The IDE republishes the editor selection to PRIMARY on every selection change, as untyped text, so
+   * ownership is routinely lost to our own process with no foreign application involved. Recognising
+   * our own text lets the type survive that.
+   */
+  private fun publishedRegisterHolding(selection: VimCopiedText): Register? =
+    injector.clipboardManager.getLastPublishedPrimaryContent()
+      ?.let { recoverRegister(selection, it.copiedText, it.selectionType) }
+
+  private fun cachedRegisterHolding(selection: VimCopiedText): Register? =
+    myRegisters[PRIMARY_REGISTER]?.let { recoverRegister(selection, it.copiedText, it.type) }
+
+  /**
+   * Rebuilds the register from [ours] when the selection still holds that text.
+   *
+   * On an exact match our own copy is returned, keeping the transferable data collected at yank time.
+   * On a stripped match only the *type* is taken from [ours]: the selection's text is what a paste
+   * should insert, and substituting ours would hand back characters the selection never held.
+   */
+  private fun recoverRegister(selection: VimCopiedText, ours: VimCopiedText, type: SelectionType): Register? = when {
+    selection.text == ours.text -> Register(PRIMARY_REGISTER, ours, type)
+    selection.isTailStrippedFormOf(ours.text) -> Register(PRIMARY_REGISTER, selection, type)
+    else -> null
+  }
+
+  /**
+   * Whether the selection can only be [ourText] with its tail eaten in transit — the trailing newline,
+   * or that newline together with the whitespace before it. Something republishes our line reformatted
+   * (the IDE reindents a pasted range, and a formatter drops trailing whitespace), and the type has to
+   * survive that.
+   *
+   * Deliberately one-directional. Text carrying trailing whitespace of its own was not produced by
+   * stripping, so it belongs to whoever put it there; comparing both sides trimmed would also collapse
+   * every whitespace-only string to the same value and let any blank selection match any blank register.
+   */
+  private fun VimCopiedText.isTailStrippedFormOf(ourText: String): Boolean {
+    if (text + "\n" == ourText) return true
+    if (text != text.trimEnd()) return false
+    return text == ourText.trimEnd()
   }
 
   private fun refreshClipboardRegister(editor: VimEditor, context: ExecutionContext): Register? {
@@ -487,8 +529,14 @@ abstract class VimRegisterGroupBase : VimRegisterGroup {
 
     val clipboardData = injector.clipboardManager.getClipboardContent(editor, context) ?: return null
     val currentRegister = myRegisters[systemAwareClipboardRegister]
-    if (currentRegister != null && clipboardData.text == currentRegister.text) {
-      return currentRegister
+    if (currentRegister != null) {
+      // Same lossy-tail tolerance as PRIMARY: the clipboard is usually faithful, but it is re-read
+      // from the X server once another application owns it, and `+` would otherwise lose its type
+      // for exactly the same reason `*` did.
+      if (clipboardData.text == currentRegister.text) return currentRegister
+      if (clipboardData.isTailStrippedFormOf(currentRegister.text)) {
+        return Register(systemAwareClipboardRegister, clipboardData, currentRegister.type)
+      }
     }
     return Register(systemAwareClipboardRegister, clipboardData, guessSelectionType(clipboardData.text))
   }


### PR DESCRIPTION
When the selection is no longer ours but still holds our text minus the tail something reformatted away, the type now comes from what we published instead of being guessed from the text.