### PR TITLE
VIM-4318 Restore selection with gv after sort

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/group/MarkUpdater.kt
+++ b/src/main/java/com/maddyhome/idea/vim/group/MarkUpdater.kt
@@ -40,10 +40,12 @@ object MarkUpdater : DocumentListener {
   override fun beforeDocumentChange(event: DocumentEvent) {
     if (VimPlugin.isNotEnabled()) return
     logger.debug { "MarkUpdater before, event = $event" }
-    if (event.oldLength == 0) return
+    if (event.oldLength == 0 && event.newLength == 0) return
     val doc = event.document
     val anEditor = getAnyEditorForDocument(doc) ?: return
-    injector.markService.updateMarksFromDelete(anEditor, event.offset, event.oldLength, event.newLength)
+    injector.markService.updateVisualSelectionMarks(anEditor, event.offset, event.oldLength, event.newFragment)
+    if (event.oldLength == 0) return
+    injector.markService.updateMarksFromDelete(anEditor, event.offset, event.oldLength)
   }
 
   /**

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/motion/visual/VisualSelectPreviousAfterRangeRewriteTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/motion/visual/VisualSelectPreviousAfterRangeRewriteTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+@file:Suppress("RemoveCurlyBracesFromTemplate")
+
+package org.jetbrains.plugins.ideavim.action.motion.visual
+
+import com.maddyhome.idea.vim.state.mode.Mode
+import com.maddyhome.idea.vim.state.mode.SelectionType
+import org.jetbrains.plugins.ideavim.VimBehaviorDiffers
+import org.jetbrains.plugins.ideavim.VimTestCase
+import org.junit.jupiter.api.Test
+
+/**
+ * `gv` must reselect the last Visual selection after the selected range has been rewritten.
+ *
+ * Reported scenario (`:'<,'>sort`, `:'<,'>sort u`, then `u`): Vim reselects the affected lines, adjusting the end of
+ * the selection for the lines removed by the command, while IdeaVim collapsed the selection to the last line.
+ *
+ * This is not specific to `:sort`. Everything that rewrites the whole selected range in a single document change is
+ * affected, e.g. `gU` or `g?`. Commands that change the lines one by one (`:s`, `:normal`, `:>`, `:m`, `:j`, `r`)
+ * restore the selection correctly.
+ *
+ * Note: entering Command-line mode from Visual mode prefills the range, so `":sort<CR>"` below is `:'<,'>sort`.
+ */
+class VisualSelectPreviousAfterRangeRewriteTest : VimTestCase() {
+  @Test
+  fun `test gv reselects sorted lines`() {
+    doTest(
+      listOf("Vjj", ":sort<CR>", "gv"),
+      """
+        one
+        ${c}two
+        two
+        three
+        four
+      """.trimIndent(),
+      """
+        one
+        ${s}three
+        two
+        ${c}two
+        ${se}four
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.LINE_WISE),
+    )
+  }
+
+  @Test
+  fun `test gv reselects remaining lines after sort removed duplicates`() {
+    doTest(
+      listOf("Vjj", ":sort u<CR>", "gv"),
+      """
+        one
+        ${c}three
+        two
+        two
+        four
+      """.trimIndent(),
+      """
+        one
+        ${s}three
+        ${c}two
+        ${se}four
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.LINE_WISE),
+    )
+  }
+
+  @VimBehaviorDiffers(
+    originalVimAfter = "one\n${s}three\ntwo\n${c}two\n${se}four",
+    description = "Vim stores the Visual area in the undo state and restores it on undo (uh_visual). IdeaVim only " +
+      "adjusts the marks for the document change, so '> stays on the line the duplicate was removed from.",
+  )
+  @Test
+  fun `test gv after undoing sort that removed duplicates`() {
+    doTest(
+      listOf("Vjj", ":sort u<CR>", "u", "gv"),
+      """
+        one
+        ${c}three
+        two
+        two
+        four
+      """.trimIndent(),
+      """
+        one
+        ${s}three
+        ${c}two
+        ${se}two
+        four
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.LINE_WISE),
+    )
+  }
+
+  @Test
+  fun `test gv reselects lines after uppercasing the selection`() {
+    doTest(
+      listOf("VjjU", "gv"),
+      """
+        one
+        ${c}two
+        two
+        three
+        four
+      """.trimIndent(),
+      """
+        one
+        ${s}TWO
+        TWO
+        ${c}THREE
+        ${se}four
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.LINE_WISE),
+    )
+  }
+
+  @Test
+  fun `test gv reselects lines after rot13 of the selection`() {
+    doTest(
+      listOf("Vjjg?", "gv"),
+      """
+        one
+        ${c}two
+        two
+        three
+        four
+      """.trimIndent(),
+      """
+        one
+        ${s}gjb
+        gjb
+        ${c}guerr
+        ${se}four
+      """.trimIndent(),
+      Mode.VISUAL(SelectionType.LINE_WISE),
+    )
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMarkService.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMarkService.kt
@@ -134,9 +134,10 @@ interface VimMarkService {
    * @param editor          The modified editor
    * @param delStartOffset  The offset within the editor where the deletion occurred
    * @param delLength       The length of the deleted text
-   * @param newLength       The length of the replacement text (0 for pure deletes)
    */
-  fun updateMarksFromDelete(editor: VimEditor, delStartOffset: Int, delLength: Int, newLength: Int = 0)
+  fun updateMarksFromDelete(editor: VimEditor, delStartOffset: Int, delLength: Int)
+
+  fun updateVisualSelectionMarks(editor: VimEditor, changeOffset: Int, oldLength: Int, newFragment: CharSequence)
 
   fun editorReleased(editor: VimEditor)
 

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMarkServiceBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimMarkServiceBase.kt
@@ -389,32 +389,12 @@ abstract class VimMarkServiceBase : VimMarkService {
       }
     }
 
-    for (caret in editor.carets()) {
-      val selectionInfo = caret.lastSelectionInfo
-
-      val startPosition = selectionInfo.start
-      var newStartPosition = selectionInfo.start
-      if (startPosition != null && insStart.line <= startPosition.line) {
-        newStartPosition = BufferPosition(startPosition.line + lines, startPosition.column, startPosition.leansForward)
-      }
-
-      val endPosition = selectionInfo.end
-      var newEndPosition = endPosition
-      if (endPosition != null && insStart.line <= endPosition.line) {
-        newEndPosition = BufferPosition(endPosition.line + lines, endPosition.column, endPosition.leansForward)
-      }
-
-      if (newStartPosition != startPosition || newEndPosition != endPosition) {
-        caret.lastSelectionInfo = SelectionInfo(newStartPosition, newEndPosition, selectionInfo.selectionType)
-      }
-    }
-
     // No notification: this runs while the document change is still being applied, so a listener that draws in the
     // editor would draw against a half-updated document. Marks are only shifted here, never added or removed, and
     // anything anchored to the document shifts with it.
   }
 
-  override fun updateMarksFromDelete(editor: VimEditor, delStartOffset: Int, delLength: Int, newLength: Int) {
+  override fun updateMarksFromDelete(editor: VimEditor, delStartOffset: Int, delLength: Int) {
     val caretToMarks = getAllMarksForFile(editor)
     if (caretToMarks.isEmpty()) return
 
@@ -457,109 +437,67 @@ abstract class VimMarkServiceBase : VimMarkService {
       }
     }
 
-    adjustVisualSelectionMarks(editor, delStartOffset, delEndOffset, delStart, delEnd, newLength)
-
     // See the note in updateMarksFromInsert on why nothing is notified here.
   }
 
-  private fun adjustVisualSelectionMarks(
+  override fun updateVisualSelectionMarks(
     editor: VimEditor,
-    delStartOffset: Int,
-    delEndOffset: Int,
-    delStart: BufferPosition,
-    delEnd: BufferPosition,
-    newLength: Int,
+    changeOffset: Int,
+    oldLength: Int,
+    newFragment: CharSequence,
   ) {
+    val changeEndOffset = changeOffset + oldLength
+    val changeStartLine = editor.offsetToBufferPosition(changeOffset).line
+    val oldEndLine = editor.offsetToBufferPosition(changeEndOffset).line
+    val newEndLine = changeStartLine + newFragment.count { it == '\n' }
+    if (oldEndLine == newEndLine) return
+
     for (caret in editor.carets()) {
       val selectionInfo = caret.lastSelectionInfo
 
       val startPosition = selectionInfo.start
       val newStartPosition = startPosition?.let {
-        adjustPositionForDelete(
-          editor,
-          it,
-          delStartOffset,
-          delEndOffset,
-          delStart,
-          delEnd,
-          newLength
-        )
+        adjustVisualMark(editor, it, changeOffset, changeEndOffset, oldEndLine, newEndLine)
       }
 
       val endPosition = selectionInfo.end
       val newEndPosition = endPosition?.let {
-        adjustPositionForDelete(
-          editor,
-          it,
-          delStartOffset,
-          delEndOffset,
-          delStart,
-          delEnd,
-          newLength
-        )
+        adjustVisualMark(editor, it, changeOffset, changeEndOffset, oldEndLine, newEndLine)
       }
 
       if (newStartPosition != startPosition || newEndPosition != endPosition) {
         caret.lastSelectionInfo = SelectionInfo(newStartPosition, newEndPosition, selectionInfo.selectionType)
       }
     }
+
+    // See the note in updateMarksFromInsert on why nothing is notified here.
   }
 
-  private fun isVisualMark(mark: VimMark): Boolean = mark.key == SELECTION_START_MARK || mark.key == SELECTION_END_MARK
-
-  private fun adjustPositionForDelete(
+  private fun adjustVisualMark(
     editor: VimEditor,
     position: BufferPosition,
-    delStartOffset: Int,
-    delEndOffset: Int,
-    delStart: BufferPosition,
-    delEnd: BufferPosition,
-    newLength: Int,
+    changeOffset: Int,
+    changeEndOffset: Int,
+    oldEndLine: Int,
+    newEndLine: Int,
   ): BufferPosition {
-    val posOffset = editor.bufferPositionToOffset(position)
-
+    val offset = editor.bufferPositionToOffset(position)
     return when {
-      isBeforeDeletion(posOffset, delStartOffset) -> position
-      isAfterDeletionOnLaterLine(position, delEnd) -> shiftLine(position, delStart, delEnd)
-      isMultiLineMerge(position, delStart) -> mergeIntoLine(position, delStart, newLength)
-      isAfterDeletionOnSameLine(posOffset, delEndOffset) -> shiftColumn(
-        position,
-        delStartOffset,
-        delEndOffset,
-        newLength
+      offset < changeOffset -> position
+      // Note that text inserted at the mark (an empty range, i.e. changeOffset == changeEndOffset) pushes the mark
+      // down, while text replacing a range that starts at the mark leaves the mark at the start of the new text
+      offset >= changeEndOffset -> BufferPosition(
+        position.line + (newEndLine - oldEndLine),
+        position.column,
+        position.leansForward,
       )
 
-      else -> position // Within deleted range: Vim preserves visual marks
+      position.line > newEndLine -> BufferPosition(newEndLine, position.column, position.leansForward)
+      else -> position
     }
   }
 
-  private fun isBeforeDeletion(posOffset: Int, delStartOffset: Int) = posOffset <= delStartOffset
-
-  private fun isAfterDeletionOnLaterLine(position: BufferPosition, delEnd: BufferPosition) = position.line > delEnd.line
-
-  private fun isMultiLineMerge(position: BufferPosition, delStart: BufferPosition) = delStart.line < position.line
-
-  private fun isAfterDeletionOnSameLine(posOffset: Int, delEndOffset: Int) = posOffset > delEndOffset
-
-  private fun shiftLine(position: BufferPosition, delStart: BufferPosition, delEnd: BufferPosition): BufferPosition {
-    val lineShift = delEnd.line - delStart.line
-    return BufferPosition(position.line - lineShift, position.column, position.leansForward)
-  }
-
-  private fun mergeIntoLine(position: BufferPosition, delStart: BufferPosition, newLength: Int): BufferPosition {
-    return BufferPosition(delStart.line, delStart.column + newLength + position.column, position.leansForward)
-  }
-
-  private fun shiftColumn(
-    position: BufferPosition,
-    delStartOffset: Int,
-    delEndOffset: Int,
-    newLength: Int,
-  ): BufferPosition {
-    val oldLength = delEndOffset - delStartOffset + 1
-    val netShift = newLength - oldLength
-    return BufferPosition(position.line, position.column + netShift, position.leansForward)
-  }
+  private fun isVisualMark(mark: VimMark): Boolean = mark.key == SELECTION_START_MARK || mark.key == SELECTION_END_MARK
 
   override fun editorReleased(editor: VimEditor) {
     setMark(editor.primaryCaret(), LAST_BUFFER_POSITION, editor.primaryCaret().offset)


### PR DESCRIPTION
We were incoretlly restoring visual selection after sort command as updateMarksFromDelete/updateMarksFromInsert was updating last selection twice