### PR TITLE
VIM-2074 Fix backspace in replace mode

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
@@ -47,7 +47,6 @@ import com.maddyhome.idea.vim.common.IndentConfig
 import com.maddyhome.idea.vim.common.LiveRange
 import com.maddyhome.idea.vim.common.TextRange
 import com.maddyhome.idea.vim.common.VimEditorReplaceMask
-import com.maddyhome.idea.vim.common.forgetAllReplaceMasks
 import com.maddyhome.idea.vim.group.visual.vimSetSystemBlockSelectionSilently
 import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.helper.StrictMode
@@ -515,7 +514,6 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor, VimEditorBase() {
     get() = (editor as? EditorEx)?.isInsertMode ?: false
     set(value) {
       (editor as? EditorEx)?.isInsertMode = value
-      forgetAllReplaceMasks()
     }
 
   override val document: VimDocument

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/change/ChangeReplaceActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/change/ChangeReplaceActionTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2003-2023 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action.change.change
+
+import com.maddyhome.idea.vim.state.mode.Mode
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+// Backspace in Replace mode is covered by InsertBackspaceActionTest, which tests the action that handles it.
+class ChangeReplaceActionTest : VimTestCase() {
+  @Test
+  fun `test enter in replace mode does not delete the character under the caret`() {
+    // Vim only pushes a separator onto the replace stack for a new line - the character the caret was on is kept and
+    // moved to the new line.
+    doTest(
+      listOf("ll", "R", "<CR>"),
+      """
+        ${c}grzyb
+        next
+      """.trimIndent(),
+      """
+        gr
+        ${c}zyb
+        next
+      """.trimIndent(),
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode past the end of the line appends instead of replacing the next line`() {
+    doTest(
+      listOf("R", "mushroom"),
+      """
+        ${c}grzyb
+        next
+      """.trimIndent(),
+      """
+        mushroom${c}
+        next
+      """.trimIndent(),
+      Mode.REPLACE,
+    )
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertBackspaceActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertBackspaceActionTest.kt
@@ -8,6 +8,7 @@
 
 package org.jetbrains.plugins.ideavim.action.change.insert
 
+import com.maddyhome.idea.vim.state.mode.Mode
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
@@ -40,5 +41,163 @@ class InsertBackspaceActionTest : VimTestCase() {
     // screen is scrolled by 'sidescroll', which has the default value of 0, so we scroll until the caret is in the
     // middle of the screen, which is 80 characters wide: 79-(80/2)=39
     assertVisibleLineBounds(0, 39, 118)
+  }
+
+  // Replace mode backspace. Vim keeps a stack of the characters that each typed character replaced, and backspace pops
+  // it to put the original text back. See `replace_do_bs` in Vim's edit.c:
+  //   - the character was replaced -> put the original character back
+  //   - the character was inserted (typed past the end of the line) -> delete it
+  //   - the stack is empty -> only move the caret
+  // These tests use <C-H> rather than <BS> so that they can be verified against Neovim - <BS> uses Neovim's termcode
+  // format, which the RPC layer used for testing cannot send in insert mode (see NEOVIM_RPC_SPECIAL_KEYS_INSERT_MODE).
+
+  @Test
+  fun `test replace mode backspace restores all replaced characters`() {
+    // "mushroom" is longer than "grzyb", so its last three characters are appended instead of replacing anything. The
+    // first three backspaces delete those, the remaining five put the original characters back.
+    doTest(
+      listOf("R", "mushroom", "<C-H>".repeat(8)),
+      "${c}grzyb",
+      "${c}grzyb",
+      Mode.REPLACE,
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.NEOVIM_RPC_SPECIAL_KEYS_INSERT_MODE)
+  @Test
+  fun `test replace mode backspace restores all replaced characters with BS key`() {
+    doTest(
+      listOf("R", "mushroom", "<BS>".repeat(8)),
+      "${c}grzyb",
+      "${c}grzyb",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace restores a character replaced at the start of the line`() {
+    doTest(
+      listOf("R", "m", "<C-H>"),
+      "${c}grzyb",
+      "${c}grzyb",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace restores characters one at a time`() {
+    doTest(
+      listOf("R", "mushroom", "<C-H>".repeat(5)),
+      "${c}grzyb",
+      "mus${c}yb",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace deletes characters appended past the end of the line`() {
+    doTest(
+      listOf("R", "mushroom", "<C-H>".repeat(3)),
+      "${c}grzyb",
+      "mushr${c}",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace restores a character replaced away from the start of the line`() {
+    doTest(
+      listOf("ll", "R", "m", "<C-H>"),
+      "${c}grzyb",
+      "gr${c}zyb",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace restores text typed by an earlier replacement`() {
+    // Escape leaves the caret on the "Y", so "ll" moves onto the "y" of the original text. Each replacement only knows
+    // about the characters it typed over itself, so this restores that "y" rather than anything the first one replaced.
+    doTest(
+      listOf("R", "XY", "<Esc>", "ll", "R", "Z", "<C-H>"),
+      "${c}grzyb",
+      "XYz${c}yb",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace with nothing replaced only moves the caret`() {
+    // Nothing has been typed, so there is nothing on the replace stack. Vim only moves the caret - the character it
+    // moves over was never replaced and must be left alone.
+    doTest(
+      listOf("l", "R", "<C-H>"),
+      "${c}grzyb",
+      "${c}grzyb",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace at the start of a line only moves the caret`() {
+    // The line the replacement started on is never joined with the previous one - Vim just moves the caret back.
+    doTest(
+      listOf("j", "R", "<C-H>"),
+      """
+        ab
+        ${c}cd
+      """.trimIndent(),
+      """
+        ab${c}
+        cd
+      """.trimIndent(),
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace does not restore before the start of the replacement`() {
+    // Replace mode was entered on the third character, so the third backspace has nothing left to restore and only
+    // moves the caret. It must not touch the two characters that were never replaced.
+    doTest(
+      listOf("ll", "R", "mu", "<C-H>".repeat(3)),
+      "${c}grzyb",
+      "g${c}rzyb",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace records replaced characters again after restoring them`() {
+    doTest(
+      listOf("R", "mu", "<C-H>".repeat(2), "xy"),
+      "${c}grzyb",
+      "xy${c}zyb",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode backspace joins the lines split by enter`() {
+    // Enter in Replace mode splits the line without consuming a character, so backspacing over it joins the lines back
+    // together, and the characters replaced on each line are still restored.
+    doTest(
+      listOf("ll", "R", "<CR>", "x", "<CR>", "y", "<C-H>".repeat(5)),
+      "${c}grzyb",
+      "g${c}rzyb",
+      Mode.REPLACE,
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.NEOVIM_RPC_SPECIAL_KEYS_INSERT_MODE)
+  @Test
+  fun `test replace mode backspace after caret movement does not restore`() {
+    // Moving the caret restarts the replacement, so backspacing before the new start point only moves the caret.
+    doTest(
+      listOf("R", "mush", "<Left>", "<C-H>"),
+      "${c}grzyb",
+      "mu${c}shb",
+      Mode.REPLACE,
+    )
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertDeletePreviousWordActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertDeletePreviousWordActionTest.kt
@@ -205,4 +205,27 @@ class InsertDeletePreviousWordActionTest : VimTestCase() {
     )
     assertState("one<caret> o<caret> <caret> \n")
   }
+
+  @Test
+  fun `test replace mode delete previous word restores replaced characters`() {
+    // <C-W> in Replace mode pops the replace stack for every character it steps over, just like backspace does, so the
+    // original text comes back instead of the word being deleted.
+    doTest(
+      listOf("R", "mushroom", "<C-W>"),
+      "${c}grzyb",
+      "${c}grzyb",
+      Mode.REPLACE,
+    )
+  }
+
+  @Test
+  fun `test replace mode delete previous word with nothing replaced only moves the caret`() {
+    // Nothing has been replaced yet, so there is nothing to put back and nothing to delete - only the caret moves.
+    doTest(
+      listOf("lll", "R", "<C-W>"),
+      "${c}grzyb",
+      "${c}grzyb",
+      Mode.REPLACE,
+    )
+  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeReplaceAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/change/ChangeReplaceAction.kt
@@ -40,5 +40,5 @@ class ChangeReplaceAction : ChangeEditorActionHandler.SingleExecution() {
  */
 private fun changeReplace(editor: VimEditor, context: ExecutionContext) {
   injector.changeGroup.initInsert(editor, context, com.maddyhome.idea.vim.state.mode.Mode.REPLACE)
-  editor.replaceMask = VimEditorReplaceMask()
+  editor.replaceMask = VimEditorReplaceMask(editor)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBackspaceAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertBackspaceAction.kt
@@ -30,15 +30,17 @@ internal class InsertBackspaceAction : VimActionHandler.SingleExecution() {
     if (editor.insertMode) {
       injector.changeGroup.processBackspace(editor, context)
     } else {
-      for (caret in editor.carets()) {
-        val offset = (caret.offset - 1).takeIf { it > 0 } ?: continue
-        val oldChar = editor.replaceMask?.popChange(editor, offset)
-        if (oldChar != null) {
-          injector.changeGroup.replaceText(editor, caret, offset, offset + 1, oldChar.toString())
-        }
-        caret.moveToOffset(offset)
-      }
+      replaceModeBackspaceAtCarets(editor)
     }
     return true
+  }
+}
+
+private fun replaceModeBackspaceAtCarets(editor: VimEditor) {
+  for (caret in editor.carets()) {
+    val previousOffset = caret.offset - 1
+    if (previousOffset >= 0) {
+      replaceModeBackspace(editor, caret, previousOffset)
+    }
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertDeletePreviousWordAction.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/InsertDeletePreviousWordAction.kt
@@ -41,15 +41,7 @@ class InsertDeletePreviousWordAction : ChangeEditorActionHandler.ForEachCaret() 
   }
 }
 
-/**
- * Deletes the text from the cursor to the start of the previous word
- *
- *
- * TODO This behavior should be configured via the `backspace` option
- *
- * @param editor The editor to delete the text from
- * @return true if able to delete text, false if not
- */
+// TODO This behavior should be configured via the `backspace` option
 private fun insertDeletePreviousWord(editor: VimEditor, context: ExecutionContext, caret: VimCaret): Boolean {
   val deleteTo: Int = if (caret.getBufferPosition().column == 0) {
     caret.offset - 1
@@ -74,6 +66,16 @@ private fun insertDeletePreviousWord(editor: VimEditor, context: ExecutionContex
     return false
   }
   val range = TextRange(deleteTo, caret.offset)
-  injector.changeGroup.deleteRange(editor, context, caret, range, SelectionType.CHARACTER_WISE, true)
+  if (editor.insertMode) {
+    injector.changeGroup.deleteRange(editor, context, caret, range, SelectionType.CHARACTER_WISE, true)
+  } else {
+    replaceModeBackspaceOverEachCharacter(editor, caret, range)
+  }
   return true
+}
+
+private fun replaceModeBackspaceOverEachCharacter(editor: VimEditor, caret: VimCaret, range: TextRange) {
+  for (offset in (range.startOffset..<range.endOffset).reversed()) {
+    replaceModeBackspace(editor, caret, offset)
+  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/ReplaceModeBackspace.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/action/change/insert/ReplaceModeBackspace.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.action.change.insert
+
+import com.maddyhome.idea.vim.api.VimCaret
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.common.ReplaceModeEdit
+
+/**
+ * Undoes the character typed at [offset] in Replace mode, then moves the caret onto it.
+ */
+internal fun replaceModeBackspace(editor: VimEditor, caret: VimCaret, offset: Int) {
+  val undoneEdit = editor.replaceMask?.popEditAt(offset)
+  if (undoneEdit != null) {
+    replaceTypedCharacter(editor, caret, offset, undoneEdit.textBeforeEdit)
+  }
+  caret.moveToOffset(offset)
+}
+
+private fun replaceTypedCharacter(editor: VimEditor, caret: VimCaret, offset: Int, text: String) {
+  injector.changeGroup.replaceText(editor, caret, offset, offset + 1, text)
+}
+
+private val ReplaceModeEdit.textBeforeEdit: String
+  get() = when (this) {
+    is ReplaceModeEdit.Overwrote -> original.toString()
+    ReplaceModeEdit.Inserted -> ""
+  }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -689,6 +689,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     }
     if (editor.mode is Mode.REPLACE) {
       editor.insertMode = false
+      editor.replaceMask?.recordLineBreakAtCaret()
     }
   }
 
@@ -823,7 +824,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
   ): Boolean {
     logger.debug { "processKey($key)" }
     if (key.keyChar != KeyEvent.CHAR_UNDEFINED) {
-      editor.replaceMask?.recordChangeAtCaret(editor)
+      editor.replaceMask?.recordTypedCharacterAtCaret()
       processResultBuilder.addExecutionStep { _, e, c ->
         type(e, c, key.keyChar)
       }
@@ -839,7 +840,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
 
     // Shift-space
     if (key.keyCode == 32 && key.modifiers and KeyEvent.SHIFT_DOWN_MASK != 0) {
-      editor.replaceMask?.recordChangeAtCaret(editor)
+      editor.replaceMask?.recordTypedCharacterAtCaret()
       processResultBuilder.addExecutionStep { _, e, c ->
         type(e, c, ' ')
       }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimEditorReplaceMask.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/common/VimEditorReplaceMask.kt
@@ -9,27 +9,63 @@
 package com.maddyhome.idea.vim.common
 
 import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.api.getLineEndForOffset
 import com.maddyhome.idea.vim.api.injector
 
-class VimEditorReplaceMask {
-  private val changedChars = mutableMapOf<LiveRange, Char>()
+sealed interface ReplaceModeEdit {
+  data class Overwrote(val original: Char) : ReplaceModeEdit
 
-  fun recordChangeAtCaret(editor: VimEditor) {
+  data object Inserted : ReplaceModeEdit
+}
+
+/**
+ * Vim's replace stack, keyed by the offset of the typed character rather than by insertion order.
+ */
+class VimEditorReplaceMask(private val editor: VimEditor) {
+  private val edits = mutableMapOf<LiveRange, ReplaceModeEdit>()
+
+  fun recordTypedCharacterAtCaret() {
     for (caret in editor.carets()) {
       val offset = caret.offset
-      if (offset < editor.fileSize()) {
-        val marker = editor.createLiveMarker(offset, offset)
-        changedChars[marker] = editor.charAt(offset)
+      if (offset < editor.getLineEndForOffset(offset)) {
+        record(offset, ReplaceModeEdit.Overwrote(editor.charAt(offset)))
+      } else {
+        record(offset, ReplaceModeEdit.Inserted)
       }
     }
   }
 
-  fun popChange(editor: VimEditor, offset: Int): Char? {
-    val marker = editor.createLiveMarker(offset, offset)
-    val change = changedChars[marker]
-    changedChars.remove(marker)
-    return change
+  fun recordLineBreakAtCaret() {
+    for (caret in editor.carets()) {
+      recordAutoIndentAndLineBreakBefore(caret.offset)
+    }
   }
+
+  private fun recordAutoIndentAndLineBreakBefore(caretOffset: Int) {
+    var offset = caretOffset - 1
+    while (offset >= 0 && isAutoIndentWhitespace(offset)) {
+      record(offset, ReplaceModeEdit.Inserted)
+      offset--
+    }
+    if (offset >= 0 && editor.charAt(offset) == '\n') {
+      record(offset, ReplaceModeEdit.Inserted)
+    }
+  }
+
+  private fun isAutoIndentWhitespace(offset: Int): Boolean {
+    val char = editor.charAt(offset)
+    return char != '\n' && char.isWhitespace()
+  }
+
+  fun popEditAt(offset: Int): ReplaceModeEdit? {
+    return edits.remove(markerAt(offset))
+  }
+
+  private fun record(offset: Int, edit: ReplaceModeEdit) {
+    edits[markerAt(offset)] = edit
+  }
+
+  private fun markerAt(offset: Int): LiveRange = editor.createLiveMarker(offset, offset)
 }
 
 fun forgetAllReplaceMasks() {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/handler/MotionActionHandler.kt
@@ -147,6 +147,12 @@ sealed class MotionActionHandler : EditorActionHandlerBase(false) {
     cmd: Command,
     operatorArguments: OperatorArguments,
   ): Boolean {
+    // Moving the caret ends the run of replaced characters, so a later backspace no longer restores them.
+    // See `start_arrow` in Vim's edit.c.
+    if (editor.mode == Mode.REPLACE) {
+      editor.replaceMask = null
+    }
+
     val blockSelectionActive = editor.inBlockSelection
 
     val handler = if (this is AmbiguousExecution) this.getMotionActionHandler(cmd.argument) else this


### PR DESCRIPTION
We didn't take into account appended and overwrote charachters in replace mode. Due to that we didn't correctly restored charachtes when backspacing