### PR TITLE
VIM-2536 NL characters in commands

### DIFF
--- a/src/test/java/org/jetbrains/plugins/ideavim/action/MacroActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/MacroActionTest.kt
@@ -519,6 +519,15 @@ class MacroActionTest : VimTestCase() {
   }
 
   @Test
+  fun `test macro from register built with CR replays as Enter`() {
+    configureByText("${c}lorem")
+    // `\<CR>` is a carriage return (0x0D), which replays as Enter, just like a recorded Enter does
+    enterCommand("""let @q = "iX\<CR>Y\<Esc>"""")
+    typeText("@q")
+    assertState("X\n${c}Ylorem")
+  }
+
+  @Test
   fun `should not record y twice when followed by motion`() {
     configureByText("${c}Spider man")
     enterCommand("map ys :echo 'hi'<CR>")

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/ExecuteCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/ExecuteCommandTest.kt
@@ -47,4 +47,19 @@ class ExecuteCommandTest : VimTestCase() {
     typeText(commandToKeys("execute('echo '.42)"))
     assertExOutput("42")
   }
+
+  @Test
+  fun `test line feed separates commands`() {
+    configureByText("\n")
+    typeText(commandToKeys("execute \"echo 1\\necho 2\""))
+    assertExOutput("1\n2")
+  }
+
+  @Test
+  fun `test line feed separates commands other than the first`() {
+    configureByText("${c}Lorem ipsum")
+    typeText(commandToKeys("execute \"echo 1\\nnormal! x\""))
+    assertExOutput("1")
+    assertState("${c}orem ipsum")
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/NormalCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/NormalCommandTest.kt
@@ -457,4 +457,153 @@ class NormalCommandTest : VimTestCase() {
       enterCommand("set nooldundo")
     }
   }
+
+  @Test
+  fun `test literal Esc typed with CTRL-V exits Insert mode`() {
+    configureByText("123${c}456")
+    typeText(":normal iFoo<C-V><Esc>x<CR>")
+    assertState("123Fo${c}456")
+  }
+
+  @Test
+  fun `test Esc in execute string exits Insert mode`() {
+    configureByText("123${c}456")
+    enterCommand("""exe "normal! iFoo\<Esc>x"""")
+    assertState("123Fo${c}456")
+  }
+
+  @Test
+  fun `test Esc as backslash-e in execute string exits Insert mode`() {
+    configureByText("123${c}456")
+    enterCommand("""exe "normal! iFoo\ex"""")
+    assertState("123Fo${c}456")
+  }
+
+  @Test
+  fun `test CTRL-A in execute string increments number`() {
+    configureByText("x ${c}41 y")
+    enterCommand("""exe "normal! \<C-A>"""")
+    assertState("x 4${c}2 y")
+  }
+
+  @Test
+  fun `test literal CR typed with CTRL-V inserts new line`() {
+    configureByText("${c}123456")
+    typeText(":normal iX<C-V><CR>Y<CR>")
+    assertState(
+      """
+      |X
+      |${c}Y123456
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test CR as backslash-r in execute string inserts new line`() {
+    configureByText("${c}123456")
+    enterCommand("""exe "normal! iX\rY"""")
+    assertState(
+      """
+      |X
+      |${c}Y123456
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test CR as octal escape in execute string inserts new line`() {
+    configureByText("${c}123456")
+    enterCommand("""exe "normal! iX\015Y"""")
+    assertState(
+      """
+      |X
+      |${c}Y123456
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test CTRL-M in execute string inserts new line`() {
+    configureByText("${c}123456")
+    enterCommand("""exe "normal! iX\<C-M>Y"""")
+    assertState(
+      """
+      |X
+      |${c}Y123456
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test CTRL-J in execute string inserts new line`() {
+    configureByText("${c}123456")
+    enterCommand("""exe "normal! iX\<C-J>Y"""")
+    assertState(
+      """
+      |X
+      |${c}Y123456
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test CR as key notation in execute string inserts new line`() {
+    configureByText("${c}123456")
+    enterCommand("""exe "normal! iX\<CR>Y"""")
+    assertState(
+      """
+      |X
+      |${c}Y123456
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test NL as backslash-n in execute string inserts new line`() {
+    configureByText("${c}123456")
+    enterCommand("""exe "normal! iX\nY"""")
+    assertState(
+      """
+      |X
+      |${c}Y123456
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test NL as key notation in execute string inserts new line`() {
+    configureByText("${c}123456")
+    enterCommand("""exe "normal! iX\<NL>Y"""")
+    assertState(
+      """
+      |X
+      |${c}Y123456
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test trailing NL in execute string is part of the argument`() {
+    configureByText("${c}123456")
+    enterCommand("""exe "normal! iX\n"""")
+    assertState(
+      """
+      |X
+      |${c}123456
+      """.trimMargin()
+    )
+  }
+
+  @Test
+  fun `test multiple NL in execute string`() {
+    configureByText("${c}123456")
+    enterCommand("""exe "normal! iA\nB\nC"""")
+    assertState(
+      """
+      |A
+      |B
+      |${c}C123456
+      """.trimMargin()
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/parser/expressions/DoubleQuotedStringTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/parser/expressions/DoubleQuotedStringTest.kt
@@ -9,6 +9,7 @@
 package org.jetbrains.plugins.ideavim.ex.parser.expressions
 
 import com.maddyhome.idea.vim.api.injector
+import org.jetbrains.plugins.ideavim.VimBehaviorDiffers
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.Test
 import java.awt.event.InputEvent.CTRL_DOWN_MASK
@@ -129,6 +130,29 @@ class DoubleQuotedStringTest : VimTestCase() {
     assertEquals(injector.parser.parseVimScriptString("\\<Esk>"), "<Esk>")
     assertEquals(injector.parser.parseVimScriptString("l\\<Esc>l"), "l" + 27.toChar() + "l")
     assertEquals(injector.parser.parseVimScriptString("\\<Space>"), " ")
+  }
+
+  @Test
+  fun `test CR is a carriage return`() {
+    // Java's VK_ENTER is 10, but Vim's <CR> is 13. `char2nr("\<CR>")` is 13 in Vim
+    assertEquals(13.toChar().toString(), injector.parser.parseVimScriptString("\\<CR>"))
+    assertEquals(13.toChar().toString(), injector.parser.parseVimScriptString("\\<Enter>"))
+    assertEquals(13.toChar().toString(), injector.parser.parseVimScriptString("\\<Return>"))
+    assertEquals("a" + 13.toChar() + "b", injector.parser.parseVimScriptString("a\\<CR>b"))
+  }
+
+  @VimBehaviorDiffers(
+    originalVimAfter = "`char2nr` of each of these is 10 in Vim",
+    description = "IdeaVim represents the line feed key as NUL, like Vim does for a NUL in text. `<NL>` follows " +
+      "`<C-J>`, so that both are recognised as the same key",
+  )
+  @Test
+  fun `test NL is the same key as C-J`() {
+    val ctrlJ = injector.parser.parseVimScriptString("\\<C-J>")
+    assertEquals(ctrlJ, injector.parser.parseVimScriptString("\\<NL>"))
+    assertEquals(ctrlJ, injector.parser.parseVimScriptString("\\<NewLine>"))
+    assertEquals(ctrlJ, injector.parser.parseVimScriptString("\\<LineFeed>"))
+    assertEquals(ctrlJ, injector.parser.parseVimScriptString("\\<LF>"))
   }
 
   @Test

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimStringParserBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimStringParserBase.kt
@@ -449,7 +449,7 @@ abstract class VimStringParserBase : VimStringParser {
           if (c == '>') {
             val specialKey = parseSpecialKey(specialKeyBuilder.toString(), 0)
             if (specialKey != null) {
-              var keyCode = specialKey.keyCode
+              var keyCode = virtualKeyCodeToCodepoint(specialKey.keyCode)
               var useKeyCode = true
               if (specialKey.keyCode == 0) {
                 keyCode = specialKey.keyChar.code
@@ -491,6 +491,8 @@ abstract class VimStringParserBase : VimStringParser {
     INIT, ESCAPE, OCTAL_NUMBER, HEX_NUMBER, SPECIAL
   }
 
+  private fun virtualKeyCodeToCodepoint(keyCode: Int) = if (keyCode == KeyEvent.VK_ENTER) '\r'.code else keyCode
+
   private fun octalDigitToNumber(c: Char): Int? {
     return if (c in '0'..'7') {
       c.code - '0'.code
@@ -512,6 +514,11 @@ abstract class VimStringParserBase : VimStringParser {
   // See https://vimdoc.sourceforge.net/htmldoc/intro.html#key-notation
   private fun parseSpecialKey(s: String, modifiers: Int): KeyStroke? {
     val lower = s.lowercase(Locale.getDefault())
+
+    if (lower in nlKeyNames) {
+      return parseSpecialKey("j", modifiers or InputEvent.CTRL_DOWN_MASK)
+    }
+
     val keyCode = getVimKeyName(lower)
     val typedChar = getVimTypedKeyName(lower)
     if (keyCode != null) {
@@ -632,5 +639,7 @@ abstract class VimStringParserBase : VimStringParser {
     private const val SHIFT_PREFIX = "s-"
     private const val VK_PLUG = KeyEvent.CHAR_UNDEFINED.code - 1
     private const val VK_ACTION = KeyEvent.CHAR_UNDEFINED.code - 2
+
+    private val nlKeyNames = setOf("nl", "newline", "linefeed", "lf")
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/ExecuteCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/ExecuteCommand.kt
@@ -34,7 +34,7 @@ data class ExecuteCommand(val range: Range, val expressions: List<Expression>) :
   ): ExecutionResult {
     val command = expressions.joinToString(separator = " ") { it.evaluate(editor, context, this).toVimString().value }
     return injector.vimscriptExecutor.execute(
-      command,
+      asSingleCommandLine(command),
       editor,
       context,
       skipHistory = true,
@@ -42,4 +42,13 @@ data class ExecuteCommand(val range: Range, val expressions: List<Expression>) :
       this.vimContext
     )
   }
+
+  private fun asSingleCommandLine(command: String): String {
+    if (!command.contains('\n')) return command
+    val firstCommand = injector.vimscriptParser.parseCommand(command.substringBefore('\n'))
+    if (!takesRestOfCommandLine(firstCommand)) return command
+    return command.replace("\r\n", "\r").replace('\n', '\r')
+  }
+
+  private fun takesRestOfCommandLine(command: Command?) = command is NormalCommand
 }


### PR DESCRIPTION
normal lost the newline and everything after it when the argument came from an :execute string (:exe "normal! iX\<CR>Y" typed only X), because \<CR> was parsed into a line feed instead of a carriage return and a line feed ends the ex command line; fixed by making \<CR> produce 0x0D, recognising <NL> as the <C-J> key, and having :execute hand line feeds to the parser as carriage returns for commands like :normal that take the rest of the line.