### PR TITLE
VIM-4272 Don't update systemSelection during indent

### DIFF
--- a/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/format/FormatRemoteApiImpl.kt
+++ b/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/format/FormatRemoteApiImpl.kt
@@ -51,7 +51,7 @@ class FormatRemoteApiImpl : FormatRemoteApi {
       for ((startLine, endLine) in sortedRanges) {
         val selStart = document.getLineStartOffset(startLine)
         val selEnd = document.getLineEndOffset(endLine)
-        editor.selectionModel.setSelection(selStart, selEnd)
+        editor.caretModel.currentCaret.setSelection(selStart, selEnd, false)
         ActionManager.getInstance().tryToExecute(action, null, editor.contentComponent, "IdeaVim", true).waitFor(5_000)
       }
       editor.selectionModel.removeSelection()


### PR DESCRIPTION
when we selected text during indentation after paste it selected part of text which in combination with unnamed resulted in duplicated/broken paste