### PR TITLE
VIM-2010 fix repeat insert with import

### DIFF
--- a/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/RepeatWithAutoImportTest.kt
+++ b/tests/java-tests/src/test/kotlin/org/jetbrains/plugins/ideavim/action/RepeatWithAutoImportTest.kt
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2003-2026 The IdeaVim authors
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE.txt file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+package org.jetbrains.plugins.ideavim.action
+
+import com.intellij.codeInsight.CodeInsightSettings
+import com.intellij.codeInsight.lookup.Lookup
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.projectRoots.JavaSdk
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.testFramework.LightProjectDescriptor
+import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
+import com.intellij.testFramework.fixtures.impl.LightTempDirTestFixtureImpl
+import org.jetbrains.plugins.ideavim.SkipNeovimReason
+import org.jetbrains.plugins.ideavim.TestWithoutNeovim
+import org.jetbrains.plugins.ideavim.VimJavaTestCase
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+/**
+ * While we are in insert mode the IDE changes the document behind our back, and those changes are recorded in the
+ * strokes that `.` replays. Adding an import is such a change - the daemon, an Alt+Enter fix and the completion lookup
+ * all do it - and `.` has to replay only what the user typed, not the import.
+ */
+@TestWithoutNeovim(
+  reason = SkipNeovimReason.SEE_DESCRIPTION,
+  description = "Adding imports while typing has no Neovim equivalent",
+)
+class RepeatWithAutoImportTest : VimJavaTestCase() {
+
+  private val twoSetFields = """
+        |import java.util.Set;
+        |
+        |class Foo {
+        |    ${c}Set<String> foo;
+        |    Set<String> bar;
+        |}
+  """.trimMargin()
+
+  private val twoSetLocals = """
+        |import java.util.HashSet;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |  void test() {
+        |    ${c}Set<String> foo = new HashSet<String>();
+        |    Set<String> bar = new HashSet<String>();
+        |  }
+        |}
+  """.trimMargin()
+
+  private var originalAddImportsOnTheFly = false
+
+  private var addImportsOnTheFly: Boolean
+    get() = CodeInsightSettings.getInstance().ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY
+    set(value) {
+      CodeInsightSettings.getInstance().ADD_UNAMBIGIOUS_IMPORTS_ON_THE_FLY = value
+    }
+
+  override fun createFixture(factory: IdeaTestFixtureFactory): CodeInsightTestFixture {
+    // The default light project descriptor has no JDK, so `java.util.List` wouldn't resolve and there would be nothing
+    // to import
+    val descriptor = object : LightProjectDescriptor() {
+      override fun getSdk(): Sdk = JavaSdk.getInstance().createJdk("Test JDK", System.getProperty("java.home"), false)
+    }
+    val fixture = factory.createLightFixtureBuilder(descriptor, "IdeaVim").fixture
+    return factory.createCodeInsightFixture(fixture, LightTempDirTestFixtureImpl(true))
+  }
+
+  @BeforeEach
+  fun enableAddImportsOnTheFly() {
+    originalAddImportsOnTheFly = addImportsOnTheFly
+    addImportsOnTheFly = true
+  }
+
+  @AfterEach
+  fun restoreAddImportsOnTheFly() {
+    addImportsOnTheFly = originalAddImportsOnTheFly
+  }
+
+  @Test
+  fun `test repeating a change that auto-imported a class does not replay the import`() {
+    configureByJavaText(twoSetFields)
+
+    // We are still in insert mode when the IDE adds `import java.util.List;` at the top of the file
+    typeText("cf>", "List<lt>String>")
+    addUnambiguousImportsOnTheFly()
+    typeText("<Esc>")
+
+    assertState(
+      """
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |    List<String${c}> foo;
+        |    Set<String> bar;
+        |}
+      """.trimMargin(),
+    )
+
+    typeText("j", "0", "w", ".")
+
+    assertState(
+      """
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |    List<String> foo;
+        |    List<Strin${c}g> bar;
+        |}
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test repeating a change whose import landed while the user kept typing`() {
+    configureByJavaText(twoSetLocals)
+
+    // The import lands in the middle of the insert, so the offsets recorded for the rest of it have to survive the
+    // text above the caret growing
+    typeText("cf;", "List<lt>String> f")
+    addUnambiguousImportsOnTheFly()
+    typeText("oo = new HashSet<lt>String>();")
+    typeText("<Esc>")
+
+    assertState(
+      """
+        |import java.util.HashSet;
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |  void test() {
+        |    List<String> foo = new HashSet<String>()${c};
+        |    Set<String> bar = new HashSet<String>();
+        |  }
+        |}
+      """.trimMargin(),
+    )
+
+    typeText("j", "0", "w", ".")
+
+    assertState(
+      """
+        |import java.util.HashSet;
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |  void test() {
+        |    List<String> foo = new HashSet<String>();
+        |    List<String> foo = new HashSet<String>()${c};
+        |  }
+        |}
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test repeating a change made with backspaces after an import landed`() {
+    configureByJavaText(twoSetLocals)
+
+    // Backspaces and caret motions end up in the strokes next to the typed text. The `<Right>`s take the caret off
+    // the reference, which is what lets the IDE add the import
+    typeText("ea", "<BS><BS><BS>", "List", "<Right><Right><Right>")
+    addUnambiguousImportsOnTheFly()
+    typeText("<Esc>")
+
+    assertState(
+      """
+        |import java.util.HashSet;
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |  void test() {
+        |    List<S${c}tring> foo = new HashSet<String>();
+        |    Set<String> bar = new HashSet<String>();
+        |  }
+        |}
+      """.trimMargin(),
+    )
+
+    // `.` repeats `a`, so the caret has to be where the original append started: at the end of the word
+    typeText("j", "0", "e", ".")
+
+    assertState(
+      """
+        |import java.util.HashSet;
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |  void test() {
+        |    List<String> foo = new HashSet<String>();
+        |    Lis${c}t<String> bar = new HashSet<String>();
+        |  }
+        |}
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test repeating a change whose import was added by a quick fix does not replay the import`() {
+    addImportsOnTheFly = false
+    configureByJavaText(twoSetFields)
+
+    typeText("cw", "List")
+    importClassWithQuickFix()
+    typeText("<Esc>")
+
+    assertState(
+      """
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |    Lis${c}t<String> foo;
+        |    Set<String> bar;
+        |}
+      """.trimMargin(),
+    )
+
+    typeText("j", "0", "w", ".")
+
+    assertState(
+      """
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |    List<String> foo;
+        |    Lis${c}t<String> bar;
+        |}
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `test repeating a change completed from the lookup does not replay the qualified name round trip`() {
+    addImportsOnTheFly = false
+    configureByJavaText(twoSetLocals)
+
+    // Picking `List` from the popup inserts `java.util.List`, adds the import and then shortens the name back to
+    // `List` - all of it while we are recording strokes
+    typeText("cw", "Lis")
+    completeBasic()
+    finishLookup()
+    typeText("<Esc>")
+
+    assertState(
+      """
+        |import java.util.HashSet;
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |  void test() {
+        |    Lis${c}t<String> foo = new HashSet<String>();
+        |    Set<String> bar = new HashSet<String>();
+        |  }
+        |}
+      """.trimMargin(),
+    )
+
+    typeText("j", "0", "w", ".")
+
+    assertState(
+      """
+        |import java.util.HashSet;
+        |import java.util.List;
+        |import java.util.Set;
+        |
+        |class Foo {
+        |  void test() {
+        |    List<String> foo = new HashSet<String>();
+        |    Lis${c}t<String> bar = new HashSet<String>();
+        |  }
+        |}
+      """.trimMargin(),
+    )
+  }
+
+  /**
+   * Runs the highlighting passes, which is what adds the unambiguous import. The IDE does this while the user keeps
+   * typing, so we run it without leaving insert mode. `canChangeDocument` has to be true - inserting the import is
+   * exactly the document change the fixture otherwise forbids during highlighting.
+   */
+  private fun addUnambiguousImportsOnTheFly() {
+    ApplicationManager.getApplication().invokeAndWait {
+      CodeInsightTestFixtureImpl.instantiateAndRun(fixture.file, fixture.editor, IntArray(0), true)
+      PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+    }
+  }
+
+  /** Invokes the "Import class" quick fix on the reference at the caret, i.e. what the user gets from Alt+Enter. */
+  private fun importClassWithQuickFix() {
+    ApplicationManager.getApplication().invokeAndWait {
+      val intentions = fixture.filterAvailableIntentions("Import class")
+      assertTrue(intentions.isNotEmpty(), "Expected an \"Import class\" quick fix to be available")
+      fixture.launchAction(intentions.first())
+      PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+    }
+  }
+
+  private fun completeBasic() {
+    ApplicationManager.getApplication().invokeAndWait {
+      fixture.completeBasic()
+      PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+    }
+  }
+
+  /**
+   * Accepts the selected lookup item the way pressing Enter does. We must not send `<C-Y>` instead: that is a Vim
+   * command of its own (insert the character above the caret), and it would become the command `.` repeats.
+   */
+  private fun finishLookup() {
+    ApplicationManager.getApplication().invokeAndWait {
+      fixture.finishLookup(Lookup.NORMAL_SELECT_CHAR)
+      PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+    }
+  }
+}

--- a/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
+++ b/vim-engine/src/main/kotlin/com/maddyhome/idea/vim/api/VimChangeGroupBase.kt
@@ -75,6 +75,8 @@ abstract class VimChangeGroupBase : VimChangeGroup {
   @JvmField
   protected var oldOffset: Int = -1
 
+  private val recordedTexts: MutableList<RecordedText> = ArrayList()
+
   @JvmField
   protected var vimDocumentListener: ChangesListener? = null
 
@@ -377,45 +379,146 @@ abstract class VimChangeGroupBase : VimChangeGroup {
     repeatAppend = false
   }
 
-  protected inner class VimChangesListener : ChangesListener {
-    override fun documentChanged(change: ChangesListener.Change) {
-      val newFragment = change.newFragment
-      val oldFragment = change.oldFragment
-      val newFragmentLength = newFragment.length
-      val oldFragmentLength = oldFragment.length
+  /** Text we have appended to [strokes], remembered so that a change taking it back can cancel the recording. */
+  private class RecordedText(
+    var offset: Int,
+    val chars: CharArray,
+    val firstStrokeIndex: Int,
+    val previousOldOffset: Int,
+  ) {
+    fun isTakenBackBy(change: ChangesListener.Change) =
+      change.offset == offset && change.oldFragment == chars.concatToString()
+  }
 
-      // Repeat buffer limits
-      if (repeatCharsCount > MAX_REPEAT_CHARS_COUNT) {
+  protected inner class VimChangesListener(private val editor: VimEditor) : ChangesListener {
+    override fun documentChanged(change: ChangesListener.Change) {
+      if (isRepeatBufferFull()) return
+
+      if (isMadeBeforeInsert(change)) {
+        followWithoutRecording(change)
         return
       }
+      if (undoLastRecordedText(change)) return
 
+      updateRecordedTexts(change)
+      record(change)
+    }
+
+    private fun isRepeatBufferFull() = repeatCharsCount > MAX_REPEAT_CHARS_COUNT
+
+    /**
+     * We do want most of what the IDE changes while we are in insert mode - that is how auto-inserted brackets and
+     * indents end up being replayed by `.`. But an import added by "add unambiguous imports on the fly" or by an
+     * Alt+Enter fix is not something the user typed. The platform doesn't tell us who made a change, so we go by the
+     * insert region: nothing before the start of the insert can be the typing we are recording. The start is a live
+     * marker ([VimCaret.vimInsertStart]), so it moves with the document.
+     */
+    private fun isMadeBeforeInsert(change: ChangesListener.Change): Boolean {
+      val insertStarts = editor.nativeCarets().map { it.vimInsertStart.startOffset }
+      return insertStarts.isNotEmpty() && insertStarts.all { change.offset < it }
+    }
+
+    /**
+     * Everything after the change has moved, and so must the offsets we remember. Otherwise the next typed character
+     * looks like a jump and we would record caret motions for it.
+     */
+    private fun followWithoutRecording(change: ChangesListener.Change) {
+      if (oldOffset >= 0) {
+        oldOffset += change.lengthDelta
+      }
+      updateRecordedTexts(change)
+    }
+
+    /**
+     * Rolls the strokes back if [change] takes back the text we recorded last, and nothing else. Completing a class
+     * name from the lookup does exactly that: it inserts the fully qualified name, adds the import and then shortens
+     * the name again. Replaying that round trip would leave the caret wherever the round trip ended.
+     */
+    private fun undoLastRecordedText(change: ChangesListener.Change): Boolean {
+      if (!change.isPureDeletion) return false
+      val last = recordedTexts.lastOrNull() ?: return false
+      if (!last.isTakenBackBy(change)) return false
+      // Strokes recorded after that text are real - a backspace over an auto-inserted bracket arrives as two changes -
+      // and dropping them along with the text would break the replay
+      if (strokes.lastOrNull() !== last.chars) return false
+
+      strokes.subList(last.firstStrokeIndex, strokes.size).clear()
+      repeatCharsCount -= last.chars.size
+      oldOffset = last.previousOldOffset
+      recordedTexts.removeAt(recordedTexts.size - 1)
+      return true
+    }
+
+    /** Keeps the remembered offsets usable now that the document has changed, and forgets what the change overwrote. */
+    private fun updateRecordedTexts(change: ChangesListener.Change) {
+      val changeEnd = change.offset + change.oldFragment.length
+      val iterator = recordedTexts.iterator()
+      while (iterator.hasNext()) {
+        val recordedText = iterator.next()
+        when {
+          recordedText.offset >= changeEnd -> recordedText.offset += change.lengthDelta
+          recordedText.offset >= change.offset -> iterator.remove()
+        }
+      }
+    }
+
+    private fun record(change: ChangesListener.Change) {
       // <Enter> is added to strokes as an action during processing in order to indent code properly in the repeat
       // command
-      if (newFragment.startsWith("\n") && newFragment.trim { it <= ' ' }.isEmpty()) {
-        strokes.addAll(getAdjustCaretActions(change))
+      if (isNewLineWithIndent(change)) {
+        recordCaretAdjustment(change)
         oldOffset = -1
         return
       }
 
       // Ignore multi-character indents as they should be inserted automatically while repeating <Enter> actions
-      if (newFragmentLength > 1 && newFragment.trim { it <= ' ' }.isEmpty()) {
-        return
-      }
-      strokes.addAll(getAdjustCaretActions(change))
-      if (oldFragmentLength > 0) {
-        val editorDelete = injector.nativeActionManager.deleteAction
-        if (editorDelete != null) {
-          repeat(oldFragmentLength) {
-            strokes.add(editorDelete)
-          }
-        }
-      }
-      if (newFragmentLength > 0) {
-        strokes.add(newFragment.toCharArray())
-      }
-      repeatCharsCount += newFragmentLength
-      oldOffset = change.offset + newFragmentLength
+      if (isMultiCharacterIndent(change)) return
+
+      val firstStrokeIndex = strokes.size
+      val previousOldOffset = oldOffset
+      recordCaretAdjustment(change)
+      recordDeletions(change.oldFragment.length)
+      recordText(change, firstStrokeIndex, previousOldOffset)
+
+      repeatCharsCount += change.newFragment.length
+      oldOffset = change.offset + change.newFragment.length
     }
+
+    private fun recordCaretAdjustment(change: ChangesListener.Change) {
+      strokes.addAll(getAdjustCaretActions(change))
+    }
+
+    private fun recordDeletions(count: Int) {
+      val deleteAction = injector.nativeActionManager.deleteAction ?: return
+      repeat(count) {
+        strokes.add(deleteAction)
+      }
+    }
+
+    private fun recordText(change: ChangesListener.Change, firstStrokeIndex: Int, previousOldOffset: Int) {
+      if (change.newFragment.isEmpty()) return
+
+      val chars = change.newFragment.toCharArray()
+      strokes.add(chars)
+      recordedTexts.add(RecordedText(change.offset, chars, firstStrokeIndex, previousOldOffset))
+      if (recordedTexts.size > MAX_RECORDED_TEXTS) {
+        recordedTexts.removeAt(0)
+      }
+    }
+
+    private fun isNewLineWithIndent(change: ChangesListener.Change) =
+      change.newFragment.startsWith("\n") && isWhitespaceOnly(change.newFragment)
+
+    private fun isMultiCharacterIndent(change: ChangesListener.Change) =
+      change.newFragment.length > 1 && isWhitespaceOnly(change.newFragment)
+
+    private fun isWhitespaceOnly(fragment: String) = fragment.trim { it <= ' ' }.isEmpty()
+
+    private val ChangesListener.Change.lengthDelta: Int
+      get() = newFragment.length - oldFragment.length
+
+    private val ChangesListener.Change.isPureDeletion: Boolean
+      get() = oldFragment.isNotEmpty() && newFragment.isEmpty()
 
     private fun getAdjustCaretActions(change: ChangesListener.Change): List<EditorActionHandlerBase> {
       val delta: Int = change.offset - oldOffset
@@ -525,14 +628,13 @@ abstract class VimChangeGroupBase : VimChangeGroup {
       editor.mode = Mode.NORMAL()
     } else {
       lastInsert = cmd
-      strokes.clear()
-      repeatCharsCount = 0
+      clearRecordedStrokes()
       val myVimDocument = vimDocument
       if (myVimDocument != null && vimDocumentListener != null) {
         myVimDocument.removeChangeListener(vimDocumentListener!!)
       }
       vimDocument = editor.document
-      val myChangeListener = VimChangesListener()
+      val myChangeListener = VimChangesListener(editor)
       vimDocumentListener = myChangeListener
       vimDocument!!.addChangeListener(myChangeListener)
       injector.application.runReadAction {
@@ -1173,11 +1275,16 @@ abstract class VimChangeGroupBase : VimChangeGroup {
    * @param editor The editor to clear strokes from.
    */
   protected fun clearStrokes(editor: VimEditor) {
-    strokes.clear()
-    repeatCharsCount = 0
+    clearRecordedStrokes()
     for (caret in editor.nativeCarets()) {
       caret.vimInsertStart = editor.createLiveMarker(caret.offset, caret.offset)
     }
+  }
+
+  private fun clearRecordedStrokes() {
+    strokes.clear()
+    recordedTexts.clear()
+    repeatCharsCount = 0
   }
 
   /**
@@ -2213,8 +2320,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
   }
 
   override fun reset() {
-    strokes.clear()
-    repeatCharsCount = 0
+    clearRecordedStrokes()
     if (lastStrokes != null) {
       lastStrokes!!.clear()
     }
@@ -2232,6 +2338,7 @@ abstract class VimChangeGroupBase : VimChangeGroup {
 
   companion object {
     private const val MAX_REPEAT_CHARS_COUNT = 10000
+    private const val MAX_RECORDED_TEXTS = 32
     private val logger = vimLogger<VimChangeGroupBase>()
 
     /**


### PR DESCRIPTION
Vim was recording strokes of adding import while insert Also after lookup it first added java.util.List and after ther it simplified it to improt