### PR TITLE
VIM-2168 separate history per split window

### DIFF
--- a/doc/set-commands.md
+++ b/doc/set-commands.md
@@ -302,4 +302,23 @@ Unless otherwise stated, these options do not have abbreviations.
         be ignored and the current Vim mode maintained.
 
         It is not expected that this value will need to be changed.
+
+'windowjumps'           boolean (default off)
+                        global
+        When on, each window (split) has its own jump list, as in Vim. When
+        off, a single jump list is shared by every window and tab of the
+        project.
+
+        Vim scopes the jump list to a window, and a new split starts with a
+        copy of the list of the window it was split from. IdeaVim's default is
+        one list per project, which is the behaviour IdeaVim has always had.
+
+        The jump list is what `:jumps`, CTRL-O and CTRL-I work with. The IDE's
+        own Back and Forward navigation is separate, and stays project wide
+        whatever this option is set to.
+
+        Only one list per project is saved between sessions, because window
+        ids do not survive a restart. The list of the most recently used
+        window is the one saved, and a window that has no list of its own -
+        after a restart, or when it is the first window - starts from it.
 ```

--- a/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
+++ b/ideavim-frontend/src/main/resources/IdeaVIM.ideavim-frontend.xml
@@ -176,6 +176,10 @@
     <applicationService serviceImplementation="com.maddyhome.idea.vim.group.VimJumpServiceImpl"
                         serviceInterface="com.maddyhome.idea.vim.api.VimJumpService"/>
 
+    <!-- Stable ids for editor windows (splits), used to scope the jump list per window -->
+    <applicationService serviceImplementation="com.maddyhome.idea.vim.group.VimWindowIdService"
+                        serviceInterface="com.maddyhome.idea.vim.api.VimWindowIdService"/>
+
     <applicationService serviceImplementation="com.maddyhome.idea.vim.group.process.IjProcessGroup"
                         serviceInterface="com.maddyhome.idea.vim.api.VimProcessGroup"/>
 

--- a/src/main/java/com/maddyhome/idea/vim/group/JumpRemoteTopicListener.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/JumpRemoteTopicListener.kt
@@ -8,15 +8,20 @@
 
 package com.maddyhome.idea.vim.group
 
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
+import com.intellij.openapi.fileEditor.impl.EditorWindow
 import com.intellij.openapi.project.Project
 import com.intellij.platform.rpc.topics.ProjectRemoteTopic
 import com.intellij.platform.rpc.topics.ProjectRemoteTopicListener
+import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.group.jump.JUMP_REMOTE_TOPIC
 import com.maddyhome.idea.vim.group.jump.JumpInfo
 import com.maddyhome.idea.vim.mark.Jump
 import com.maddyhome.idea.vim.newapi.globalIjOptions
 import com.maddyhome.idea.vim.newapi.initInjector
+import com.maddyhome.idea.vim.newapi.vim
 
 /**
  * Receives jump events from the backend [JumpsListener] via [JUMP_REMOTE_TOPIC]
@@ -37,14 +42,35 @@ internal class JumpRemoteTopicListener : ProjectRemoteTopicListener<JumpInfo> {
     val jumpService = injector.jumpService
     if (event.timestamp < jumpService.lastJumpTimeStamp) return
 
-    val projectId = injector.file.getProjectId(project)
+    val scopeId = scopeIdFor(project, event)
     val jump = Jump(event.line, event.col, event.filepath, event.protocol)
 
     if (event.added) {
-      jumpService.addJump(projectId, jump, true)
+      jumpService.addJump(scopeId, jump, true)
       injector.markService.setJumpMark(event.filepath, event.protocol, event.line, event.col)
     } else {
-      jumpService.removeJump(projectId, jump)
+      jumpService.removeJump(scopeId, jump)
     }
+  }
+
+  private fun scopeIdFor(project: Project, event: JumpInfo): String {
+    val projectId = injector.file.getProjectId(project)
+    if (!injector.globalOptions().windowjumps) return projectId
+
+    val window = windowFor(project, event.filepath) ?: return projectId
+    val editor = (window.selectedComposite?.selectedEditor as? TextEditor)?.editor ?: return projectId
+    return injector.windowIdService.getWindowScopeId(editor.vim) ?: projectId
+  }
+
+  /** A window showing the file, preferring the focused one, since that is where the user navigated */
+  private fun windowFor(project: Project, filepath: String): EditorWindow? {
+    val fileEditorManager = FileEditorManagerEx.getInstanceEx(project)
+    val focused = fileEditorManager.currentWindow
+    if (focused?.shows(filepath) == true) return focused
+    return fileEditorManager.windows.firstOrNull { it.shows(filepath) } ?: focused
+  }
+
+  private fun EditorWindow.shows(filepath: String): Boolean {
+    return allComposites.any { it.file.path == filepath }
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/group/VimJumpServiceImpl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/VimJumpServiceImpl.kt
@@ -38,6 +38,9 @@ import org.jdom.Element
 internal class VimJumpServiceImpl : VimJumpServiceBase(), PersistentStateComponent<Element?> {
   companion object {
     private val logger = vimLogger<VimJumpServiceImpl>()
+
+    /** Separates the project id from the window id in a window scoped jump list's scope id */
+    private const val WINDOW_SCOPE_SEPARATOR = '/'
   }
 
   override var lastJumpTimeStamp: Long = 0
@@ -57,7 +60,7 @@ internal class VimJumpServiceImpl : VimJumpServiceBase(), PersistentStateCompone
   // (e.g., recent files), than for the 100 jumps (max number of records) to consume enough space to be noticeable.
   override fun getState(): Element {
     val projectsElem = Element("projects")
-    for ((project, jumps) in projectToJumps) {
+    for ((project, jumps) in jumpsByProject()) {
       val projectElement = Element("project").setAttribute("id", project)
       for (jump in jumps) {
         val jumpElem = Element("jump")
@@ -73,6 +76,25 @@ internal class VimJumpServiceImpl : VimJumpServiceBase(), PersistentStateCompone
       projectsElem.addContent(projectElement)
     }
     return projectsElem
+  }
+
+  /**
+   * The jump lists to persist, keyed by project id
+   *
+   * With the 'windowjumps' option set, a jump list is scoped to a window and its scope id is `"<projectId>/<windowId>"`
+   * (see [com.maddyhome.idea.vim.newapi.IjVimEditor.jumpListId]). Window ids only mean something within a session, so
+   * persisting them would write records that can never be read back, and which would accumulate over time. Instead we
+   * save one list per project, taken from the most recently used window - the closest thing to Vim's single `viminfo`
+   * jump list. [scopeToJumps] iterates from least to most recently updated, so later entries win.
+   *
+   * Without 'windowjumps' the scope id *is* the project id, and this grouping is a no-op.
+   */
+  private fun jumpsByProject(): Map<String, List<Jump>> {
+    val result = LinkedHashMap<String, List<Jump>>()
+    for ((scopeId, jumps) in scopeToJumps) {
+      result[scopeId.substringBefore(WINDOW_SCOPE_SEPARATOR)] = jumps
+    }
+    return result
   }
 
   override fun loadLegacyState(element: Any) {
@@ -98,7 +120,7 @@ internal class VimJumpServiceImpl : VimJumpServiceBase(), PersistentStateCompone
         logger.debug("jumps=$jumps")
       }
       val projectId = projectElement.getAttributeValue("id")
-      projectToJumps[projectId] = jumps
+      scopeToJumps[projectId] = jumps
     }
   }
 }

--- a/src/main/java/com/maddyhome/idea/vim/group/VimJumpServiceImpl.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/VimJumpServiceImpl.kt
@@ -17,6 +17,7 @@ import com.intellij.openapi.util.text.StringUtil
 import com.intellij.platform.project.projectId
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.VimJumpServiceBase
+import com.maddyhome.idea.vim.api.VimWindowIdService
 import com.maddyhome.idea.vim.diagnostic.vimLogger
 import com.maddyhome.idea.vim.group.jump.JumpRemoteApi
 import com.maddyhome.idea.vim.mark.Jump
@@ -38,9 +39,6 @@ import org.jdom.Element
 internal class VimJumpServiceImpl : VimJumpServiceBase(), PersistentStateComponent<Element?> {
   companion object {
     private val logger = vimLogger<VimJumpServiceImpl>()
-
-    /** Separates the project id from the window id in a window scoped jump list's scope id */
-    private const val WINDOW_SCOPE_SEPARATOR = '/'
   }
 
   override var lastJumpTimeStamp: Long = 0
@@ -79,20 +77,15 @@ internal class VimJumpServiceImpl : VimJumpServiceBase(), PersistentStateCompone
   }
 
   /**
-   * The jump lists to persist, keyed by project id
+   * One jump list per project, taken from the most recently used window
    *
-   * With the 'windowjumps' option set, a jump list is scoped to a window and its scope id is `"<projectId>/<windowId>"`
-   * (see [com.maddyhome.idea.vim.newapi.IjVimEditor.jumpListId]). Window ids only mean something within a session, so
-   * persisting them would write records that can never be read back, and which would accumulate over time. Instead we
-   * save one list per project, taken from the most recently used window - the closest thing to Vim's single `viminfo`
-   * jump list. [scopeToJumps] iterates from least to most recently updated, so later entries win.
-   *
-   * Without 'windowjumps' the scope id *is* the project id, and this grouping is a no-op.
+   * Window ids mean nothing after a restart, so saving a list per window would write records that can never be read
+   * back. Vim also keeps a single list in `viminfo`.
    */
   private fun jumpsByProject(): Map<String, List<Jump>> {
     val result = LinkedHashMap<String, List<Jump>>()
     for ((scopeId, jumps) in scopeToJumps) {
-      result[scopeId.substringBefore(WINDOW_SCOPE_SEPARATOR)] = jumps
+      result[VimWindowIdService.projectIdOf(scopeId)] = jumps
     }
     return result
   }

--- a/src/main/java/com/maddyhome/idea/vim/group/VimWindowIdService.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/VimWindowIdService.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.group
+
+import com.intellij.openapi.fileEditor.impl.EditorWindow
+import com.maddyhome.idea.vim.api.VimEditor
+import com.maddyhome.idea.vim.helper.EditorHelper
+import com.maddyhome.idea.vim.newapi.ij
+import java.util.*
+
+class VimWindowIdService : com.maddyhome.idea.vim.api.VimWindowIdService {
+
+  private val ids = WeakHashMap<EditorWindow, String>()
+  private var counter = 0
+
+  override fun getWindowId(editor: VimEditor): String? {
+    val window = EditorHelper.getOwningEditorWindow(editor.ij) ?: return null
+    return idFor(window)
+  }
+
+  private fun idFor(window: EditorWindow): String {
+    return ids.computeIfAbsent(window) { "vim-window-${counter++}" }
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/group/WindowJumpsChangeListener.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/WindowJumpsChangeListener.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.group
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
+import com.intellij.openapi.fileEditor.impl.EditorWindow
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.maddyhome.idea.vim.api.globalOptions
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.options.GlobalOptionChangeListener
+
+internal object WindowJumpsChangeListener : GlobalOptionChangeListener {
+  override fun onGlobalOptionChanged() {
+    val perWindow = injector.globalOptions().windowjumps
+    for (project in ProjectManager.getInstance().openProjects) {
+      if (project.isDisposed) continue
+      if (perWindow) {
+        seedWindowsFromProject(project)
+      } else {
+        collapseToFocusedWindow(project)
+      }
+    }
+  }
+
+  private fun seedWindowsFromProject(project: Project) {
+    val projectId = injector.file.getProjectId(project)
+    for (window in FileEditorManagerEx.getInstanceEx(project).windows) {
+      val scopeId = windowScopeId(window) ?: continue
+      injector.jumpService.copyJumps(projectId, scopeId)
+    }
+  }
+
+  private fun collapseToFocusedWindow(project: Project) {
+    val projectId = injector.file.getProjectId(project)
+    val fileEditorManager = FileEditorManagerEx.getInstanceEx(project)
+    val focusedScopeId = fileEditorManager.currentWindow?.let { windowScopeId(it) }
+
+    if (focusedScopeId != null) {
+      if (injector.jumpService.getJumps(focusedScopeId).isNotEmpty()) {
+        injector.jumpService.copyJumps(focusedScopeId, projectId)
+      } else {
+        injector.jumpService.clearJumps(projectId)
+      }
+    }
+
+    for (window in fileEditorManager.windows) {
+      val scopeId = windowScopeId(window) ?: continue
+      injector.jumpService.clearJumps(scopeId)
+    }
+  }
+
+  private fun windowScopeId(window: EditorWindow): String? {
+    val editor = window.selectedEditor() ?: return null
+    return injector.windowIdService.getWindowScopeId(editor.vim)
+  }
+
+  private fun EditorWindow.selectedEditor(): Editor? {
+    return (selectedComposite?.selectedEditor as? TextEditor)?.editor
+  }
+}

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.java
@@ -13,6 +13,12 @@ import com.intellij.openapi.editor.*;
 import com.intellij.openapi.editor.ex.util.EditorUtil;
 import com.intellij.openapi.editor.impl.EditorImpl;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx;
+import com.intellij.openapi.fileEditor.impl.EditorComposite;
+import com.intellij.openapi.fileEditor.impl.EditorWindow;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.registry.Registry;
@@ -59,6 +65,22 @@ public class EditorHelper {
       return area;
     }
     return new Rectangle(area.x, area.y + stickyLinesHeight, area.width, max(0, area.height - stickyLinesHeight));
+  }
+
+  public static @Nullable EditorWindow getOwningEditorWindow(@NotNull Editor editor) {
+    final Project project = editor.getProject();
+    if (project == null) return null;
+
+    for (EditorWindow editorWindow : FileEditorManagerEx.getInstanceEx(project).getWindows()) {
+      for (EditorComposite composite : editorWindow.getAllComposites()) {
+        for (FileEditor fileEditor : composite.getAllEditors()) {
+          if (fileEditor instanceof TextEditor textEditor && textEditor.getEditor() == editor) {
+            return editorWindow;
+          }
+        }
+      }
+    }
+    return null;
   }
 
   public static boolean scrollVertically(@NotNull Editor editor, int verticalOffset) {

--- a/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/EditorHelper.kt
@@ -101,6 +101,7 @@ internal fun Editor.isPrimaryEditor(): Boolean {
   return fileEditorManager.allEditors.any { fileEditor -> this == EditorUtil.getEditorEx(fileEditor) }
 }
 
+
 /**
  * Checks if the editor should be treated like a terminal. I.e. switch to Insert mode automatically
  *

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -93,6 +93,7 @@ import com.maddyhome.idea.vim.group.MotionGroup
 import com.maddyhome.idea.vim.group.NumberChangeListener
 import com.maddyhome.idea.vim.group.OptionGroup
 import com.maddyhome.idea.vim.group.ScrollOptionsChangeListener
+import com.maddyhome.idea.vim.group.WindowJumpsChangeListener
 import com.maddyhome.idea.vim.group.visual.IdeaSelectionControl
 import com.maddyhome.idea.vim.group.visual.VimVisualTimer
 import com.maddyhome.idea.vim.group.visual.moveCaretOneCharLeftFromSelectionEnd
@@ -243,6 +244,7 @@ object VimListenerManager {
       optionGroup.addGlobalOptionChangeListener(Options.showmode, modeWidgetOptionListener)
       optionGroup.addGlobalOptionChangeListener(Options.showmode, macroWidgetOptionListener)
       optionGroup.addEffectiveOptionValueChangeListener(Options.keymap, KeymapChangeListener)
+      optionGroup.addGlobalOptionChangeListener(Options.windowjumps, WindowJumpsChangeListener)
 
       // The listeners are registered _after_ ideavimrc has been evaluated, so trigger these listeners to ensure we're
       // up to date
@@ -288,6 +290,7 @@ object VimListenerManager {
       optionGroup.removeGlobalOptionChangeListener(Options.showcmd, ShowCmdOptionChangeListener)
       optionGroup.removeGlobalOptionChangeListener(Options.showmode, modeWidgetOptionListener)
       optionGroup.removeGlobalOptionChangeListener(Options.showmode, macroWidgetOptionListener)
+      optionGroup.removeGlobalOptionChangeListener(Options.windowjumps, WindowJumpsChangeListener)
 
       BufNewFileTracker.clear()
     }

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -76,6 +76,7 @@ import com.maddyhome.idea.vim.api.VirtualBufferKind
 import com.maddyhome.idea.vim.api.coerceOffset
 import com.maddyhome.idea.vim.api.getLineEndForOffset
 import com.maddyhome.idea.vim.api.getLineStartForOffset
+import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.autocmd.AutoCmdEvent
 import com.maddyhome.idea.vim.autocmd.IjFileTypeMapping
@@ -693,6 +694,9 @@ object VimListenerManager {
             editor.document == openingEditor.editor.document -> LocalOptionInitialisationScenario.SPLIT
             (openingEditor.canBeReused || openingEditor.isPreview) && isInSameSplit && openingEditorIsClosed -> LocalOptionInitialisationScenario.EDIT
             else -> LocalOptionInitialisationScenario.NEW
+          }
+          if (scenario == LocalOptionInitialisationScenario.SPLIT && injector.globalOptions().windowjumps) {
+            injector.jumpService.copyJumps(openingEditor?.editor?.vim?.jumpListId ?: "", editor.vim.jumpListId ?: "")
           }
           EditorListeners.add(editor, openingEditor?.editor?.vim ?: injector.fallbackWindow, scenario)
           firstEditorInitialised = true

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -569,7 +569,7 @@ object VimListenerManager {
 
         // Keep a track of the owner of the opening editor, so we can compare later, potentially after the opening
         // editor has been closed. This is nullable, but should always have a value
-        val owningEditorWindow = getOwningEditorWindow(openingEditor)
+        val owningEditorWindow = EditorHelper.getOwningEditorWindow(openingEditor)
 
         event.editor.putUserData(
           openingEditorKey,
@@ -675,7 +675,7 @@ object VimListenerManager {
           if (editor.vimInitialised) return@let
 
           val openingEditor = editor.removeUserData(openingEditorKey)
-          val owningEditorWindow = getOwningEditorWindow(editor)
+          val owningEditorWindow = EditorHelper.getOwningEditorWindow(editor)
           val isInSameSplit = owningEditorWindow == openingEditor?.owningEditorWindow
 
           // Sometimes the platform will not reuse a tab when you expect it to, e.g. when reuse tabs is enabled and
@@ -702,13 +702,6 @@ object VimListenerManager {
       }
     }
 
-    private fun getOwningEditorWindow(editor: Editor) = editor.project?.let { p ->
-      FileEditorManagerEx.getInstanceEx(p).windows.find { editorWindow ->
-        editorWindow.allComposites.any { composite ->
-          composite.allEditors.filterIsInstance<TextEditor>().any { it.editor == editor }
-        }
-      }
-    }
   }
 
 

--- a/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
+++ b/src/main/java/com/maddyhome/idea/vim/listener/VimListenerManager.kt
@@ -698,8 +698,11 @@ object VimListenerManager {
             (openingEditor.canBeReused || openingEditor.isPreview) && isInSameSplit && openingEditorIsClosed -> LocalOptionInitialisationScenario.EDIT
             else -> LocalOptionInitialisationScenario.NEW
           }
-          if (scenario == LocalOptionInitialisationScenario.SPLIT && injector.globalOptions().windowjumps) {
-            injector.jumpService.copyJumps(openingEditor?.editor?.vim?.jumpListId ?: "", editor.vim.jumpListId ?: "")
+          // Vim copies the jump list into any window created by a split, whichever buffer ends up in the new window -
+          // `:vsplit {file}`, `:vnew` and "Open in Right Split" included. The SPLIT scenario above is narrower than
+          // that: it only covers a new window showing the *same* document, so it cannot be the condition here
+          if (!isInSameSplit && openingEditor != null && injector.globalOptions().windowjumps) {
+            injector.jumpService.inheritJumps(openingEditor.editor.vim.jumpListId, editor.vim.jumpListId)
           }
           EditorListeners.add(editor, openingEditor?.editor?.vim ?: injector.fallbackWindow, scenario)
           firstEditorInitialised = true

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimEditor.kt
@@ -42,6 +42,7 @@ import com.maddyhome.idea.vim.api.VimVirtualFile
 import com.maddyhome.idea.vim.api.VimVisualPosition
 import com.maddyhome.idea.vim.api.VirtualBufferKind
 import com.maddyhome.idea.vim.api.getVisualStartLine
+import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.common.IndentConfig
 import com.maddyhome.idea.vim.common.LiveRange
@@ -83,6 +84,12 @@ class IjVimEditor(editor: Editor) : MutableLinearEditor, VimEditorBase() {
     get() = editor.replaceMask
     set(value) {
       editor.replaceMask = value
+    }
+  override val jumpListId: String
+    get() {
+      if (!injector.globalOptions().windowjumps) return projectId
+      val windowId = injector.windowIdService.getWindowId(this) ?: return projectId
+      return "$projectId/$windowId"
     }
 
   override fun updateMode(mode: Mode) {

--- a/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
+++ b/src/main/java/com/maddyhome/idea/vim/newapi/IjVimInjector.kt
@@ -62,6 +62,7 @@ import com.maddyhome.idea.vim.api.VimStorageService
 import com.maddyhome.idea.vim.api.VimStringParser
 import com.maddyhome.idea.vim.api.VimTemplateManager
 import com.maddyhome.idea.vim.api.VimVisualMotionGroup
+import com.maddyhome.idea.vim.api.VimWindowIdService
 import com.maddyhome.idea.vim.api.VimrcFileState
 import com.maddyhome.idea.vim.api.VimscriptExecutor
 import com.maddyhome.idea.vim.api.VimscriptFunctionService
@@ -179,6 +180,8 @@ internal class IjVimInjector : VimInjectorBase() {
   override val markService: VimMarkService
     get() = service()
   override val jumpService: VimJumpService
+    get() = service()
+  override val windowIdService: VimWindowIdService
     get() = service()
   override val application: VimApplication
     get() = service()

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsPersistenceTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsPersistenceTest.kt
@@ -11,6 +11,7 @@ package org.jetbrains.plugins.ideavim.option
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.impl.EditorWindow
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.group.JumpRemoteTopicListener
 import com.maddyhome.idea.vim.group.jump.JumpInfo
@@ -75,6 +76,28 @@ class WindowJumpsPersistenceTest : VimSplitWindowTestCase() {
     }
   }
 
+  /** Builds the saved state of a jump list for the current project, in the format [persistedJumps] reads back */
+  private fun savedState(editor: Editor, vararg positions: Pair<Int, Int>): Element {
+    val projectElement = Element("project").setAttribute("id", injector.file.getProjectId(fixture.project))
+    for ((line, col) in positions) {
+      projectElement.addContent(
+        Element("jump")
+          .setAttribute("line", line.toString())
+          .setAttribute("column", col.toString())
+          .setAttribute("filename", editor.virtualFile!!.path)
+          .setAttribute("protocol", "file"),
+      )
+    }
+    return Element("projects").addContent(projectElement)
+  }
+
+  private fun loadSavedState(state: Element) {
+    ApplicationManager.getApplication().invokeAndWait {
+      @Suppress("UNCHECKED_CAST")
+      (injector.jumpService as PersistentStateComponent<Element>).loadState(state)
+    }
+  }
+
   /** The persisted jumps of every project in the saved state, as "line:col" */
   private fun persistedJumps(): List<List<String>> {
     var state: Element? = null
@@ -112,5 +135,76 @@ class WindowJumpsPersistenceTest : VimSplitWindowTestCase() {
 
     // With the option reset, the project id *is* the scope of the real jump list - it must still be saved
     assertEquals(listOf(listOf("0:8", "2:29")), persistedJumps())
+  }
+
+  @Test
+  fun `test window with no jumps of its own shows the list restored from disk`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+
+    // State is read at startup, before any window exists, so it can only be stored per project. A window that has no
+    // list of its own has to inherit it - the same way a window inherits the list of the window it was split from
+    loadSavedState(savedState(mainWindow, 0 to 8, 2 to 29))
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 I found it in a legendary land
+        |   1     3   29 where it was settled on some sodden sand
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test only the most recently used window's list is saved for a project`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    val splitWindow = openSplitWindow(mainWindow)
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("torrent")
+
+    // One list per project, taken from the window used last. Window ids mean nothing after a restart, so there is no
+    // point saving one list per window
+    assertEquals(listOf(listOf("0:8", "2:29", "6:12", "8:0")), persistedJumps())
+  }
+
+  @Test
+  fun `test window that jumps before reading its list still inherits the restored one`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    loadSavedState(savedState(mainWindow, 0 to 8, 2 to 29))
+
+    // The first thing this window does is jump, without ever reading its list first - which is the normal case after a
+    // restart. `j` is not a jump, it just moves off the restored positions so the new entry is distinguishable
+    typeText("j")
+    enterSearch("torrent")
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   3     1    8 I found it in a legendary land
+        |   2     3   29 where it was settled on some sodden sand
+        |   1     2    8 all rocks and lavender and tufted grass,
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test clearjumps in a window that has not read its list is not undone by the restored list`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    loadSavedState(savedState(mainWindow, 0 to 8, 2 to 29))
+
+    // The window has never read or written its own list, so the only list around is the project's. Clearing has to be
+    // remembered, or the next read inherits the very entries that were just cleared
+    enterCommand("clearjumps")
+
+    assertCommandOutput("jumps", " jump line  col file/text\n>")
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsPersistenceTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsPersistenceTest.kt
@@ -207,4 +207,31 @@ class WindowJumpsPersistenceTest : VimSplitWindowTestCase() {
 
     assertCommandOutput("jumps", " jump line  col file/text\n>")
   }
+
+  @Test
+  fun `test collapsing to the focused window beats the list of a window that was closed`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    // Mirroring of IDE navigation is asynchronous and would add entries of its own, see WindowJumpsTest
+    enterCommand("set nounifyjumps")
+
+    // The project key exists first, as it does after reading the state from disk
+    loadSavedState(savedState(mainWindow, 0 to 8))
+
+    typeText("j")
+    enterSearch("torrent")
+
+    // A window with a longer list, which is then closed - nothing removes the list of a closed window
+    val splitWindow = openSplitWindow(mainWindow)
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("sodden")
+    closeWindow(splitWindow)
+
+    selectWindow(mainWindow)
+    enterCommand("set nowindowjumps")
+
+    // The list of the window that is actually focused has to win, not whichever scope happens to have been written last
+    assertEquals(listOf(listOf("0:8", "1:8")), persistedJumps())
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsPersistenceTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsPersistenceTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.option
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.group.JumpRemoteTopicListener
+import com.maddyhome.idea.vim.group.jump.JumpInfo
+import org.jdom.Element
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimSplitWindowTestCase
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What gets written to `vim_settings_local.xml` when the jump list is scoped to a window
+ *
+ * Unlike the rest of the jump list tests, these reach into the service instead of driving `:`-commands: persistence
+ * lives in a `PersistentStateComponent` and is not observable from Vim. IDE navigation is fed straight to
+ * [JumpRemoteTopicListener] rather than through the platform, because the real event depends on RPC timing and would
+ * make the test flaky.
+ */
+@TestWithoutNeovim(
+  reason = SkipNeovimReason.SEE_DESCRIPTION,
+  description = "Persistence of the jump list is an IdeaVim concern. Vim writes its jump list to viminfo, which the " +
+    "test framework does not read.",
+)
+class WindowJumpsPersistenceTest : VimSplitWindowTestCase() {
+  private fun configureMainWindow(): Editor {
+    var editor: Editor? = null
+    ApplicationManager.getApplication().invokeAndWait {
+      editor = configureByText(
+        """I found ${c}it in a legendary land
+          |all rocks and lavender and tufted grass,
+          |where it was settled on some sodden sand
+          |hard by the torrent of a mountain pass.
+          |
+          |The features it combines mark it as new
+          |to science: shape and shade -- the special tinge,
+          |akin to moonlight, tempering its blue,
+          |the dingy underside, the checquered fringe.
+        """.trimMargin(),
+      )
+    }
+    return editor!!
+  }
+
+  /**
+   * Feeds an IDE navigation event to the listener that implements the `unifyjumps` sync
+   *
+   * The timestamp has to be ahead of [com.maddyhome.idea.vim.api.VimJumpService.lastJumpTimeStamp], which Vim's own
+   * jumps push into the future to suppress the platform's echo of them.
+   */
+  private fun recordPlatformJump(editor: Editor, line: Int, col: Int) {
+    val event = JumpInfo(
+      line = line,
+      col = col,
+      filepath = editor.virtualFile!!.path,
+      protocol = "file",
+      added = true,
+      timestamp = System.currentTimeMillis() + 10_000,
+    )
+    ApplicationManager.getApplication().invokeAndWait {
+      JumpRemoteTopicListener().handleEvent(fixture.project, event)
+    }
+  }
+
+  /** The persisted jumps of every project in the saved state, as "line:col" */
+  private fun persistedJumps(): List<List<String>> {
+    var state: Element? = null
+    ApplicationManager.getApplication().invokeAndWait {
+      @Suppress("UNCHECKED_CAST")
+      state = (injector.jumpService as PersistentStateComponent<Element>).state
+    }
+    return state!!.getChildren("project").map { project ->
+      project.getChildren("jump").map { "${it.getAttributeValue("line")}:${it.getAttributeValue("column")}" }
+    }
+  }
+
+  @Test
+  fun `test IDE navigation is persisted as part of the window list`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    recordPlatformJump(mainWindow, line = 5, col = 3)
+
+    // The IDE's jump joins the window's list, and that list is what gets saved. Recorded against the project instead, it
+    // would be saved as a list of its own. Not asserted exactly: the platform also mirrors the file being opened, and
+    // when that arrives is not something the test controls
+    val persisted = persistedJumps().single()
+    assertTrue(persisted.containsAll(listOf("0:8", "2:29")), "The window's own jumps should be saved: $persisted")
+    assertTrue(persisted.contains("5:3"), "The IDE navigation should be saved with them: $persisted")
+  }
+
+  @Test
+  fun `test project wide list is persisted when windowjumps is not set`() {
+    configureMainWindow()
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    // With the option reset, the project id *is* the scope of the real jump list - it must still be saved
+    assertEquals(listOf(listOf("0:8", "2:29")), persistedJumps())
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
@@ -14,6 +14,8 @@ import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimSplitWindowTestCase
 import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 /**
  * Tests the scope of the jump list - one list shared by the whole project, or one list per window
@@ -421,5 +423,117 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
         |>
       """.trimMargin(),
     )
+  }
+
+
+  @Test
+  fun `test enabling windowjumps seeds every open window from the shared list`() {
+    val mainWindow = configureMainWindow()
+    enterSearch("sodden")
+    enterSearch("shape")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    enterCommand("set windowjumps")
+
+    val expected = """ jump line  col file/text
+      |   2     1    8 I found it in a legendary land
+      |   1     3   29 where it was settled on some sodden sand
+      |>
+    """.trimMargin()
+
+    selectWindow(mainWindow)
+    assertCommandOutput("jumps", expected)
+
+    selectWindow(splitWindow)
+    assertCommandOutput("jumps", expected)
+  }
+
+  @Test
+  fun `test windows seeded when enabling windowjumps get independent copies`() {
+    val mainWindow = configureMainWindow()
+    enterSearch("sodden")
+    enterSearch("shape")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    enterCommand("set windowjumps")
+
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("torrent")
+
+    selectWindow(mainWindow)
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 I found it in a legendary land
+        |   1     3   29 where it was settled on some sodden sand
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test disabling windowjumps keeps the focused window's list`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("torrent")
+
+    selectWindow(mainWindow)
+    enterSearch("sodden")
+
+    // The split is the focused window when the option goes off, so its list is the one that survives
+    selectWindow(splitWindow)
+    enterCommand("set nowindowjumps")
+
+    selectWindow(mainWindow)
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 I found it in a legendary land
+        |   1     9    0 the dingy underside, the checquered fringe.
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  // Cycle 7 - IDE navigation reaching us through 'unifyjumps' has to be attributed to a window, not to the project.
+
+  @Test
+  fun `test IDE navigation is recorded in the window showing the file when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    selectWindow(splitWindow)
+    recordPlatformJump(splitWindow, line = 5, col = 3)
+
+    // The lists cannot be asserted exactly: the platform mirrors the file being opened as a jump of its own, and when
+    // that arrives is not something the test controls. What matters is which window the navigation was recorded in
+    val recordedJump = "6    3 The features it combines mark it as new"
+    assertTrue(commandOutput("jumps").contains(recordedJump), "The navigation should be recorded in this window")
+
+    selectWindow(mainWindow)
+    assertFalse(commandOutput("jumps").contains(recordedJump), "The other window should not see it")
+  }
+
+  /** Feeds an IDE navigation event to the listener behind the `unifyjumps` sync. See `WindowJumpsPersistenceTest` */
+  private fun recordPlatformJump(editor: Editor, line: Int, col: Int) {
+    val event = com.maddyhome.idea.vim.group.jump.JumpInfo(
+      line = line,
+      col = col,
+      filepath = editor.virtualFile!!.path,
+      protocol = "file",
+      added = true,
+      timestamp = System.currentTimeMillis() + 10_000,
+    )
+    ApplicationManager.getApplication().invokeAndWait {
+      com.maddyhome.idea.vim.group.JumpRemoteTopicListener().handleEvent(fixture.project, event)
+    }
   }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
@@ -327,4 +327,99 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
       """.trimMargin(),
     )
   }
+
+  @Test
+  fun `test split copies the jump list from the opening window when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    val splitWindow = openSplitWindow(mainWindow)
+    selectWindow(splitWindow)
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 I found it in a legendary land
+        |   1     3   29 where it was settled on some sodden sand
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test split copies the current jump spot too when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    enterSearch("sodden")
+    enterSearch("shape")
+    typeText("<C-O>")
+
+    val expected = """ jump line  col file/text
+      |   1     1    8 I found it in a legendary land
+      |>  0     3   29 where it was settled on some sodden sand
+      |   1     7   12 to science: shape and shade -- the special tinge,
+    """.trimMargin()
+
+    // The opening window has walked back one entry, so its spot is no longer at the end of the list
+    assertCommandOutput("jumps", expected)
+
+    val splitWindow = openSplitWindow(mainWindow)
+    selectWindow(splitWindow)
+
+    assertCommandOutput("jumps", expected)
+  }
+
+  @Test
+  fun `test jumps made in the new split do not leak back to the opening window when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    val splitWindow = openSplitWindow(mainWindow)
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("torrent")
+
+    selectWindow(mainWindow)
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 I found it in a legendary land
+        |   1     3   29 where it was settled on some sodden sand
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test reopened split starts from a fresh copy when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    val splitWindow = openSplitWindow(mainWindow)
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("torrent")
+    closeWindow(splitWindow)
+
+    selectWindow(mainWindow)
+    val reopenedSplitWindow = openSplitWindow(mainWindow)
+    selectWindow(reopenedSplitWindow)
+
+    // A copy of the opening window's list, with nothing left over from the split that was closed
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 I found it in a legendary land
+        |   1     3   29 where it was settled on some sodden sand
+        |>
+      """.trimMargin(),
+    )
+  }
 }

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
@@ -17,10 +17,6 @@ import org.junit.jupiter.api.Test
 
 /**
  * Tests the scope of the jump list - one list shared by the whole project, or one list per window
- *
- * IdeaVim keeps a single jump list per project, while Vim keeps one per window. These tests describe the current,
- * project-wide behaviour, which is what the (not yet implemented) `'windowjumps'` option will keep as its default.
- * See VIM-window-jumps-plan.md.
  */
 @TestWithoutNeovim(
   reason = SkipNeovimReason.SEE_DESCRIPTION,
@@ -158,6 +154,170 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
       """I found it in a legendary land
         |all rocks and lavender and tufted grass,
         |where it was settled on some ${c}sodden sand
+        |hard by the torrent of a mountain pass.
+        |
+        |The features it combines mark it as new
+        |to science: shape and shade -- the special tinge,
+        |akin to moonlight, tempering its blue,
+        |the dingy underside, the checquered fringe.
+      """.trimMargin(),
+    )
+  }
+
+
+  @Test
+  fun `test jumps recorded in one split do not appear in the other when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    selectWindow(mainWindow)
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    selectWindow(splitWindow)
+
+    assertCommandOutput("jumps", " jump line  col file/text\n>")
+  }
+
+  @Test
+  fun `test jumps recorded in a split stay in that split when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("torrent")
+
+    selectWindow(mainWindow)
+
+    assertCommandOutput("jumps", " jump line  col file/text\n>")
+  }
+
+  @Test
+  fun `test control-O does not use the other split's history when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    selectWindow(mainWindow)
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    selectWindow(splitWindow)
+    typeText("<C-O>")
+
+    // This split has no history of its own, so there is nowhere to jump back to and the caret stays put
+    assertState(
+      """I found ${c}it in a legendary land
+        |all rocks and lavender and tufted grass,
+        |where it was settled on some sodden sand
+        |hard by the torrent of a mountain pass.
+        |
+        |The features it combines mark it as new
+        |to science: shape and shade -- the special tinge,
+        |akin to moonlight, tempering its blue,
+        |the dingy underside, the checquered fringe.
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test clearjumps only clears the current window when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    selectWindow(mainWindow)
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("torrent")
+    enterCommand("clearjumps")
+
+    selectWindow(mainWindow)
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 I found it in a legendary land
+        |   1     3   29 where it was settled on some sodden sand
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test jump list survives switching to another buffer in the same split when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    val mainWindowPath = mainWindow.virtualFile!!.path
+    val otherBufferWindow = openNewBufferWindow("bbb.txt")
+    selectWindow(otherBufferWindow)
+
+    // A Vim window keeps its jump list when the buffer it shows changes. Note that a new buffer in the same split is a
+    // new IntelliJ editor, so this only holds while the list is scoped to the editor *window*
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 $mainWindowPath
+        |   1     3   29 $mainWindowPath
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test control-I returns to the position control-O jumped from when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("torrent")
+    typeText("<C-O>")
+    typeText("<C-I>")
+
+    assertState(
+      """I found it in a legendary land
+        |all rocks and lavender and tufted grass,
+        |where it was settled on some sodden sand
+        |hard by the ${c}torrent of a mountain pass.
+        |
+        |The features it combines mark it as new
+        |to science: shape and shade -- the special tinge,
+        |akin to moonlight, tempering its blue,
+        |the dingy underside, the checquered fringe.
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test control-I does not use the other split's history when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    val splitWindow = openSplitWindow(mainWindow)
+
+    selectWindow(mainWindow)
+    enterSearch("sodden")
+    enterSearch("shape")
+    typeText("<C-O>")
+
+    // The other split has somewhere to jump forward to, this one has no history at all
+    selectWindow(splitWindow)
+    typeText("<C-I>")
+
+    assertState(
+      """I found ${c}it in a legendary land
+        |all rocks and lavender and tufted grass,
+        |where it was settled on some sodden sand
         |hard by the torrent of a mountain pass.
         |
         |The features it combines mark it as new

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.option
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Editor
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimSplitWindowTestCase
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests the scope of the jump list - one list shared by the whole project, or one list per window
+ *
+ * IdeaVim keeps a single jump list per project, while Vim keeps one per window. These tests describe the current,
+ * project-wide behaviour, which is what the (not yet implemented) `'windowjumps'` option will keep as its default.
+ * See VIM-window-jumps-plan.md.
+ */
+@TestWithoutNeovim(
+  reason = SkipNeovimReason.SEE_DESCRIPTION,
+  description = "These tests need more than one window showing the same buffer. Neovim testing drives a single editor, " +
+    "so there is nothing to compare split specific behaviour against.",
+)
+class WindowJumpsTest : VimSplitWindowTestCase() {
+  private val loremText = """I found ${c}it in a legendary land
+    |all rocks and lavender and tufted grass,
+    |where it was settled on some sodden sand
+    |hard by the torrent of a mountain pass.
+    |
+    |The features it combines mark it as new
+    |to science: shape and shade -- the special tinge,
+    |akin to moonlight, tempering its blue,
+    |the dingy underside, the checquered fringe.
+  """.trimMargin()
+
+  private fun configureMainWindow(): Editor {
+    var editor: Editor? = null
+    ApplicationManager.getApplication().invokeAndWait {
+      editor = configureByText(loremText)
+    }
+    return editor!!
+  }
+
+  @Test
+  fun `test jump list is shared between splits`() {
+    val mainWindow = configureMainWindow()
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    val splitWindow = openSplitWindow(mainWindow)
+    selectWindow(splitWindow)
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 I found it in a legendary land
+        |   1     3   29 where it was settled on some sodden sand
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test jumps recorded in a split are visible in the other split`() {
+    val mainWindow = configureMainWindow()
+    val splitWindow = openSplitWindow(mainWindow)
+
+    // Jump to a line that the other window's caret has never visited, so we know the entry comes from this split
+    selectWindow(splitWindow)
+    typeText("G")
+    enterSearch("torrent")
+
+    selectWindow(mainWindow)
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 I found it in a legendary land
+        |   1     9    0 the dingy underside, the checquered fringe.
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test jump list survives switching to another buffer in the same split`() {
+    val mainWindow = configureMainWindow()
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    val mainWindowPath = mainWindow.virtualFile!!.path
+    val otherBufferWindow = openNewBufferWindow("bbb.txt")
+    selectWindow(otherBufferWindow)
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 $mainWindowPath
+        |   1     3   29 $mainWindowPath
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test control-O in a split walks the history recorded in the other split`() {
+    val mainWindow = configureMainWindow()
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    val splitWindow = openSplitWindow(mainWindow)
+    selectWindow(splitWindow)
+    typeText("<C-O>")
+
+    // The newest entry of the shared jump list - the position the other split was at before searching for "shape"
+    assertState(
+      """I found it in a legendary land
+        |all rocks and lavender and tufted grass,
+        |where it was settled on some ${c}sodden sand
+        |hard by the torrent of a mountain pass.
+        |
+        |The features it combines mark it as new
+        |to science: shape and shade -- the special tinge,
+        |akin to moonlight, tempering its blue,
+        |the dingy underside, the checquered fringe.
+      """.trimMargin(),
+    )
+  }
+}

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
@@ -48,6 +48,41 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
   }
 
   @Test
+  fun `test windowjumps is off by default`() {
+    configureMainWindow()
+
+    assertCommandOutput("set windowjumps?", "nowindowjumps")
+  }
+
+  @Test
+  fun `test windowjumps can be enabled`() {
+    configureMainWindow()
+
+    enterCommand("set windowjumps")
+
+    assertCommandOutput("set windowjumps?", "  windowjumps")
+  }
+
+  @Test
+  fun `test windowjumps can be disabled again`() {
+    configureMainWindow()
+
+    enterCommand("set windowjumps")
+    enterCommand("set nowindowjumps")
+
+    assertCommandOutput("set windowjumps?", "nowindowjumps")
+  }
+
+  @Test
+  fun `test windowjumps is a global option`() {
+    configureMainWindow()
+
+    enterCommand("setlocal windowjumps")
+
+    assertCommandOutput("setglobal windowjumps?", "  windowjumps")
+  }
+
+  @Test
   fun `test jump list is shared between splits`() {
     val mainWindow = configureMainWindow()
     enterSearch("sodden")

--- a/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/option/WindowJumpsTest.kt
@@ -10,6 +10,9 @@ package org.jetbrains.plugins.ideavim.option
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.group.jump.JumpInfo
+import com.maddyhome.idea.vim.group.JumpRemoteTopicListener
+import com.intellij.openapi.vfs.VirtualFile
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimSplitWindowTestCase
@@ -171,6 +174,7 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
   fun `test jumps recorded in one split do not appear in the other when windowjumps is set`() {
     val mainWindow = configureMainWindow()
     enterCommand("set windowjumps")
+    disableIdeNavigationMirroring()
     val splitWindow = openSplitWindow(mainWindow)
 
     selectWindow(mainWindow)
@@ -186,6 +190,7 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
   fun `test jumps recorded in a split stay in that split when windowjumps is set`() {
     val mainWindow = configureMainWindow()
     enterCommand("set windowjumps")
+    disableIdeNavigationMirroring()
     val splitWindow = openSplitWindow(mainWindow)
 
     selectWindow(splitWindow)
@@ -201,6 +206,7 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
   fun `test control-O does not use the other split's history when windowjumps is set`() {
     val mainWindow = configureMainWindow()
     enterCommand("set windowjumps")
+    disableIdeNavigationMirroring()
     val splitWindow = openSplitWindow(mainWindow)
 
     selectWindow(mainWindow)
@@ -305,6 +311,7 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
   fun `test control-I does not use the other split's history when windowjumps is set`() {
     val mainWindow = configureMainWindow()
     enterCommand("set windowjumps")
+    disableIdeNavigationMirroring()
     val splitWindow = openSplitWindow(mainWindow)
 
     selectWindow(mainWindow)
@@ -502,7 +509,6 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
     )
   }
 
-  // Cycle 7 - IDE navigation reaching us through 'unifyjumps' has to be attributed to a window, not to the project.
 
   @Test
   fun `test IDE navigation is recorded in the window showing the file when windowjumps is set`() {
@@ -522,9 +528,9 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
     assertFalse(commandOutput("jumps").contains(recordedJump), "The other window should not see it")
   }
 
-  /** Feeds an IDE navigation event to the listener behind the `unifyjumps` sync. See `WindowJumpsPersistenceTest` */
+  /** Feeds an IDE navigation event to the listener behind the `unifyjumps` sync */
   private fun recordPlatformJump(editor: Editor, line: Int, col: Int) {
-    val event = com.maddyhome.idea.vim.group.jump.JumpInfo(
+    val event = JumpInfo(
       line = line,
       col = col,
       filepath = editor.virtualFile!!.path,
@@ -533,7 +539,43 @@ class WindowJumpsTest : VimSplitWindowTestCase() {
       timestamp = System.currentTimeMillis() + 10_000,
     )
     ApplicationManager.getApplication().invokeAndWait {
-      com.maddyhome.idea.vim.group.JumpRemoteTopicListener().handleEvent(fixture.project, event)
+      JumpRemoteTopicListener().handleEvent(fixture.project, event)
     }
+  }
+
+  @Test
+  fun `test split showing a different file also inherits the jump list when windowjumps is set`() {
+    val mainWindow = configureMainWindow()
+    enterCommand("set windowjumps")
+    enterSearch("sodden")
+    enterSearch("shape")
+
+    val mainWindowPath = mainWindow.virtualFile!!.path
+    // Vim's `:vsplit {file}` copies the jump list of the window it splits, whichever buffer ends up in the new window
+    var otherFile: VirtualFile? = null
+    ApplicationManager.getApplication().invokeAndWait {
+      otherFile = fixture.createFile("bbb.txt", "lorem ipsum\n")
+    }
+    val splitWindow = openSplitWindow(mainWindow, otherFile)
+    selectWindow(splitWindow)
+
+    assertCommandOutput(
+      "jumps",
+      """ jump line  col file/text
+        |   2     1    8 $mainWindowPath
+        |   1     3   29 $mainWindowPath
+        |>
+      """.trimMargin(),
+    )
+  }
+
+  /**
+   * Stops IDE navigation from being mirrored into the jump list
+   *
+   * The platform's "place" for opening a file reaches us asynchronously, so asserting that a window's list is empty
+   * would race with it. Mirroring has its own tests.
+   */
+  private fun disableIdeNavigationMirroring() {
+    enterCommand("set nounifyjumps")
   }
 }

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimSplitWindowTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimSplitWindowTestCase.kt
@@ -116,6 +116,18 @@ abstract class VimSplitWindowTestCase : VimTestCase() {
   }
 
   /**
+   * Runs an Ex command and returns what it printed
+   *
+   * For assertions that cannot be exact: the platform mirrors IDE navigation into the jump list asynchronously (see
+   * `unifyjumps`), so a list can legitimately carry entries a test never made.
+   */
+  protected fun commandOutput(command: String): String {
+    clearOutputPanel()
+    enterCommand(command)
+    return readOutputPanel { it.text } ?: error("No Ex output for '$command'")
+  }
+
+  /**
    * Selects the window that owns the given editor, and points the test fixture at it
    *
    * All of [VimTestCase]'s helpers (`typeText`, `enterCommand`, `enterSearch`, `assertState`, `assertExOutput`, ...) act

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimSplitWindowTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimSplitWindowTestCase.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.ComponentManagerEx
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.impl.EditorWindow
+import com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl
+import com.intellij.platform.util.coroutines.childScope
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import com.intellij.testFramework.replaceService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInfo
+import javax.swing.SwingConstants
+
+/**
+ * Base class for tests that need more than one Vim window (i.e. more than one IntelliJ editor)
+ *
+ * The default test fixture cannot split windows, so we replace [FileEditorManager] with a real
+ * [FileEditorManagerImpl] (as `FileEditorManagerTestCase` does), which in turn means we can't use the light project
+ * descriptor.
+ *
+ * Two kinds of "new window" are available, and the difference matters for anything scoped to a Vim window:
+ * * [openNewBufferWindow] opens a file in a new tab of the *current* split. Vim's equivalent is `:edit {file}` (see the
+ *   note in [openNewBufferWindow]).
+ * * [openSplitWindow] splits the current window, so the new editor lives in a *different* split.
+ *
+ * A test drives one window at a time: call [selectWindow] and then use the normal [VimTestCase] helpers. See
+ * [selectWindow] for why typing directly into an unselected editor does not work.
+ */
+@Suppress("SameParameterValue")
+abstract class VimSplitWindowTestCase : VimTestCase() {
+  protected lateinit var fileEditorManager: FileEditorManagerImpl
+
+  @BeforeEach
+  override fun setUp(testInfo: TestInfo) {
+    super.setUp(testInfo)
+
+    // Copied from FileEditorManagerTestCase to allow us to split windows
+    fileEditorManager = FileEditorManagerImpl(
+      fixture.project,
+      (fixture.project as ComponentManagerEx).getCoroutineScope().childScope(name = javaClass.simpleName),
+    )
+    fixture.project.replaceService(FileEditorManager::class.java, fileEditorManager, fixture.testRootDisposable)
+  }
+
+  // If we're replacing the test FileEditorManager, then we can't use the default light project descriptor
+  override fun createFixture(factory: IdeaTestFixtureFactory): CodeInsightTestFixture {
+    val fixture = factory.createFixtureBuilder("IdeaVim").fixture
+    return factory.createCodeInsightFixture(fixture)
+  }
+
+  /**
+   * Opens a new buffer in a new tab of the current split, and moves the focus to it
+   *
+   * Vim's `:new {file}` splits the current window and edits the file in the new split, while `:edit {file}` reuses the
+   * current window. IdeaVim doesn't support `:new {file}`, and its `:edit {file}` opens a new tab in the current split -
+   * which is what this function does. The new editor is a new Vim *buffer*, but stays in the same split.
+   *
+   * Note that this overwrites `fixture.editor`!
+   *
+   * @return the `Editor` representing the new window
+   */
+  protected fun openNewBufferWindow(filename: String, content: String = "lorem ipsum"): Editor {
+    ApplicationManager.getApplication().invokeAndWait {
+      fixture.openFileInEditor(fixture.createFile(filename, content))
+    }
+    return fixture.editor
+  }
+
+  /**
+   * Splits the given editor/Vim window vertically and moves the focus to the new editor
+   *
+   * Equivalent to `<C-W>v` or `:vsplit` with the `'splitright'` option enabled in Vim. (Note that IdeaVim doesn't
+   * currently support `'splitright'` or `'splitbelow'`.)
+   *
+   * @return the `Editor` representing the new window
+   */
+  protected fun openSplitWindow(editor: Editor): Editor {
+    // Open the split with the API, rather than Vim commands, so we get the editor
+    var splitWindow: EditorWindow? = null
+    ApplicationManager.getApplication().invokeAndWait {
+      val currentWindow = fileEditorManager.currentWindow
+      splitWindow = currentWindow!!.split(SwingConstants.VERTICAL, true, editor.virtualFile, false)
+    }
+
+    // Waiting till the selected editor will appear
+    waitUntil {
+      splitWindow!!.allComposites.first().selectedEditor != null
+    }
+    return (splitWindow!!.allComposites.first().selectedEditor as TextEditor).editor
+  }
+
+  /**
+   * Closes the window (split or tab) that owns the given editor
+   */
+  protected fun closeWindow(editor: Editor) {
+    ApplicationManager.getApplication().invokeAndWait {
+      // Just using fileEditorManager.closeFile(editor.virtualFile) can cause weird side effects, like opening a
+      // different buffer in an open editor. See IjFileGroup.closeFile
+      val virtualFile = editor.virtualFile ?: return@invokeAndWait
+      val editorWindow = windowFor(editor) ?: return@invokeAndWait
+      editorWindow.closeFile(virtualFile)
+      editorWindow.requestFocus(true)
+    }
+  }
+
+  /**
+   * Selects the window that owns the given editor, and points the test fixture at it
+   *
+   * All of [VimTestCase]'s helpers (`typeText`, `enterCommand`, `enterSearch`, `assertState`, `assertExOutput`, ...) act
+   * on `fixture.editor`, and IdeaVim resolves the editor to act on from the *selected* window rather than from the
+   * editor a keystroke was sent to. Typing into an editor that isn't selected therefore does the wrong thing - the keys
+   * are applied to the selected editor, and Ex commands produce no output at all. That never happens in a real IDE,
+   * because the user can only type into the focused window.
+   *
+   * Call this before driving a window, then use the normal [VimTestCase] helpers:
+   * ```
+   * val splitWindow = openSplitWindow(mainWindow)
+   * selectWindow(splitWindow)
+   * enterCommand("jumps")
+   * ```
+   */
+  protected fun selectWindow(editor: Editor) {
+    ApplicationManager.getApplication().invokeAndWait {
+      fileEditorManager.currentWindow = windowFor(editor)
+      // Re-point fixture.editor at this editor. The file is already open in this window, so this selects it rather than
+      // opening anything new
+      editor.virtualFile?.let { fixture.openFileInEditor(it) }
+    }
+
+    // Fail loudly rather than silently driving the wrong window
+    check(fixture.editor === editor) { "Could not select the requested window. fixture.editor is a different editor" }
+  }
+
+  /**
+   * The [EditorWindow] (split) that owns the given editor. Must be called on the EDT
+   */
+  private fun windowFor(editor: Editor): EditorWindow? {
+    // We can't rely on the current EditorWindow. E.g., if we're looking for a file that's not currently open in the
+    // current window, or is open in a split while we want the *other* editor
+    return fileEditorManager.windows.find { window ->
+      window.allComposites.any { composite ->
+        composite.allEditors.filterIsInstance<TextEditor>().any { it.editor == editor }
+      }
+    }
+  }
+}

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimSplitWindowTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimSplitWindowTestCase.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.impl.EditorWindow
 import com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.util.coroutines.childScope
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
@@ -84,14 +85,16 @@ abstract class VimSplitWindowTestCase : VimTestCase() {
    * Equivalent to `<C-W>v` or `:vsplit` with the `'splitright'` option enabled in Vim. (Note that IdeaVim doesn't
    * currently support `'splitright'` or `'splitbelow'`.)
    *
+   * Pass [file] to open a different file in the new window, which is Vim's `:vsplit {file}`.
+   *
    * @return the `Editor` representing the new window
    */
-  protected fun openSplitWindow(editor: Editor): Editor {
+  protected fun openSplitWindow(editor: Editor, file: VirtualFile? = editor.virtualFile): Editor {
     // Open the split with the API, rather than Vim commands, so we get the editor
     var splitWindow: EditorWindow? = null
     ApplicationManager.getApplication().invokeAndWait {
       val currentWindow = fileEditorManager.currentWindow
-      splitWindow = currentWindow!!.split(SwingConstants.VERTICAL, true, editor.virtualFile, false)
+      splitWindow = currentWindow!!.split(SwingConstants.VERTICAL, true, file, false)
     }
 
     // Waiting till the selected editor will appear

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -754,7 +754,7 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
   }
 
   /** Clear the current output panel, on the EDT. See [readOutputPanel] */
-  private fun clearOutputPanel() {
+  protected fun clearOutputPanel() {
     ApplicationManager.getApplication().invokeAndWait {
       injector.outputPanel.getCurrentOutputPanel()?.clearText()
     }

--- a/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
+++ b/src/testFixtures/kotlin/org/jetbrains/plugins/ideavim/VimTestCase.kt
@@ -745,7 +745,7 @@ abstract class VimTestCase(private val defaultEditorText: String? = null) {
   /**
    * Read a value from the current output panel, on the EDT
    */
-  private fun <T> readOutputPanel(getter: (VimOutputPanel) -> T): T? {
+  protected fun <T> readOutputPanel(getter: (VimOutputPanel) -> T): T? {
     var value: T? = null
     ApplicationManager.getApplication().invokeAndWait {
       value = injector.outputPanel.getCurrentOutputPanel()?.let(getter)

--- a/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/IdeaVimStarterTestBase.kt
+++ b/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/IdeaVimStarterTestBase.kt
@@ -14,6 +14,7 @@ import com.intellij.driver.sdk.singleProject
 import com.intellij.driver.sdk.ui.requestFocusFromIde
 import com.intellij.driver.sdk.ui.components.UiComponent.Companion.waitFound
 import com.intellij.driver.sdk.ui.components.common.codeEditor
+import com.intellij.driver.sdk.ui.components.common.codeEditorForFile
 import com.intellij.driver.sdk.ui.components.common.ideFrame
 import com.intellij.driver.sdk.waitForIndicators
 import com.intellij.ide.starter.config.ConfigurationStorage
@@ -307,6 +308,87 @@ abstract class IdeaVimStarterTestBase {
           click()
         }
       }
+    }
+  }
+
+  // ── Helpers for more than one editor ────────────────────────
+  //
+  // `codeEditor()` requires exactly one editor component to be present, so it throws as soon as the editor is split.
+  // These variants address an editor by the file it shows, which means splits have to show *different* files to be
+  // addressable - two splits of the same buffer are indistinguishable in the component tree.
+
+  /**
+   * Opens a file in the *current* editor window, without going through [openFile]'s readiness check
+   *
+   * [openFile] waits on `codeEditor()`, which throws once the editor is split. Use this to give a split a file of its
+   * own, then address both editors with the helpers below.
+   */
+  protected fun openFileInCurrentWindow(relativePath: String, fileName: String) {
+    driver.withContext { openFile(relativePath) }
+    val opened = waitUntil(timeoutMs = 15_000, pollMs = 500) {
+      try {
+        driver.withContext { ideFrame { codeEditorForFile(fileName).apply { waitFound() } } }
+        true
+      } catch (_: Exception) {
+        false
+      }
+    }
+    check(opened) { "Editor for '$fileName' did not appear within timeout" }
+  }
+
+  /** Types vim keys in the editor showing the given file (its simple name, e.g. `Jump1.txt`). */
+  protected fun typeVimInFile(fileName: String, keys: String) {
+    driver.withContext {
+      requestFocusFromIde(singleProject())
+      ideFrame {
+        codeEditorForFile(fileName).apply {
+          waitFound()
+          // No click: clicking would move the caret of the editor under test
+          component.requestFocus()
+          keyboard { typeText(keys) }
+        }
+      }
+    }
+  }
+
+  /** Presses Ctrl-O (jump backward) in the editor showing the given file. */
+  protected fun ctrlOInFile(fileName: String) {
+    driver.withContext {
+      requestFocusFromIde(singleProject())
+      ideFrame {
+        codeEditorForFile(fileName).apply {
+          waitFound()
+          component.requestFocus()
+          keyboard { hotKey(java.awt.event.KeyEvent.VK_CONTROL, java.awt.event.KeyEvent.VK_O) }
+        }
+      }
+    }
+  }
+
+  /** Reads the caret line (1-based) of the editor showing the given file. */
+  protected fun caretLineInFile(fileName: String): Int {
+    var result = 0
+    driver.withContext {
+      ideFrame { result = codeEditorForFile(fileName).apply { waitFound() }.getCaretLine() }
+    }
+    return result
+  }
+
+  /** Asserts the caret in the given file's editor is before the given line, polling until timeout. */
+  protected fun assertCaretInFileBefore(fileName: String, line: Int, message: String? = null) {
+    var actual = 0
+    val found = waitUntil { actual = caretLineInFile(fileName); actual < line }
+    assertTrue(found) {
+      (message ?: "Caret in $fileName should be before line $line") + ". Actual line: $actual"
+    }
+  }
+
+  /** Asserts the caret in the given file's editor is past the given line, polling until timeout. */
+  protected fun assertCaretInFileAfter(fileName: String, line: Int, message: String? = null) {
+    var actual = 0
+    val found = waitUntil { actual = caretLineInFile(fileName); actual > line }
+    assertTrue(found) {
+      (message ?: "Caret in $fileName should be after line $line") + ". Actual line: $actual"
     }
   }
 

--- a/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/WindowJumpsSplitTest.kt
+++ b/tests/split-mode-tests/src/test/kotlin/com/maddyhome/idea/vim/split/WindowJumpsSplitTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.split
+
+import org.junit.jupiter.api.Test
+
+/**
+ * Smoke tests for the `'windowjumps'` option in split mode
+ *
+ * The jump list is scoped to a window by composing the project id with an id for the containing `EditorWindow`, resolved
+ * through `FileEditorManagerEx`. That only exists on the frontend, and the service handing out the ids is registered in
+ * `IdeaVIM.ideavim-frontend.xml`, so these tests check that per window jump lists survive the frontend/backend split -
+ * every other test for this option runs in a monolith.
+ *
+ * The two splits show *different* files on purpose: `codeEditor()` requires exactly one editor component, so a split of
+ * the same buffer cannot be addressed at all from the driver. See the helpers in [IdeaVimStarterTestBase].
+ */
+class WindowJumpsSplitTest : IdeaVimStarterTestBase() {
+
+  override fun ideaVimRcContent(): String = "set windowjumps\n"
+
+  private fun longFile(name: String): String {
+    val lines = (1..50).joinToString("\n") { "Line $it of content" }
+    return createFile("src/$name.txt", lines + "\n")
+  }
+
+  @Test
+  fun `jump list works when scoped to a window`() {
+    openFile(longFile("WindowJumps1"))
+
+    typeVim("G")
+    pause(500)
+    assertCaretAfter(40, "G should go to end of file")
+
+    ctrlO()
+    pause(500)
+    // Reaching the jump means the window's scope was resolved on the frontend and the jump was recorded under it
+    assertCaretBefore(10, "Ctrl-O should jump back to start with 'windowjumps' set")
+  }
+
+  @Test
+  fun `jumps made in one split do not appear in the other`() {
+    val first = longFile("WindowJumpsA")
+    val second = longFile("WindowJumpsB")
+    openFile(first)
+
+    // Recorded in the original window's list, while it is still the only window
+    typeVim("G")
+    pause(500)
+    assertCaretAfter(40, "G should go to the end of the first file")
+
+    // Split, then give the new window a file of its own. `:vsplit {path}` would be shorter, but the driver can only
+    // address an editor by the file it shows, so two splits of the same buffer are indistinguishable
+    exCommand("vsplit")
+    pause(1000)
+    openFileInCurrentWindow(second, "WindowJumpsB.txt")
+
+    // Recorded in the new window's list
+    typeVimInFile("WindowJumpsB.txt", "G")
+    pause(500)
+    assertCaretInFileAfter("WindowJumpsB.txt", 40, "G should go to the end of the second file")
+
+    // The original window walks its own history, which never saw the second file. With one shared list its newest entry
+    // would be in the other file, and this caret would stay where it is
+    ctrlOInFile("WindowJumpsA.txt")
+    pause(1000)
+    assertCaretInFileBefore("WindowJumpsA.txt", 10, "Ctrl-O should walk this window's own jump list")
+    assertCaretInFileAfter("WindowJumpsB.txt", 40, "The other window's caret should not have moved")
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/OptionProperties.kt
@@ -39,6 +39,7 @@ open class GlobalOptions(scope: OptionAccessScope) : OptionsPropertiesBase(scope
   var more: Boolean by optionProperty(Options.more)
   var operatorfunc: String by optionProperty(Options.operatorfunc)
   var scrolljump: Int by optionProperty(Options.scrolljump)
+  var windowjumps: Boolean by optionProperty(Options.windowjumps)
   var selection: String by optionProperty(Options.selection)
   val selectmode: StringListOptionValue by optionProperty(Options.selectmode)
   var shell: String by optionProperty(Options.shell)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -447,6 +447,8 @@ object Options {
     }
   })
 
+  val windowjumps: ToggleOption =
+    addOption(ToggleOption("windowjumps", GLOBAL, "windowjumps", false, isHidden = false))
   val scrolljump: NumberOption = addOption(object : NumberOption("scrolljump", GLOBAL, "sj", 1) {
     override fun checkIfValueValid(value: VimDataType, token: String) {
       super.checkIfValueValid(value, token)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/Options.kt
@@ -448,7 +448,7 @@ object Options {
   })
 
   val windowjumps: ToggleOption =
-    addOption(ToggleOption("windowjumps", GLOBAL, "windowjumps", false, isHidden = false))
+    addOption(ToggleOption("windowjumps", GLOBAL, "windowjumps", false, isHidden = true))
   val scrolljump: NumberOption = addOption(object : NumberOption("scrolljump", GLOBAL, "sj", 1) {
     override fun checkIfValueValid(value: VimDataType, token: String) {
       super.checkIfValueValid(value, token)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimEditor.kt
@@ -380,6 +380,8 @@ interface VimEditor {
     }
   }
 
+  val jumpListId: String get() = projectId
+
   /**
    * Toggles the insert/overwrite state. If currently insert, goto replace mode. If currently replace, goto insert
    * mode.

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimInjector.kt
@@ -136,6 +136,8 @@ interface VimInjector {
 
   val psiService: VimPsiService
 
+  val windowIdService: VimWindowIdService
+
   val vimscriptExecutor: VimscriptExecutor
 
   val vimscriptParser: VimscriptParser

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpService.kt
@@ -15,7 +15,11 @@ import org.jetbrains.annotations.TestOnly
 // todo docs
 // todo it would be better to have some Vim scope for this purpose (p:), to store things project-wise like for buffers
 /**
- * This service manages jump lists for different projects
+ * This service manages jump lists, keyed by scope id
+ *
+ * The scope of a jump list is decided by [VimEditor.jumpListId]: project-wide by default, one per window (split) when
+ * the 'windowjumps' option is set. Prefer the [VimEditor]-based extension functions below over passing a scope id
+ * directly.
  */
 interface VimJumpService {
   /**
@@ -25,19 +29,19 @@ interface VimJumpService {
    */
   var lastJumpTimeStamp: Long
 
-  fun getJump(projectId: String, count: Int): Jump?
-  fun getJumps(projectId: String): List<Jump>
-  fun getJumpSpot(projectId: String): Int
+  fun getJump(scopeId: String, count: Int): Jump?
+  fun getJumps(scopeId: String): List<Jump>
+  fun getJumpSpot(scopeId: String): Int
 
-  fun addJump(projectId: String, jump: Jump, reset: Boolean)
+  fun addJump(scopeId: String, jump: Jump, reset: Boolean)
   fun saveJumpLocation(editor: VimEditor)
 
-  fun removeJump(projectId: String, jump: Jump)
-  fun dropLastJump(projectId: String)
-  fun clearJumps(projectId: String)
+  fun removeJump(scopeId: String, jump: Jump)
+  fun dropLastJump(scopeId: String)
+  fun clearJumps(scopeId: String)
 
-  fun updateJumpsFromInsert(projectId: String, startOffset: Int, length: Int)
-  fun updateJumpsFromDelete(projectId: String, startOffset: Int, length: Int)
+  fun updateJumpsFromInsert(scopeId: String, startOffset: Int, length: Int)
+  fun updateJumpsFromDelete(scopeId: String, startOffset: Int, length: Int)
 
   fun includeCurrentCommandAsNavigation(editor: VimEditor)
 
@@ -61,33 +65,33 @@ fun VimJumpService.addJump(editor: VimEditor, reset: Boolean) {
 }
 
 fun VimJumpService.getJump(editor: VimEditor, count: Int): Jump? {
-  return getJump(editor.projectId, count)
+  return getJump(editor.jumpListId, count)
 }
 
 fun VimJumpService.getJumps(editor: VimEditor): List<Jump> {
-  return getJumps(editor.projectId)
+  return getJumps(editor.jumpListId)
 }
 
 fun VimJumpService.getJumpSpot(editor: VimEditor): Int {
-  return getJumpSpot(editor.projectId)
+  return getJumpSpot(editor.jumpListId)
 }
 
 fun VimJumpService.addJump(editor: VimEditor, jump: Jump, reset: Boolean) {
-  return addJump(editor.projectId, jump, reset)
+  return addJump(editor.jumpListId, jump, reset)
 }
 
 fun VimJumpService.removeJump(editor: VimEditor, jump: Jump) {
-  return removeJump(editor.projectId, jump)
+  return removeJump(editor.jumpListId, jump)
 }
 
 fun VimJumpService.dropLastJump(editor: VimEditor) {
-  return dropLastJump(editor.projectId)
+  return dropLastJump(editor.jumpListId)
 }
 
 fun VimJumpService.updateJumpsFromInsert(editor: VimEditor, startOffset: Int, length: Int) {
-  return updateJumpsFromInsert(editor.projectId, startOffset, length)
+  return updateJumpsFromInsert(editor.jumpListId, startOffset, length)
 }
 
 fun VimJumpService.updateJumpsFromDelete(editor: VimEditor, startOffset: Int, length: Int) {
-  return updateJumpsFromDelete(editor.projectId, startOffset, length)
+  return updateJumpsFromDelete(editor.jumpListId, startOffset, length)
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpService.kt
@@ -39,6 +39,7 @@ interface VimJumpService {
   fun removeJump(scopeId: String, jump: Jump)
   fun dropLastJump(scopeId: String)
   fun clearJumps(scopeId: String)
+  fun copyJumps(fromId: String, toId: String)
 
   fun updateJumpsFromInsert(scopeId: String, startOffset: Int, length: Int)
   fun updateJumpsFromDelete(scopeId: String, startOffset: Int, length: Int)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpService.kt
@@ -41,6 +41,15 @@ interface VimJumpService {
   fun clearJumps(scopeId: String)
   fun copyJumps(fromId: String, toId: String)
 
+  /**
+   * Gives a scope that has never had a list of its own a copy of another scope's list
+   *
+   * This is what happens when a window is created: in Vim the new window inherits the jump list of the window it was
+   * split from, even when that list is empty. A scope that already has a list keeps it - selecting a file in an existing
+   * window is not a new window, and must not inherit anything.
+   */
+  fun inheritJumps(fromId: String, toId: String)
+
   fun updateJumpsFromInsert(scopeId: String, startOffset: Int, length: Int)
   fun updateJumpsFromDelete(scopeId: String, startOffset: Int, length: Int)
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpServiceBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpServiceBase.kt
@@ -11,37 +11,36 @@ package com.maddyhome.idea.vim.api
 import com.maddyhome.idea.vim.mark.Jump
 
 abstract class VimJumpServiceBase : VimJumpService {
-  protected val projectToJumps: MutableMap<String, MutableList<Jump>> = mutableMapOf()
-  protected val projectToJumpSpot: MutableMap<String, Int> = mutableMapOf()
+  protected val scopeToJumps: MutableMap<String, MutableList<Jump>> = mutableMapOf()
+  protected val scopeToJumpSpot: MutableMap<String, Int> = mutableMapOf()
 
-  override fun getJump(projectId: String, count: Int): Jump? {
-    // Update timestamp to suppress Platform's recentPlaceAdded events caused by
-    // Ctrl-O/Ctrl-I cursor movements (see lastJumpTimeStamp doc).
-    // Small margin accounts for PlaceInfo being created slightly after this call.
+  override fun getJump(scopeId: String, count: Int): Jump? {
     lastJumpTimeStamp = System.currentTimeMillis() + JUMP_NAVIGATION_SUPPRESS_MS
-    val jumps = projectToJumps[projectId] ?: mutableListOf()
-    projectToJumpSpot.putIfAbsent(projectId, -1)
-    val index = jumps.size - 1 - (projectToJumpSpot[projectId]!! - count)
+    val jumps = scopeToJumps[scopeId] ?: mutableListOf()
+    scopeToJumpSpot.putIfAbsent(scopeId, -1)
+    val index = jumps.size - 1 - (scopeToJumpSpot[scopeId]!! - count)
     return jumps.getOrNull(index)?.also {
-      projectToJumpSpot[projectId] = projectToJumpSpot[projectId]!! - count
+      scopeToJumpSpot[scopeId] = scopeToJumpSpot[scopeId]!! - count
     }
   }
 
-  override fun getJumps(projectId: String): List<Jump> {
-    return projectToJumps[projectId] ?: emptyList()
+  override fun getJumps(scopeId: String): List<Jump> {
+    return scopeToJumps[scopeId] ?: emptyList()
   }
 
-  override fun getJumpSpot(projectId: String): Int {
-    return projectToJumpSpot[projectId] ?: -1
+  override fun getJumpSpot(scopeId: String): Int {
+    return scopeToJumpSpot[scopeId] ?: -1
   }
 
-  override fun addJump(projectId: String, jump: Jump, reset: Boolean) {
+  override fun addJump(scopeId: String, jump: Jump, reset: Boolean) {
     lastJumpTimeStamp = System.currentTimeMillis() + JUMP_NAVIGATION_SUPPRESS_MS
-    val jumps = projectToJumps.getOrPut(projectId) { mutableListOf() }
+    // Remove and re-insert, so that the map iterates from least to most recently updated scope
+    val jumps = scopeToJumps.remove(scopeId) ?: mutableListOf()
     jumps.removeIf { it.filepath == jump.filepath && it.line == jump.line }
     jumps.add(jump)
+    scopeToJumps[scopeId] = jumps
 
-    projectToJumpSpot[projectId] = if (reset) -1 else (projectToJumpSpot[projectId] ?: -1) + 1
+    scopeToJumpSpot[scopeId] = if (reset) -1 else (scopeToJumpSpot[scopeId] ?: -1) + 1
 
     if (jumps.size > SAVE_JUMP_COUNT) {
       jumps.removeFirst()
@@ -54,30 +53,30 @@ abstract class VimJumpServiceBase : VimJumpService {
     includeCurrentCommandAsNavigation(editor)
   }
 
-  override fun removeJump(projectId: String, jump: Jump) {
-    projectToJumps[projectId]?.removeIf { it == jump }
+  override fun removeJump(scopeId: String, jump: Jump) {
+    scopeToJumps[scopeId]?.removeIf { it == jump }
   }
 
-  override fun dropLastJump(projectId: String) {
-    projectToJumps[projectId]?.removeLastOrNull()
+  override fun dropLastJump(scopeId: String) {
+    scopeToJumps[scopeId]?.removeLastOrNull()
   }
 
-  override fun clearJumps(projectId: String) {
-    projectToJumps.remove(projectId)
-    projectToJumpSpot.remove(projectId)
+  override fun clearJumps(scopeId: String) {
+    scopeToJumps.remove(scopeId)
+    scopeToJumpSpot.remove(scopeId)
   }
 
-  override fun updateJumpsFromInsert(projectId: String, startOffset: Int, length: Int) {
+  override fun updateJumpsFromInsert(scopeId: String, startOffset: Int, length: Int) {
     TODO("Not yet implemented")
   }
 
-  override fun updateJumpsFromDelete(projectId: String, startOffset: Int, length: Int) {
+  override fun updateJumpsFromDelete(scopeId: String, startOffset: Int, length: Int) {
     TODO("Not yet implemented")
   }
 
   override fun resetJumps() {
-    projectToJumps.clear()
-    projectToJumpSpot.clear()
+    scopeToJumps.clear()
+    scopeToJumpSpot.clear()
   }
 
   companion object {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpServiceBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpServiceBase.kt
@@ -13,8 +13,10 @@ import com.maddyhome.idea.vim.mark.Jump
 abstract class VimJumpServiceBase : VimJumpService {
   protected val scopeToJumps: MutableMap<String, MutableList<Jump>> = mutableMapOf()
   protected val scopeToJumpSpot: MutableMap<String, Int> = mutableMapOf()
+  private val seededScopes = mutableSetOf<String>()
 
   override fun getJump(scopeId: String, count: Int): Jump? {
+    ensureSeeded(scopeId)
     lastJumpTimeStamp = System.currentTimeMillis() + JUMP_NAVIGATION_SUPPRESS_MS
     val jumps = scopeToJumps[scopeId] ?: mutableListOf()
     scopeToJumpSpot.putIfAbsent(scopeId, -1)
@@ -25,14 +27,17 @@ abstract class VimJumpServiceBase : VimJumpService {
   }
 
   override fun getJumps(scopeId: String): List<Jump> {
+    ensureSeeded(scopeId)
     return scopeToJumps[scopeId] ?: emptyList()
   }
 
   override fun getJumpSpot(scopeId: String): Int {
+    ensureSeeded(scopeId)
     return scopeToJumpSpot[scopeId] ?: -1
   }
 
   override fun addJump(scopeId: String, jump: Jump, reset: Boolean) {
+    ensureSeeded(scopeId)
     lastJumpTimeStamp = System.currentTimeMillis() + JUMP_NAVIGATION_SUPPRESS_MS
     // Remove and re-insert, so that the map iterates from least to most recently updated scope
     val jumps = scopeToJumps.remove(scopeId) ?: mutableListOf()
@@ -62,6 +67,7 @@ abstract class VimJumpServiceBase : VimJumpService {
   }
 
   override fun clearJumps(scopeId: String) {
+    seededScopes.add(scopeId)
     scopeToJumps.remove(scopeId)
     scopeToJumpSpot.remove(scopeId)
   }
@@ -83,6 +89,14 @@ abstract class VimJumpServiceBase : VimJumpService {
   override fun resetJumps() {
     scopeToJumps.clear()
     scopeToJumpSpot.clear()
+  }
+
+  private fun ensureSeeded(scopeId: String) {
+    if (!seededScopes.add(scopeId)) return
+    if (scopeToJumps.containsKey(scopeId)) return
+    val projectId = scopeId.substringBeforeLast(VimWindowIdService.WINDOW_SCOPE_SEPARATOR)
+    if (projectId == scopeId) return
+    copyJumps(projectId, scopeId)
   }
 
   companion object {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpServiceBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpServiceBase.kt
@@ -13,10 +13,10 @@ import com.maddyhome.idea.vim.mark.Jump
 abstract class VimJumpServiceBase : VimJumpService {
   protected val scopeToJumps: MutableMap<String, MutableList<Jump>> = mutableMapOf()
   protected val scopeToJumpSpot: MutableMap<String, Int> = mutableMapOf()
-  private val seededScopes = mutableSetOf<String>()
+  private val scopesWithOwnList = mutableSetOf<String>()
 
   override fun getJump(scopeId: String, count: Int): Jump? {
-    ensureSeeded(scopeId)
+    inheritProjectListIfNeeded(scopeId)
     lastJumpTimeStamp = System.currentTimeMillis() + JUMP_NAVIGATION_SUPPRESS_MS
     val jumps = scopeToJumps[scopeId] ?: mutableListOf()
     scopeToJumpSpot.putIfAbsent(scopeId, -1)
@@ -27,23 +27,22 @@ abstract class VimJumpServiceBase : VimJumpService {
   }
 
   override fun getJumps(scopeId: String): List<Jump> {
-    ensureSeeded(scopeId)
+    inheritProjectListIfNeeded(scopeId)
     return scopeToJumps[scopeId] ?: emptyList()
   }
 
   override fun getJumpSpot(scopeId: String): Int {
-    ensureSeeded(scopeId)
+    inheritProjectListIfNeeded(scopeId)
     return scopeToJumpSpot[scopeId] ?: -1
   }
 
   override fun addJump(scopeId: String, jump: Jump, reset: Boolean) {
-    ensureSeeded(scopeId)
+    inheritProjectListIfNeeded(scopeId)
     lastJumpTimeStamp = System.currentTimeMillis() + JUMP_NAVIGATION_SUPPRESS_MS
-    // Remove and re-insert, so that the map iterates from least to most recently updated scope
-    val jumps = scopeToJumps.remove(scopeId) ?: mutableListOf()
+    val jumps = scopeToJumps[scopeId] ?: mutableListOf()
     jumps.removeIf { it.filepath == jump.filepath && it.line == jump.line }
     jumps.add(jump)
-    scopeToJumps[scopeId] = jumps
+    putAsMostRecentlyUsed(scopeId, jumps)
 
     scopeToJumpSpot[scopeId] = if (reset) -1 else (scopeToJumpSpot[scopeId] ?: -1) + 1
 
@@ -67,14 +66,23 @@ abstract class VimJumpServiceBase : VimJumpService {
   }
 
   override fun clearJumps(scopeId: String) {
-    seededScopes.add(scopeId)
+    // An emptied list is still the scope's own, so it must not inherit the project's again
+    scopesWithOwnList.add(scopeId)
     scopeToJumps.remove(scopeId)
     scopeToJumpSpot.remove(scopeId)
   }
 
   override fun copyJumps(fromId: String, toId: String) {
     val jumps = scopeToJumps[fromId] ?: return
-    scopeToJumps[toId] = jumps.toMutableList()
+    putAsMostRecentlyUsed(toId, jumps.toMutableList())
+    scopeToJumpSpot[toId] = scopeToJumpSpot[fromId] ?: -1
+  }
+
+  override fun inheritJumps(fromId: String, toId: String) {
+    if (toId in scopesWithOwnList || scopeToJumps.containsKey(toId)) return
+    // An inherited empty list is the window's own list, as in Vim - not an absence to be filled in later
+    scopesWithOwnList.add(toId)
+    scopeToJumps[toId] = scopeToJumps[fromId]?.toMutableList() ?: mutableListOf()
     scopeToJumpSpot[toId] = scopeToJumpSpot[fromId] ?: -1
   }
 
@@ -89,14 +97,30 @@ abstract class VimJumpServiceBase : VimJumpService {
   override fun resetJumps() {
     scopeToJumps.clear()
     scopeToJumpSpot.clear()
+    scopesWithOwnList.clear()
   }
 
-  private fun ensureSeeded(scopeId: String) {
-    if (!seededScopes.add(scopeId)) return
+  /**
+   * Gives a window scope the project's list the first time it is used
+   *
+   * The list read from disk can only be stored per project - at startup there are no windows yet - so a window that has
+   * never had a list of its own starts from it, the same way a new window inherits from the window it was split from.
+   */
+  private fun inheritProjectListIfNeeded(scopeId: String) {
+    if (scopeId in scopesWithOwnList) return
+    scopesWithOwnList.add(scopeId)
     if (scopeToJumps.containsKey(scopeId)) return
-    val projectId = scopeId.substringBeforeLast(VimWindowIdService.WINDOW_SCOPE_SEPARATOR)
-    if (projectId == scopeId) return
-    copyJumps(projectId, scopeId)
+
+    val projectId = VimWindowIdService.projectIdOf(scopeId)
+    if (projectId != scopeId) {
+      copyJumps(projectId, scopeId)
+    }
+  }
+
+  /** The map iterates in this order, and the list that comes last is the one persisted for the project */
+  private fun putAsMostRecentlyUsed(scopeId: String, jumps: MutableList<Jump>) {
+    scopeToJumps.remove(scopeId)
+    scopeToJumps[scopeId] = jumps
   }
 
   companion object {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpServiceBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimJumpServiceBase.kt
@@ -66,6 +66,12 @@ abstract class VimJumpServiceBase : VimJumpService {
     scopeToJumpSpot.remove(scopeId)
   }
 
+  override fun copyJumps(fromId: String, toId: String) {
+    val jumps = scopeToJumps[fromId] ?: return
+    scopeToJumps[toId] = jumps.toMutableList()
+    scopeToJumpSpot[toId] = scopeToJumpSpot[fromId] ?: -1
+  }
+
   override fun updateJumpsFromInsert(scopeId: String, startOffset: Int, length: Int) {
     TODO("Not yet implemented")
   }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimWindowIdService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimWindowIdService.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package com.maddyhome.idea.vim.api
+
+/**
+ * Provides a stable id for the window (split) that an editor lives in
+ *
+ * IdeaVim's [VimEditor] is per split *and* per tab - opening another file in the same split creates a new [VimEditor].
+ * A Vim window, on the other hand, keeps its identity when the buffer it shows changes. This service provides the
+ * identity of the containing window, so that state which Vim scopes to a window (e.g. the jump list) can outlive a
+ * change of buffer.
+ */
+interface VimWindowIdService {
+  /**
+   * The id of the window (split) containing the given editor, or null if the editor doesn't belong to one - e.g. the
+   * fallback window, a diff view, or a console
+   */
+  fun getWindowId(editor: VimEditor): String?
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimWindowIdService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimWindowIdService.kt
@@ -24,11 +24,9 @@ interface VimWindowIdService {
   fun getWindowId(editor: VimEditor): String?
 
   /**
-   * The scope id of the window containing the given editor, in the form `"<projectId>/<windowId>"`
+   * The scope id of the window containing the given editor, or null when the editor doesn't belong to a window
    *
-   * This is the key that scopes window local state (currently just the jump list) and it is composed here so that the
-   * format has a single home. Returns null when the editor doesn't belong to a window, in which case callers fall back
-   * to the project id.
+   * Composed and taken apart in this one place, so that the encoding has a single home. See [projectIdOf].
    */
   fun getWindowScopeId(editor: VimEditor): String? {
     val windowId = getWindowId(editor) ?: return null
@@ -36,7 +34,9 @@ interface VimWindowIdService {
   }
 
   companion object {
-    /** Separates the project id from the window id in a window scoped id */
-    const val WINDOW_SCOPE_SEPARATOR: String = "/"
+    private const val WINDOW_SCOPE_SEPARATOR: String = "/"
+
+    /** The project a scope id belongs to, whether it is a window scope id or a project id already */
+    fun projectIdOf(scopeId: String): String = scopeId.substringBeforeLast(WINDOW_SCOPE_SEPARATOR)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimWindowIdService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimWindowIdService.kt
@@ -22,4 +22,21 @@ interface VimWindowIdService {
    * fallback window, a diff view, or a console
    */
   fun getWindowId(editor: VimEditor): String?
+
+  /**
+   * The scope id of the window containing the given editor, in the form `"<projectId>/<windowId>"`
+   *
+   * This is the key that scopes window local state (currently just the jump list) and it is composed here so that the
+   * format has a single home. Returns null when the editor doesn't belong to a window, in which case callers fall back
+   * to the project id.
+   */
+  fun getWindowScopeId(editor: VimEditor): String? {
+    val windowId = getWindowId(editor) ?: return null
+    return editor.projectId + WINDOW_SCOPE_SEPARATOR + windowId
+  }
+
+  companion object {
+    /** Separates the project id from the window id in a window scoped id */
+    const val WINDOW_SCOPE_SEPARATOR: String = "/"
+  }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/thinapi/editor/EditorAccessorImpl.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/thinapi/editor/EditorAccessorImpl.kt
@@ -80,15 +80,15 @@ open class EditorAccessorImpl(
     get() = injector.markService.getAllGlobalMarks().map { it.toApiMark() }.toSet()
 
   override fun getJump(count: Int): Jump? {
-    val jump = injector.jumpService.getJump(vimEditor.projectId, count)
+    val jump = injector.jumpService.getJump(vimEditor.jumpListId, count)
     return jump?.toApiJump()
   }
 
   override val jumps: List<Jump>
-    get() = injector.jumpService.getJumps(vimEditor.projectId).map { it.toApiJump() }
+    get() = injector.jumpService.getJumps(vimEditor.jumpListId).map { it.toApiJump() }
 
   override val currentJumpIndex: Int
-    get() = injector.jumpService.getJumpSpot(vimEditor.projectId)
+    get() = injector.jumpService.getJumpSpot(vimEditor.jumpListId)
 
   override fun scrollCaretIntoView() {
     return injector.scroll.scrollCaretIntoView(vimEditor)

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/thinapi/editor/TransactionImpl.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/thinapi/editor/TransactionImpl.kt
@@ -110,21 +110,21 @@ class TransactionImpl(
     val protocol = jump.filepath.protocol
     val filePath = jump.filepath.getFilePath()
     val engineJump = EngineJump(jump.line, jump.col, filePath, protocol)
-    injector.jumpService.addJump(vimEditor.projectId, engineJump, reset)
+    injector.jumpService.addJump(vimEditor.jumpListId, engineJump, reset)
   }
 
   override fun removeJump(jump: Jump) {
     val protocol = jump.filepath.protocol
     val filePath = jump.filepath.getFilePath()
     val engineJump = EngineJump(jump.line, jump.col, filePath, protocol)
-    injector.jumpService.removeJump(vimEditor.projectId, engineJump)
+    injector.jumpService.removeJump(vimEditor.jumpListId, engineJump)
   }
 
   override fun dropLastJump() {
-    injector.jumpService.dropLastJump(vimEditor.projectId)
+    injector.jumpService.dropLastJump(vimEditor.jumpListId)
   }
 
   override fun clearJumps() {
-    injector.jumpService.clearJumps(vimEditor.projectId)
+    injector.jumpService.clearJumps(vimEditor.jumpListId)
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/thinapi/editor/caret/CaretTransactionImpl.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/thinapi/editor/caret/CaretTransactionImpl.kt
@@ -274,7 +274,7 @@ class CaretTransactionImpl(
     val protocol = virtualFile.protocol
     val position = vimEditor.offsetToBufferPosition(vimCaret.offset)
     val jump = EngineJump(position.line, position.column, path, protocol)
-    injector.jumpService.addJump(vimEditor.projectId, jump, reset)
+    injector.jumpService.addJump(vimEditor.jumpListId, jump, reset)
   }
 
   override fun saveJumpLocation() {

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/ClearJumpsCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/ClearJumpsCommand.kt
@@ -31,7 +31,7 @@ data class ClearJumpsCommand(val range: Range, val modifier: CommandModifier, va
     context: ExecutionContext,
     operatorArguments: OperatorArguments,
   ): ExecutionResult {
-    injector.jumpService.clearJumps(editor.projectId)
+    injector.jumpService.clearJumps(editor.jumpListId)
     return ExecutionResult.Success
   }
 }

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/JumpsCommand.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/vimscript/model/commands/JumpsCommand.kt
@@ -66,6 +66,7 @@ data class JumpsCommand(val range: Range, val modifier: CommandModifier, val arg
       text.append(">\n")
     }
 
+    injector.outputPanel.clear(editor, context)
     injector.outputPanel.output(editor, context, text.toString())
     return ExecutionResult.Success
   }


### PR DESCRIPTION
when `windowjumps` option is set each split window will contain it's own jump history
Hidden by this option to preserve deafault behaviour