### PR TITLE
VIM-1180 Pass eof to external command

### DIFF
--- a/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/process/ProcessGroup.kt
+++ b/ideavim-backend/src/main/java/com/maddyhome/idea/vim/group/process/ProcessGroup.kt
@@ -125,20 +125,21 @@ class ProcessGroup : VimProcessGroupBase() {
           commandLine.setWorkDirectory(currentDirectoryPath)
         }
         val handler = CapturingProcessHandler(commandLine)
-        if (input != null) {
-          handler.addProcessListener(object : ProcessListener {
-            override fun startNotified(event: ProcessEvent) {
-              try {
-                val charSequenceReader = CharSequenceReader(input)
-                val outputStreamWriter = BufferedWriter(OutputStreamWriter(handler.processInput))
-                charSequenceReader.transferTo(outputStreamWriter)
-                outputStreamWriter.close()
-              } catch (e: IOException) {
-                logger.error(e)
+        handler.addProcessListener(object : ProcessListener {
+          override fun startNotified(event: ProcessEvent) {
+            try {
+              // Close stdin even when there is nothing to write. Without EOF, a command that reads stdin, such as
+              // `:!sort`, would block forever. Vim hands such a command its terminal; we have none, like Neovim.
+              BufferedWriter(OutputStreamWriter(handler.processInput)).use { writer ->
+                if (input != null) {
+                  CharSequenceReader(input).transferTo(writer)
+                }
               }
+            } catch (e: IOException) {
+              logger.error(e)
             }
-          })
-        }
+          }
+        })
 
         val progressIndicator = ProgressIndicatorProvider.getInstance().progressIndicator
         val output = handler.runProcessWithProgressIndicator(progressIndicator)

--- a/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/CmdFilterCommandTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/ex/implementation/commands/CmdFilterCommandTest.kt
@@ -10,8 +10,12 @@ package org.jetbrains.plugins.ideavim.ex.implementation.commands
 
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.vimscript.model.commands.CmdFilterCommand
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
 import org.jetbrains.plugins.ideavim.VimTestCase
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -21,5 +25,21 @@ class CmdFilterCommandTest : VimTestCase() {
     val command = injector.vimscriptParser.parseCommand("!ls")
     assertTrue(command is CmdFilterCommand)
     assertEquals("ls", command.argument)
+  }
+
+  @Test
+  @TestWithoutNeovim(
+    reason = SkipNeovimReason.SEE_DESCRIPTION,
+    description = "Runs an external command. Neovim's own output for `:!` is not routed through IdeaVim's ex output " +
+      "panel, so there is nothing to compare.",
+  )
+  @DisabledOnOs(OS.WINDOWS, disabledReason = "Uses the POSIX 'sort' command and a POSIX shell")
+  fun `command reading stdin does not wait for input`() {
+    configureByText("Lorem ipsum dolor sit amet\n")
+
+    // `sort` with no arguments reads stdin. Vim hands such a command the terminal it is running in, and Neovim
+    // redirects stdin to /dev/null. We have no terminal to hand over, so the command must see an immediate EOF and
+    // exit, rather than blocking forever waiting for input that can never arrive.
+    assertCommandOutput("!sort", ":!sort\n")
   }
 }


### PR DESCRIPTION
Without that commands like `!sort` would never finish as they waited for user input. This is same way as neovim does. We also don;t support interactive commands