### PR TITLE
VIM-2127 Update corresponding html tag while editing

### DIFF
--- a/src/main/java/com/maddyhome/idea/vim/helper/IjActionExecutor.kt
+++ b/src/main/java/com/maddyhome/idea/vim/helper/IjActionExecutor.kt
@@ -33,6 +33,7 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.OperatorArguments
 import com.maddyhome.idea.vim.handler.EditorActionHandlerBase
 import com.maddyhome.idea.vim.newapi.IjNativeAction
+import com.maddyhome.idea.vim.newapi.IjVimDocument
 import com.maddyhome.idea.vim.newapi.ij
 import org.jetbrains.annotations.NonNls
 import java.awt.Component
@@ -136,8 +137,7 @@ class IjActionExecutor : VimActionExecutor {
       }
 
       fun AnAction.getId(): String? {
-        return actionManager.getId(this)
-          ?: (shortcutSet as? ProxyShortcutSet)?.actionId
+        return actionManager.getId(this) ?: (shortcutSet as? ProxyShortcutSet)?.actionId
       }
 
       for (action in listOfActions) {
@@ -156,7 +156,8 @@ class IjActionExecutor : VimActionExecutor {
     name: @NlsContexts.Command String?,
     groupId: Any?,
   ) {
-    CommandProcessor.getInstance().executeCommand(editor?.ij?.project, runnable, name, groupId)
+    CommandProcessor.getInstance()
+      .executeCommand(editor?.ij?.project, runnable, name, groupId, (editor?.document as IjVimDocument).document)
   }
 
   override fun executeEsc(editor: VimEditor, context: ExecutionContext): Boolean {
@@ -175,8 +176,7 @@ class IjActionExecutor : VimActionExecutor {
       cmd.execute(editor, context, operatorArguments)
       return
     }
-    CommandProcessor.getInstance()
-      .executeCommand(
+    CommandProcessor.getInstance().executeCommand(
         editor.ij.project,
         { cmd.execute(editor, context, operatorArguments) },
         cmd.id,

--- a/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertBackspaceActionTest.kt
+++ b/src/test/java/org/jetbrains/plugins/ideavim/action/change/insert/InsertBackspaceActionTest.kt
@@ -8,6 +8,7 @@
 
 package org.jetbrains.plugins.ideavim.action.change.insert
 
+import com.intellij.ide.highlighter.HtmlFileType
 import com.maddyhome.idea.vim.state.mode.Mode
 import org.jetbrains.plugins.ideavim.SkipNeovimReason
 import org.jetbrains.plugins.ideavim.TestWithoutNeovim
@@ -198,6 +199,41 @@ class InsertBackspaceActionTest : VimTestCase() {
       "${c}grzyb",
       "mu${c}shb",
       Mode.REPLACE,
+    )
+  }
+
+  @TestWithoutNeovim(SkipNeovimReason.NEOVIM_RPC_SPECIAL_KEYS_INSERT_MODE)
+  @Test
+  fun `test backspace inside html tag updates second one also`() {
+    doTest(
+      listOf("i", "<BS>"),
+      "<tag${c}></tag>",
+      "<ta${c}></ta>",
+      Mode.INSERT,
+      HtmlFileType.INSTANCE,
+
+      )
+  }
+
+  @Test
+  fun `test insert inside html tag updates second one also`() {
+    doTest(
+      listOf("i", "s"),
+      "<tag${c}></tag>",
+      "<tags${c}></tags>",
+      Mode.INSERT,
+      HtmlFileType.INSTANCE,
+    )
+  }
+
+  @Test
+  fun `test replace inside html tag updates second one also`() {
+    doTest(
+      listOf("r", "s"),
+      "<ta${c}g></tag>",
+      "<ta${c}s></tas>",
+      Mode.NORMAL(),
+      HtmlFileType.INSTANCE,
     )
   }
 }


### PR DESCRIPTION
document was not passed to executeCommand and without that XmlTagNameSynchronizer couldn't find synchronizer for sam tag editions